### PR TITLE
fix(scoring): static import for onnxruntime-node so Vercel tracer shi…

### DIFF
--- a/app/api/cron/update-cameras/lib/aiScoring.ts
+++ b/app/api/cron/update-cameras/lib/aiScoring.ts
@@ -68,8 +68,12 @@ function resolveModelVersion(): string {
 
 async function getOrt(): Promise<unknown> {
   if (cachedOrt) return cachedOrt;
-  const moduleName = 'onnxruntime-node';
-  cachedOrt = await import(moduleName);
+  // Static string is required so Vercel's output-file tracer detects the
+  // dependency. A variable-indirection (`await import(varName)`) is opaque
+  // to the tracer and ships a function bundle without the package, causing
+  // MODULE_NOT_FOUND at runtime. `serverExternalPackages` in next.config.ts
+  // is what prevents bundling.
+  cachedOrt = await import('onnxruntime-node');
   return cachedOrt;
 }
 


### PR DESCRIPTION
…ps it

The `await import(varName)` indirection hid the dependency from Vercel's output-file tracer. Combined with `serverExternalPackages: ['onnxruntime-node']` (which tells Next not to bundle it), this meant the function deployed without the package and every tick fell through to baseline with `Cannot find module 'onnxruntime-node' (MODULE_NOT_FOUND)`.

Static `await import('onnxruntime-node')` is detectable by the tracer while still being a runtime import. serverExternalPackages still prevents webpack from trying to bundle the native module.

Verified by 100% fallback rate in production cron logs since the v4 deploy: every webcam scored hit the baseline-fallback path.