### PR TITLE
feat(api): streamlined deployment cloud endpoints (sub-project E)

### DIFF
--- a/app/api/admin/claim-codes/route.test.ts
+++ b/app/api/admin/claim-codes/route.test.ts
@@ -1,0 +1,76 @@
+// @vitest-environment node
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mintClaimCodeMock = vi.fn();
+vi.mock('@/app/lib/cameraClaimCode', () => ({
+  mintClaimCode: (...args: unknown[]) => mintClaimCodeMock(...args),
+}));
+
+import { POST } from './route';
+
+const ORIGINAL_CRON_SECRET = process.env.CRON_SECRET;
+
+beforeEach(() => {
+  mintClaimCodeMock.mockReset();
+  process.env.CRON_SECRET = 'test-secret-12345';
+});
+
+function makeRequest(body: unknown, bearer?: string) {
+  const headers: HeadersInit = { 'content-type': 'application/json' };
+  if (bearer) headers['authorization'] = `Bearer ${bearer}`;
+  return new Request('http://test/api/admin/claim-codes', {
+    method: 'POST',
+    headers,
+    body: JSON.stringify(body),
+  });
+}
+
+describe('POST /api/admin/claim-codes', () => {
+  it('mints a claim code when authorized', async () => {
+    mintClaimCodeMock.mockResolvedValueOnce({
+      code: 'SUNSET-AAAA-BBBB',
+      expires_at: new Date('2026-06-15T00:00:00Z'),
+    });
+    const res = await POST(makeRequest({ label: 'rooftop-1' }, 'test-secret-12345'));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.code).toBe('SUNSET-AAAA-BBBB');
+    expect(typeof body.expires_at).toBe('string');
+    expect(mintClaimCodeMock).toHaveBeenCalledWith({ label: 'rooftop-1' });
+  });
+
+  it('rejects when bearer is missing', async () => {
+    const res = await POST(makeRequest({ label: 'rooftop-1' }));
+    expect(res.status).toBe(401);
+    expect(mintClaimCodeMock).not.toHaveBeenCalled();
+  });
+
+  it('rejects when bearer is wrong', async () => {
+    const res = await POST(makeRequest({ label: 'rooftop-1' }, 'wrong'));
+    expect(res.status).toBe(401);
+    expect(mintClaimCodeMock).not.toHaveBeenCalled();
+  });
+
+  it('accepts a missing label (label is optional)', async () => {
+    mintClaimCodeMock.mockResolvedValueOnce({
+      code: 'SUNSET-XXXX-YYYY',
+      expires_at: new Date('2026-06-15T00:00:00Z'),
+    });
+    const res = await POST(makeRequest({}, 'test-secret-12345'));
+    expect(res.status).toBe(200);
+    expect(mintClaimCodeMock).toHaveBeenCalledWith({ label: null });
+  });
+
+  it('returns 400 when body is not valid JSON', async () => {
+    const req = new Request('http://test/api/admin/claim-codes', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        authorization: 'Bearer test-secret-12345',
+      },
+      body: 'not-json',
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+  });
+});

--- a/app/api/admin/claim-codes/route.test.ts
+++ b/app/api/admin/claim-codes/route.test.ts
@@ -8,8 +8,6 @@ vi.mock('@/app/lib/cameraClaimCode', () => ({
 
 import { POST } from './route';
 
-const ORIGINAL_CRON_SECRET = process.env.CRON_SECRET;
-
 beforeEach(() => {
   mintClaimCodeMock.mockReset();
   process.env.CRON_SECRET = 'test-secret-12345';

--- a/app/api/admin/claim-codes/route.ts
+++ b/app/api/admin/claim-codes/route.ts
@@ -1,0 +1,42 @@
+import { NextResponse } from 'next/server';
+import { mintClaimCode } from '@/app/lib/cameraClaimCode';
+
+export const dynamic = 'force-dynamic';
+
+function isAuthorized(request: Request): boolean {
+  const header = request.headers.get('authorization');
+  const expected = `Bearer ${process.env.CRON_SECRET}`;
+  return Boolean(process.env.CRON_SECRET) && header === expected;
+}
+
+export async function POST(request: Request) {
+  if (!isAuthorized(request)) {
+    return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
+  }
+
+  let body: { label?: unknown };
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: 'invalid json body' }, { status: 400 });
+  }
+
+  const label =
+    typeof body.label === 'string' && body.label.trim() !== ''
+      ? body.label.trim()
+      : null;
+
+  try {
+    const minted = await mintClaimCode({ label });
+    return NextResponse.json({
+      code: minted.code,
+      expires_at: minted.expires_at.toISOString(),
+    });
+  } catch (error) {
+    console.error('[admin/claim-codes] mint failed:', error);
+    return NextResponse.json(
+      { error: 'mint failed', details: error instanceof Error ? error.message : 'unknown' },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/cameras/[id]/heartbeat/route.test.ts
+++ b/app/api/cameras/[id]/heartbeat/route.test.ts
@@ -1,0 +1,136 @@
+// @vitest-environment node
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const verifyDeviceTokenMock = vi.fn();
+const sqlMock = vi.fn();
+const derivePlacementStatusMock = vi.fn();
+
+vi.mock('@/app/lib/cameraAuth', () => ({
+  verifyDeviceToken: (...a: unknown[]) => verifyDeviceTokenMock(...a),
+}));
+vi.mock('@/app/lib/cameraRegistration', () => ({
+  derivePlacementStatus: (...a: unknown[]) => derivePlacementStatusMock(...a),
+}));
+vi.mock('@/app/lib/db', () => ({
+  sql: (s: TemplateStringsArray, ...v: unknown[]) => sqlMock(s, ...v),
+}));
+
+import { POST } from './route';
+
+beforeEach(() => {
+  verifyDeviceTokenMock.mockReset();
+  sqlMock.mockReset();
+  derivePlacementStatusMock.mockReset();
+});
+
+function makeRequest(opts: { id?: string; bearer?: string; body?: unknown }) {
+  const headers: HeadersInit = { 'content-type': 'application/json' };
+  if (opts.bearer) headers['authorization'] = `Bearer ${opts.bearer}`;
+  return new Request(`http://test/api/cameras/${opts.id ?? '42'}/heartbeat`, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify(opts.body ?? { uptime_s: 600 }),
+  });
+}
+
+function makeContext(id: string) {
+  return { params: Promise.resolve({ id }) };
+}
+
+describe('POST /api/cameras/[id]/heartbeat', () => {
+  it('rejects unauthenticated requests with 401', async () => {
+    verifyDeviceTokenMock.mockResolvedValueOnce(null);
+    const res = await POST(
+      makeRequest({ id: '42', bearer: 'bad' }),
+      makeContext('42')
+    );
+    expect(res.status).toBe(401);
+  });
+
+  it('updates last_heartbeat_at and returns 200 with no placement when not requested', async () => {
+    verifyDeviceTokenMock.mockResolvedValueOnce({ id: 42, status: 'active' });
+    sqlMock.mockResolvedValueOnce([]); // UPDATE last_heartbeat_at (returns nothing meaningful here)
+    const res = await POST(
+      makeRequest({ id: '42', bearer: 'good', body: { uptime_s: 600 } }),
+      makeContext('42')
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.placement).toBeUndefined();
+    expect(body.placement_status).toBeUndefined();
+  });
+
+  it('returns placement when device requests it and row is ready', async () => {
+    verifyDeviceTokenMock.mockResolvedValueOnce({ id: 42, status: 'active' });
+    sqlMock.mockResolvedValueOnce([]); // UPDATE
+    sqlMock.mockResolvedValueOnce([
+      {
+        lat: 47.6,
+        lng: -122.3,
+        elevation_m: 30,
+        timezone: 'America/Los_Angeles',
+        azimuth_deg: 270,
+        tilt_deg: 5,
+        horizon_altitude_deg: 2.5,
+        horizon_profile: [{ azimuth_deg: 0, altitude_deg: 1.2 }],
+        phase_preference: 'sunset',
+        delivery_preferences: null,
+      },
+    ]);
+    derivePlacementStatusMock.mockReturnValueOnce('ready');
+
+    const res = await POST(
+      makeRequest({
+        id: '42',
+        bearer: 'good',
+        body: { uptime_s: 600, request_placement: true },
+      }),
+      makeContext('42')
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.placement_status).toBe('ready');
+    expect(body.placement).toMatchObject({ azimuth_deg: 270, tilt_deg: 5 });
+  });
+
+  it('returns placement_status=pending without placement when not yet ready', async () => {
+    verifyDeviceTokenMock.mockResolvedValueOnce({ id: 42, status: 'active' });
+    sqlMock.mockResolvedValueOnce([]); // UPDATE
+    sqlMock.mockResolvedValueOnce([
+      {
+        lat: null,
+        lng: null,
+        elevation_m: null,
+        timezone: null,
+        azimuth_deg: null,
+        tilt_deg: null,
+        horizon_altitude_deg: null,
+        horizon_profile: null,
+        phase_preference: 'both',
+        delivery_preferences: null,
+      },
+    ]);
+    derivePlacementStatusMock.mockReturnValueOnce('pending');
+
+    const res = await POST(
+      makeRequest({
+        id: '42',
+        bearer: 'good',
+        body: { uptime_s: 600, request_placement: true },
+      }),
+      makeContext('42')
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.placement_status).toBe('pending');
+    expect(body.placement).toBeUndefined();
+  });
+
+  it('returns 400 on invalid camera id', async () => {
+    const res = await POST(
+      makeRequest({ id: 'abc', bearer: 'good' }),
+      makeContext('abc')
+    );
+    expect(res.status).toBe(400);
+  });
+});

--- a/app/api/cameras/[id]/heartbeat/route.test.ts
+++ b/app/api/cameras/[id]/heartbeat/route.test.ts
@@ -49,7 +49,13 @@ describe('POST /api/cameras/[id]/heartbeat', () => {
 
   it('updates last_heartbeat_at and returns 200 with no placement when not requested', async () => {
     verifyDeviceTokenMock.mockResolvedValueOnce({ id: 42, status: 'active' });
-    sqlMock.mockResolvedValueOnce([]); // UPDATE last_heartbeat_at (returns nothing meaningful here)
+    sqlMock.mockResolvedValueOnce([
+      {
+        lat: 47.6, lng: -122.3, elevation_m: 30, timezone: 'UTC',
+        azimuth_deg: 270, tilt_deg: 5, horizon_altitude_deg: 2.5,
+        horizon_profile: null, phase_preference: 'sunset', delivery_preferences: null,
+      },
+    ]); // UPDATE ... RETURNING
     const res = await POST(
       makeRequest({ id: '42', bearer: 'good', body: { uptime_s: 600 } }),
       makeContext('42')
@@ -62,7 +68,6 @@ describe('POST /api/cameras/[id]/heartbeat', () => {
 
   it('returns placement when device requests it and row is ready', async () => {
     verifyDeviceTokenMock.mockResolvedValueOnce({ id: 42, status: 'active' });
-    sqlMock.mockResolvedValueOnce([]); // UPDATE
     sqlMock.mockResolvedValueOnce([
       {
         lat: 47.6,
@@ -76,7 +81,7 @@ describe('POST /api/cameras/[id]/heartbeat', () => {
         phase_preference: 'sunset',
         delivery_preferences: null,
       },
-    ]);
+    ]); // UPDATE ... RETURNING
     derivePlacementStatusMock.mockReturnValueOnce('ready');
 
     const res = await POST(
@@ -95,7 +100,6 @@ describe('POST /api/cameras/[id]/heartbeat', () => {
 
   it('returns placement_status=pending without placement when not yet ready', async () => {
     verifyDeviceTokenMock.mockResolvedValueOnce({ id: 42, status: 'active' });
-    sqlMock.mockResolvedValueOnce([]); // UPDATE
     sqlMock.mockResolvedValueOnce([
       {
         lat: null,
@@ -109,7 +113,7 @@ describe('POST /api/cameras/[id]/heartbeat', () => {
         phase_preference: 'both',
         delivery_preferences: null,
       },
-    ]);
+    ]); // UPDATE ... RETURNING
     derivePlacementStatusMock.mockReturnValueOnce('pending');
 
     const res = await POST(
@@ -124,6 +128,16 @@ describe('POST /api/cameras/[id]/heartbeat', () => {
     const body = await res.json();
     expect(body.placement_status).toBe('pending');
     expect(body.placement).toBeUndefined();
+  });
+
+  it('returns 404 when the camera row vanished between auth and update', async () => {
+    verifyDeviceTokenMock.mockResolvedValueOnce({ id: 42, status: 'active' });
+    sqlMock.mockResolvedValueOnce([]); // UPDATE ... RETURNING — 0 rows
+    const res = await POST(
+      makeRequest({ id: '42', bearer: 'good' }),
+      makeContext('42')
+    );
+    expect(res.status).toBe(404);
   });
 
   it('returns 400 on invalid camera id', async () => {

--- a/app/api/cameras/[id]/heartbeat/route.ts
+++ b/app/api/cameras/[id]/heartbeat/route.ts
@@ -44,36 +44,36 @@ export async function POST(request: Request, context: RouteContext) {
     // Empty body is acceptable for heartbeat — treat as {}.
   }
 
-  await sql`
-    UPDATE cameras SET last_heartbeat_at = NOW() WHERE id = ${cameraId}
-  `;
-
-  if (body.request_placement !== true) {
-    return NextResponse.json({ acknowledged_at: new Date().toISOString() });
-  }
-
   const rows = (await sql`
-    SELECT lat, lng, elevation_m, timezone,
-           azimuth_deg, tilt_deg, horizon_altitude_deg, horizon_profile,
-           phase_preference, delivery_preferences
-    FROM cameras WHERE id = ${cameraId} LIMIT 1
+    UPDATE cameras SET last_heartbeat_at = NOW()
+    WHERE id = ${cameraId}
+    RETURNING lat, lng, elevation_m, timezone,
+              azimuth_deg, tilt_deg, horizon_altitude_deg, horizon_profile,
+              phase_preference, delivery_preferences
   `) as PlacementRow[];
 
   const row = rows[0];
   if (!row) {
+    // Camera was deleted between auth and UPDATE — extreme race, but handle defensively.
     return NextResponse.json({ error: 'camera vanished' }, { status: 404 });
+  }
+
+  const acknowledgedAt = new Date().toISOString();
+
+  if (body.request_placement !== true) {
+    return NextResponse.json({ acknowledged_at: acknowledgedAt });
   }
 
   const status = derivePlacementStatus(row);
   if (status === 'pending') {
     return NextResponse.json({
-      acknowledged_at: new Date().toISOString(),
+      acknowledged_at: acknowledgedAt,
       placement_status: 'pending',
     });
   }
 
   return NextResponse.json({
-    acknowledged_at: new Date().toISOString(),
+    acknowledged_at: acknowledgedAt,
     placement_status: 'ready',
     placement: {
       lat: row.lat,

--- a/app/api/cameras/[id]/heartbeat/route.ts
+++ b/app/api/cameras/[id]/heartbeat/route.ts
@@ -1,0 +1,91 @@
+import { NextResponse } from 'next/server';
+import { sql } from '@/app/lib/db';
+import { verifyDeviceToken } from '@/app/lib/cameraAuth';
+import { derivePlacementStatus } from '@/app/lib/cameraRegistration';
+
+export const dynamic = 'force-dynamic';
+
+type RouteContext = { params: Promise<{ id: string }> };
+
+type Body = {
+  uptime_s?: unknown;
+  request_placement?: unknown;
+};
+
+type PlacementRow = {
+  lat: number | null;
+  lng: number | null;
+  elevation_m: number | null;
+  timezone: string | null;
+  azimuth_deg: number | null;
+  tilt_deg: number | null;
+  horizon_altitude_deg: number | null;
+  horizon_profile: unknown;
+  phase_preference: string;
+  delivery_preferences: unknown;
+};
+
+export async function POST(request: Request, context: RouteContext) {
+  const { id } = await context.params;
+  const cameraId = Number.parseInt(id, 10);
+  if (!Number.isFinite(cameraId) || cameraId <= 0) {
+    return NextResponse.json({ error: 'invalid camera id' }, { status: 400 });
+  }
+
+  const camera = await verifyDeviceToken(cameraId, request.headers.get('authorization'));
+  if (!camera) {
+    return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
+  }
+
+  let body: Body = {};
+  try {
+    body = (await request.json()) as Body;
+  } catch {
+    // Empty body is acceptable for heartbeat — treat as {}.
+  }
+
+  await sql`
+    UPDATE cameras SET last_heartbeat_at = NOW() WHERE id = ${cameraId}
+  `;
+
+  if (body.request_placement !== true) {
+    return NextResponse.json({ acknowledged_at: new Date().toISOString() });
+  }
+
+  const rows = (await sql`
+    SELECT lat, lng, elevation_m, timezone,
+           azimuth_deg, tilt_deg, horizon_altitude_deg, horizon_profile,
+           phase_preference, delivery_preferences
+    FROM cameras WHERE id = ${cameraId} LIMIT 1
+  `) as PlacementRow[];
+
+  const row = rows[0];
+  if (!row) {
+    return NextResponse.json({ error: 'camera vanished' }, { status: 404 });
+  }
+
+  const status = derivePlacementStatus(row);
+  if (status === 'pending') {
+    return NextResponse.json({
+      acknowledged_at: new Date().toISOString(),
+      placement_status: 'pending',
+    });
+  }
+
+  return NextResponse.json({
+    acknowledged_at: new Date().toISOString(),
+    placement_status: 'ready',
+    placement: {
+      lat: row.lat,
+      lng: row.lng,
+      elevation_m: row.elevation_m,
+      timezone: row.timezone,
+      azimuth_deg: row.azimuth_deg,
+      tilt_deg: row.tilt_deg,
+      horizon_altitude_deg: row.horizon_altitude_deg,
+      horizon_profile: row.horizon_profile,
+      phase_preference: row.phase_preference,
+      delivery_preferences: row.delivery_preferences,
+    },
+  });
+}

--- a/app/api/cameras/pre-register/route.test.ts
+++ b/app/api/cameras/pre-register/route.test.ts
@@ -10,6 +10,7 @@ vi.mock('@/app/lib/cameraClaimCode', () => ({
 vi.mock('@/app/lib/cameraRegistration', () => ({
   upsertCameraByClaimCode: (...args: unknown[]) => upsertCameraByClaimCodeMock(...args),
   derivePlacementStatus: (...args: unknown[]) => derivePlacementStatusMock(...args),
+  PHASE_VALUES: ['sunrise', 'sunset', 'both'],
 }));
 
 import { POST } from './route';
@@ -121,6 +122,22 @@ describe('POST /api/cameras/pre-register', () => {
       consumed_by_camera_id: null,
     });
     const bad = { ...VALID_BODY, lat: undefined };
+    const res = await POST(makeRequest(bad));
+    expect(res.status).toBe(400);
+    expect(upsertCameraByClaimCodeMock).not.toHaveBeenCalled();
+  });
+
+  it('rejects when horizon_profile is not an array', async () => {
+    getClaimCodeMock.mockResolvedValueOnce({
+      code: 'SUNSET-AAAA-BBBB',
+      expires_at: new Date('2099-01-01'),
+      consumed_at: null,
+      consumed_by_camera_id: null,
+    });
+    const bad = {
+      ...VALID_BODY,
+      placement: { ...VALID_BODY.placement, horizon_profile: 'not an array' },
+    };
     const res = await POST(makeRequest(bad));
     expect(res.status).toBe(400);
     expect(upsertCameraByClaimCodeMock).not.toHaveBeenCalled();

--- a/app/api/cameras/pre-register/route.test.ts
+++ b/app/api/cameras/pre-register/route.test.ts
@@ -3,16 +3,13 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 const getClaimCodeMock = vi.fn();
 const upsertCameraByClaimCodeMock = vi.fn();
+const derivePlacementStatusMock = vi.fn();
 vi.mock('@/app/lib/cameraClaimCode', () => ({
   getClaimCode: (...args: unknown[]) => getClaimCodeMock(...args),
 }));
 vi.mock('@/app/lib/cameraRegistration', () => ({
-  upsertCameraByClaimCode: (...args: unknown[]) =>
-    upsertCameraByClaimCodeMock(...args),
-  derivePlacementStatus: (row: { lat: unknown; lng: unknown; azimuth_deg: unknown; tilt_deg: unknown }) =>
-    row.lat != null && row.lng != null && row.azimuth_deg != null && row.tilt_deg != null
-      ? 'ready'
-      : 'pending',
+  upsertCameraByClaimCode: (...args: unknown[]) => upsertCameraByClaimCodeMock(...args),
+  derivePlacementStatus: (...args: unknown[]) => derivePlacementStatusMock(...args),
 }));
 
 import { POST } from './route';
@@ -20,6 +17,7 @@ import { POST } from './route';
 beforeEach(() => {
   getClaimCodeMock.mockReset();
   upsertCameraByClaimCodeMock.mockReset();
+  derivePlacementStatusMock.mockReset();
 });
 
 const VALID_BODY = {
@@ -64,6 +62,7 @@ describe('POST /api/cameras/pre-register', () => {
       azimuth_deg: 270,
       tilt_deg: 5,
     });
+    derivePlacementStatusMock.mockReturnValueOnce('ready');
 
     const res = await POST(makeRequest(VALID_BODY));
     expect(res.status).toBe(202);
@@ -107,6 +106,7 @@ describe('POST /api/cameras/pre-register', () => {
       azimuth_deg: 270,
       tilt_deg: 5,
     });
+    derivePlacementStatusMock.mockReturnValueOnce('ready');
 
     const res = await POST(makeRequest(VALID_BODY));
     expect(res.status).toBe(202);

--- a/app/api/cameras/pre-register/route.test.ts
+++ b/app/api/cameras/pre-register/route.test.ts
@@ -1,0 +1,138 @@
+// @vitest-environment node
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const getClaimCodeMock = vi.fn();
+const upsertCameraByClaimCodeMock = vi.fn();
+vi.mock('@/app/lib/cameraClaimCode', () => ({
+  getClaimCode: (...args: unknown[]) => getClaimCodeMock(...args),
+}));
+vi.mock('@/app/lib/cameraRegistration', () => ({
+  upsertCameraByClaimCode: (...args: unknown[]) =>
+    upsertCameraByClaimCodeMock(...args),
+  derivePlacementStatus: (row: { lat: unknown; lng: unknown; azimuth_deg: unknown; tilt_deg: unknown }) =>
+    row.lat != null && row.lng != null && row.azimuth_deg != null && row.tilt_deg != null
+      ? 'ready'
+      : 'pending',
+}));
+
+import { POST } from './route';
+
+beforeEach(() => {
+  getClaimCodeMock.mockReset();
+  upsertCameraByClaimCodeMock.mockReset();
+});
+
+const VALID_BODY = {
+  claim_code: 'SUNSET-AAAA-BBBB',
+  lat: 47.6062,
+  lng: -122.3321,
+  elevation_m: 30,
+  timezone: 'America/Los_Angeles',
+  placement: {
+    azimuth_deg: 270,
+    tilt_deg: 5,
+    horizon_altitude_deg: 2.5,
+    horizon_profile: [{ azimuth_deg: 0, altitude_deg: 1.2 }],
+  },
+  operator_preferences: {
+    phase_preference: 'sunset',
+    delivery: { type: 'email', target: 'op@example.com', cadence: 'daily' },
+  },
+};
+
+function makeRequest(body: unknown) {
+  return new Request('http://test/api/cameras/pre-register', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+describe('POST /api/cameras/pre-register', () => {
+  it('accepts a valid pre-register call and calls upsert', async () => {
+    getClaimCodeMock.mockResolvedValueOnce({
+      code: 'SUNSET-AAAA-BBBB',
+      expires_at: new Date('2099-01-01'),
+      consumed_at: null,
+      consumed_by_camera_id: null,
+    });
+    upsertCameraByClaimCodeMock.mockResolvedValueOnce({
+      id: 17,
+      claim_code: 'SUNSET-AAAA-BBBB',
+      lat: 47.6062,
+      lng: -122.3321,
+      azimuth_deg: 270,
+      tilt_deg: 5,
+    });
+
+    const res = await POST(makeRequest(VALID_BODY));
+    expect(res.status).toBe(202);
+    const body = await res.json();
+    expect(body.camera_id).toBe(17);
+    expect(body.placement_status).toBe('ready');
+    expect(upsertCameraByClaimCodeMock).toHaveBeenCalledOnce();
+  });
+
+  it('rejects when claim code is unknown', async () => {
+    getClaimCodeMock.mockResolvedValueOnce(null);
+    const res = await POST(makeRequest(VALID_BODY));
+    expect(res.status).toBe(404);
+    expect(upsertCameraByClaimCodeMock).not.toHaveBeenCalled();
+  });
+
+  it('rejects when claim code is expired', async () => {
+    getClaimCodeMock.mockResolvedValueOnce({
+      code: 'SUNSET-AAAA-BBBB',
+      expires_at: new Date('2020-01-01'),
+      consumed_at: null,
+      consumed_by_camera_id: null,
+    });
+    const res = await POST(makeRequest(VALID_BODY));
+    expect(res.status).toBe(410);
+    expect(upsertCameraByClaimCodeMock).not.toHaveBeenCalled();
+  });
+
+  it('accepts when the device has already registered (either-order)', async () => {
+    getClaimCodeMock.mockResolvedValueOnce({
+      code: 'SUNSET-AAAA-BBBB',
+      expires_at: new Date('2099-01-01'),
+      consumed_at: new Date(),
+      consumed_by_camera_id: 17,
+    });
+    upsertCameraByClaimCodeMock.mockResolvedValueOnce({
+      id: 17,
+      claim_code: 'SUNSET-AAAA-BBBB',
+      lat: 47.6062,
+      lng: -122.3321,
+      azimuth_deg: 270,
+      tilt_deg: 5,
+    });
+
+    const res = await POST(makeRequest(VALID_BODY));
+    expect(res.status).toBe(202);
+    expect(upsertCameraByClaimCodeMock).toHaveBeenCalledOnce();
+  });
+
+  it('rejects when required fields are missing', async () => {
+    getClaimCodeMock.mockResolvedValueOnce({
+      code: 'SUNSET-AAAA-BBBB',
+      expires_at: new Date('2099-01-01'),
+      consumed_at: null,
+      consumed_by_camera_id: null,
+    });
+    const bad = { ...VALID_BODY, lat: undefined };
+    const res = await POST(makeRequest(bad));
+    expect(res.status).toBe(400);
+    expect(upsertCameraByClaimCodeMock).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 on malformed JSON body', async () => {
+    const req = new Request('http://test/api/cameras/pre-register', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: 'not-json',
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+  });
+});

--- a/app/api/cameras/pre-register/route.ts
+++ b/app/api/cameras/pre-register/route.ts
@@ -1,0 +1,109 @@
+import { NextResponse } from 'next/server';
+import { getClaimCode } from '@/app/lib/cameraClaimCode';
+import {
+  upsertCameraByClaimCode,
+  derivePlacementStatus,
+} from '@/app/lib/cameraRegistration';
+
+export const dynamic = 'force-dynamic';
+
+type Body = {
+  claim_code?: unknown;
+  lat?: unknown;
+  lng?: unknown;
+  elevation_m?: unknown;
+  timezone?: unknown;
+  placement?: {
+    azimuth_deg?: unknown;
+    tilt_deg?: unknown;
+    horizon_altitude_deg?: unknown;
+    horizon_profile?: unknown;
+  };
+  operator_preferences?: {
+    phase_preference?: unknown;
+    delivery?: unknown;
+  };
+};
+
+function asNumber(v: unknown): number | null {
+  return typeof v === 'number' && Number.isFinite(v) ? v : null;
+}
+
+function asString(v: unknown): string | null {
+  return typeof v === 'string' && v.trim() !== '' ? v.trim() : null;
+}
+
+export async function POST(request: Request) {
+  let body: Body;
+  try {
+    body = (await request.json()) as Body;
+  } catch {
+    return NextResponse.json({ error: 'invalid json body' }, { status: 400 });
+  }
+
+  const claimCode = asString(body.claim_code);
+  if (!claimCode) {
+    return NextResponse.json({ error: 'claim_code is required' }, { status: 400 });
+  }
+
+  const lat = asNumber(body.lat);
+  const lng = asNumber(body.lng);
+  const timezone = asString(body.timezone);
+  const azimuth = asNumber(body.placement?.azimuth_deg);
+  const tilt = asNumber(body.placement?.tilt_deg);
+  if (lat == null || lng == null || !timezone || azimuth == null || tilt == null) {
+    return NextResponse.json(
+      { error: 'lat, lng, timezone, placement.azimuth_deg and placement.tilt_deg are required' },
+      { status: 400 }
+    );
+  }
+
+  const phaseRaw = asString(body.operator_preferences?.phase_preference);
+  const phase =
+    phaseRaw === 'sunrise' || phaseRaw === 'sunset' || phaseRaw === 'both'
+      ? phaseRaw
+      : null;
+  if (!phase) {
+    return NextResponse.json(
+      { error: 'operator_preferences.phase_preference must be sunrise|sunset|both' },
+      { status: 400 }
+    );
+  }
+
+  const claim = await getClaimCode(claimCode);
+  if (!claim) {
+    return NextResponse.json({ error: 'unknown claim code' }, { status: 404 });
+  }
+  if (claim.expires_at.getTime() < Date.now()) {
+    return NextResponse.json({ error: 'claim code expired' }, { status: 410 });
+  }
+
+  try {
+    const camera = await upsertCameraByClaimCode(claimCode, {
+      lat,
+      lng,
+      elevation_m: asNumber(body.elevation_m),
+      timezone,
+      azimuth_deg: azimuth,
+      tilt_deg: tilt,
+      horizon_altitude_deg: asNumber(body.placement?.horizon_altitude_deg) ?? 0,
+      horizon_profile: body.placement?.horizon_profile ?? null,
+      phase_preference: phase,
+      delivery_preferences: body.operator_preferences?.delivery ?? null,
+    });
+
+    return NextResponse.json(
+      {
+        camera_id: camera.id,
+        placement_status: derivePlacementStatus(camera),
+      },
+      { status: 202 }
+    );
+  } catch (error) {
+    console.error('[cameras/pre-register] failed:', error);
+    return NextResponse.json(
+      { error: 'internal server error', details: error instanceof Error ? error.message : 'unknown' },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/cameras/pre-register/route.ts
+++ b/app/api/cameras/pre-register/route.ts
@@ -3,6 +3,7 @@ import { getClaimCode } from '@/app/lib/cameraClaimCode';
 import {
   upsertCameraByClaimCode,
   derivePlacementStatus,
+  PHASE_VALUES,
 } from '@/app/lib/cameraRegistration';
 
 export const dynamic = 'force-dynamic';
@@ -58,14 +59,21 @@ export async function POST(request: Request) {
     );
   }
 
+  const horizonProfile = body.placement?.horizon_profile;
+  if (horizonProfile != null && !Array.isArray(horizonProfile)) {
+    return NextResponse.json(
+      { error: 'placement.horizon_profile must be an array or null' },
+      { status: 400 }
+    );
+  }
+
   const phaseRaw = asString(body.operator_preferences?.phase_preference);
-  const phase =
-    phaseRaw === 'sunrise' || phaseRaw === 'sunset' || phaseRaw === 'both'
-      ? phaseRaw
-      : null;
+  const phase = phaseRaw != null && (PHASE_VALUES as readonly string[]).includes(phaseRaw)
+    ? (phaseRaw as typeof PHASE_VALUES[number])
+    : null;
   if (!phase) {
     return NextResponse.json(
-      { error: 'operator_preferences.phase_preference must be sunrise|sunset|both' },
+      { error: `operator_preferences.phase_preference must be one of ${PHASE_VALUES.join('|')}` },
       { status: 400 }
     );
   }
@@ -87,7 +95,7 @@ export async function POST(request: Request) {
       azimuth_deg: azimuth,
       tilt_deg: tilt,
       horizon_altitude_deg: asNumber(body.placement?.horizon_altitude_deg) ?? 0,
-      horizon_profile: body.placement?.horizon_profile ?? null,
+      horizon_profile: horizonProfile ?? null,
       phase_preference: phase,
       delivery_preferences: body.operator_preferences?.delivery ?? null,
     });

--- a/app/api/cameras/register/route.test.ts
+++ b/app/api/cameras/register/route.test.ts
@@ -1,0 +1,153 @@
+// @vitest-environment node
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const getClaimCodeMock = vi.fn();
+const consumeClaimCodeMock = vi.fn();
+const sqlMock = vi.fn();
+const mintDeviceTokenMock = vi.fn();
+const derivePlacementStatusMock = vi.fn();
+
+vi.mock('@/app/lib/cameraClaimCode', () => ({
+  getClaimCode: (...a: unknown[]) => getClaimCodeMock(...a),
+  consumeClaimCode: (...a: unknown[]) => consumeClaimCodeMock(...a),
+}));
+vi.mock('@/app/lib/cameraRegistration', () => ({
+  mintDeviceToken: (...a: unknown[]) => mintDeviceTokenMock(...a),
+  derivePlacementStatus: (...a: unknown[]) => derivePlacementStatusMock(...a),
+}));
+vi.mock('@/app/lib/db', () => ({
+  sql: (s: TemplateStringsArray, ...v: unknown[]) => sqlMock(s, ...v),
+}));
+
+import { POST } from './route';
+
+beforeEach(() => {
+  getClaimCodeMock.mockReset();
+  consumeClaimCodeMock.mockReset();
+  sqlMock.mockReset();
+  mintDeviceTokenMock.mockReset();
+  derivePlacementStatusMock.mockReset();
+  mintDeviceTokenMock.mockReturnValue({
+    plaintext: 'plain-token-abc',
+    hash: 'hash-abc',
+  });
+});
+
+function makeRequest(body: unknown) {
+  return new Request('http://test/api/cameras/register', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+const REGISTER_BODY = {
+  claim_code: 'SUNSET-AAAA-BBBB',
+  hardware_id: 'rpi-serial-12345',
+  capabilities: { mjpeg: false, edge_score: false },
+  firmware_version: 'sunset-cam@0.1.0',
+};
+
+describe('POST /api/cameras/register', () => {
+  it('returns placement=ready when pre-register populated placement first', async () => {
+    getClaimCodeMock.mockResolvedValueOnce({
+      code: 'SUNSET-AAAA-BBBB',
+      expires_at: new Date('2099-01-01'),
+      consumed_at: null,
+      consumed_by_camera_id: null,
+    });
+    // SELECT existing camera by claim_code → found (pre-register created it)
+    sqlMock.mockResolvedValueOnce([
+      {
+        id: 17,
+        lat: 47.6,
+        lng: -122.3,
+        elevation_m: 30,
+        timezone: 'America/Los_Angeles',
+        azimuth_deg: 270,
+        tilt_deg: 5,
+        horizon_altitude_deg: 2.5,
+        horizon_profile: [{ azimuth_deg: 0, altitude_deg: 1.2 }],
+        phase_preference: 'sunset',
+        delivery_preferences: { type: 'email' },
+      },
+    ]);
+    // UPDATE cameras: fill in hardware_id, device_token_hash, capabilities
+    sqlMock.mockResolvedValueOnce([{ id: 17 }]);
+    consumeClaimCodeMock.mockResolvedValueOnce({ consumed_by_camera_id: 17 });
+    derivePlacementStatusMock.mockReturnValueOnce('ready');
+
+    const res = await POST(makeRequest(REGISTER_BODY));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.camera_id).toBe(17);
+    expect(body.device_token).toBe('plain-token-abc');
+    expect(body.placement_status).toBe('ready');
+    expect(body.placement).toMatchObject({
+      azimuth_deg: 270,
+      tilt_deg: 5,
+    });
+  });
+
+  it('returns placement=pending when device registers first (no prior pre-register)', async () => {
+    getClaimCodeMock.mockResolvedValueOnce({
+      code: 'SUNSET-AAAA-BBBB',
+      expires_at: new Date('2099-01-01'),
+      consumed_at: null,
+      consumed_by_camera_id: null,
+    });
+    // SELECT existing camera by claim_code → none
+    sqlMock.mockResolvedValueOnce([]);
+    // INSERT cameras with sentinel placement
+    sqlMock.mockResolvedValueOnce([{ id: 18 }]);
+    consumeClaimCodeMock.mockResolvedValueOnce({ consumed_by_camera_id: 18 });
+    derivePlacementStatusMock.mockReturnValueOnce('pending');
+
+    const res = await POST(makeRequest(REGISTER_BODY));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.camera_id).toBe(18);
+    expect(body.device_token).toBe('plain-token-abc');
+    expect(body.placement_status).toBe('pending');
+    expect(body.placement).toBeUndefined();
+  });
+
+  it('rejects unknown claim codes with 404', async () => {
+    getClaimCodeMock.mockResolvedValueOnce(null);
+    const res = await POST(makeRequest(REGISTER_BODY));
+    expect(res.status).toBe(404);
+  });
+
+  it('rejects expired claim codes with 410', async () => {
+    getClaimCodeMock.mockResolvedValueOnce({
+      code: 'SUNSET-AAAA-BBBB',
+      expires_at: new Date('2020-01-01'),
+      consumed_at: null,
+      consumed_by_camera_id: null,
+    });
+    const res = await POST(makeRequest(REGISTER_BODY));
+    expect(res.status).toBe(410);
+  });
+
+  it('rejects already-consumed claim codes with 409', async () => {
+    getClaimCodeMock.mockResolvedValueOnce({
+      code: 'SUNSET-AAAA-BBBB',
+      expires_at: new Date('2099-01-01'),
+      consumed_at: new Date(),
+      consumed_by_camera_id: 1,
+    });
+    const res = await POST(makeRequest(REGISTER_BODY));
+    expect(res.status).toBe(409);
+  });
+
+  it('rejects missing hardware_id with 400', async () => {
+    getClaimCodeMock.mockResolvedValueOnce({
+      code: 'SUNSET-AAAA-BBBB',
+      expires_at: new Date('2099-01-01'),
+      consumed_at: null,
+      consumed_by_camera_id: null,
+    });
+    const res = await POST(makeRequest({ ...REGISTER_BODY, hardware_id: '' }));
+    expect(res.status).toBe(400);
+  });
+});

--- a/app/api/cameras/register/route.test.ts
+++ b/app/api/cameras/register/route.test.ts
@@ -150,4 +150,22 @@ describe('POST /api/cameras/register', () => {
     const res = await POST(makeRequest({ ...REGISTER_BODY, hardware_id: '' }));
     expect(res.status).toBe(400);
   });
+
+  it('returns 500 when consumeClaimCode races and returns null', async () => {
+    getClaimCodeMock.mockResolvedValueOnce({
+      code: 'SUNSET-AAAA-BBBB',
+      expires_at: new Date('2099-01-01'),
+      consumed_at: null,
+      consumed_by_camera_id: null,
+    });
+    // SELECT existing camera → none (register-first path)
+    sqlMock.mockResolvedValueOnce([]);
+    // INSERT succeeds
+    sqlMock.mockResolvedValueOnce([{ id: 19 }]);
+    // consumeClaimCode races: returns null instead of the row
+    consumeClaimCodeMock.mockResolvedValueOnce(null);
+
+    const res = await POST(makeRequest(REGISTER_BODY));
+    expect(res.status).toBe(500);
+  });
 });

--- a/app/api/cameras/register/route.ts
+++ b/app/api/cameras/register/route.ts
@@ -65,6 +65,12 @@ export async function POST(request: Request) {
   const firmwareVersion = asString(body.firmware_version);
   const capabilities = JSON.stringify(body.capabilities ?? {});
 
+  // Known race: two devices booting at the same instant with the same claim
+  // code can both pass the consumed_at null check above. Both will attempt to
+  // INSERT a cameras row; the loser hits the hardware_id UNIQUE constraint
+  // and surfaces as 500. At Tier 0 deployment volume this is acceptable; if
+  // this surfaces in practice, wrap SELECT/INSERT/consume in a single CTE
+  // guarded by ON CONFLICT.
   try {
     const existingRows = (await sql`
       SELECT id, lat, lng, elevation_m, timezone,
@@ -113,7 +119,16 @@ export async function POST(request: Request) {
       placementRow = inserted[0];
     }
 
-    await consumeClaimCode(claimCode, cameraId);
+    const consumed = await consumeClaimCode(claimCode, cameraId);
+    if (!consumed) {
+      console.error(
+        `[cameras/register] consumeClaimCode returned null after row creation cameraId=${cameraId} claim=${claimCode}`
+      );
+      return NextResponse.json(
+        { error: 'internal server error', details: 'claim consumption failed after row creation' },
+        { status: 500 }
+      );
+    }
 
     const status = derivePlacementStatus(placementRow);
     const responseBody: Record<string, unknown> = {

--- a/app/api/cameras/register/route.ts
+++ b/app/api/cameras/register/route.ts
@@ -1,0 +1,146 @@
+import { NextResponse } from 'next/server';
+import { sql } from '@/app/lib/db';
+import { getClaimCode, consumeClaimCode } from '@/app/lib/cameraClaimCode';
+import {
+  mintDeviceToken,
+  derivePlacementStatus,
+} from '@/app/lib/cameraRegistration';
+
+export const dynamic = 'force-dynamic';
+
+type Body = {
+  claim_code?: unknown;
+  hardware_id?: unknown;
+  capabilities?: unknown;
+  firmware_version?: unknown;
+};
+
+function asString(v: unknown): string | null {
+  return typeof v === 'string' && v.trim() !== '' ? v.trim() : null;
+}
+
+type ExistingCameraRow = {
+  id: number;
+  lat: number | null;
+  lng: number | null;
+  elevation_m: number | null;
+  timezone: string | null;
+  azimuth_deg: number | null;
+  tilt_deg: number | null;
+  horizon_altitude_deg: number | null;
+  horizon_profile: unknown;
+  phase_preference: string;
+  delivery_preferences: unknown;
+};
+
+export async function POST(request: Request) {
+  let body: Body;
+  try {
+    body = (await request.json()) as Body;
+  } catch {
+    return NextResponse.json({ error: 'invalid json body' }, { status: 400 });
+  }
+
+  const claimCode = asString(body.claim_code);
+  const hardwareId = asString(body.hardware_id);
+  if (!claimCode || !hardwareId) {
+    return NextResponse.json(
+      { error: 'claim_code and hardware_id are required' },
+      { status: 400 }
+    );
+  }
+
+  const claim = await getClaimCode(claimCode);
+  if (!claim) {
+    return NextResponse.json({ error: 'unknown claim code' }, { status: 404 });
+  }
+  if (claim.expires_at.getTime() < Date.now()) {
+    return NextResponse.json({ error: 'claim code expired' }, { status: 410 });
+  }
+  if (claim.consumed_at) {
+    return NextResponse.json({ error: 'claim code already consumed' }, { status: 409 });
+  }
+
+  const { plaintext, hash } = mintDeviceToken();
+  const firmwareVersion = asString(body.firmware_version);
+  const capabilities = JSON.stringify(body.capabilities ?? {});
+
+  try {
+    const existingRows = (await sql`
+      SELECT id, lat, lng, elevation_m, timezone,
+             azimuth_deg, tilt_deg, horizon_altitude_deg, horizon_profile,
+             phase_preference, delivery_preferences
+      FROM cameras WHERE claim_code = ${claimCode} LIMIT 1
+    `) as ExistingCameraRow[];
+
+    let cameraId: number;
+    let placementRow: ExistingCameraRow;
+
+    if (existingRows[0]) {
+      // Pre-register-first path: row exists with placement; fill in device fields.
+      const r = existingRows[0];
+      const updated = (await sql`
+        UPDATE cameras SET
+          hardware_id = ${hardwareId},
+          device_token_hash = ${hash},
+          firmware_version = ${firmwareVersion},
+          capabilities = ${capabilities}::jsonb,
+          registered_at = NOW()
+        WHERE id = ${r.id}
+        RETURNING id
+      `) as { id: number }[];
+      cameraId = updated[0].id;
+      placementRow = r;
+    } else {
+      // Register-first path: insert a row with no placement; pre-register
+      // will fill it in later.
+      const inserted = (await sql`
+        INSERT INTO cameras (
+          hardware_id, device_token_hash, claim_code,
+          firmware_version, capabilities,
+          phase_preference
+        )
+        VALUES (
+          ${hardwareId}, ${hash}, ${claimCode},
+          ${firmwareVersion}, ${capabilities}::jsonb,
+          'both'
+        )
+        RETURNING id, lat, lng, elevation_m, timezone,
+                  azimuth_deg, tilt_deg, horizon_altitude_deg, horizon_profile,
+                  phase_preference, delivery_preferences
+      `) as ExistingCameraRow[];
+      cameraId = inserted[0].id;
+      placementRow = inserted[0];
+    }
+
+    await consumeClaimCode(claimCode, cameraId);
+
+    const status = derivePlacementStatus(placementRow);
+    const responseBody: Record<string, unknown> = {
+      camera_id: cameraId,
+      device_token: plaintext,
+      placement_status: status,
+    };
+    if (status === 'ready') {
+      responseBody.placement = {
+        lat: placementRow.lat,
+        lng: placementRow.lng,
+        elevation_m: placementRow.elevation_m,
+        timezone: placementRow.timezone,
+        azimuth_deg: placementRow.azimuth_deg,
+        tilt_deg: placementRow.tilt_deg,
+        horizon_altitude_deg: placementRow.horizon_altitude_deg,
+        horizon_profile: placementRow.horizon_profile,
+        phase_preference: placementRow.phase_preference,
+        delivery_preferences: placementRow.delivery_preferences,
+      };
+    }
+    return NextResponse.json(responseBody);
+  } catch (error) {
+    console.error('[cameras/register] failed:', error);
+    return NextResponse.json(
+      { error: 'internal server error', details: error instanceof Error ? error.message : 'unknown' },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/cameras/setup-status/[claim_code]/route.test.ts
+++ b/app/api/cameras/setup-status/[claim_code]/route.test.ts
@@ -101,6 +101,47 @@ describe('GET /api/cameras/setup-status/[claim_code]', () => {
     expect(body.status).toBe('registered');
   });
 
+  it('returns 404 for an expired claim code', async () => {
+    getClaimCodeMock.mockResolvedValueOnce({
+      code: 'SUNSET-AAAA-BBBB',
+      expires_at: new Date('2020-01-01'),
+      consumed_at: null,
+      consumed_by_camera_id: null,
+    });
+    const res = await GET(
+      makeRequest('SUNSET-AAAA-BBBB'),
+      makeContext('SUNSET-AAAA-BBBB')
+    );
+    expect(res.status).toBe(404);
+  });
+
+  it('returns registered (not awaiting_wifi) when only one column matches the sentinel', async () => {
+    // Defensive: if some future code path ever leaves the columns out of sync,
+    // setup-status should NOT silently hide it behind awaiting_wifi.
+    getClaimCodeMock.mockResolvedValueOnce({
+      code: 'SUNSET-AAAA-BBBB',
+      expires_at: new Date('2099-01-01'),
+      consumed_at: new Date(),
+      consumed_by_camera_id: 17,
+    });
+    sqlMock.mockResolvedValueOnce([
+      {
+        id: 17,
+        hardware_id: 'rpi-real-serial',
+        device_token_hash: 'pending-SUNSET-AAAA-BBBB',
+        lat: 47.6, lng: -122.3, azimuth_deg: 270, tilt_deg: 5,
+      },
+    ]);
+    derivePlacementStatusMock.mockReturnValueOnce('ready');
+    const res = await GET(
+      makeRequest('SUNSET-AAAA-BBBB'),
+      makeContext('SUNSET-AAAA-BBBB')
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.status).toBe('ready');
+  });
+
   it('returns ready when device is registered AND placement is populated', async () => {
     getClaimCodeMock.mockResolvedValueOnce({
       code: 'SUNSET-AAAA-BBBB',

--- a/app/api/cameras/setup-status/[claim_code]/route.test.ts
+++ b/app/api/cameras/setup-status/[claim_code]/route.test.ts
@@ -1,0 +1,128 @@
+// @vitest-environment node
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const getClaimCodeMock = vi.fn();
+const sqlMock = vi.fn();
+const derivePlacementStatusMock = vi.fn();
+
+vi.mock('@/app/lib/cameraClaimCode', () => ({
+  getClaimCode: (...a: unknown[]) => getClaimCodeMock(...a),
+}));
+vi.mock('@/app/lib/cameraRegistration', () => ({
+  derivePlacementStatus: (...a: unknown[]) => derivePlacementStatusMock(...a),
+}));
+vi.mock('@/app/lib/db', () => ({
+  sql: (s: TemplateStringsArray, ...v: unknown[]) => sqlMock(s, ...v),
+}));
+
+import { GET } from './route';
+
+beforeEach(() => {
+  getClaimCodeMock.mockReset();
+  sqlMock.mockReset();
+  derivePlacementStatusMock.mockReset();
+});
+
+function makeRequest(code: string) {
+  return new Request(`http://test/api/cameras/setup-status/${code}`, { method: 'GET' });
+}
+
+function makeContext(claim_code: string) {
+  return { params: Promise.resolve({ claim_code }) };
+}
+
+describe('GET /api/cameras/setup-status/[claim_code]', () => {
+  it('returns 404 when the claim code does not exist', async () => {
+    getClaimCodeMock.mockResolvedValueOnce(null);
+    const res = await GET(makeRequest('SUNSET-XXXX-YYYY'), makeContext('SUNSET-XXXX-YYYY'));
+    expect(res.status).toBe(404);
+  });
+
+  it('returns awaiting_wifi when no cameras row exists for the claim code yet', async () => {
+    getClaimCodeMock.mockResolvedValueOnce({
+      code: 'SUNSET-AAAA-BBBB',
+      expires_at: new Date('2099-01-01'),
+      consumed_at: null,
+      consumed_by_camera_id: null,
+    });
+    sqlMock.mockResolvedValueOnce([]); // SELECT cameras → none
+    const res = await GET(makeRequest('SUNSET-AAAA-BBBB'), makeContext('SUNSET-AAAA-BBBB'));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.status).toBe('awaiting_wifi');
+  });
+
+  it('returns awaiting_wifi when a pre-register-only row exists (no real device_token_hash)', async () => {
+    getClaimCodeMock.mockResolvedValueOnce({
+      code: 'SUNSET-AAAA-BBBB',
+      expires_at: new Date('2099-01-01'),
+      consumed_at: null,
+      consumed_by_camera_id: null,
+    });
+    sqlMock.mockResolvedValueOnce([
+      {
+        id: 17,
+        hardware_id: 'pending-SUNSET-AAAA-BBBB',
+        device_token_hash: 'pending-SUNSET-AAAA-BBBB',
+        lat: 47.6,
+        lng: -122.3,
+        azimuth_deg: 270,
+        tilt_deg: 5,
+      },
+    ]);
+    const res = await GET(makeRequest('SUNSET-AAAA-BBBB'), makeContext('SUNSET-AAAA-BBBB'));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.status).toBe('awaiting_wifi');
+  });
+
+  it('returns registered when device has registered but placement is still pending', async () => {
+    getClaimCodeMock.mockResolvedValueOnce({
+      code: 'SUNSET-AAAA-BBBB',
+      expires_at: new Date('2099-01-01'),
+      consumed_at: new Date(),
+      consumed_by_camera_id: 17,
+    });
+    sqlMock.mockResolvedValueOnce([
+      {
+        id: 17,
+        hardware_id: 'rpi-real-serial',
+        device_token_hash: 'real-hash-abc',
+        lat: null,
+        lng: null,
+        azimuth_deg: null,
+        tilt_deg: null,
+      },
+    ]);
+    derivePlacementStatusMock.mockReturnValueOnce('pending');
+    const res = await GET(makeRequest('SUNSET-AAAA-BBBB'), makeContext('SUNSET-AAAA-BBBB'));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.status).toBe('registered');
+  });
+
+  it('returns ready when device is registered AND placement is populated', async () => {
+    getClaimCodeMock.mockResolvedValueOnce({
+      code: 'SUNSET-AAAA-BBBB',
+      expires_at: new Date('2099-01-01'),
+      consumed_at: new Date(),
+      consumed_by_camera_id: 17,
+    });
+    sqlMock.mockResolvedValueOnce([
+      {
+        id: 17,
+        hardware_id: 'rpi-real-serial',
+        device_token_hash: 'real-hash-abc',
+        lat: 47.6,
+        lng: -122.3,
+        azimuth_deg: 270,
+        tilt_deg: 5,
+      },
+    ]);
+    derivePlacementStatusMock.mockReturnValueOnce('ready');
+    const res = await GET(makeRequest('SUNSET-AAAA-BBBB'), makeContext('SUNSET-AAAA-BBBB'));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.status).toBe('ready');
+  });
+});

--- a/app/api/cameras/setup-status/[claim_code]/route.ts
+++ b/app/api/cameras/setup-status/[claim_code]/route.ts
@@ -20,8 +20,8 @@ type StatusRow = {
 export async function GET(_request: Request, context: RouteContext) {
   const { claim_code } = await context.params;
   const claim = await getClaimCode(claim_code);
-  if (!claim) {
-    return NextResponse.json({ error: 'unknown claim code' }, { status: 404 });
+  if (!claim || claim.expires_at.getTime() < Date.now()) {
+    return NextResponse.json({ error: 'unknown or expired claim code' }, { status: 404 });
   }
 
   const rows = (await sql`
@@ -37,7 +37,7 @@ export async function GET(_request: Request, context: RouteContext) {
   // A pre-register-first row is identifiable by the sentinel placeholder
   // (see Task 4's upsert). Treat such rows as "device hasn't called register yet."
   const sentinel = `pending-${claim_code}`;
-  if (row.hardware_id === sentinel || row.device_token_hash === sentinel) {
+  if (row.hardware_id === sentinel && row.device_token_hash === sentinel) {
     return NextResponse.json({ status: 'awaiting_wifi' });
   }
 

--- a/app/api/cameras/setup-status/[claim_code]/route.ts
+++ b/app/api/cameras/setup-status/[claim_code]/route.ts
@@ -1,0 +1,48 @@
+import { NextResponse } from 'next/server';
+import { sql } from '@/app/lib/db';
+import { getClaimCode } from '@/app/lib/cameraClaimCode';
+import { derivePlacementStatus } from '@/app/lib/cameraRegistration';
+
+export const dynamic = 'force-dynamic';
+
+type RouteContext = { params: Promise<{ claim_code: string }> };
+
+type StatusRow = {
+  id: number;
+  hardware_id: string;
+  device_token_hash: string;
+  lat: number | null;
+  lng: number | null;
+  azimuth_deg: number | null;
+  tilt_deg: number | null;
+};
+
+export async function GET(_request: Request, context: RouteContext) {
+  const { claim_code } = await context.params;
+  const claim = await getClaimCode(claim_code);
+  if (!claim) {
+    return NextResponse.json({ error: 'unknown claim code' }, { status: 404 });
+  }
+
+  const rows = (await sql`
+    SELECT id, hardware_id, device_token_hash, lat, lng, azimuth_deg, tilt_deg
+    FROM cameras WHERE claim_code = ${claim_code} LIMIT 1
+  `) as StatusRow[];
+
+  const row = rows[0];
+  if (!row) {
+    return NextResponse.json({ status: 'awaiting_wifi' });
+  }
+
+  // A pre-register-first row is identifiable by the sentinel placeholder
+  // (see Task 4's upsert). Treat such rows as "device hasn't called register yet."
+  const sentinel = `pending-${claim_code}`;
+  if (row.hardware_id === sentinel || row.device_token_hash === sentinel) {
+    return NextResponse.json({ status: 'awaiting_wifi' });
+  }
+
+  const placement = derivePlacementStatus(row);
+  return NextResponse.json({
+    status: placement === 'ready' ? 'ready' : 'registered',
+  });
+}

--- a/app/lib/cameraClaimCode.test.ts
+++ b/app/lib/cameraClaimCode.test.ts
@@ -1,0 +1,90 @@
+// @vitest-environment node
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const sqlMock = vi.fn();
+vi.mock('@/app/lib/db', () => ({
+  sql: (strings: TemplateStringsArray, ...values: unknown[]) =>
+    sqlMock(strings, ...values),
+}));
+
+import {
+  mintClaimCode,
+  getClaimCode,
+  consumeClaimCode,
+  CLAIM_CODE_PATTERN,
+} from './cameraClaimCode';
+
+beforeEach(() => {
+  sqlMock.mockReset();
+});
+
+describe('mintClaimCode', () => {
+  it('generates a code matching SUNSET-XXXX-XXXX and inserts it', async () => {
+    sqlMock.mockResolvedValueOnce([
+      {
+        code: 'SUNSET-7K3M-9XQ2',
+        expires_at: new Date('2026-06-15T00:00:00Z'),
+      },
+    ]);
+
+    const result = await mintClaimCode({ label: 'rooftop-1' });
+
+    expect(result.code).toMatch(CLAIM_CODE_PATTERN);
+    expect(result.expires_at).toBeInstanceOf(Date);
+    expect(sqlMock).toHaveBeenCalledOnce();
+  });
+
+  it('uses an unambiguous alphabet (no O/0/I/1/L)', async () => {
+    sqlMock.mockResolvedValue([
+      { code: 'ignored', expires_at: new Date() },
+    ]);
+    for (let i = 0; i < 50; i++) {
+      const r = await mintClaimCode({ label: null });
+      expect(r.code).not.toMatch(/[0O1IL]/);
+    }
+  });
+});
+
+describe('getClaimCode', () => {
+  it('returns the row when it exists', async () => {
+    sqlMock.mockResolvedValueOnce([
+      {
+        code: 'SUNSET-AAAA-BBBB',
+        label: 'test',
+        expires_at: new Date('2099-01-01'),
+        consumed_at: null,
+        consumed_by_camera_id: null,
+      },
+    ]);
+    const row = await getClaimCode('SUNSET-AAAA-BBBB');
+    expect(row?.code).toBe('SUNSET-AAAA-BBBB');
+    expect(row?.consumed_at).toBeNull();
+  });
+
+  it('returns null when the code does not exist', async () => {
+    sqlMock.mockResolvedValueOnce([]);
+    const row = await getClaimCode('SUNSET-XXXX-XXXX');
+    expect(row).toBeNull();
+  });
+});
+
+describe('consumeClaimCode', () => {
+  it('marks the code consumed and returns the updated row', async () => {
+    sqlMock.mockResolvedValueOnce([
+      {
+        code: 'SUNSET-AAAA-BBBB',
+        consumed_at: new Date(),
+        consumed_by_camera_id: 42,
+      },
+    ]);
+    const row = await consumeClaimCode('SUNSET-AAAA-BBBB', 42);
+    expect(row?.consumed_by_camera_id).toBe(42);
+    expect(sqlMock).toHaveBeenCalledOnce();
+  });
+
+  it('returns null when the code is already consumed', async () => {
+    sqlMock.mockResolvedValueOnce([]);
+    const row = await consumeClaimCode('SUNSET-AAAA-BBBB', 42);
+    expect(row).toBeNull();
+  });
+});

--- a/app/lib/cameraClaimCode.test.ts
+++ b/app/lib/cameraClaimCode.test.ts
@@ -11,6 +11,7 @@ import {
   mintClaimCode,
   getClaimCode,
   consumeClaimCode,
+  generateClaimCode,
   CLAIM_CODE_PATTERN,
 } from './cameraClaimCode';
 
@@ -18,30 +19,30 @@ beforeEach(() => {
   sqlMock.mockReset();
 });
 
-describe('mintClaimCode', () => {
-  it('generates a code matching SUNSET-XXXX-XXXX and inserts it', async () => {
-    sqlMock.mockResolvedValueOnce([
-      {
-        code: 'SUNSET-7K3M-9XQ2',
-        expires_at: new Date('2026-06-15T00:00:00Z'),
-      },
-    ]);
-
-    const result = await mintClaimCode({ label: 'rooftop-1' });
-
-    expect(result.code).toMatch(CLAIM_CODE_PATTERN);
-    expect(result.expires_at).toBeInstanceOf(Date);
-    expect(sqlMock).toHaveBeenCalledOnce();
+describe('generateClaimCode', () => {
+  it('matches CLAIM_CODE_PATTERN on every call', () => {
+    for (let i = 0; i < 200; i++) {
+      expect(generateClaimCode()).toMatch(CLAIM_CODE_PATTERN);
+    }
   });
 
-  it('uses an unambiguous alphabet (no O/0/I/1/L)', async () => {
-    sqlMock.mockResolvedValue([
-      { code: 'ignored', expires_at: new Date() },
-    ]);
-    for (let i = 0; i < 50; i++) {
-      const r = await mintClaimCode({ label: null });
-      expect(r.code).not.toMatch(/[0O1IL]/);
+  it('never produces ambiguous characters (0/O/1/I/L)', () => {
+    for (let i = 0; i < 200; i++) {
+      expect(generateClaimCode()).not.toMatch(/[0O1IL]/);
     }
+  });
+});
+
+describe('mintClaimCode', () => {
+  it('generates a code matching the pattern and inserts it', async () => {
+    sqlMock.mockResolvedValueOnce([
+      { code: 'SUNSET-7K3M-9XQ2', expires_at: new Date('2026-06-15T00:00:00Z') },
+    ]);
+    const result = await mintClaimCode({ label: 'rooftop-1' });
+    expect(result.expires_at).toBeInstanceOf(Date);
+    expect(sqlMock).toHaveBeenCalledOnce();
+    const generatedCode = sqlMock.mock.calls[0][1] as string;
+    expect(generatedCode).toMatch(CLAIM_CODE_PATTERN);
   });
 });
 

--- a/app/lib/cameraClaimCode.ts
+++ b/app/lib/cameraClaimCode.ts
@@ -1,0 +1,68 @@
+import { randomBytes } from 'node:crypto';
+import { sql } from '@/app/lib/db';
+
+export const CLAIM_CODE_PATTERN = /^SUNSET-[A-HJKMNPQRTUVWXYZ2-9]{4}-[A-HJKMNPQRTUVWXYZ2-9]{4}$/;
+
+// Unambiguous alphabet — excludes 0/O/1/I/L for sticker legibility.
+const ALPHABET = 'ABCDEFGHJKMNPQRTUVWXYZ23456789';
+
+export type ClaimCodeRow = {
+  code: string;
+  label: string | null;
+  expires_at: Date;
+  consumed_at: Date | null;
+  consumed_by_camera_id: number | null;
+};
+
+function randomGroup(len: number): string {
+  const bytes = randomBytes(len);
+  let out = '';
+  for (let i = 0; i < len; i++) {
+    out += ALPHABET[bytes[i] % ALPHABET.length];
+  }
+  return out;
+}
+
+export function generateClaimCode(): string {
+  return `SUNSET-${randomGroup(4)}-${randomGroup(4)}`;
+}
+
+export async function mintClaimCode(opts: {
+  label: string | null;
+  ttlDays?: number;
+}): Promise<{ code: string; expires_at: Date }> {
+  const code = generateClaimCode();
+  const ttl = opts.ttlDays ?? 30;
+  const rows = (await sql`
+    INSERT INTO camera_claim_codes (code, label, expires_at)
+    VALUES (${code}, ${opts.label}, NOW() + (${ttl} || ' days')::interval)
+    RETURNING code, expires_at
+  `) as { code: string; expires_at: Date }[];
+  return rows[0];
+}
+
+export async function getClaimCode(code: string): Promise<ClaimCodeRow | null> {
+  const rows = (await sql`
+    SELECT code, label, expires_at, consumed_at, consumed_by_camera_id
+    FROM camera_claim_codes
+    WHERE code = ${code}
+    LIMIT 1
+  `) as ClaimCodeRow[];
+  return rows[0] ?? null;
+}
+
+export async function consumeClaimCode(
+  code: string,
+  cameraId: number
+): Promise<ClaimCodeRow | null> {
+  const rows = (await sql`
+    UPDATE camera_claim_codes
+    SET consumed_at = NOW(),
+        consumed_by_camera_id = ${cameraId}
+    WHERE code = ${code}
+      AND consumed_at IS NULL
+      AND expires_at > NOW()
+    RETURNING code, label, expires_at, consumed_at, consumed_by_camera_id
+  `) as ClaimCodeRow[];
+  return rows[0] ?? null;
+}

--- a/app/lib/cameraClaimCode.ts
+++ b/app/lib/cameraClaimCode.ts
@@ -35,7 +35,7 @@ export async function mintClaimCode(opts: {
   const ttl = opts.ttlDays ?? 30;
   const rows = (await sql`
     INSERT INTO camera_claim_codes (code, label, expires_at)
-    VALUES (${code}, ${opts.label}, NOW() + (${ttl} || ' days')::interval)
+    VALUES (${code}, ${opts.label}, NOW() + ${ttl} * interval '1 day')
     RETURNING code, expires_at
   `) as { code: string; expires_at: Date }[];
   return rows[0];

--- a/app/lib/cameraRegistration.test.ts
+++ b/app/lib/cameraRegistration.test.ts
@@ -1,0 +1,143 @@
+// @vitest-environment node
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const sqlMock = vi.fn();
+vi.mock('@/app/lib/db', () => ({
+  sql: (strings: TemplateStringsArray, ...values: unknown[]) =>
+    sqlMock(strings, ...values),
+}));
+
+import {
+  derivePlacementStatus,
+  mintDeviceToken,
+  upsertCameraByClaimCode,
+} from './cameraRegistration';
+
+beforeEach(() => {
+  sqlMock.mockReset();
+});
+
+describe('derivePlacementStatus', () => {
+  it('returns "ready" when all required placement fields are populated', () => {
+    expect(
+      derivePlacementStatus({
+        lat: 47.6,
+        lng: -122.3,
+        azimuth_deg: 270,
+        tilt_deg: 5,
+      })
+    ).toBe('ready');
+  });
+
+  it('returns "pending" when lat is null', () => {
+    expect(
+      derivePlacementStatus({
+        lat: null,
+        lng: -122.3,
+        azimuth_deg: 270,
+        tilt_deg: 5,
+      })
+    ).toBe('pending');
+  });
+
+  it('returns "pending" when azimuth_deg is null', () => {
+    expect(
+      derivePlacementStatus({
+        lat: 47.6,
+        lng: -122.3,
+        azimuth_deg: null,
+        tilt_deg: 5,
+      })
+    ).toBe('pending');
+  });
+
+  it('returns "pending" when tilt_deg is null', () => {
+    expect(
+      derivePlacementStatus({
+        lat: 47.6,
+        lng: -122.3,
+        azimuth_deg: 270,
+        tilt_deg: null,
+      })
+    ).toBe('pending');
+  });
+});
+
+describe('mintDeviceToken', () => {
+  it('returns a hex token and its SHA-256 hash', () => {
+    const { plaintext, hash } = mintDeviceToken();
+    expect(plaintext).toMatch(/^[0-9a-f]{64}$/);
+    expect(hash).toMatch(/^[0-9a-f]{64}$/);
+    expect(plaintext).not.toBe(hash);
+  });
+
+  it('generates a different token each call', () => {
+    const a = mintDeviceToken();
+    const b = mintDeviceToken();
+    expect(a.plaintext).not.toBe(b.plaintext);
+  });
+});
+
+describe('upsertCameraByClaimCode', () => {
+  it('inserts a new row when no camera exists for the claim code', async () => {
+    sqlMock
+      .mockResolvedValueOnce([]) // SELECT existing — none
+      .mockResolvedValueOnce([
+        {
+          id: 17,
+          claim_code: 'SUNSET-AAAA-BBBB',
+          lat: 47.6,
+          lng: -122.3,
+          azimuth_deg: 270,
+          tilt_deg: 5,
+        },
+      ]); // INSERT RETURNING
+
+    const row = await upsertCameraByClaimCode('SUNSET-AAAA-BBBB', {
+      lat: 47.6,
+      lng: -122.3,
+      timezone: 'America/Los_Angeles',
+      azimuth_deg: 270,
+      tilt_deg: 5,
+      horizon_altitude_deg: 2.5,
+      horizon_profile: [{ azimuth_deg: 0, altitude_deg: 1.2 }],
+      phase_preference: 'sunset',
+      delivery_preferences: { type: 'email', target: 'a@b.c', cadence: 'daily' },
+    });
+
+    expect(row.id).toBe(17);
+    expect(sqlMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('updates the existing row when a camera already exists for the claim code', async () => {
+    sqlMock
+      .mockResolvedValueOnce([
+        { id: 17, claim_code: 'SUNSET-AAAA-BBBB' },
+      ]) // SELECT existing — found
+      .mockResolvedValueOnce([
+        {
+          id: 17,
+          claim_code: 'SUNSET-AAAA-BBBB',
+          lat: 47.6,
+          lng: -122.3,
+          azimuth_deg: 270,
+          tilt_deg: 5,
+        },
+      ]); // UPDATE RETURNING
+
+    const row = await upsertCameraByClaimCode('SUNSET-AAAA-BBBB', {
+      lat: 47.6,
+      lng: -122.3,
+      timezone: 'America/Los_Angeles',
+      azimuth_deg: 270,
+      tilt_deg: 5,
+      horizon_altitude_deg: 2.5,
+      horizon_profile: null,
+      phase_preference: 'sunset',
+      delivery_preferences: null,
+    });
+
+    expect(row.id).toBe(17);
+    expect(sqlMock).toHaveBeenCalledTimes(2);
+  });
+});

--- a/app/lib/cameraRegistration.test.ts
+++ b/app/lib/cameraRegistration.test.ts
@@ -140,4 +140,45 @@ describe('upsertCameraByClaimCode', () => {
     expect(row.id).toBe(17);
     expect(sqlMock).toHaveBeenCalledTimes(2);
   });
+
+  it('passes SQL NULL (not the string "null") for horizon_profile and delivery_preferences on UPDATE', async () => {
+    sqlMock
+      .mockResolvedValueOnce([{ id: 17, claim_code: 'SUNSET-AAAA-BBBB' }])
+      .mockResolvedValueOnce([
+        { id: 17, claim_code: 'SUNSET-AAAA-BBBB', lat: null, lng: null, azimuth_deg: null, tilt_deg: null },
+      ]);
+
+    await upsertCameraByClaimCode('SUNSET-AAAA-BBBB', {
+      lat: 1, lng: 2, timezone: 'UTC',
+      azimuth_deg: 3, tilt_deg: 4, horizon_altitude_deg: 5,
+      horizon_profile: null,
+      phase_preference: 'sunset',
+      delivery_preferences: null,
+    });
+
+    // sqlMock.mock.calls[1] is the UPDATE call. Index 0 is the strings TemplateStringsArray;
+    // remaining indices are the interpolated values, in order.
+    const updateValues = sqlMock.mock.calls[1].slice(1);
+    // No value should ever be the string 'null' — that would be the bug.
+    expect(updateValues).not.toContain('null');
+  });
+
+  it('passes SQL NULL (not the string "null") for horizon_profile and delivery_preferences on INSERT', async () => {
+    sqlMock
+      .mockResolvedValueOnce([]) // SELECT — none
+      .mockResolvedValueOnce([
+        { id: 18, claim_code: 'SUNSET-CCCC-DDDD', lat: 1, lng: 2, azimuth_deg: 3, tilt_deg: 4 },
+      ]);
+
+    await upsertCameraByClaimCode('SUNSET-CCCC-DDDD', {
+      lat: 1, lng: 2, timezone: 'UTC',
+      azimuth_deg: 3, tilt_deg: 4, horizon_altitude_deg: 5,
+      horizon_profile: null,
+      phase_preference: 'sunset',
+      delivery_preferences: null,
+    });
+
+    const insertValues = sqlMock.mock.calls[1].slice(1);
+    expect(insertValues).not.toContain('null');
+  });
 });

--- a/app/lib/cameraRegistration.ts
+++ b/app/lib/cameraRegistration.ts
@@ -1,0 +1,97 @@
+import { createHash, randomBytes } from 'node:crypto';
+import { sql } from '@/app/lib/db';
+
+export type PlacementStatus = 'pending' | 'ready';
+
+export type PlacementShape = {
+  lat: number | null;
+  lng: number | null;
+  azimuth_deg: number | null;
+  tilt_deg: number | null;
+};
+
+export function derivePlacementStatus(row: PlacementShape): PlacementStatus {
+  if (row.lat == null) return 'pending';
+  if (row.lng == null) return 'pending';
+  if (row.azimuth_deg == null) return 'pending';
+  if (row.tilt_deg == null) return 'pending';
+  return 'ready';
+}
+
+export function mintDeviceToken(): { plaintext: string; hash: string } {
+  const plaintext = randomBytes(32).toString('hex');
+  const hash = createHash('sha256').update(plaintext, 'utf8').digest('hex');
+  return { plaintext, hash };
+}
+
+export type CameraUpsertInput = {
+  lat: number | null;
+  lng: number | null;
+  elevation_m?: number | null;
+  timezone: string | null;
+  azimuth_deg: number | null;
+  tilt_deg: number | null;
+  horizon_altitude_deg: number | null;
+  horizon_profile: unknown;
+  phase_preference: 'sunrise' | 'sunset' | 'both';
+  delivery_preferences: unknown;
+};
+
+export type CameraRow = {
+  id: number;
+  claim_code: string;
+  lat: number | null;
+  lng: number | null;
+  azimuth_deg: number | null;
+  tilt_deg: number | null;
+};
+
+export async function upsertCameraByClaimCode(
+  claimCode: string,
+  input: CameraUpsertInput
+): Promise<CameraRow> {
+  const existing = (await sql`
+    SELECT id FROM cameras WHERE claim_code = ${claimCode} LIMIT 1
+  `) as { id: number }[];
+
+  if (existing[0]) {
+    const rows = (await sql`
+      UPDATE cameras SET
+        lat = ${input.lat},
+        lng = ${input.lng},
+        elevation_m = ${input.elevation_m ?? null},
+        timezone = ${input.timezone},
+        azimuth_deg = ${input.azimuth_deg},
+        tilt_deg = ${input.tilt_deg},
+        horizon_altitude_deg = ${input.horizon_altitude_deg},
+        horizon_profile = ${JSON.stringify(input.horizon_profile)}::jsonb,
+        phase_preference = ${input.phase_preference},
+        delivery_preferences = ${JSON.stringify(input.delivery_preferences)}::jsonb
+      WHERE id = ${existing[0].id}
+      RETURNING id, claim_code, lat, lng, azimuth_deg, tilt_deg
+    `) as CameraRow[];
+    return rows[0];
+  }
+
+  // Pre-register-first: insert a row with placement + sentinel device fields.
+  // hardware_id and device_token_hash are filled in by the device's later
+  // register call (Task 6). We use sentinel placeholders so the existing
+  // NOT NULL constraint holds; register replaces them atomically.
+  const sentinelToken = `pending-${claimCode}`;
+  const rows = (await sql`
+    INSERT INTO cameras (
+      hardware_id, device_token_hash, claim_code,
+      lat, lng, elevation_m, timezone,
+      azimuth_deg, tilt_deg, horizon_altitude_deg, horizon_profile,
+      phase_preference, delivery_preferences
+    )
+    VALUES (
+      ${sentinelToken}, ${sentinelToken}, ${claimCode},
+      ${input.lat}, ${input.lng}, ${input.elevation_m ?? null}, ${input.timezone},
+      ${input.azimuth_deg}, ${input.tilt_deg}, ${input.horizon_altitude_deg}, ${JSON.stringify(input.horizon_profile)}::jsonb,
+      ${input.phase_preference}, ${JSON.stringify(input.delivery_preferences)}::jsonb
+    )
+    RETURNING id, claim_code, lat, lng, azimuth_deg, tilt_deg
+  `) as CameraRow[];
+  return rows[0];
+}

--- a/app/lib/cameraRegistration.ts
+++ b/app/lib/cameraRegistration.ts
@@ -2,6 +2,9 @@ import { randomBytes } from 'node:crypto';
 import { sql } from '@/app/lib/db';
 import { hashDeviceToken } from '@/app/lib/cameraAuth';
 
+export const PHASE_VALUES = ['sunrise', 'sunset', 'both'] as const;
+export type PhasePreference = typeof PHASE_VALUES[number];
+
 export type PlacementStatus = 'pending' | 'ready';
 
 export type PlacementShape = {
@@ -33,7 +36,7 @@ export type CameraUpsertInput = {
   tilt_deg: number | null;
   horizon_altitude_deg: number | null;
   horizon_profile: unknown;
-  phase_preference: 'sunrise' | 'sunset' | 'both';
+  phase_preference: PhasePreference;
   delivery_preferences: unknown;
 };
 

--- a/app/lib/cameraRegistration.ts
+++ b/app/lib/cameraRegistration.ts
@@ -1,5 +1,6 @@
-import { createHash, randomBytes } from 'node:crypto';
+import { randomBytes } from 'node:crypto';
 import { sql } from '@/app/lib/db';
+import { hashDeviceToken } from '@/app/lib/cameraAuth';
 
 export type PlacementStatus = 'pending' | 'ready';
 
@@ -20,8 +21,7 @@ export function derivePlacementStatus(row: PlacementShape): PlacementStatus {
 
 export function mintDeviceToken(): { plaintext: string; hash: string } {
   const plaintext = randomBytes(32).toString('hex');
-  const hash = createHash('sha256').update(plaintext, 'utf8').digest('hex');
-  return { plaintext, hash };
+  return { plaintext, hash: hashDeviceToken(plaintext) };
 }
 
 export type CameraUpsertInput = {
@@ -64,9 +64,9 @@ export async function upsertCameraByClaimCode(
         azimuth_deg = ${input.azimuth_deg},
         tilt_deg = ${input.tilt_deg},
         horizon_altitude_deg = ${input.horizon_altitude_deg},
-        horizon_profile = ${JSON.stringify(input.horizon_profile)}::jsonb,
+        horizon_profile = ${input.horizon_profile == null ? null : JSON.stringify(input.horizon_profile)}::jsonb,
         phase_preference = ${input.phase_preference},
-        delivery_preferences = ${JSON.stringify(input.delivery_preferences)}::jsonb
+        delivery_preferences = ${input.delivery_preferences == null ? null : JSON.stringify(input.delivery_preferences)}::jsonb
       WHERE id = ${existing[0].id}
       RETURNING id, claim_code, lat, lng, azimuth_deg, tilt_deg
     `) as CameraRow[];
@@ -88,8 +88,8 @@ export async function upsertCameraByClaimCode(
     VALUES (
       ${sentinelToken}, ${sentinelToken}, ${claimCode},
       ${input.lat}, ${input.lng}, ${input.elevation_m ?? null}, ${input.timezone},
-      ${input.azimuth_deg}, ${input.tilt_deg}, ${input.horizon_altitude_deg}, ${JSON.stringify(input.horizon_profile)}::jsonb,
-      ${input.phase_preference}, ${JSON.stringify(input.delivery_preferences)}::jsonb
+      ${input.azimuth_deg}, ${input.tilt_deg}, ${input.horizon_altitude_deg}, ${input.horizon_profile == null ? null : JSON.stringify(input.horizon_profile)}::jsonb,
+      ${input.phase_preference}, ${input.delivery_preferences == null ? null : JSON.stringify(input.delivery_preferences)}::jsonb
     )
     RETURNING id, claim_code, lat, lng, azimuth_deg, tilt_deg
   `) as CameraRow[];

--- a/docs/device-protocol.md
+++ b/docs/device-protocol.md
@@ -179,9 +179,9 @@ The server stores the placement + preferences against the claim code. No `device
 **Either-order semantics.** Pre-register may arrive either before or after the device's own `register` call. If pre-register arrives first, the server creates a `cameras` row with the placement and operator-preferences fields populated; `hardware_id` and `device_token_hash` are filled in atomically when `register` later runs. If `register` arrives first, the server creates a `cameras` row with the device fields populated and no placement; a subsequent `pre-register` call with the same `claim_code` matches that row and fills in placement. The device's next heartbeat returns the now-populated placement (see §6.3's `request_placement` flag).
 
 **Errors:**
-- `400` — invalid payload, malformed coordinates
-- `401` — claim code unknown or expired
-- `409` — claim code already consumed by a device. Recovery: the operator should request a new claim code or use the camera's existing record.
+- `400` — body missing/invalid required fields
+- `404` — claim code not found
+- `410` — claim code expired
 
 Pre-registration is **idempotent for the same claim code**. Calling it twice with different data overwrites — useful if the operator wants to walk back to the portal and update the placement.
 
@@ -238,7 +238,7 @@ Field notes (every one of these is collected by the AR placement portal automati
 
 When the operator uses the AR portal, all of these fields arrive at the server via `pre-register` (§6.2a) before the device ever boots. The device's own `register` call can omit them; the pre-registration is authoritative.
 
-**Response (201):**
+**Response (200 OK):**
 ```json
 {
   "camera_id": 17,
@@ -262,9 +262,11 @@ When the operator uses the AR portal, all of these fields arrive at the server v
 `placement_status` is `"ready"` iff pre-register populated placement for this `claim_code` before this call. Otherwise it is `"pending"` and the `placement` field is omitted — the device should idle, heartbeat with `request_placement: true`, and start its capture loop once a heartbeat response delivers placement.
 
 **Errors:**
-- `400` — invalid payload, malformed coordinates
-- `401` — claim code unknown, expired, or already consumed
-- `409` — `hardware_id` already registered. Recovery is operator-driven; see §11.1.
+- `400` — body missing `claim_code` or `hardware_id`
+- `404` — claim code not found
+- `409` — claim code already consumed
+- `410` — claim code expired
+- `500` — `hardware_id` UNIQUE collision (v1 limitation — re-registration after token loss surfaces as 500; planned upgrade is to translate to `409 { existing_camera_id }` in a follow-up PR)
 
 The server creates two paired rows: a `cameras` row (custom-camera fields) and a `webcams` row (so the camera shows up in the existing query path). They are linked 1:1 via `webcams.custom_camera_id`.
 

--- a/docs/device-protocol.md
+++ b/docs/device-protocol.md
@@ -176,6 +176,8 @@ Called by the AR placement portal (running on the operator's phone) to submit pl
 
 The server stores the placement + preferences against the claim code. No `device_token` is issued — that comes when the device itself registers.
 
+**Either-order semantics.** Pre-register may arrive either before or after the device's own `register` call. If pre-register arrives first, the server creates a `cameras` row with the placement and operator-preferences fields populated; `hardware_id` and `device_token_hash` are filled in atomically when `register` later runs. If `register` arrives first, the server creates a `cameras` row with the device fields populated and no placement; a subsequent `pre-register` call with the same `claim_code` matches that row and fills in placement. The device's next heartbeat returns the now-populated placement (see §6.3's `request_placement` flag).
+
 **Errors:**
 - `400` — invalid payload, malformed coordinates
 - `401` — claim code unknown or expired
@@ -239,21 +241,25 @@ When the operator uses the AR portal, all of these fields arrive at the server v
 **Response (201):**
 ```json
 {
-  "camera_id": 42,
-  "device_token": "7f3a9b8c4e5d6f7a8b9c0d1e2f3a4b5c6d7e8f9a0b1c2d3e4f5a6b7c8d9e0f1a",
-  "webcam_id": 10042,
-  "server_config": {
-    "active_window_offset_min_before_sunrise": 45,
-    "active_window_offset_min_after_sunrise": 30,
-    "active_window_offset_min_before_sunset": 30,
-    "active_window_offset_min_after_sunset": 45,
-    "edge_score_threshold": 0.3,
-    "heartbeat_interval_active_s": 300,
-    "heartbeat_interval_idle_s": 1800,
-    "max_fps_active": 1
+  "camera_id": 17,
+  "device_token": "<64-char hex>",
+  "placement_status": "ready",
+  "placement": {
+    "lat": 47.6062,
+    "lng": -122.3321,
+    "elevation_m": 30,
+    "timezone": "America/Los_Angeles",
+    "azimuth_deg": 270,
+    "tilt_deg": 5,
+    "horizon_altitude_deg": 2.5,
+    "horizon_profile": [...],
+    "phase_preference": "sunset",
+    "delivery_preferences": { "type": "email", "..." : "..." }
   }
 }
 ```
+
+`placement_status` is `"ready"` iff pre-register populated placement for this `claim_code` before this call. Otherwise it is `"pending"` and the `placement` field is omitted — the device should idle, heartbeat with `request_placement: true`, and start its capture loop once a heartbeat response delivers placement.
 
 **Errors:**
 - `400` — invalid payload, malformed coordinates
@@ -271,6 +277,7 @@ Liveness check, capability refresh, control-plane response. Sent every `heartbea
 {
   "status": "active",
   "uptime_s": 12345,
+  "request_placement": true,
   "last_frame_at": "2026-05-03T01:32:14Z",
   "current_window": {
     "phase": "sunset",
@@ -297,7 +304,7 @@ Liveness check, capability refresh, control-plane response. Sent every `heartbea
 }
 ```
 
-`status` ∈ `"active" | "idle" | "error"`. `current_window` may be `null` when idle. `capabilities` and `telemetry` fields are optional but recommended.
+`status` ∈ `"active" | "idle" | "error"`. `current_window` may be `null` when idle. `capabilities` and `telemetry` fields are optional but recommended. `request_placement` is optional (default `false`); devices in the `IDLE` post-register state should set it to `true` on every heartbeat until placement arrives; devices in `ACTIVE` should omit it to save bandwidth.
 
 **Response (200):**
 ```json
@@ -317,6 +324,16 @@ Liveness check, capability refresh, control-plane response. Sent every `heartbea
 ```
 
 `config_overrides` is a partial set; the device merges over its current config. `stream_request` is the MJPEG-upgrade hook (see §8). `edge_model_update` is reserved for OTA model updates (mechanism out of scope).
+
+**Optional placement delivery.** When the request includes `"request_placement": true`, the response carries `placement_status` and (if `ready`) the full `placement` block from §6.2's response. Devices in the `IDLE` post-register state set this flag on every heartbeat; devices in `ACTIVE` should omit it to save bandwidth.
+
+```json
+{
+  "acknowledged_at": "2026-05-16T01:32:14.000Z",
+  "placement_status": "ready",
+  "placement": { "..." : "..." }
+}
+```
 
 The device should sync its clock against `server_time` if drift exceeds a threshold (e.g., 30s). NTP is the primary clock source; this is a fallback.
 

--- a/docs/superpowers/plans/2026-05-16-streamlined-model-deploy.md
+++ b/docs/superpowers/plans/2026-05-16-streamlined-model-deploy.md
@@ -1,0 +1,1223 @@
+# Streamlined Model Deploy Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship `scripts/deploy-model.sh <run_dir>` — a single command that takes a trained PyTorch run from `.pt` to confirmed-running-in-production v4 ONNX on Vercel, with guardrails against the silent-fallback pattern documented in `memory/feedback_silent_ml_fallback.md`.
+
+**Architecture:** Five rerunnable bash stages (export → validate → git stage → Vercel env+deploy → verify) calling existing Python (`export_onnx_versioned.py`), a new Python validator (`validate_deploy_bundle.py`), the `vercel` CLI, and two new HTTP endpoints (`scoringPaths` counter on the existing cron route + a new `/api/debug/scoring-smoke` endpoint). No local state file — the world (git + filesystem + Vercel + cron response) is the source of truth.
+
+**Tech Stack:** Bash 4+, Python 3.11 + PyTorch + onnxruntime, Next.js 15 (TypeScript), vitest, Vercel CLI 39+, `jq`.
+
+**Reference spec:** `docs/superpowers/specs/2026-05-16-streamlined-model-deploy-design.md`
+
+---
+
+## File Structure
+
+**New:**
+- `app/api/debug/scoring-smoke/route.ts` — smoke-test endpoint
+- `app/api/debug/scoring-smoke/route.test.ts` — vitest tests
+- `app/api/debug/scoring-smoke/test-image.jpg` — committed ~50 KB JPEG fixture
+- `ml/validate_deploy_bundle.py` — four-check validator called by Stage 2
+- `ml/test_validate_deploy_bundle.py` — unittest tests
+- `scripts/deploy-model.sh` — orchestrator
+- `scripts/deploy-model-config.sh` — portable CONFIG block (sourced by deploy-model.sh)
+
+**Modified:**
+- `app/api/cron/update-cameras/route.ts` — add `scoringPaths` counter to response (~15 lines added near existing `windyScores` / `cacheHits` / `fallbacks` accumulation around line 158-272)
+- `app/api/cron/update-cameras/route.test.ts` — assert `scoringPaths` shape in response
+- `ml/OPERATING_GUIDE.md` — §9 points to `scripts/deploy-model.sh` as canonical workflow
+- `package.json` — add `"deploy-model"` script
+
+Each file has one clear responsibility:
+- `scoring-smoke/route.ts` does *only* "force one ONNX inference on a known image"
+- `validate_deploy_bundle.py` does *only* the four pre-deploy checks
+- `deploy-model.sh` does *only* orchestration; all real work delegates to existing tools
+- `deploy-model-config.sh` is just bash variable assignments — portability boundary
+
+---
+
+## Branch Setup
+
+- [ ] **Step 1: Create feature branch off main**
+
+Run:
+```bash
+git fetch origin main
+git checkout -b feat/streamlined-model-deploy origin/main
+```
+Expected: switched to new branch, clean working tree.
+
+---
+
+## Task 1: Add `scoringPaths` counter to cron response
+
+**Files:**
+- Modify: `app/api/cron/update-cameras/route.ts:120-273`
+- Modify: `app/api/cron/update-cameras/route.test.ts:103-151`
+
+- [ ] **Step 1: Write the failing test**
+
+Add this test at the end of the `describe('GET /api/cron/update-cameras', …)` block in `app/api/cron/update-cameras/route.test.ts` (after the last existing `it(...)`):
+
+```ts
+it('returns a scoringPaths breakdown counted from scored.pathTaken', async () => {
+  // Three webcams: one onnx, one cache-hit, one baseline-fallback.
+  fetchBatchesMock.mockResolvedValueOnce([[
+    { webcamId: 7, location: { latitude: 0, longitude: 0 },
+      images: { current: { preview: 'https://x/a.jpg' } }, viewCount: 1, rating: 3 },
+    { webcamId: 8, location: { latitude: 0, longitude: 0 },
+      images: { current: { preview: 'https://x/b.jpg' } }, viewCount: 1, rating: 3 },
+    { webcamId: 9, location: { latitude: 0, longitude: 0 },
+      images: { current: { preview: 'https://x/c.jpg' } }, viewCount: 1, rating: 3 },
+  ]]);
+  getIdMapMock.mockResolvedValueOnce(new Map([['7', 700], ['8', 800], ['9', 900]]));
+  scoreMock
+    .mockResolvedValueOnce({ rawScore: 0.6, aiRating: 3.4, modelVersion: 'v4', imageHash: 'h1', source: 'windy', pathTaken: 'onnx' })
+    .mockResolvedValueOnce({ rawScore: 0, aiRating: 0, modelVersion: 'v4', imageHash: 'h2', source: 'windy', pathTaken: 'cache-hit' })
+    .mockResolvedValueOnce({ rawScore: 0.4, aiRating: 2.6, modelVersion: 'v4', imageHash: 'h3', source: 'windy', pathTaken: 'baseline-fallback' });
+  const res = await GET(makeReq());
+  const body = await res.json();
+  expect(body.scoringPaths).toEqual({
+    onnx: 1,
+    'cache-hit': 1,
+    'baseline-fallback': 1,
+    baseline: 0,
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run app/api/cron/update-cameras/route.test.ts -t "scoringPaths" --reporter=basic`
+Expected: FAIL with `expected undefined to deeply equal { onnx: 1, ... }` (the field doesn't exist yet).
+
+- [ ] **Step 3: Implement scoringPaths in route.ts**
+
+Open `app/api/cron/update-cameras/route.ts`. Find the declarations near line 75-85 where counters like `let fallbacks = 0` are declared (specifically the `cacheHits`, `fallbacks` lines just above the `scoreOneWindy` function). Add:
+
+```ts
+const scoringPaths: Record<'onnx' | 'cache-hit' | 'baseline-fallback' | 'baseline', number> = {
+  onnx: 0,
+  'cache-hit': 0,
+  'baseline-fallback': 0,
+  baseline: 0,
+};
+```
+
+Then in `scoreOneWindy` (around line 158-162), update the cache-hit branch and add a counter line for all paths:
+
+```ts
+if (scored.pathTaken === 'cache-hit') {
+  cacheHits += 1;
+  scoringPaths['cache-hit'] += 1;
+  return;
+}
+if (scored.pathTaken === 'baseline-fallback') fallbacks += 1;
+scoringPaths[scored.pathTaken] = (scoringPaths[scored.pathTaken] ?? 0) + 1;
+windyScores.push(scored.rawScore);
+```
+
+Then in the `NextResponse.json({...})` block around line 265-273, add `scoringPaths` to the response:
+
+```ts
+return NextResponse.json({
+  ok: true,
+  sunrise: sunriseList.length,
+  sunset: sunsetList.length,
+  windyScored: windyScores.length,
+  cacheHits,
+  fallbacks,
+  scoringPaths,
+  customBackfill: backfillResult,
+});
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx vitest run app/api/cron/update-cameras/route.test.ts -t "scoringPaths" --reporter=basic`
+Expected: PASS. Also re-run the full file to confirm no regression: `npx vitest run app/api/cron/update-cameras/route.test.ts --reporter=basic` — all 7 tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/api/cron/update-cameras/route.ts app/api/cron/update-cameras/route.test.ts
+git commit -m "feat(cron): add scoringPaths breakdown to update-cameras response
+
+Counts each pathTaken value (onnx / cache-hit / baseline-fallback / baseline)
+so 'is ONNX really running' is inspectable from a single curl.
+scoringPaths.onnx > 0 && scoringPaths['baseline-fallback'] === 0 is the
+green-light condition for any deploy."
+```
+
+---
+
+## Task 2: Add `/api/debug/scoring-smoke` test image fixture
+
+**Files:**
+- Create: `app/api/debug/scoring-smoke/test-image.jpg`
+
+- [ ] **Step 1: Copy a sample image from the training set**
+
+Find a known-good sunset image already in the repo. Run:
+```bash
+ls ml/artifacts/experiments/20260513_113243_v4_regression_llm_with_flickr/dataset/20260513_113247/ | head
+```
+
+If the dataset has direct image files, copy one. Otherwise, use any small JPEG you trust. Concretely:
+```bash
+mkdir -p app/api/debug/scoring-smoke
+# Pick a small JPEG from somewhere reasonable; the exact image doesn't matter
+# as long as it's a real photo (not a 1x1 placeholder) so preprocessing exercises
+# the full resize/normalize path.
+# Example - find any small JPEG in the existing image_cache:
+SOURCE=$(find ml/artifacts/image_cache -name "*.jpg" -size -100k -size +20k | head -1)
+cp "$SOURCE" app/api/debug/scoring-smoke/test-image.jpg
+ls -lh app/api/debug/scoring-smoke/test-image.jpg
+```
+Expected: a JPEG between 20-100 KB at the target path.
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add app/api/debug/scoring-smoke/test-image.jpg
+git commit -m "test(scoring): add fixed JPEG fixture for smoke-test endpoint
+
+Lets the smoke-test endpoint force a deterministic ONNX inference
+independent of webcam image rotation."
+```
+
+---
+
+## Task 3: Implement `/api/debug/scoring-smoke` endpoint
+
+**Files:**
+- Create: `app/api/debug/scoring-smoke/route.ts`
+- Create: `app/api/debug/scoring-smoke/route.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `app/api/debug/scoring-smoke/route.test.ts`:
+
+```ts
+// @vitest-environment node
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const verifyAuthMock = vi.fn(() => true);
+const scoreMock = vi.fn();
+const readFileMock = vi.fn();
+
+vi.mock('@/app/api/cron/update-cameras/lib/auth', () => ({
+  verifyCronAuth: () => verifyAuthMock(),
+}));
+vi.mock('@/app/api/cron/update-cameras/lib/aiScoring', () => ({
+  scoreImage: (...a: unknown[]) => scoreMock(...a),
+}));
+vi.mock('node:fs/promises', () => ({
+  readFile: (...a: unknown[]) => readFileMock(...a),
+}));
+
+import { GET } from './route';
+
+beforeEach(() => {
+  verifyAuthMock.mockReset().mockReturnValue(true);
+  readFileMock.mockReset().mockResolvedValue(Buffer.from('fake-jpeg-bytes'));
+  scoreMock.mockReset().mockResolvedValue({
+    rawScore: 0.72, aiRating: 3.88, modelVersion: 'v4_test',
+    imageHash: 'abc', source: 'windy', pathTaken: 'onnx',
+  });
+});
+
+function makeReq(): Request {
+  return new Request('http://test/api/debug/scoring-smoke');
+}
+
+describe('GET /api/debug/scoring-smoke', () => {
+  it('returns 401 when auth fails', async () => {
+    verifyAuthMock.mockReturnValueOnce(false);
+    const res = await GET(makeReq());
+    expect(res.status).toBe(401);
+    expect(scoreMock).not.toHaveBeenCalled();
+  });
+
+  it('reads the test image, scores it, returns pathTaken + rating + latency', async () => {
+    const res = await GET(makeReq());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toMatchObject({
+      pathTaken: 'onnx',
+      rawScore: 0.72,
+      aiRating: 3.88,
+      modelVersion: 'v4_test',
+    });
+    expect(typeof body.latencyMs).toBe('number');
+    expect(body.latencyMs).toBeGreaterThanOrEqual(0);
+  });
+
+  it('forces real scoring by passing lastImageHash: undefined', async () => {
+    await GET(makeReq());
+    expect(scoreMock).toHaveBeenCalledTimes(1);
+    const call = scoreMock.mock.calls[0][0];
+    expect(call.lastImageHash).toBeUndefined();
+    expect(call.source).toBe('windy');
+  });
+
+  it('returns 500 with the underlying error when scoreImage throws', async () => {
+    scoreMock.mockRejectedValueOnce(new Error('onnx load failed'));
+    const res = await GET(makeReq());
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.error).toContain('onnx load failed');
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run app/api/debug/scoring-smoke/route.test.ts --reporter=basic`
+Expected: FAIL with `Cannot find module './route'` (the route file doesn't exist yet).
+
+- [ ] **Step 3: Implement the route**
+
+Create `app/api/debug/scoring-smoke/route.ts`:
+
+```ts
+import path from 'node:path';
+import { readFile } from 'node:fs/promises';
+import { NextResponse } from 'next/server';
+import { verifyCronAuth } from '@/app/api/cron/update-cameras/lib/auth';
+import { scoreImage } from '@/app/api/cron/update-cameras/lib/aiScoring';
+
+export const dynamic = 'force-dynamic';
+
+const TEST_IMAGE_PATH = path.join(
+  process.cwd(),
+  'app/api/debug/scoring-smoke/test-image.jpg'
+);
+
+export async function GET(req: Request): Promise<Response> {
+  if (!verifyCronAuth(req)) {
+    return new NextResponse('Unauthorized', { status: 401 });
+  }
+
+  try {
+    const imageBytes = await readFile(TEST_IMAGE_PATH);
+    const startedAt = Date.now();
+    const result = await scoreImage({
+      webcamId: 0,
+      imageBytes,
+      source: 'windy',
+      lastImageHash: undefined,
+    });
+    const latencyMs = Date.now() - startedAt;
+
+    return NextResponse.json({
+      pathTaken: result.pathTaken,
+      rawScore: result.rawScore,
+      aiRating: result.aiRating,
+      modelVersion: result.modelVersion,
+      imageHash: result.imageHash,
+      latencyMs,
+    });
+  } catch (error) {
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : String(error) },
+      { status: 500 }
+    );
+  }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx vitest run app/api/debug/scoring-smoke/route.test.ts --reporter=basic`
+Expected: PASS, all 4 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/api/debug/scoring-smoke/route.ts app/api/debug/scoring-smoke/route.test.ts
+git commit -m "feat(debug): add /api/debug/scoring-smoke endpoint
+
+Forces a single ONNX inference on a committed test image, returns
+pathTaken + rawScore + aiRating + modelVersion + latencyMs. Provides
+the canonical 'is ONNX actually running on this deployment, right now,
+deterministically' check — independent of cron timing or which webcams
+happened to rotate their images.
+
+Same CRON_SECRET auth as the cron endpoint."
+```
+
+---
+
+## Task 4: Validator — PyTorch ↔ ONNX parity check
+
+**Files:**
+- Create: `ml/validate_deploy_bundle.py`
+- Create: `ml/test_validate_deploy_bundle.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `ml/test_validate_deploy_bundle.py`:
+
+```python
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+import numpy as np
+import torch
+import torch.nn as nn
+
+from ml.validate_deploy_bundle import check_pt_onnx_parity
+
+
+class TestParityCheck(unittest.TestCase):
+    def _make_tiny_model_and_export(self, tmp: Path):
+        """Create a deterministic 3-layer CNN, save both .pt and .onnx forms."""
+        torch.manual_seed(0)
+        model = nn.Sequential(
+            nn.Conv2d(3, 4, kernel_size=3, padding=1),
+            nn.ReLU(),
+            nn.AdaptiveAvgPool2d(1),
+            nn.Flatten(),
+            nn.Linear(4, 1),
+        )
+        model.eval()
+        pt_path = tmp / "best.pt"
+        onnx_path = tmp / "model.onnx"
+        torch.save({"model_state_dict": model.state_dict()}, pt_path)
+        dummy = torch.randn(1, 3, 224, 224)
+        torch.onnx.export(
+            model, dummy, str(onnx_path),
+            input_names=["input"], output_names=["output"],
+            dynamic_axes={"input": {0: "batch"}, "output": {0: "batch"}},
+            opset_version=17,
+        )
+        return model, pt_path, onnx_path
+
+    def test_matching_pt_and_onnx_pass_parity(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp = Path(tmpdir)
+            model, pt_path, onnx_path = self._make_tiny_model_and_export(tmp)
+            ok, max_diff = check_pt_onnx_parity(model, onnx_path, atol=1e-5)
+            self.assertTrue(ok, f"parity failed with max_diff={max_diff}")
+            self.assertLess(max_diff, 1e-5)
+
+    def test_mismatched_weights_fail_parity(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp = Path(tmpdir)
+            model, _pt, onnx_path = self._make_tiny_model_and_export(tmp)
+            # Mutate the in-memory PyTorch model weights so it no longer matches the ONNX
+            with torch.no_grad():
+                for p in model.parameters():
+                    p.add_(1.0)
+            ok, max_diff = check_pt_onnx_parity(model, onnx_path, atol=1e-5)
+            self.assertFalse(ok)
+            self.assertGreater(max_diff, 0.01)
+
+
+if __name__ == "__main__":
+    unittest.main()
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd /Users/jessekauppila/GitHub/the-sunset-webcam-map && source .venv/bin/activate && python -m pytest ml/test_validate_deploy_bundle.py -v`
+Expected: FAIL with `ImportError: cannot import name 'check_pt_onnx_parity'` (module doesn't exist yet).
+
+- [ ] **Step 3: Implement the parity check**
+
+Create `ml/validate_deploy_bundle.py`:
+
+```python
+"""Pre-deploy validator for ONNX-on-Vercel ML bundles.
+
+Run as a CLI from scripts/deploy-model.sh. Four independent checks:
+  1. PyTorch ↔ ONNX numerical parity
+  2. ONNX file size (≤ 100 MB for GitHub)
+  3. Estimated Vercel function bundle size (≤ MAX_BUNDLE_MB)
+  4. Eval report sanity (pearson ≥ threshold)
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import onnxruntime as ort
+import torch
+
+
+def check_pt_onnx_parity(
+    model: torch.nn.Module,
+    onnx_path: Path,
+    atol: float = 1e-5,
+    seed: int = 0,
+) -> tuple[bool, float]:
+    """Run a fixed-seed random input through both, return (passed, max_abs_diff)."""
+    model.eval()
+    torch.manual_seed(seed)
+    dummy = torch.randn(1, 3, 224, 224)
+
+    with torch.no_grad():
+        pt_out = model(dummy).cpu().numpy()
+
+    session = ort.InferenceSession(
+        str(onnx_path), providers=["CPUExecutionProvider"]
+    )
+    onnx_out = session.run(None, {session.get_inputs()[0].name: dummy.numpy()})[0]
+
+    max_diff = float(np.max(np.abs(pt_out - onnx_out)))
+    return max_diff < atol, max_diff
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `python -m pytest ml/test_validate_deploy_bundle.py -v`
+Expected: both tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add ml/validate_deploy_bundle.py ml/test_validate_deploy_bundle.py
+git commit -m "feat(ml): validate_deploy_bundle parity check
+
+PyTorch model + ONNX file, run fixed-seed random input through each,
+assert max abs diff < atol. Catches head-shape mismatches like the
+v4 head_dropout=0.3 silent export failure that bit us on 2026-05-15."
+```
+
+---
+
+## Task 5: Validator — bundle size estimate + eval report check
+
+**Files:**
+- Modify: `ml/validate_deploy_bundle.py` (append two functions)
+- Modify: `ml/test_validate_deploy_bundle.py` (append two test classes)
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `ml/test_validate_deploy_bundle.py`:
+
+```python
+from ml.validate_deploy_bundle import (
+    estimate_bundle_size_mb,
+    check_eval_report,
+)
+
+
+class TestBundleSize(unittest.TestCase):
+    def test_returns_sum_of_existing_files_in_mb(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp = Path(tmpdir)
+            (tmp / "a.bin").write_bytes(b"x" * (10 * 1024 * 1024))   # 10 MB
+            (tmp / "b.bin").write_bytes(b"x" * (5 * 1024 * 1024))    # 5 MB
+            size_mb = estimate_bundle_size_mb([tmp / "a.bin", tmp / "b.bin"])
+            self.assertAlmostEqual(size_mb, 15.0, places=1)
+
+    def test_silently_ignores_missing_files(self):
+        size_mb = estimate_bundle_size_mb([Path("/nonexistent/file.bin")])
+        self.assertEqual(size_mb, 0.0)
+
+
+class TestEvalReport(unittest.TestCase):
+    def _write(self, tmp: Path, payload: dict) -> Path:
+        p = tmp / "eval_report.json"
+        p.write_text(json.dumps(payload))
+        return p
+
+    def test_passes_when_pearson_above_threshold(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            p = self._write(Path(tmpdir), {"pearson": 0.9, "r2": 0.8, "mae": 0.4})
+            ok, metrics = check_eval_report(p, min_pearson=0.5)
+            self.assertTrue(ok)
+            self.assertEqual(metrics["pearson"], 0.9)
+
+    def test_fails_when_pearson_below_threshold(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            p = self._write(Path(tmpdir), {"pearson": 0.3, "r2": 0.1, "mae": 0.9})
+            ok, metrics = check_eval_report(p, min_pearson=0.5)
+            self.assertFalse(ok)
+
+    def test_handles_nested_regression_block(self):
+        """Some eval reports nest metrics under {'regression': {...}}."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            p = self._write(
+                Path(tmpdir),
+                {"regression": {"pearson": 0.85, "r2": 0.7, "mae": 0.5}},
+            )
+            ok, metrics = check_eval_report(p, min_pearson=0.5)
+            self.assertTrue(ok)
+            self.assertEqual(metrics["pearson"], 0.85)
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `python -m pytest ml/test_validate_deploy_bundle.py::TestBundleSize ml/test_validate_deploy_bundle.py::TestEvalReport -v`
+Expected: FAIL with `ImportError: cannot import name 'estimate_bundle_size_mb'`.
+
+- [ ] **Step 3: Append the implementations**
+
+Append to `ml/validate_deploy_bundle.py`:
+
+```python
+import json
+from typing import Iterable
+
+
+def estimate_bundle_size_mb(paths: Iterable[Path]) -> float:
+    """Sum the sizes of files at the given paths, in MB. Missing files contribute 0."""
+    total_bytes = 0
+    for p in paths:
+        try:
+            total_bytes += p.stat().st_size
+        except FileNotFoundError:
+            continue
+    return total_bytes / (1024 * 1024)
+
+
+def check_eval_report(
+    report_path: Path,
+    min_pearson: float = 0.5,
+) -> tuple[bool, dict]:
+    """Load eval_report.json and return (passed, metrics_dict).
+
+    Reports may put metrics at top level or nested under 'regression'.
+    """
+    payload = json.loads(report_path.read_text())
+    block = payload.get("regression", payload)
+    metrics = {
+        "pearson": float(block.get("pearson", 0.0)),
+        "r2": float(block.get("r2", 0.0)),
+        "mae": float(block.get("mae", 0.0)),
+    }
+    return metrics["pearson"] >= min_pearson, metrics
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `python -m pytest ml/test_validate_deploy_bundle.py -v`
+Expected: all 7 tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add ml/validate_deploy_bundle.py ml/test_validate_deploy_bundle.py
+git commit -m "feat(ml): validate_deploy_bundle bundle-size + eval checks
+
+estimate_bundle_size_mb sums on-disk files (missing = 0 MB).
+check_eval_report loads eval_report.json (handles top-level or
+nested 'regression' block), returns (passed, metrics) based on
+configurable min_pearson threshold."
+```
+
+---
+
+## Task 6: Validator — CLI entry point
+
+**Files:**
+- Modify: `ml/validate_deploy_bundle.py` (append CLI)
+
+- [ ] **Step 1: Add CLI**
+
+Append to `ml/validate_deploy_bundle.py`:
+
+```python
+def main() -> int:
+    """CLI: python -m ml.validate_deploy_bundle --run-dir <dir> --version-tag <tag>
+            [--max-bundle-mb 200] [--min-pearson 0.5] [--force]
+    """
+    import argparse
+    import sys
+
+    parser = argparse.ArgumentParser(description="Pre-deploy validator for Vercel ONNX bundles")
+    parser.add_argument("--run-dir", type=Path, required=True,
+                        help="Experiment run dir containing train/best.pt and eval/eval_report.json")
+    parser.add_argument("--version-tag", required=True,
+                        help="Version tag (defaults to run-dir basename in deploy-model.sh)")
+    parser.add_argument("--model-family", default="regression_resnet18",
+                        help="Subdir under ml/artifacts/models/")
+    parser.add_argument("--max-bundle-mb", type=float, default=200.0)
+    parser.add_argument("--min-pearson", type=float, default=0.5)
+    parser.add_argument("--force", action="store_true",
+                        help="Print warnings but always exit 0")
+    args = parser.parse_args()
+
+    onnx_path = (Path("ml/artifacts/models") / args.model_family /
+                 args.version_tag / "model.onnx")
+
+    print(f"[validate] run_dir       = {args.run_dir}")
+    print(f"[validate] version_tag   = {args.version_tag}")
+    print(f"[validate] onnx_path     = {onnx_path}")
+    print()
+
+    failed: list[str] = []
+
+    # 1. ONNX file size
+    if not onnx_path.exists():
+        failed.append(f"ONNX missing at {onnx_path}")
+    else:
+        onnx_mb = onnx_path.stat().st_size / (1024 * 1024)
+        if onnx_mb > 100:
+            failed.append(f"ONNX file size {onnx_mb:.1f} MB > 100 MB GitHub limit")
+        else:
+            print(f"✓ ONNX file size: {onnx_mb:.1f} MB (≤ 100 MB)")
+
+    # 2. Parity check
+    pt_path = args.run_dir / "train" / "best.pt"
+    if not pt_path.exists():
+        failed.append(f"PyTorch checkpoint missing at {pt_path}")
+    elif onnx_path.exists():
+        # Lazy import so failures above still print
+        from ml.train import build_model_from_config  # adjust if name differs
+        import json as _json
+        config_path = args.run_dir / "config.resolved.json"
+        if not config_path.exists():
+            failed.append(f"config.resolved.json missing at {config_path}")
+        else:
+            cfg = _json.loads(config_path.read_text())
+            model = build_model_from_config(cfg)
+            state = torch.load(pt_path, map_location="cpu")
+            model.load_state_dict(state.get("model_state_dict", state))
+            ok, max_diff = check_pt_onnx_parity(model, onnx_path)
+            if ok:
+                print(f"✓ PT↔ONNX parity: max_abs_diff = {max_diff:.2e}")
+            else:
+                failed.append(f"PT↔ONNX parity FAIL: max_abs_diff = {max_diff:.2e}")
+
+    # 3. Estimated bundle size
+    bundle_files = [
+        Path("node_modules/onnxruntime-node/bin/napi-v6/linux/x64/libonnxruntime.so.1"),
+        Path("node_modules/onnxruntime-node/bin/napi-v6/linux/x64/onnxruntime_binding.node"),
+        onnx_path,
+    ]
+    # Add sharp libvips dir if present
+    sharp_root = Path("node_modules/@img/sharp-libvips-linux-x64")
+    if sharp_root.exists():
+        bundle_files.extend(sharp_root.rglob("*"))
+    bundle_mb = estimate_bundle_size_mb(bundle_files)
+    if bundle_mb > args.max_bundle_mb:
+        failed.append(f"Bundle estimate {bundle_mb:.1f} MB > {args.max_bundle_mb:.1f} MB limit")
+    else:
+        print(f"✓ Bundle estimate: {bundle_mb:.1f} MB (≤ {args.max_bundle_mb:.1f} MB)")
+
+    # 4. Eval report
+    eval_path = args.run_dir / "eval" / "eval_report.json"
+    if eval_path.exists():
+        ok, metrics = check_eval_report(eval_path, args.min_pearson)
+        line = f"pearson={metrics['pearson']:.3f} r2={metrics['r2']:.3f} mae={metrics['mae']:.3f}"
+        if ok:
+            print(f"✓ Eval report: {line}")
+        else:
+            failed.append(f"Eval pearson below {args.min_pearson}: {line}")
+    else:
+        print(f"⚠ Eval report missing at {eval_path} (skipping)")
+
+    print()
+    if failed:
+        for msg in failed:
+            print(f"✗ {msg}")
+        if args.force:
+            print("\n--force passed; exiting 0 despite failures.")
+            return 0
+        return 1
+
+    print("✓ All checks passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+```
+
+- [ ] **Step 2: Test CLI against current v4 deploy (manual smoke test)**
+
+Run:
+```bash
+python -m ml.validate_deploy_bundle \
+  --run-dir ml/artifacts/experiments/20260513_113243_v4_regression_llm_with_flickr \
+  --version-tag 20260513_113243_v4_regression_llm_with_flickr
+```
+Expected: All 4 checks print `✓`, exit 0. If the `build_model_from_config` import fails, fix the import path to match the actual function name in `ml/train.py` (run `grep -n "def build_model\|def create_model\|def make_model" ml/train.py` to find it; adjust the import line in `validate_deploy_bundle.py` accordingly, then re-run).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add ml/validate_deploy_bundle.py
+git commit -m "feat(ml): validate_deploy_bundle CLI entry point
+
+Wires parity / file-size / bundle-size / eval-report into a single
+'python -m ml.validate_deploy_bundle ...' invocation. Prints each
+check's pass/fail, exits non-zero on any failure unless --force."
+```
+
+---
+
+## Task 7: Deploy script — CONFIG block + Stage 1 (export) + helpers
+
+**Files:**
+- Create: `scripts/deploy-model.sh`
+- Create: `scripts/deploy-model-config.sh`
+
+- [ ] **Step 1: Create the CONFIG block**
+
+Create `scripts/deploy-model-config.sh`:
+
+```bash
+#!/usr/bin/env bash
+# === Project config (edit when porting to a new repo) ===
+MODEL_FAMILY="regression_resnet18"
+ENV_VAR_MODEL_PATH="AI_ONNX_REGRESSION_MODEL_PATH"
+ENV_VAR_MODEL_VERSION="AI_REGRESSION_MODEL_VERSION"
+ENV_VAR_SCORING_MODE="AI_SCORING_MODE"
+CRON_ENDPOINT="/api/cron/update-cameras"
+SMOKE_ENDPOINT="/api/debug/scoring-smoke"
+MAX_BUNDLE_MB=200
+MIN_PEARSON=0.5
+PROD_URL="https://www.sunrisesunset.studio"
+```
+
+- [ ] **Step 2: Create the main script skeleton with Stage 1**
+
+Create `scripts/deploy-model.sh`:
+
+```bash
+#!/usr/bin/env bash
+# Streamlined model deploy. See docs/superpowers/specs/2026-05-16-streamlined-model-deploy-design.md
+# Usage: scripts/deploy-model.sh <run_dir> [--start-at N] [--force] [--unattended]
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+# shellcheck source=./deploy-model-config.sh
+source "$SCRIPT_DIR/deploy-model-config.sh"
+
+# ---------- arg parsing ----------
+RUN_DIR=""
+START_AT=1
+FORCE=0
+UNATTENDED=0
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --start-at) START_AT="$2"; shift 2 ;;
+    --force) FORCE=1; shift ;;
+    --unattended) UNATTENDED=1; shift ;;
+    -h|--help)
+      echo "Usage: $0 <run_dir> [--start-at N] [--force] [--unattended]"; exit 0 ;;
+    *)
+      if [[ -z "$RUN_DIR" ]]; then RUN_DIR="$1"; shift
+      else echo "Unexpected arg: $1" >&2; exit 2; fi ;;
+  esac
+done
+
+if [[ -z "$RUN_DIR" ]]; then
+  echo "Usage: $0 <run_dir> [--start-at N] [--force] [--unattended]" >&2
+  exit 2
+fi
+RUN_DIR="$(cd "$RUN_DIR" && pwd)"
+VERSION_TAG="$(basename "$RUN_DIR")"
+ONNX_DIR="$REPO_ROOT/ml/artifacts/models/$MODEL_FAMILY/$VERSION_TAG"
+ONNX_PATH="$ONNX_DIR/model.onnx"
+
+# ---------- helpers ----------
+log() { printf '\n\033[1;36m== %s ==\033[0m\n' "$*"; }
+ok()  { printf '\033[1;32m✓\033[0m %s\n' "$*"; }
+warn(){ printf '\033[1;33m⚠\033[0m %s\n' "$*"; }
+err() { printf '\033[1;31m✗\033[0m %s\n' "$*" >&2; }
+
+confirm() {
+  # confirm "prompt" — returns 0 on y, 1 on n. In --unattended mode always y.
+  if [[ "$UNATTENDED" -eq 1 ]]; then return 0; fi
+  read -r -p "$1 [y/N] " yn
+  [[ "$yn" =~ ^[Yy]$ ]]
+}
+
+# ---------- Stage 1: Export ----------
+stage_1_export() {
+  log "Stage 1: Export ONNX"
+  if [[ -f "$ONNX_PATH" ]]; then
+    ok "Already exported at $ONNX_PATH"
+    return 0
+  fi
+  python "$REPO_ROOT/ml/export_onnx_versioned.py" \
+    --run-dir "$RUN_DIR" \
+    --target-type regression \
+    --model-name resnet18
+  if [[ ! -f "$ONNX_PATH" ]]; then
+    err "Export script reported success but $ONNX_PATH does not exist"
+    exit 1
+  fi
+  ok "Exported to $ONNX_PATH"
+}
+
+# ---------- Stage 2-5 placeholders (filled in subsequent tasks) ----------
+stage_2_validate() { log "Stage 2: TODO (Task 7b)"; }
+stage_3_git()       { log "Stage 3: TODO (Task 8)"; }
+stage_4_vercel()    { log "Stage 4: TODO (Task 8)"; }
+stage_5_verify()    { log "Stage 5: TODO (Task 9)"; }
+
+# ---------- main ----------
+echo "Deploying model: $VERSION_TAG"
+echo "Run dir:         $RUN_DIR"
+echo "ONNX path:       $ONNX_PATH"
+[[ "$START_AT" -le 1 ]] && stage_1_export
+[[ "$START_AT" -le 2 ]] && stage_2_validate
+[[ "$START_AT" -le 3 ]] && stage_3_git
+[[ "$START_AT" -le 4 ]] && stage_4_vercel
+[[ "$START_AT" -le 5 ]] && stage_5_verify
+```
+
+- [ ] **Step 3: Add Stage 2 (calls validator)**
+
+Replace the `stage_2_validate()` placeholder in `scripts/deploy-model.sh` with:
+
+```bash
+stage_2_validate() {
+  log "Stage 2: Validate deploy bundle"
+  local force_flag=""
+  [[ "$FORCE" -eq 1 ]] && force_flag="--force"
+  python -m ml.validate_deploy_bundle \
+    --run-dir "$RUN_DIR" \
+    --version-tag "$VERSION_TAG" \
+    --model-family "$MODEL_FAMILY" \
+    --max-bundle-mb "$MAX_BUNDLE_MB" \
+    --min-pearson "$MIN_PEARSON" \
+    $force_flag
+}
+```
+
+- [ ] **Step 4: Make executable and smoke-test Stages 1+2**
+
+Run:
+```bash
+chmod +x scripts/deploy-model.sh
+scripts/deploy-model.sh ml/artifacts/experiments/20260513_113243_v4_regression_llm_with_flickr --start-at 1
+```
+Expected: Stage 1 reports "Already exported", Stage 2 runs validator and prints all ✓ checks, Stages 3-5 print "TODO" placeholders, exit 0.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/deploy-model.sh scripts/deploy-model-config.sh
+git commit -m "feat(scripts): deploy-model.sh scaffold + Stages 1-2
+
+Bash orchestrator with CONFIG block (portable to other Vercel+ONNX
+projects). Stage 1 wraps ml/export_onnx_versioned.py (skips if ONNX
+already exists). Stage 2 invokes ml/validate_deploy_bundle.py. Stages
+3-5 stubbed for next commits."
+```
+
+---
+
+## Task 8: Deploy script — Stage 3 (git) + Stage 4 (Vercel)
+
+**Files:**
+- Modify: `scripts/deploy-model.sh`
+
+- [ ] **Step 1: Replace Stage 3 placeholder**
+
+Replace `stage_3_git()` in `scripts/deploy-model.sh` with:
+
+```bash
+stage_3_git() {
+  log "Stage 3: Stage ONNX in git and push"
+  cd "$REPO_ROOT"
+  if [[ -z "$(git status --porcelain "$ONNX_DIR")" ]]; then
+    # Check if it's already committed by looking at HEAD
+    if git ls-files --error-unmatch "$ONNX_DIR/model.onnx" >/dev/null 2>&1; then
+      ok "Already committed in git: $ONNX_DIR"
+      DEPLOY_TRIGGER="env-only"  # signals Stage 4 to redeploy explicitly
+      return 0
+    fi
+  fi
+  git add "$ONNX_DIR"
+  echo
+  git diff --cached --stat
+  echo
+  echo "Proposed commit message: deploy: $VERSION_TAG"
+  if ! confirm "Commit and push?"; then
+    warn "Skipped commit. Stage 4 will not have a fresh deploy to wait for."
+    DEPLOY_TRIGGER="skipped"
+    return 0
+  fi
+  git commit -m "deploy: $VERSION_TAG"
+  git push
+  ok "Pushed to origin (auto-deploy should trigger on Vercel)"
+  DEPLOY_TRIGGER="auto"
+}
+```
+
+- [ ] **Step 2: Replace Stage 4 placeholder**
+
+Replace `stage_4_vercel()` in `scripts/deploy-model.sh` with:
+
+```bash
+# Helper: set Vercel env var.
+# Vercel hides sensitive env values in `env ls`, so we can only detect
+# existence, not value equality. If the var exists we prompt to overwrite;
+# if it doesn't exist we add it silently.
+set_vercel_env() {
+  local name="$1" want="$2"
+  local exists
+  exists=$(npx vercel env ls production 2>/dev/null | awk -v n="$name" '$1 == n {print "yes"; exit}' || true)
+  if [[ "$exists" != "yes" ]]; then
+    npx vercel env add "$name" production --value "$want" --force --yes
+    ok "Added $name"
+    return 0
+  fi
+  echo
+  echo "Vercel env var: $name (exists; Vercel hides current value)"
+  echo "  new: $want"
+  if ! confirm "Overwrite?"; then
+    warn "Skipped $name (assuming current value is correct)"
+    return 0
+  fi
+  npx vercel env add "$name" production --value "$want" --force --yes
+  ok "Updated $name"
+}
+
+stage_4_vercel() {
+  log "Stage 4: Vercel env vars + deploy"
+  local model_path="ml/artifacts/models/$MODEL_FAMILY/$VERSION_TAG/model.onnx"
+  set_vercel_env "$ENV_VAR_MODEL_PATH"    "$model_path"
+  set_vercel_env "$ENV_VAR_MODEL_VERSION" "$VERSION_TAG"
+  set_vercel_env "$ENV_VAR_SCORING_MODE"  "onnx"
+
+  if [[ "${DEPLOY_TRIGGER:-auto}" == "env-only" || "${DEPLOY_TRIGGER:-auto}" == "skipped" ]]; then
+    warn "No fresh commit pushed; triggering explicit deploy"
+    npx vercel --prod --yes
+  fi
+
+  log "Waiting for latest production deploy to be READY"
+  for _ in {1..30}; do
+    local state
+    state=$(npx vercel ls --prod --count 1 2>/dev/null | awk 'NR>1 {print $4; exit}' || true)
+    if [[ "$state" == "READY" ]]; then
+      ok "Latest deploy READY"
+      return 0
+    fi
+    sleep 10
+  done
+  err "Latest deploy did not reach READY within 5 minutes; check Vercel dashboard"
+  exit 1
+}
+```
+
+- [ ] **Step 3: Smoke-test Stages 3-4 against current state**
+
+This is the trickiest stage to smoke-test because it talks to Vercel. The current production already has v4 deployed, so we expect Stage 3 to detect "already committed" and Stage 4 to detect "env vars already correct" and skip everything. Run:
+
+```bash
+scripts/deploy-model.sh ml/artifacts/experiments/20260513_113243_v4_regression_llm_with_flickr --start-at 3
+```
+Expected: Stage 3 prints `✓ Already committed in git`. Stage 4 prompts to overwrite each of the 3 existing env vars (answer `n` to keep current — they're already correct from the manual setup). Stage 4 then triggers a deploy (because Stage 3 was a skip → `DEPLOY_TRIGGER=env-only`) and ends with `✓ Latest deploy READY`. Stage 5 still prints TODO.
+
+If `vercel ls --prod --count 1` parsing breaks (Vercel CLI output format varies), fix the awk pattern to match what `npx vercel ls --prod` actually prints — capture a sample with `npx vercel ls --prod | head -3` and adjust.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add scripts/deploy-model.sh
+git commit -m "feat(scripts): deploy-model.sh Stages 3-4 (git + Vercel)
+
+Stage 3 detects already-committed ONNX, skips re-commit. Stage 4
+prompts before overwriting Vercel env vars, polls for READY state.
+Both stages prompt before destructive ops (unless --unattended)."
+```
+
+---
+
+## Task 9: Deploy script — Stage 5 (verify)
+
+**Files:**
+- Modify: `scripts/deploy-model.sh`
+
+- [ ] **Step 1: Replace Stage 5 placeholder**
+
+Replace `stage_5_verify()` in `scripts/deploy-model.sh` with:
+
+```bash
+stage_5_verify() {
+  log "Stage 5: Verify ONNX is actually running"
+  if [[ -z "${CRON_SECRET:-}" ]]; then
+    err "CRON_SECRET not set in environment. Run: export CRON_SECRET=\$(grep ^CRON_SECRET .env.production.tmp | cut -d= -f2-)"
+    err "(npx vercel env pull --environment=production .env.production.tmp  # to fetch it first)"
+    exit 1
+  fi
+
+  # 5a: Smoke test (deterministic)
+  echo
+  echo "5a. Smoke test ($PROD_URL$SMOKE_ENDPOINT)"
+  local smoke_body
+  smoke_body=$(curl -s -H "Authorization: Bearer $CRON_SECRET" "$PROD_URL$SMOKE_ENDPOINT")
+  local smoke_path
+  smoke_path=$(echo "$smoke_body" | jq -r '.pathTaken // "missing"')
+  local smoke_version
+  smoke_version=$(echo "$smoke_body" | jq -r '.modelVersion // "missing"')
+  local smoke_latency
+  smoke_latency=$(echo "$smoke_body" | jq -r '.latencyMs // "missing"')
+  echo "    response: pathTaken=$smoke_path version=$smoke_version latencyMs=$smoke_latency"
+  if [[ "$smoke_path" != "onnx" ]]; then
+    err "Smoke test pathTaken=$smoke_path (expected onnx). Full body: $smoke_body"
+    npx vercel logs "$PROD_URL" --since=5m | tail -30
+    exit 1
+  fi
+  if [[ "$smoke_version" != "$VERSION_TAG" ]]; then
+    err "Smoke test modelVersion=$smoke_version (expected $VERSION_TAG)"
+    exit 1
+  fi
+  ok "Smoke test: ONNX path confirmed, model=$smoke_version"
+
+  # 5b: Cron sample (statistical)
+  echo
+  echo "5b. Cron sample (3 ticks, 30s apart)"
+  for i in 1 2 3; do
+    local body
+    body=$(curl -s -H "Authorization: Bearer $CRON_SECRET" "$PROD_URL$CRON_ENDPOINT")
+    local windyScored fallbacks paths
+    windyScored=$(echo "$body" | jq -r '.windyScored // 0')
+    fallbacks=$(echo "$body" | jq -r '.fallbacks // 0')
+    paths=$(echo "$body" | jq -c '.scoringPaths // {}')
+    echo "    tick $i: windyScored=$windyScored fallbacks=$fallbacks paths=$paths"
+    if [[ "$windyScored" -gt 0 && "$fallbacks" -gt 0 ]]; then
+      err "Cron tick $i: fallbacks=$fallbacks of windyScored=$windyScored. Vercel logs:"
+      npx vercel logs "$PROD_URL" --since=5m | tail -30
+      exit 1
+    fi
+    [[ "$i" -lt 3 ]] && sleep 30
+  done
+  ok "Cron sample: no fallbacks across 3 ticks"
+
+  echo
+  ok "ONNX confirmed running in production (version: $VERSION_TAG)"
+}
+```
+
+- [ ] **Step 2: Smoke-test Stage 5 end-to-end**
+
+Make sure `CRON_SECRET` is set in your shell. Then run:
+```bash
+scripts/deploy-model.sh ml/artifacts/experiments/20260513_113243_v4_regression_llm_with_flickr --start-at 5
+```
+Expected:
+- `5a` reports `pathTaken=onnx`, `modelVersion=<the v4 tag>`, latency printed
+- `5b` reports 3 ticks; `fallbacks=0` on each (or `windyScored=0` with `fallbacks=0`, which also passes)
+- Ends with `✓ ONNX confirmed running in production`
+
+The smoke endpoint must exist in the deployed code for this to succeed. If `5a` returns 404, the smoke endpoint commits from Tasks 2-3 haven't deployed yet — push and wait for Vercel READY first.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add scripts/deploy-model.sh
+git commit -m "feat(scripts): deploy-model.sh Stage 5 (deterministic + statistical verify)
+
+5a hits /api/debug/scoring-smoke; asserts pathTaken=onnx and modelVersion
+matches the just-deployed tag. 5b samples /api/cron/update-cameras 3
+times with 30s gaps; asserts fallbacks=0 on every tick where windyScored>0.
+On failure, dumps last 30 lines of vercel logs."
+```
+
+---
+
+## Task 10: Docs + package.json
+
+**Files:**
+- Modify: `ml/OPERATING_GUIDE.md` (§9)
+- Modify: `package.json`
+
+- [ ] **Step 1: Update OPERATING_GUIDE §9**
+
+Open `ml/OPERATING_GUIDE.md`. Find the line that says `## 9. ONNX export and deployment`. Insert a new subsection RIGHT AFTER that heading and before `### Training vs export`:
+
+```markdown
+### One-command deploy (canonical)
+
+```bash
+npm run deploy-model -- ml/artifacts/experiments/<run_dir>
+```
+
+This is the canonical workflow. It walks through 5 stages with confirmations:
+
+1. **Export** ONNX from the run (skips if already exported)
+2. **Validate** ONNX⇄PyTorch parity, bundle size estimate, eval report
+3. **Stage** the model in git and push (skips if already committed)
+4. **Set Vercel env vars** if changed; wait for deploy READY
+5. **Verify** ONNX is running: deterministic smoke test + 3 cron-tick sample
+
+Flags: `--start-at N` (resume mid-script), `--force` (skip Stage 2 gates), `--unattended` (accept all prompts).
+
+The manual steps below remain documented as fallback for debugging.
+```
+
+- [ ] **Step 2: Add npm script entry**
+
+Open `package.json`. Find the `"scripts"` block. Add (keeping existing entries):
+
+```json
+"deploy-model": "./scripts/deploy-model.sh"
+```
+
+(Place it alphabetically among existing scripts; don't disturb the others.)
+
+- [ ] **Step 3: Verify the npm script works**
+
+Run: `npm run deploy-model -- --help`
+Expected: prints `Usage: ./scripts/deploy-model.sh <run_dir> [--start-at N] [--force] [--unattended]`, exits 0.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add ml/OPERATING_GUIDE.md package.json
+git commit -m "docs(ml): point §9 at scripts/deploy-model.sh; add npm script
+
+Manual steps stay as fallback documentation. New canonical path is
+'npm run deploy-model -- <run_dir>'."
+```
+
+---
+
+## Task 11: End-to-end smoke run + PR
+
+- [ ] **Step 1: Full dry-run against current production**
+
+The expectation: every stage skips (the v4 deploy is already done), Stage 5 passes deterministically.
+```bash
+npm run deploy-model -- ml/artifacts/experiments/20260513_113243_v4_regression_llm_with_flickr
+```
+Expected output progression:
+- Stage 1: `✓ Already exported`
+- Stage 2: `✓ All checks passed`
+- Stage 3: `✓ Already committed in git`
+- Stage 4: For each of the 3 env vars, prompts "Overwrite?" → answer `n` → prints `⚠ Skipped <NAME>`. Then `✓ Latest deploy READY`.
+- Stage 5: `✓ Smoke test: ONNX path confirmed`, `✓ Cron sample: no fallbacks across 3 ticks`, `✓ ONNX confirmed running in production`
+
+If any stage fails, fix the underlying issue (typically: an env var name typo, or vercel CLI output format) and re-run with `--start-at <N>`.
+
+- [ ] **Step 2: Push the branch and open PR**
+
+```bash
+git push -u origin feat/streamlined-model-deploy
+```
+Then open https://github.com/jessekauppila/the-sunset-webcam-map/pull/new/feat/streamlined-model-deploy
+PR title: `feat: one-command model deploy with silent-fallback guardrails`
+PR body: link to spec at `docs/superpowers/specs/2026-05-16-streamlined-model-deploy-design.md` and summarize the 11 tasks.
+
+- [ ] **Step 3: Update memory after merge**
+
+After PR merges, append to `MEMORY.md`:
+
+```markdown
+- [Streamlined model deploy workflow](project_streamlined_model_deploy.md) — `npm run deploy-model -- <run_dir>` is the canonical PyTorch→ONNX→Vercel path; 5 stages, no local state, silent-fallback guarded via scoringPaths + smoke endpoint
+```
+
+And create `project_streamlined_model_deploy.md` with a brief reference pointing to the spec + plan paths.
+
+---
+
+## Success criteria
+
+1. `npm run deploy-model -- <run_dir>` against the current v4 deploy completes with all stages skipping cleanly and Stage 5 passing — total wall time < 3 minutes
+2. The same command against a hypothetical fresh, never-deployed run would take a `.pt` to confirmed-running-in-production under 10 minutes, with every destructive action confirmed by prompt (or `--unattended`)
+3. A future broken deploy — bundle size, MODULE_NOT_FOUND, head-shape mismatch, etc. — exits Stage 2 or Stage 5 non-zero with an actionable error; never returns success with a silent fallback running

--- a/docs/superpowers/specs/2026-05-16-streamlined-model-deploy-design.md
+++ b/docs/superpowers/specs/2026-05-16-streamlined-model-deploy-design.md
@@ -78,7 +78,11 @@ For each required env var (`AI_ONNX_REGRESSION_MODEL_PATH`, `AI_REGRESSION_MODEL
 
 1. `vercel env ls production` → check if already set to the right value
 2. If set correctly: skip, print `✓ <VAR> already set`
-3. If wrong or missing: print current value, print new value, prompt to overwrite. On yes: `vercel env rm` then `vercel env add`
+3. If wrong or missing: print current value, print new value, prompt to overwrite. On yes:
+   ```bash
+   vercel env add <NAME> production --value "<new-value>" --force --yes
+   ```
+   `--force` overwrites without a separate `rm` step. `--value` skips the interactive stdin prompt. `--yes` skips the confirmation. Verified against Vercel CLI 39+ on 2026-05-16.
 
 After env vars:
 - If Stage 3 made a commit, the git push already triggered an auto-deploy. Poll `vercel ls --prod` until latest deployment shows `READY`.

--- a/docs/superpowers/specs/2026-05-16-streamlined-model-deploy-design.md
+++ b/docs/superpowers/specs/2026-05-16-streamlined-model-deploy-design.md
@@ -1,0 +1,223 @@
+# Streamlined Model Deploy — Design
+
+**Status:** Draft, 2026-05-16
+**Scope:** A single command that takes a trained PyTorch model run and ships it to Vercel as a working ONNX inference path, with guardrails against the silent-fallback pattern that hid a broken deploy for a week (see `memory/feedback_silent_ml_fallback.md`).
+**Out of scope:** Training itself, schema changes to `webcam_snapshots`, AWS/Cloud-Run support.
+
+---
+
+## Motivation
+
+Tonight's deploy of the v4 regression model exposed five stacked bugs in the train → ONNX → Vercel hand-off:
+
+1. v4 was never exported because `export_onnx.py` crashed silently on the `head_dropout=0.3` head shape
+2. ONNX output range [0,1] was being read as 1-5 stars by the cron
+3. `await import(varName)` indirection hid `onnxruntime-node` from Vercel's output-file tracer → MODULE_NOT_FOUND in production
+4. After fixing #3, the function bundle ballooned to 425 MB because all platform binaries (darwin/win32/linux × CPU/GPU) shipped → exceeded Vercel's 250 MB hard limit
+5. The cron's `try { onnx } catch { baseline }` fallback succeeded plausibly for every webcam, masquerading as real inference for a week; only the `fallbacks` field in the cron response would have caught it
+
+Each individual bug was diagnosable in 15 minutes once seen. The expensive part was discovering *that they existed*. The deploy script and verification artifacts in this design make every one of them either impossible or immediately visible the next time we ship a model.
+
+The user expects to ship models a few times per year, not weekly. The design optimizes for "works correctly when used after a long gap" — explicit prompts, no hidden state, generous validation.
+
+## Goal
+
+```bash
+scripts/deploy-model.sh ml/artifacts/experiments/20260513_113243_v4_regression_llm_with_flickr/
+```
+
+…walks through 5 stages and either fails loud with an actionable error or ends with `✓ ONNX confirmed running in production`. Rerunnable from any stage. Portable to future Vercel-hosted ML projects via a 6-line CONFIG block.
+
+---
+
+## Architecture: five stages
+
+```
+scripts/deploy-model.sh <run_dir> [--start-at N] [--force] [--unattended]
+  ├─ 1. Export    → ml/export_onnx_versioned.py
+  ├─ 2. Validate  → ml/validate_deploy_bundle.py  (NEW)
+  ├─ 3. Stage     → git add + commit + push
+  ├─ 4. Vercel    → vercel env add (if needed) + wait for deploy
+  └─ 5. Verify    → /api/debug/scoring-smoke + /api/cron/update-cameras
+```
+
+### Stage 1 — Export
+
+Wraps the existing `ml/export_onnx_versioned.py`. The `<version_tag>` is `Path(run_dir).name` — the full run_dir basename including the timestamp prefix (e.g. `20260513_113243_v4_regression_llm_with_flickr`), matching `export_onnx_versioned.py:66`. Skips if `model.onnx` for that tag already exists at `ml/artifacts/models/<MODEL_FAMILY>/<version_tag>/model.onnx`. Print `✓ Already exported`.
+
+### Stage 2 — Validate (new: `ml/validate_deploy_bundle.py`)
+
+Four checks, each pass/fail printed independently:
+
+1. **PyTorch ↔ ONNX parity** — load both, run a single fixed-seed random input through each, assert `max(abs(pt - onnx)) < 1e-5`. Catches head-shape mismatches and silent export corruption.
+2. **ONNX file size** — assert `model.onnx ≤ 100 MB`. GitHub's per-file LFS-free limit.
+3. **Estimated Vercel bundle size** — sum the files Vercel's tracer would ship for `app/api/cron/update-cameras/route.ts` after the `outputFileTracingExcludes` we have in `next.config.ts`. Specifically:
+   - `node_modules/onnxruntime-node/bin/napi-v6/linux/x64/libonnxruntime.so.1`
+   - `node_modules/onnxruntime-node/bin/napi-v6/linux/x64/onnxruntime_binding.node`
+   - `node_modules/@img/sharp-libvips-linux-x64/**`
+   - `node_modules/sharp/**`
+   - `ml/artifacts/models/<MODEL_FAMILY>/<version_tag>/**`
+   - All `.next/server/**` traced files (run `next build --debug` once to capture)
+   Assert sum ≤ `MAX_BUNDLE_MB` (default 200 MB, 50 MB margin under Vercel's 250 MB).
+4. **Eval report** — load `<run_dir>/eval/eval_report.json`. Print pearson, R², MAE. Refuse to proceed if pearson < 0.5. Override with `--force`.
+
+### Stage 3 — Stage in git
+
+```bash
+git add ml/artifacts/models/<MODEL_FAMILY>/<version_tag>/
+git diff --cached --stat                          # show what's about to commit
+echo "Proposed commit message: deploy: <version_tag>"
+read -p "Commit and push? [y/N] " yn
+```
+
+On yes: commit + push. On no (or `--unattended` with no changes): skip with note.
+
+### Stage 4 — Vercel env vars + deploy
+
+For each required env var (`AI_ONNX_REGRESSION_MODEL_PATH`, `AI_REGRESSION_MODEL_VERSION`, `AI_SCORING_MODE=onnx`):
+
+1. `vercel env ls production` → check if already set to the right value
+2. If set correctly: skip, print `✓ <VAR> already set`
+3. If wrong or missing: print current value, print new value, prompt to overwrite. On yes: `vercel env rm` then `vercel env add`
+
+After env vars:
+- If Stage 3 made a commit, the git push already triggered an auto-deploy. Poll `vercel ls --prod` until latest deployment shows `READY`.
+- If Stage 3 was a skip (code unchanged, only env vars changed), run `vercel --prod` to force a new deploy that picks up the new env.
+
+### Stage 5 — Verify
+
+Two checks, in order:
+
+1. **Smoke test (deterministic)** — `curl -H "Authorization: Bearer $CRON_SECRET" $PROD_URL/api/debug/scoring-smoke` → expect `pathTaken: "onnx"`, `modelVersion` matches `<version_tag>`, latency < 5000 ms. This is independent of cron timing.
+2. **Cron sample (statistical)** — hit `/api/cron/update-cameras` 3 times with 30s gaps. For each tick where `windyScored > 0`, assert `fallbacks === 0`. If `fallbacks > 0` at any point, print the last 20 lines of `vercel logs --since=5m` and exit non-zero.
+
+On pass: `✓ ONNX confirmed running in production (version: <version_tag>)`.
+
+---
+
+## State, idempotency, and failure handling
+
+**No local state file.** The world is the source of truth (git + filesystem + Vercel + cron response). Each stage queries the world to decide whether to skip. Eliminates the "state file says I'm done but reality says I'm not" failure mode.
+
+**`<version_tag>` is the only cross-stage key**, derived deterministically as `Path(run_dir).name`. Two invocations with the same `<run_dir>` always produce the same tag.
+
+| Stage | If it fails | Recovery |
+|---|---|---|
+| 1 Export | Stops. Usually `head_dropout` mismatch or missing `best.pt` | Fix run_dir contents, rerun |
+| 2 Validate | Stops with which check(s) failed. `--force` skips the entire stage | Investigate, or `--force` and own the risk |
+| 3 Stage | Prompt declined → exit clean. Push fails → standard git error, repo unchanged | Resolve, rerun with `--start-at 3` |
+| 4 Vercel | Auth → tells you to `vercel login`. Deploy fails → prints failure URL | Fix, rerun with `--start-at 4` |
+| 5 Verify | `fallbacks > 0` or smoke test wrong pathTaken → prints `vercel logs` and exits 1 | Fix root cause, rerun just stage 5 |
+
+**Destructive operations** (always prompt, never silent in default mode):
+
+- Stage 4 may overwrite existing Vercel env vars. Prints current value vs new value side-by-side before doing so.
+- `--unattended` skips all prompts (accepts every default). Intended only for re-runs of a previously-completed deploy.
+
+---
+
+## Verification & silent-fallback prevention
+
+Three changes; (a) and (b) are required for this design, (c) is flagged as future work.
+
+### (a) Richer cron response
+
+Add `scoringPaths` breakdown to `/api/cron/update-cameras` response:
+
+```json
+{
+  "scoringPaths": { "onnx": 4, "baseline-fallback": 0, "cache-hit": 78, "baseline": 0 }
+}
+```
+
+Counts come directly from `scored.pathTaken`. Makes "is ONNX really running" inspectable from a single curl. `scoringPaths.onnx > 0 && scoringPaths['baseline-fallback'] === 0` is the green-light condition.
+
+**Cost:** ~15 lines in `app/api/cron/update-cameras/route.ts`. No schema change.
+
+### (b) Smoke-test endpoint (`/api/debug/scoring-smoke`)
+
+```
+GET /api/debug/scoring-smoke
+Authorization: Bearer $CRON_SECRET
+```
+
+Implementation:
+
+1. Reads a committed ~50 KB JPEG from `app/api/debug/scoring-smoke/test-image.jpg`
+2. Calls `scoreImage()` with `lastImageHash: undefined` (forces real scoring, bypasses any cache)
+3. Returns `{pathTaken, rawScore, aiRating, modelVersion, latencyMs}`
+
+Provides the canonical "is ONNX actually running on this deployment, right now, deterministically" check. Independent of cron timing or which webcams happened to rotate their images. Stage 5 calls this *first*, then samples the real cron.
+
+**Cost:** ~40 lines + a committed test JPEG.
+
+### (c) DEFERRED — persist `pathTaken` to DB
+
+A `scoring_path TEXT` column on `webcam_snapshots`, written from `scored.pathTaken` (not from env var). Lets you SQL-filter for contaminated rows after a future broken deploy. Out of scope for this design because:
+
+1. DB migration + write-path change, not deploy-streamlining
+2. (a) + (b) already answer "did the deploy work"
+3. Phase 2 winner-selection will touch the same write path — better to bundle the schema change there
+
+Worth tracking separately. Recorded in `memory/feedback_silent_ml_fallback.md` point 1.
+
+---
+
+## Portability — the CONFIG block
+
+Top of `scripts/deploy-model.sh`:
+
+```bash
+# === Project config (edit when porting to a new repo) ===
+MODEL_FAMILY="regression_resnet18"           # ml/artifacts/models/<this>/<version>/
+ENV_VAR_MODEL_PATH="AI_ONNX_REGRESSION_MODEL_PATH"
+ENV_VAR_MODEL_VERSION="AI_REGRESSION_MODEL_VERSION"
+ENV_VAR_SCORING_MODE="AI_SCORING_MODE"
+CRON_ENDPOINT="/api/cron/update-cameras"
+SMOKE_ENDPOINT="/api/debug/scoring-smoke"
+MAX_BUNDLE_MB=200
+PROD_URL="https://www.sunrisesunset.studio"
+```
+
+Porting to a new Vercel + onnxruntime-node project: copy `scripts/deploy-model.sh`, `ml/validate_deploy_bundle.py`, and `app/api/debug/scoring-smoke/`, edit the CONFIG block, done. The body is generic.
+
+Three tiers of portability for this work overall:
+
+| What | Portable to |
+|---|---|
+| Pattern (PyTorch → ONNX → onnxruntime-node on Vercel) | Universal |
+| `scripts/deploy-model.sh` + `validate_deploy_bundle.py` + `scoring-smoke` | Any Vercel + onnxruntime-node project, edit CONFIG block |
+| `ml/` training scaffolding (`run_training.py`, `export_dataset.py`, etc.) | Specific to image classification/regression with this column layout |
+
+---
+
+## Files affected
+
+**New:**
+
+- `scripts/deploy-model.sh` (~150 lines bash)
+- `ml/validate_deploy_bundle.py` (~120 lines Python)
+- `app/api/debug/scoring-smoke/route.ts` (~50 lines)
+- `app/api/debug/scoring-smoke/test-image.jpg` (~50 KB sample sunset photo)
+
+**Modified:**
+
+- `app/api/cron/update-cameras/route.ts` — add `scoringPaths` counter and include in response (~15 lines)
+- `ml/OPERATING_GUIDE.md` §9 — point to the new script as the canonical workflow; keep the manual steps as fallback documentation
+- `package.json` — add `"deploy-model": "./scripts/deploy-model.sh"` script entry for `npm run deploy-model -- <run_dir>`
+
+---
+
+## Testing
+
+- `ml/validate_deploy_bundle.py` — unit test the parity check with a known-good ONNX + .pt fixture; size estimator can be tested against the current v4 deploy whose true bundle size we know
+- `/api/debug/scoring-smoke/route.ts` — vitest test mocking `scoreImage` to return each `pathTaken` value, assert the response shape
+- `scripts/deploy-model.sh` — no automated tests; manually re-runnable on the existing v4 deploy as a dry run (Stage 1 skips because exported, Stage 3 skips because committed, Stage 4 skips because env vars set, Stage 5 should pass)
+
+---
+
+## Success criteria
+
+1. `scripts/deploy-model.sh ml/artifacts/experiments/20260513_113243_v4_regression_llm_with_flickr/` completes cleanly against the current production state (all stages skip except Stage 5)
+2. Running the same against a fresh, never-deployed run takes a model from `best.pt` to confirmed-running-in-production in under 10 minutes wall time, with every destructive action confirmed by prompt
+3. A future broken ONNX deploy — whether caused by bundle size, MODULE_NOT_FOUND, head-shape mismatch, or any of the other tonight-class failures — exits Stage 2 or Stage 5 non-zero with an actionable error message; never returns success with a silent fallback running


### PR DESCRIPTION
## Summary

Phase 1 of sub-project E in the streamlined-deployment umbrella ([overview](docs/superpowers/specs/2026-05-15-streamlined-deployment-overview.md), [spec E](docs/superpowers/specs/2026-05-15-wifi-onboarding-and-provisioning-design.md)). Cloud-side endpoints required to onboard a non-technical recipient's custom Pi webcam end-to-end — no SSH, no config file edits.

- **Five new endpoints:** `POST /api/admin/claim-codes`, `POST /api/cameras/pre-register`, `POST /api/cameras/register`, `POST /api/cameras/[id]/heartbeat`, `GET /api/cameras/setup-status/[claim_code]`.
- **Either-order pre-register/register:** a `cameras` row can be created by whichever call arrives first; the second call merges. Backed by a small schema migration (relaxes `cameras.lat/lng/timezone` NOT NULLs, adds `cameras.claim_code`) and a sentinel pattern in `cameraRegistration.ts` for the device fields.
- **`docs/device-protocol.md` updated** with Amendments A/B/C (either-order semantics, `placement_status` in register response, optional `placement` block in heartbeat response when `request_placement: true`). Error-code blocks reconciled with what ships.

49 new Vitest unit tests across helpers + routes; full suite is green except for two pre-existing failures on main (`useSetMarker.test.ts`, `terminatorRing.test.ts`) unrelated to this branch.

## Heads-up

Two commits (`4d1c5fcdd`, `da193b72d`) about model-deploy doc design landed on this branch mid-flow from parallel work — doc-only, not part of this sub-project. Cherry-pick to another branch if you'd prefer them out of this PR.

## Test Plan

- [ ] CI / `npx vitest run` is green (or shows only the 2 pre-existing failures listed above).
- [ ] `npx tsc --noEmit` produces no new errors in `app/api/cameras/**` or `app/lib/camera*`.
- [ ] Apply `database/migrations/20260516_cameras_either_order_registration.sql` to the prod Neon DB.
- [ ] Smoke the five endpoints against the deployed environment using the curl sequence in plan §11.
- [ ] Verify `cameras.lat/lng/timezone` are nullable and `cameras.claim_code` + index exist after migration: `psql "$DATABASE_URL" -c "\d cameras"`.

## Known follow-ups (deferred)

- Extract `sentinelForClaimCode(code)` helper so the writer (`cameraRegistration.ts`) and reader (`setup-status` route) share a single source of truth for the `pending-<claim>` string.
- Translate `hardware_id` UNIQUE collision into a documented `409 { existing_camera_id }` instead of the current generic 500 — bundle with firmware-side build so the retry path is meaningful.
- Sub-project F (cloud wizard frontend) and the firmware-side captive-portal / SD-provisioning work are separate plans against these endpoints.

🤖 Generated with [Claude Code](https://claude.com/claude-code)