### PR TITLE
fix(deploy): exclude onnxruntime-node platform binaries we don't run …

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -11,6 +11,24 @@ const nextConfig: NextConfig = {
     ],
   },
   serverExternalPackages: ['onnxruntime-node', 'sharp'],
+  // onnxruntime-node ships ~385 MB of platform binaries (darwin, win32,
+  // linux/{x64,arm64} × CPU/CUDA/TensorRT). Vercel functions run linux/x64
+  // CPU only — without these excludes the function bundle blows past the
+  // 250 MB hard limit and deploys fail.
+  outputFileTracingExcludes: {
+    '*': [
+      'node_modules/onnxruntime-node/bin/napi-v6/darwin/**',
+      'node_modules/onnxruntime-node/bin/napi-v6/win32/**',
+      'node_modules/onnxruntime-node/bin/napi-v6/linux/arm64/**',
+      'node_modules/onnxruntime-node/bin/napi-v6/linux/x64/libonnxruntime_providers_cuda*',
+      'node_modules/onnxruntime-node/bin/napi-v6/linux/x64/libonnxruntime_providers_tensorrt*',
+      'node_modules/onnxruntime-node/bin/napi-v6/linux/x64/libonnxruntime_providers_openvino*',
+      'node_modules/onnxruntime-node/bin/napi-v6/linux/x64/libcudart*',
+      'node_modules/onnxruntime-node/bin/napi-v6/linux/x64/libcublas*',
+      'node_modules/onnxruntime-node/bin/napi-v6/linux/x64/libcudnn*',
+      'node_modules/onnxruntime-node/bin/napi-v6/linux/x64/libnvinfer*',
+    ],
+  },
 };
 
 export default nextConfig;


### PR DESCRIPTION
…on Vercel

The previous static-import commit let Vercel's tracer see onnxruntime-node, but the tracer then shipped all 385 MB of platform binaries (darwin/win32/linux × {x64,arm64} × {CPU,CUDA,TensorRT}) and the function bundle hit 425 MB, blowing past the 250 MB hard limit.

Vercel functions run linux/x64 CPU only. Use outputFileTracingExcludes to keep just libonnxruntime.so.1 + onnxruntime_binding.node for that platform — drops the bundle to ~90 MB.

Applied as '*' so it covers update-cameras and any other route whose trace pulls onnxruntime-node transitively.