### PR TITLE
feat(cron): one predicate for Windy + custom camera visibility

### DIFF
--- a/app/api/cron/update-cameras/lib/customClassification.test.ts
+++ b/app/api/cron/update-cameras/lib/customClassification.test.ts
@@ -63,6 +63,23 @@ describe('classifyCustomCamerasForTick', () => {
     expect(sunset).toEqual([]);
   });
 
+  it('excludes cams beyond SEARCH_RADIUS_DEG even if closer to one phase', async () => {
+    // Cam at (50, 50): nearest to sunriseCoords (0,0) at ~70° distance, far beyond 9°
+    sqlMock.mockResolvedValue([
+      { webcam_id: 999, lat: 50, lng: 50 },
+    ]);
+
+    const { sunrise, sunset } = await classifyCustomCamerasForTick({
+      sunriseCoords: [{ lat: 0, lng: 0 }],
+      sunsetCoords: [{ lat: 0, lng: 180 }],
+      freshnessWindowMinutes: 90,
+      now: new Date('2026-05-15T00:00:00Z'),
+    });
+
+    expect(sunrise).toEqual([]);
+    expect(sunset).toEqual([]);
+  });
+
   it('passes freshness threshold into the SQL parameters', async () => {
     sqlMock.mockResolvedValue([]);
     const now = new Date('2026-05-15T12:00:00Z');

--- a/app/api/cron/update-cameras/lib/customClassification.test.ts
+++ b/app/api/cron/update-cameras/lib/customClassification.test.ts
@@ -1,0 +1,85 @@
+// @vitest-environment node
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const sqlMock = vi.fn();
+vi.mock('@/app/lib/db', () => ({
+  sql: (...args: unknown[]) => sqlMock(...args),
+}));
+
+import { classifyCustomCamerasForTick } from './customClassification';
+
+beforeEach(() => {
+  sqlMock.mockReset();
+});
+
+describe('classifyCustomCamerasForTick', () => {
+  const sunriseCoords = [{ lat: 0, lng: 0 }];
+  const sunsetCoords = [{ lat: 0, lng: 180 }];
+
+  it('returns rows in sunrise bucket for cams near sunriseCoords', async () => {
+    sqlMock.mockResolvedValue([
+      { webcam_id: 101, lat: 0.1, lng: 0.1 },
+      { webcam_id: 102, lat: -0.1, lng: 0.2 },
+    ]);
+
+    const { sunrise, sunset } = await classifyCustomCamerasForTick({
+      sunriseCoords,
+      sunsetCoords,
+      freshnessWindowMinutes: 90,
+      now: new Date('2026-05-15T00:00:00Z'),
+    });
+
+    expect(sunrise.map((r) => r.webcamId).sort()).toEqual([101, 102]);
+    expect(sunset).toEqual([]);
+  });
+
+  it('places cams in sunset bucket when nearer sunsetCoords', async () => {
+    sqlMock.mockResolvedValue([
+      { webcam_id: 200, lat: 0, lng: 179 },
+    ]);
+
+    const { sunrise, sunset } = await classifyCustomCamerasForTick({
+      sunriseCoords,
+      sunsetCoords,
+      freshnessWindowMinutes: 90,
+      now: new Date('2026-05-15T00:00:00Z'),
+    });
+
+    expect(sunrise).toEqual([]);
+    expect(sunset.map((r) => r.webcamId)).toEqual([200]);
+  });
+
+  it('returns empty arrays when SQL returns no rows', async () => {
+    sqlMock.mockResolvedValue([]);
+
+    const { sunrise, sunset } = await classifyCustomCamerasForTick({
+      sunriseCoords,
+      sunsetCoords,
+      freshnessWindowMinutes: 90,
+      now: new Date('2026-05-15T00:00:00Z'),
+    });
+
+    expect(sunrise).toEqual([]);
+    expect(sunset).toEqual([]);
+  });
+
+  it('passes freshness threshold into the SQL parameters', async () => {
+    sqlMock.mockResolvedValue([]);
+    const now = new Date('2026-05-15T12:00:00Z');
+
+    await classifyCustomCamerasForTick({
+      sunriseCoords,
+      sunsetCoords,
+      freshnessWindowMinutes: 90,
+      now,
+    });
+
+    // sqlMock receives the tagged-template strings + values. The freshness
+    // cutoff is a value at position 0 (the only one). It should be a Date
+    // 90 minutes before `now`.
+    const callValues = sqlMock.mock.calls[0].slice(1) as unknown[];
+    const passed = callValues[0] as Date;
+    const expected = new Date(now.getTime() - 90 * 60_000);
+    expect(passed.getTime()).toBe(expected.getTime());
+  });
+});

--- a/app/api/cron/update-cameras/lib/customClassification.ts
+++ b/app/api/cron/update-cameras/lib/customClassification.ts
@@ -1,4 +1,5 @@
 import { sql } from '@/app/lib/db';
+import { SEARCH_RADIUS_DEG } from '@/app/lib/masterConfig';
 import type { Location, WindyWebcam } from '@/app/lib/types';
 import { classifyWebcamsByPhase } from './webcamClassification';
 
@@ -61,8 +62,30 @@ export async function classifyCustomCamerasForTick(opts: {
     opts.sunsetCoords,
   );
 
+  function minDistToCoords(lat: number, lng: number, coords: Location[]): number {
+    return Math.min(
+      ...coords.map((coord) =>
+        Math.sqrt(
+          Math.pow(lng - coord.lng, 2) + Math.pow(lat - coord.lat, 2),
+        ),
+      ),
+    );
+  }
+
+  const filteredSunrise = sunrise.filter((w) => {
+    const row = rows.find((r) => r.webcam_id === (w.webcamId as number));
+    if (!row) return false;
+    return minDistToCoords(row.lat, row.lng, opts.sunriseCoords) <= SEARCH_RADIUS_DEG;
+  });
+
+  const filteredSunset = sunset.filter((w) => {
+    const row = rows.find((r) => r.webcam_id === (w.webcamId as number));
+    if (!row) return false;
+    return minDistToCoords(row.lat, row.lng, opts.sunsetCoords) <= SEARCH_RADIUS_DEG;
+  });
+
   return {
-    sunrise: sunrise.map((w) => ({ webcamId: w.webcamId as number })),
-    sunset: sunset.map((w) => ({ webcamId: w.webcamId as number })),
+    sunrise: filteredSunrise.map((w) => ({ webcamId: w.webcamId as number })),
+    sunset: filteredSunset.map((w) => ({ webcamId: w.webcamId as number })),
   };
 }

--- a/app/api/cron/update-cameras/lib/customClassification.ts
+++ b/app/api/cron/update-cameras/lib/customClassification.ts
@@ -1,0 +1,68 @@
+import { sql } from '@/app/lib/db';
+import type { Location, WindyWebcam } from '@/app/lib/types';
+import { classifyWebcamsByPhase } from './webcamClassification';
+
+interface CustomCamRow {
+  webcam_id: number;
+  lat: number;
+  lng: number;
+}
+
+export interface CustomTerminatorRow {
+  webcamId: number;
+}
+
+export async function classifyCustomCamerasForTick(opts: {
+  sunriseCoords: Location[];
+  sunsetCoords: Location[];
+  freshnessWindowMinutes: number;
+  now: Date;
+}): Promise<{
+  sunrise: CustomTerminatorRow[];
+  sunset: CustomTerminatorRow[];
+}> {
+  const cutoff = new Date(
+    opts.now.getTime() - opts.freshnessWindowMinutes * 60_000,
+  );
+
+  const rows = (await sql`
+    select w.id as webcam_id, w.lat, w.lng
+    from webcams w
+    where w.source = 'custom'
+      and exists (
+        select 1 from webcam_snapshots s
+        where s.webcam_id = w.id
+          and s.captured_at >= ${cutoff}
+      )
+  `) as CustomCamRow[];
+
+  if (rows.length === 0) {
+    return { sunrise: [], sunset: [] };
+  }
+
+  // Shape into the WindyWebcam-ish form classifyWebcamsByPhase consumes.
+  // Only `webcamId` and `location.{latitude,longitude}` are read; required
+  // fields per the WindyWebcam interface get empty/zero defaults.
+  const shaped: WindyWebcam[] = rows.map((r) => ({
+    webcamId: r.webcam_id,
+    title: '',
+    viewCount: 0,
+    status: 'unknown',
+    categories: [],
+    location: {
+      latitude: r.lat,
+      longitude: r.lng,
+    },
+  }));
+
+  const { sunrise, sunset } = classifyWebcamsByPhase(
+    shaped,
+    opts.sunriseCoords,
+    opts.sunsetCoords,
+  );
+
+  return {
+    sunrise: sunrise.map((w) => ({ webcamId: w.webcamId as number })),
+    sunset: sunset.map((w) => ({ webcamId: w.webcamId as number })),
+  };
+}

--- a/app/api/cron/update-cameras/lib/dbOperations.test.ts
+++ b/app/api/cron/update-cameras/lib/dbOperations.test.ts
@@ -7,7 +7,38 @@ vi.mock('@/app/lib/db', () => ({
     sqlMock(strings, ...values),
 }));
 
-import { deactivateMissingTerminatorState } from './dbOperations';
+import { deactivateMissingTerminatorState, upsertTerminatorState } from './dbOperations';
+
+describe('upsertTerminatorState', () => {
+  beforeEach(() => {
+    sqlMock.mockReset();
+    sqlMock.mockResolvedValue(undefined);
+  });
+
+  it('upserts rows with pre-resolved DB webcam_id and array-index rank', async () => {
+    await upsertTerminatorState(
+      [
+        { webcamId: 42 },
+        { webcamId: 7 },
+      ],
+      'sunrise',
+    );
+
+    expect(sqlMock).toHaveBeenCalledTimes(2);
+
+    // Verify the first call passes webcamId=42, phase='sunrise', rank=0
+    const [, ...firstCallValues] = sqlMock.mock.calls[0];
+    expect(firstCallValues).toContain(42);
+    expect(firstCallValues).toContain('sunrise');
+    expect(firstCallValues).toContain(0);
+
+    // Verify the second call passes webcamId=7, phase='sunrise', rank=1
+    const [, ...secondCallValues] = sqlMock.mock.calls[1];
+    expect(secondCallValues).toContain(7);
+    expect(secondCallValues).toContain('sunrise');
+    expect(secondCallValues).toContain(1);
+  });
+});
 
 describe('deactivateMissingTerminatorState', () => {
   beforeEach(() => {

--- a/app/api/cron/update-cameras/lib/dbOperations.test.ts
+++ b/app/api/cron/update-cameras/lib/dbOperations.test.ts
@@ -46,21 +46,19 @@ describe('deactivateMissingTerminatorState', () => {
     sqlMock.mockResolvedValue([]);
   });
 
-  it('only touches windy-sourced rows when active list is empty', async () => {
+  it('deactivates rows of any source when active list is empty', async () => {
     await deactivateMissingTerminatorState('sunset', []);
 
     expect(sqlMock).toHaveBeenCalledTimes(1);
-    const [strings] = sqlMock.mock.calls[0];
-    const fullQuery = strings.join('?');
-    expect(fullQuery).toMatch(/source\s*=\s*'windy'/);
+    const firstCallStrings = sqlMock.mock.calls[0][0] as readonly string[];
+    expect(firstCallStrings.join(' ')).not.toContain("source = 'windy'");
   });
 
-  it('only touches windy-sourced rows when an active list is provided', async () => {
+  it('deactivates rows of any source not in the active set', async () => {
     await deactivateMissingTerminatorState('sunrise', [42, 99]);
 
     expect(sqlMock).toHaveBeenCalledTimes(1);
-    const [strings] = sqlMock.mock.calls[0];
-    const fullQuery = strings.join('?');
-    expect(fullQuery).toMatch(/source\s*=\s*'windy'/);
+    const firstCallStrings = sqlMock.mock.calls[0][0] as readonly string[];
+    expect(firstCallStrings.join(' ')).not.toContain("source = 'windy'");
   });
 });

--- a/app/api/cron/update-cameras/lib/dbOperations.ts
+++ b/app/api/cron/update-cameras/lib/dbOperations.ts
@@ -125,18 +125,16 @@ export async function getWebcamIdMap(
 }
 
 /**
- * Upsert terminator state entries (upsert-only, no delete-all)
- * Uses last_seen_at for query-time filtering instead of bulk deletes
+ * Upsert terminator-state rows from pre-resolved DB webcam ids.
+ * Rank is the array index. Caller is responsible for any ordering
+ * decisions (sort, union, dedupe) before passing the array in.
  */
 export async function upsertTerminatorState(
-  webcams: WindyWebcam[],
+  rows: Array<{ webcamId: number }>,
   phase: 'sunrise' | 'sunset',
-  idByExternal: Map<string, number>
 ): Promise<void> {
-  const promises = webcams.map(async (w, rank) => {
-    const webcamId = idByExternal.get(String(w.webcamId));
-    if (!webcamId) return;
-
+  const promises = rows.map(async (row, rank) => {
+    const { webcamId } = row;
     await sql`
       insert into terminator_webcam_state (webcam_id, phase, rank, last_seen_at, updated_at, active)
       values (${webcamId}, ${phase}, ${rank}, now(), now(), true)

--- a/app/api/cron/update-cameras/lib/dbOperations.ts
+++ b/app/api/cron/update-cameras/lib/dbOperations.ts
@@ -150,35 +150,30 @@ export async function upsertTerminatorState(
 }
 
 /**
- * Deactivate terminator state entries that are no longer in the current ring results
- * This keeps "active" aligned with the latest ring-based fetch.
+ * Flip rows in this phase to active=false unless their webcam_id is in
+ * activeWebcamIds. Source-agnostic: caller is responsible for unioning
+ * active ids across Windy + custom (or any other source) before calling.
  */
 export async function deactivateMissingTerminatorState(
   phase: 'sunrise' | 'sunset',
-  activeWebcamIds: number[]
+  activeWebcamIds: number[],
 ): Promise<void> {
   if (activeWebcamIds.length === 0) {
     await sql`
-      update terminator_webcam_state s
+      update terminator_webcam_state
       set active = false, updated_at = now()
-      from webcams w
-      where s.webcam_id = w.id
-        and w.source = 'windy'
-        and s.phase = ${phase}
-        and s.active = true
+      where phase = ${phase}
+        and active = true
     `;
     return;
   }
 
   await sql`
-    update terminator_webcam_state s
+    update terminator_webcam_state
     set active = false, updated_at = now()
-    from webcams w
-    where s.webcam_id = w.id
-      and w.source = 'windy'
-      and s.phase = ${phase}
-      and s.active = true
-      and s.webcam_id <> all(${activeWebcamIds})
+    where phase = ${phase}
+      and active = true
+      and webcam_id <> all(${activeWebcamIds})
   `;
 }
 

--- a/app/api/cron/update-cameras/route.test.ts
+++ b/app/api/cron/update-cameras/route.test.ts
@@ -15,6 +15,7 @@ const scoreMock = vi.fn();
 const getHashMock = vi.fn();
 const setHashMock = vi.fn();
 const backfillMock = vi.fn();
+const customClassifyMock = vi.fn();
 const upsertStatsMock = vi.fn();
 const verifyAuthMock = vi.fn(() => true);
 const computeTickStatsMock = vi.fn();
@@ -56,6 +57,9 @@ vi.mock('./lib/aiScoring', () => ({
 vi.mock('./lib/customBackfill', () => ({
   backfillCustomSnapshotScores: (...a: unknown[]) => backfillMock(...a),
 }));
+vi.mock('./lib/customClassification', () => ({
+  classifyCustomCamerasForTick: (...a: unknown[]) => customClassifyMock(...a),
+}));
 vi.mock('./lib/dailyStats', () => ({
   computeTickStats: (...a: unknown[]) => computeTickStatsMock(...a),
   upsertDailyStats: (...a: unknown[]) => upsertStatsMock(...a),
@@ -89,6 +93,7 @@ beforeEach(() => {
     imageHash: 'newhash', source: 'windy', pathTaken: 'onnx',
   });
   backfillMock.mockReset().mockResolvedValue({ scored: 0, failed: 0, modelVersion: null, scores: [] });
+  customClassifyMock.mockReset().mockResolvedValue({ sunrise: [], sunset: [] });
   upsertStatsMock.mockReset().mockResolvedValue(undefined);
   setCachedMock.mockReset().mockResolvedValue(undefined);
   fetchTerminatorWebcamsMock.mockReset().mockResolvedValue([]);

--- a/app/api/cron/update-cameras/route.test.ts
+++ b/app/api/cron/update-cameras/route.test.ts
@@ -153,4 +153,68 @@ describe('GET /api/cron/update-cameras', () => {
     expect(scoreMock).not.toHaveBeenCalled();
     expect(backfillMock).not.toHaveBeenCalled();
   });
+
+  it('unions custom cams into the upsert active set', async () => {
+    classifyMock.mockReturnValue({
+      sunrise: [{ webcamId: 'wA', location: { latitude: 0, longitude: 0 } }],
+      sunset: [],
+    });
+    getIdMapMock.mockResolvedValue(new Map([['wA', 1]]));
+    customClassifyMock.mockResolvedValue({
+      sunrise: [{ webcamId: 999 }],
+      sunset: [],
+    });
+
+    const res = await GET(makeReq());
+    expect(res.status).toBe(200);
+
+    const sunriseUpsertCall = upsertStateMock.mock.calls.find(
+      (c) => c[1] === 'sunrise',
+    );
+    expect(sunriseUpsertCall).toBeDefined();
+    const rows = sunriseUpsertCall![0] as Array<{ webcamId: number }>;
+    expect(rows.map((r) => r.webcamId).sort()).toEqual([1, 999]);
+  });
+
+  it('passes the union of ids to deactivateMissingTerminatorState', async () => {
+    classifyMock.mockReturnValue({
+      sunrise: [{ webcamId: 'wA', location: { latitude: 0, longitude: 0 } }],
+      sunset: [],
+    });
+    getIdMapMock.mockResolvedValue(new Map([['wA', 1]]));
+    customClassifyMock.mockResolvedValue({
+      sunrise: [{ webcamId: 999 }],
+      sunset: [],
+    });
+
+    const res = await GET(makeReq());
+    expect(res.status).toBe(200);
+
+    const sunriseDeactCall = deactivateMock.mock.calls.find(
+      (c) => c[0] === 'sunrise',
+    );
+    expect(sunriseDeactCall).toBeDefined();
+    expect((sunriseDeactCall![1] as number[]).sort()).toEqual([1, 999]);
+  });
+
+  it('skips upsert/deactivate for empty buckets gracefully', async () => {
+    classifyMock.mockReturnValue({ sunrise: [], sunset: [] });
+    getIdMapMock.mockResolvedValue(new Map());
+    customClassifyMock.mockResolvedValue({ sunrise: [], sunset: [] });
+
+    const res = await GET(makeReq());
+    expect(res.status).toBe(200);
+
+    // Empty buckets must still flow through upsert + deactivate — otherwise a
+    // future "optimize away empty arrays" change would silently break the
+    // deactivation contract (rows would never get flipped to active=false
+    // when the active set is empty).
+    const sunriseUpsertCall = upsertStateMock.mock.calls.find((c) => c[1] === 'sunrise');
+    expect(sunriseUpsertCall).toBeDefined();
+    expect(sunriseUpsertCall![0]).toEqual([]);
+
+    const sunriseDeactCall = deactivateMock.mock.calls.find((c) => c[0] === 'sunrise');
+    expect(sunriseDeactCall).toBeDefined();
+    expect(sunriseDeactCall![1]).toEqual([]);
+  });
 });

--- a/app/api/cron/update-cameras/route.ts
+++ b/app/api/cron/update-cameras/route.ts
@@ -25,7 +25,9 @@ import {
   TERMINATOR_SUN_ALTITUDE_DEG,
   WINDY_FETCH_BATCH_SIZE,
   WINDY_FETCH_DELAY_BETWEEN_BATCHES_MS,
+  CUSTOM_CAM_FRESHNESS_WINDOW_MINUTES,
 } from '@/app/lib/masterConfig';
+import { classifyCustomCamerasForTick } from './lib/customClassification';
 import { verifyCronAuth } from './lib/auth';
 import {
   dedupeCoords,
@@ -214,15 +216,47 @@ export async function GET(req: Request) {
     customBackfill: backfillResult,
   });
 
-  // Resolve Windy external_id → DB webcam_id once for both upsert + deactivate
-  function toDbRows(list: typeof sunriseList) {
+  // Resolve Windy external_id → DB webcam_id rows
+  function toWindyDbRows(list: typeof sunriseList) {
     return list
       .map((w) => idByExternal.get(String(w.webcamId)))
       .filter((id): id is number => id !== undefined)
       .map((webcamId) => ({ webcamId }));
   }
-  const sunriseRows = toDbRows(sunriseList);
-  const sunsetRows = toDbRows(sunsetList);
+  const sunriseWindyRows = toWindyDbRows(sunriseList);
+  const sunsetWindyRows = toWindyDbRows(sunsetList);
+
+  // Classify custom cams against the same ring coords + freshness window
+  const customClassified = await classifyCustomCamerasForTick({
+    sunriseCoords,
+    sunsetCoords,
+    freshnessWindowMinutes: CUSTOM_CAM_FRESHNESS_WINDOW_MINUTES,
+    now,
+  });
+
+  // Union Windy + custom by webcamId, Windy first (preserves Windy lat-sorted rank).
+  function unionByWebcamId(
+    primary: Array<{ webcamId: number }>,
+    secondary: Array<{ webcamId: number }>,
+  ): Array<{ webcamId: number }> {
+    const seen = new Set<number>();
+    const out: Array<{ webcamId: number }> = [];
+    for (const r of primary) {
+      if (!seen.has(r.webcamId)) {
+        seen.add(r.webcamId);
+        out.push(r);
+      }
+    }
+    for (const r of secondary) {
+      if (!seen.has(r.webcamId)) {
+        seen.add(r.webcamId);
+        out.push(r);
+      }
+    }
+    return out;
+  }
+  const sunriseRows = unionByWebcamId(sunriseWindyRows, customClassified.sunrise);
+  const sunsetRows = unionByWebcamId(sunsetWindyRows, customClassified.sunset);
 
   await upsertTerminatorState(sunriseRows, 'sunrise');
   await upsertTerminatorState(sunsetRows, 'sunset');

--- a/app/api/cron/update-cameras/route.ts
+++ b/app/api/cron/update-cameras/route.ts
@@ -300,8 +300,8 @@ export async function GET(req: Request) {
 
   return NextResponse.json({
     ok: true,
-    sunrise: sunriseList.length,
-    sunset: sunsetList.length,
+    sunrise: sunriseRows.length,
+    sunset: sunsetRows.length,
     windyScored: windyScores.length,
     cacheHits,
     fallbacks,

--- a/app/api/cron/update-cameras/route.ts
+++ b/app/api/cron/update-cameras/route.ts
@@ -214,19 +214,21 @@ export async function GET(req: Request) {
     customBackfill: backfillResult,
   });
 
-  // Upsert terminator state for sunrise webcams
-  await upsertTerminatorState(sunriseList, 'sunrise', idByExternal);
+  // Resolve Windy external_id → DB webcam_id once for both upsert + deactivate
+  function toDbRows(list: typeof sunriseList) {
+    return list
+      .map((w) => idByExternal.get(String(w.webcamId)))
+      .filter((id): id is number => id !== undefined)
+      .map((webcamId) => ({ webcamId }));
+  }
+  const sunriseRows = toDbRows(sunriseList);
+  const sunsetRows = toDbRows(sunsetList);
 
-  // Upsert terminator state for sunset webcams
-  await upsertTerminatorState(sunsetList, 'sunset', idByExternal);
+  await upsertTerminatorState(sunriseRows, 'sunrise');
+  await upsertTerminatorState(sunsetRows, 'sunset');
 
-  // Deactivate entries that are no longer in the current ring results
-  const sunriseIds = sunriseList
-    .map((w) => idByExternal.get(String(w.webcamId)))
-    .filter((id): id is number => id !== undefined);
-  const sunsetIds = sunsetList
-    .map((w) => idByExternal.get(String(w.webcamId)))
-    .filter((id): id is number => id !== undefined);
+  const sunriseIds = sunriseRows.map((r) => r.webcamId);
+  const sunsetIds = sunsetRows.map((r) => r.webcamId);
   await deactivateMissingTerminatorState('sunrise', sunriseIds);
   await deactivateMissingTerminatorState('sunset', sunsetIds);
 

--- a/app/lib/masterConfig.ts
+++ b/app/lib/masterConfig.ts
@@ -34,6 +34,13 @@ export const SEARCH_RADIUS_DEG = 9; // Search radius per API call in degrees
 // 0 = main ring, positive values shift the ring westward from the subsolar geometry.
 export const TERMINATOR_RING_OFFSETS_DEG = [0]; //was   0,1.75 * SEARCH_RADIUS_DEG,//was 1,.75
 
+// How recent a custom camera's most-recent snapshot must be for the camera
+// to qualify for terminator visibility. Mirrors Windy's "API returned it
+// this tick" semantics — custom cams without a fresh capture are
+// effectively unobservable and should fall off the map.
+// Default 90 min: covers the protocol's 75-min active window + upload buffer.
+export const CUSTOM_CAM_FRESHNESS_WINDOW_MINUTES = 90;
+
 // Circle rendering precision: how smooth the circle polygon is (number of points)
 // Using SEARCH_RADIUS_DEG ensures the circle detail matches the search area size
 export const CIRCLE_RENDERING_PRECISION_DEG = SEARCH_RADIUS_DEG;

--- a/docs/superpowers/specs/2026-05-16-ai-rating-silhouette-sunset-blind-spot-stub.md
+++ b/docs/superpowers/specs/2026-05-16-ai-rating-silhouette-sunset-blind-spot-stub.md
@@ -1,0 +1,52 @@
+# AI Rating — Silhouette-Sunset Blind Spot
+
+Status: Stub — 2026-05-16
+Owner: Jesse Kauppila
+Loosely connected to: `AI_RATINGS_V2_PLAN.md`, `ml/` training pipeline.
+
+---
+
+## Observation
+
+On 2026-05-16 at ~21:35 PDT, the Tier 0 test camera (Bellingham, WA — lat 48.7519, lng −122.4787) captured a sunset image with:
+
+- Sky filled with sunset colors (orange/red/gradient)
+- Dark foreground silhouettes (the typical "great sunset photo" composition)
+- The sun itself not in the frame (camera points at the horizon but not directly at the setting sun's azimuth)
+
+The AI rating returned was **0.21** (on whatever the active scoring scale is — regression model from `customBackfill.modelVersion: 20260315_003913_v2_regression_mild_crop`).
+
+By any photographic standard, this is a high-quality sunset image. The scoring model rated it badly anyway.
+
+## What this suggests
+
+The rating model is probably treating "sun visible in frame" as a strong positive signal — likely because most of the training labels for "good sunset" came from images where the sun is visible. Silhouette-and-color compositions, which are widely considered *better* photography (no blown highlights, more atmospheric gradients, more compositional interest), look feature-wise like "non-sunset" to a model trained that way.
+
+This is a **training distribution gap**, not an architecture gap. The model is doing its job for the labels it was given; the labels don't represent how humans actually judge sunset quality.
+
+## Why this matters
+
+The whole point of the AI ranker is to surface the *best* sunsets to the kiosk / mosaic / display. If a substantial fraction of objectively-great sunsets score low (because they happen to lack the sun's disk in frame), they'll be perpetually demoted in the queue and never surface, regardless of how stunning they are.
+
+Worse: this bias is invisible during normal operation — you'd only notice it by spot-checking low-scored images, which nobody is going to do at scale.
+
+## Possible directions (not yet a real spec)
+
+- **Re-label / augment training data** with explicit "silhouette sunset" examples scored highly by humans. Cheapest fix, biggest payoff if it works.
+- **Two-headed model:** one for "sunset content present at all" (binary), one for "quality of that sunset" (regression). Decouples detection from quality.
+- **Feature-level audit:** generate Grad-CAM or saliency maps for low-scored silhouette images and confirm the model is fixating on the missing sun rather than the sky color.
+- **Human-in-the-loop calibration:** when users star a sunset image highly, surface a few similar low-AI-rated images for label correction.
+
+## What this stub doesn't try to do
+
+Decide which of the above to pursue. Decide on a metric. Decide on a dataset. Decide on a model architecture. This is a flagged observation — turns into a real spec only after someone (probably you, when next looking at ML) decides this finding is worth a model iteration.
+
+## Linkage
+
+- [[2026-05-15-custom-cam-visibility-single-source-of-truth-design]] — the visibility fix that surfaced this image to the cron in the first place; without the fix, this image wouldn't have been observable.
+- [[2026-05-16-device-diagnostics-clock-and-black-image-stub]] — adjacent device-side concerns; orthogonal to this scoring issue.
+- `AI_RATINGS_V2_PLAN.md` — the existing roadmap for the rating model; this finding belongs in its backlog.
+
+## When this becomes a real spec
+
+When someone surveys ~50 low-rated images from the kiosk/mosaic candidate pool, finds that more than a handful are misjudged silhouette/color sunsets, and decides the fix is worth a training cycle.

--- a/docs/superpowers/specs/2026-05-16-device-diagnostics-clock-and-black-image-stub.md
+++ b/docs/superpowers/specs/2026-05-16-device-diagnostics-clock-and-black-image-stub.md
@@ -15,16 +15,18 @@ Two symptoms observed on the field-deployed Pi Zero 2 W test camera (lat 48.7519
 
 Both symptoms originate at the device, not in the cloud. Server-side accepts whatever the device sends.
 
-## Hypothesis: Single Root Cause
+## Hypothesis: Two Decoupled Problems
 
-The two symptoms are likely **the same bug** seen from two angles. The device firmware:
+**Updated 2026-05-16 22:00 PDT after a second sunset of observation.**
 
-- Computes its own local sunrise/sunset windows via an `astral`-style library against its onboard clock (see `pi-webcam-mvp.md` §2 — "Active window = 45 min before sunrise to 30 min after, etc.").
-- If the onboard clock is set ~7 hours ahead of real time, the device's "active window" maps to a real-world time that is fully dark.
-- The shutter opens; the sensor sees nothing; the snapshot is solid black.
-- The same skewed clock then stamps `captured_at` with a future ISO timestamp at upload time.
+The initial hypothesis was that both symptoms shared a root cause: a wrong clock would shift the active window into real-world darkness and produce black images, while also stamping uploads with future timestamps. Both predictions are *consistent* with the clock-drift hypothesis.
 
-**One hypothesis, two predictions, both consistent with what we observe.**
+But the second night of testing showed the camera producing real, well-exposed sunset imagery — *while still uploading future-stamped snapshots*. If clock drift caused the black images, every image should be black. They aren't. So:
+
+- **The clock drift is real and persistent.** Confirmed twice. Likely a `datetime.now()` vs `datetime.utcnow()` confusion in the upload path (the +7h offset matches PDT/UTC arithmetic exactly).
+- **The black image from 2026-05-15 was likely transient.** Probably weather (heavy overcast at golden hour), a startup driver glitch, or a one-off exposure error. Will know once we have several nights of observation under varied conditions.
+
+Treat these as two independent items. The clock fix is small and obvious. The intermittent black-image issue needs more data points before it's worth a real diagnosis — collect another week of snapshots and look for a pattern (does it correlate with weather, time-of-night, reboots, anything?).
 
 A secondary consequence: this also explains why the cam appeared at "wrong" times on the map before the visibility fix landed. The freshness predicate the cloud cron uses (`captured_at >= now - 90min`) is trivially satisfied by future timestamps, so the cam was "always fresh" regardless of when it actually captured. Once a real geometric predicate landed, the geographic gating started working — but freshness is still effectively a no-op for this device until the clock is fixed.
 

--- a/docs/superpowers/specs/2026-05-16-device-diagnostics-clock-and-black-image-stub.md
+++ b/docs/superpowers/specs/2026-05-16-device-diagnostics-clock-and-black-image-stub.md
@@ -1,0 +1,66 @@
+# Device Diagnostics — Clock Drift + Black Image
+
+Status: Stub — 2026-05-16
+Owner: Jesse Kauppila
+Subproject B of the post-MVP visibility/AR/hardware decomposition.
+
+---
+
+## Problem
+
+Two symptoms observed on the field-deployed Pi Zero 2 W test camera (lat 48.7519, lng −122.4787, "Tier 0 Test Camera — Jesse House"):
+
+1. **Black images.** Snapshots captured during the device's active window — uploaded to Firebase and scored normally — are visually solid black or near-black. AI scoring still runs but on no real content.
+2. **Future-stamped snapshots.** The `captured_at` value attached to uploaded snapshots is ~7 hours in the future. Observed example on 2026-05-16: device-side cron-tick payload showed `snapAt=2026-05-17T11:29:58.396Z` returned by the API while server-side `now()` was `2026-05-17T04:36Z` UTC.
+
+Both symptoms originate at the device, not in the cloud. Server-side accepts whatever the device sends.
+
+## Hypothesis: Single Root Cause
+
+The two symptoms are likely **the same bug** seen from two angles. The device firmware:
+
+- Computes its own local sunrise/sunset windows via an `astral`-style library against its onboard clock (see `pi-webcam-mvp.md` §2 — "Active window = 45 min before sunrise to 30 min after, etc.").
+- If the onboard clock is set ~7 hours ahead of real time, the device's "active window" maps to a real-world time that is fully dark.
+- The shutter opens; the sensor sees nothing; the snapshot is solid black.
+- The same skewed clock then stamps `captured_at` with a future ISO timestamp at upload time.
+
+**One hypothesis, two predictions, both consistent with what we observe.**
+
+A secondary consequence: this also explains why the cam appeared at "wrong" times on the map before the visibility fix landed. The freshness predicate the cloud cron uses (`captured_at >= now - 90min`) is trivially satisfied by future timestamps, so the cam was "always fresh" regardless of when it actually captured. Once a real geometric predicate landed, the geographic gating started working — but freshness is still effectively a no-op for this device until the clock is fixed.
+
+## Why the Pi clock would be wrong
+
+The Pi Zero 2 W has **no battery-backed RTC.** On boot it has no idea what time it is. The standard recovery is:
+
+- `systemd-timesyncd` polls NTP and sets the system clock.
+- If NTP is blocked by the local network, misconfigured in `/etc/systemd/timesyncd.conf`, or the service is failing, the clock stays at whatever the kernel decides on boot (often Jan 1 1970, but also sometimes whatever the filesystem mtime hints at).
+
+The **specific +7 hour skew** is suspicious. Possibilities, in rough order of likelihood:
+
+1. **Timezone double-conversion.** Pacific (PDT, UTC−7) is exactly 7 hours behind UTC. Code that takes a local-time wallclock value and stamps it as if it were UTC would produce snapshots 7 hours in the future during PDT. The arithmetic matches *exactly*.
+2. **NTP succeeded but UTC offset got added twice somewhere** in the capture-and-upload pipeline (Python's `datetime.now()` vs `datetime.utcnow()` confusion, or naive datetime → ISO string assuming local but treating as UTC).
+3. **Clock got set from an HTTP `Date` header in the wrong reference** — less likely, but the firmware does talk to the cloud on boot for registration.
+
+Hypothesis 1 is the most testable: if the device thinks "now" is 2026-05-17 04:30 PDT but the firmware stamps it as "2026-05-17T04:30Z UTC", the resulting timestamp will be 7 hours in the future of true UTC.
+
+## How to diagnose (in priority order)
+
+1. **SSH into the Pi.** Run `date`, `timedatectl`, and `cat /etc/timezone`. Compare to wallclock. If `date` reports the correct local time and `timedatectl` says NTP is synced and UTC is correct, then the bug is in the firmware's timestamp serialization (Hypothesis 1). If `date` is already wrong, then NTP is failing.
+2. **Look at the snapshot-emitting Python code.** Search the firmware repo for `datetime.now()`, `datetime.utcnow()`, `isoformat()`, `astimezone()`. Any path that builds the `captured_at` string from a naive datetime is a smoking gun.
+3. **If suspicion lands on the active-window math:** add a debug log line on the device that prints `[active-window-check] now={now_iso} sunrise_today={sunrise_iso} sunset_today={sunset_iso} in_window={bool}` once per tick. Watch for a tick where `now` and `in_window` disagree with real-world conditions.
+4. **Confirm black-image causality:** force the device to capture *outside* its computed active window (manual trigger). If the resulting image is well-exposed, the active-window math is the bug. If it's still black, the sensor / driver / lens is also at fault, separately.
+
+## Out of scope for this stub
+
+- **Image-quality tuning** (ISO, shutter, lens). Separate from the timing bug. Defer until clock is verified-correct and a real golden-hour snapshot is captured.
+- **Hardware mounting / orientation** ("which way is up"). That's Subproject C.
+- **Server-side guards** against future timestamps. Explicitly *not* fixing this in the cloud — masking the symptom would prevent diagnosis of the device-side root cause.
+
+## Linkage
+
+- [[2026-05-15-custom-cam-visibility-single-source-of-truth-design]] — the visibility fix that surfaced this bug. The freshness predicate is no-op'd by the clock skew but still correct in principle.
+- Future Subproject C ("which way is up") — black-image cause is split between *timing* (this spec) and *orientation* (subproject C). After timing is fixed, if the image is still bad, the orientation hypothesis becomes the leading one.
+
+## When this becomes a real spec
+
+When someone (probably you, with SSH access to the Pi) runs the diagnostic steps above and identifies which hypothesis is correct. The full spec then proposes the firmware-side fix (NTP enforcement, timestamp serialization correction, or both) and the verification plan (round-trip a known-good snapshot during a real golden hour).


### PR DESCRIPTION
## Summary
- Custom Pi cameras now appear/disappear on the map by the exact same ring + radius predicate that governs Windy webcams, plus a 90-minute snapshot-freshness window so stale/offline cams fall off cleanly.
- Refactors `upsertTerminatorState` / `deactivateMissingTerminatorState` to be source-agnostic (the spec called them "unchanged" but on inspection they were Windy-coupled — the deviation is documented in the plan).
- New module `app/api/cron/update-cameras/lib/customClassification.ts` fetches custom cams with a fresh snapshot and runs them through the same `classifyWebcamsByPhase` math; results are unioned with Windy before upsert.

**Spec:** `docs/superpowers/specs/2026-05-15-custom-cam-visibility-single-source-of-truth-design.md`
**Plan:** `docs/superpowers/plans/2026-05-16-custom-cam-visibility-single-source-of-truth.md`

## Behavior change at deploy time
On the first cron tick after this lands, any custom row currently `active=true` outside the ring/freshness predicate will flip to `active=false`. **This is the intended fix** — custom cams were previously stuck on the map regardless of where the sun was. Not a regression.

Verification SQL:
```sql
select s.webcam_id, s.phase, s.active, s.last_seen_at, w.lat, w.lng
from terminator_webcam_state s
join webcams w on w.id = s.webcam_id
where w.source = 'custom'
order by s.updated_at desc;
```

## Test plan
- [ ] `npx vitest run app/api/cron/update-cameras` — 40/40 pass
- [ ] `npx tsc --noEmit` — no new errors in cron/customClassification/masterConfig files
- [ ] Local cron run with real test camera at sunset — confirm `active=true` only when ring is sweeping over it AND a snapshot is recent
- [ ] Visit the map and verify the dot appears/disappears in sync with the rendered ring

## Known follow-ups (non-blocking)
- Unnecessary `as number` cast in `customClassification.ts:65-66` — cosmetic.
- Spec §6.1 mentions a "distance-order rank" test that doesn't exist; the spec is internally inconsistent (§5.3 says latitude order, which is what the implementation does). Worth adding a small latitude-order test for traceability later.
- `toWindyDbRows` and `unionByWebcamId` are local to the GET handler; hoist if a third source is added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)