### PR TITLE
feat(cron): one predicate for Windy + custom camera visibility

### DIFF
--- a/app/api/cron/update-cameras/lib/customClassification.test.ts
+++ b/app/api/cron/update-cameras/lib/customClassification.test.ts
@@ -63,6 +63,23 @@ describe('classifyCustomCamerasForTick', () => {
     expect(sunset).toEqual([]);
   });
 
+  it('excludes cams beyond SEARCH_RADIUS_DEG even if closer to one phase', async () => {
+    // Cam at (50, 50): nearest to sunriseCoords (0,0) at ~70° distance, far beyond 9°
+    sqlMock.mockResolvedValue([
+      { webcam_id: 999, lat: 50, lng: 50 },
+    ]);
+
+    const { sunrise, sunset } = await classifyCustomCamerasForTick({
+      sunriseCoords: [{ lat: 0, lng: 0 }],
+      sunsetCoords: [{ lat: 0, lng: 180 }],
+      freshnessWindowMinutes: 90,
+      now: new Date('2026-05-15T00:00:00Z'),
+    });
+
+    expect(sunrise).toEqual([]);
+    expect(sunset).toEqual([]);
+  });
+
   it('passes freshness threshold into the SQL parameters', async () => {
     sqlMock.mockResolvedValue([]);
     const now = new Date('2026-05-15T12:00:00Z');

--- a/app/api/cron/update-cameras/lib/customClassification.test.ts
+++ b/app/api/cron/update-cameras/lib/customClassification.test.ts
@@ -1,0 +1,85 @@
+// @vitest-environment node
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const sqlMock = vi.fn();
+vi.mock('@/app/lib/db', () => ({
+  sql: (...args: unknown[]) => sqlMock(...args),
+}));
+
+import { classifyCustomCamerasForTick } from './customClassification';
+
+beforeEach(() => {
+  sqlMock.mockReset();
+});
+
+describe('classifyCustomCamerasForTick', () => {
+  const sunriseCoords = [{ lat: 0, lng: 0 }];
+  const sunsetCoords = [{ lat: 0, lng: 180 }];
+
+  it('returns rows in sunrise bucket for cams near sunriseCoords', async () => {
+    sqlMock.mockResolvedValue([
+      { webcam_id: 101, lat: 0.1, lng: 0.1 },
+      { webcam_id: 102, lat: -0.1, lng: 0.2 },
+    ]);
+
+    const { sunrise, sunset } = await classifyCustomCamerasForTick({
+      sunriseCoords,
+      sunsetCoords,
+      freshnessWindowMinutes: 90,
+      now: new Date('2026-05-15T00:00:00Z'),
+    });
+
+    expect(sunrise.map((r) => r.webcamId).sort()).toEqual([101, 102]);
+    expect(sunset).toEqual([]);
+  });
+
+  it('places cams in sunset bucket when nearer sunsetCoords', async () => {
+    sqlMock.mockResolvedValue([
+      { webcam_id: 200, lat: 0, lng: 179 },
+    ]);
+
+    const { sunrise, sunset } = await classifyCustomCamerasForTick({
+      sunriseCoords,
+      sunsetCoords,
+      freshnessWindowMinutes: 90,
+      now: new Date('2026-05-15T00:00:00Z'),
+    });
+
+    expect(sunrise).toEqual([]);
+    expect(sunset.map((r) => r.webcamId)).toEqual([200]);
+  });
+
+  it('returns empty arrays when SQL returns no rows', async () => {
+    sqlMock.mockResolvedValue([]);
+
+    const { sunrise, sunset } = await classifyCustomCamerasForTick({
+      sunriseCoords,
+      sunsetCoords,
+      freshnessWindowMinutes: 90,
+      now: new Date('2026-05-15T00:00:00Z'),
+    });
+
+    expect(sunrise).toEqual([]);
+    expect(sunset).toEqual([]);
+  });
+
+  it('passes freshness threshold into the SQL parameters', async () => {
+    sqlMock.mockResolvedValue([]);
+    const now = new Date('2026-05-15T12:00:00Z');
+
+    await classifyCustomCamerasForTick({
+      sunriseCoords,
+      sunsetCoords,
+      freshnessWindowMinutes: 90,
+      now,
+    });
+
+    // sqlMock receives the tagged-template strings + values. The freshness
+    // cutoff is a value at position 0 (the only one). It should be a Date
+    // 90 minutes before `now`.
+    const callValues = sqlMock.mock.calls[0].slice(1) as unknown[];
+    const passed = callValues[0] as Date;
+    const expected = new Date(now.getTime() - 90 * 60_000);
+    expect(passed.getTime()).toBe(expected.getTime());
+  });
+});

--- a/app/api/cron/update-cameras/lib/customClassification.ts
+++ b/app/api/cron/update-cameras/lib/customClassification.ts
@@ -1,4 +1,5 @@
 import { sql } from '@/app/lib/db';
+import { SEARCH_RADIUS_DEG } from '@/app/lib/masterConfig';
 import type { Location, WindyWebcam } from '@/app/lib/types';
 import { classifyWebcamsByPhase } from './webcamClassification';
 
@@ -64,8 +65,30 @@ export async function classifyCustomCamerasForTick(opts: {
     opts.sunsetCoords,
   );
 
+  function minDistToCoords(lat: number, lng: number, coords: Location[]): number {
+    return Math.min(
+      ...coords.map((coord) =>
+        Math.sqrt(
+          Math.pow(lng - coord.lng, 2) + Math.pow(lat - coord.lat, 2),
+        ),
+      ),
+    );
+  }
+
+  const filteredSunrise = sunrise.filter((w) => {
+    const row = rows.find((r) => r.webcam_id === (w.webcamId as number));
+    if (!row) return false;
+    return minDistToCoords(row.lat, row.lng, opts.sunriseCoords) <= SEARCH_RADIUS_DEG;
+  });
+
+  const filteredSunset = sunset.filter((w) => {
+    const row = rows.find((r) => r.webcam_id === (w.webcamId as number));
+    if (!row) return false;
+    return minDistToCoords(row.lat, row.lng, opts.sunsetCoords) <= SEARCH_RADIUS_DEG;
+  });
+
   return {
-    sunrise: sunrise.map((w) => ({ webcamId: w.webcamId as number })),
-    sunset: sunset.map((w) => ({ webcamId: w.webcamId as number })),
+    sunrise: filteredSunrise.map((w) => ({ webcamId: w.webcamId as number })),
+    sunset: filteredSunset.map((w) => ({ webcamId: w.webcamId as number })),
   };
 }

--- a/app/api/cron/update-cameras/lib/customClassification.ts
+++ b/app/api/cron/update-cameras/lib/customClassification.ts
@@ -1,0 +1,68 @@
+import { sql } from '@/app/lib/db';
+import type { Location, WindyWebcam } from '@/app/lib/types';
+import { classifyWebcamsByPhase } from './webcamClassification';
+
+interface CustomCamRow {
+  webcam_id: number;
+  lat: number;
+  lng: number;
+}
+
+export interface CustomTerminatorRow {
+  webcamId: number;
+}
+
+export async function classifyCustomCamerasForTick(opts: {
+  sunriseCoords: Location[];
+  sunsetCoords: Location[];
+  freshnessWindowMinutes: number;
+  now: Date;
+}): Promise<{
+  sunrise: CustomTerminatorRow[];
+  sunset: CustomTerminatorRow[];
+}> {
+  const cutoff = new Date(
+    opts.now.getTime() - opts.freshnessWindowMinutes * 60_000,
+  );
+
+  const rows = (await sql`
+    select w.id as webcam_id, w.lat, w.lng
+    from webcams w
+    where w.source = 'custom'
+      and exists (
+        select 1 from webcam_snapshots s
+        where s.webcam_id = w.id
+          and s.captured_at >= ${cutoff}
+      )
+  `) as CustomCamRow[];
+
+  if (rows.length === 0) {
+    return { sunrise: [], sunset: [] };
+  }
+
+  // Shape into the WindyWebcam-ish form classifyWebcamsByPhase consumes.
+  // Only `webcamId` and `location.{latitude,longitude}` are read; required
+  // fields per the WindyWebcam interface get empty/zero defaults.
+  const shaped: WindyWebcam[] = rows.map((r) => ({
+    webcamId: r.webcam_id,
+    title: '',
+    viewCount: 0,
+    status: 'unknown',
+    categories: [],
+    location: {
+      latitude: r.lat,
+      longitude: r.lng,
+    },
+  }));
+
+  const { sunrise, sunset } = classifyWebcamsByPhase(
+    shaped,
+    opts.sunriseCoords,
+    opts.sunsetCoords,
+  );
+
+  return {
+    sunrise: sunrise.map((w) => ({ webcamId: w.webcamId as number })),
+    sunset: sunset.map((w) => ({ webcamId: w.webcamId as number })),
+  };
+}

--- a/app/api/cron/update-cameras/lib/customClassification.ts
+++ b/app/api/cron/update-cameras/lib/customClassification.ts
@@ -4,8 +4,11 @@ import { classifyWebcamsByPhase } from './webcamClassification';
 
 interface CustomCamRow {
   webcam_id: number;
-  lat: number;
-  lng: number;
+  // Postgres NUMERIC columns come back from the Neon driver as strings.
+  // We coerce to number when building the shaped WindyWebcam below so
+  // downstream consumers see consistent numeric types.
+  lat: number | string;
+  lng: number | string;
 }
 
 export interface CustomTerminatorRow {
@@ -50,8 +53,8 @@ export async function classifyCustomCamerasForTick(opts: {
     status: 'unknown',
     categories: [],
     location: {
-      latitude: r.lat,
-      longitude: r.lng,
+      latitude: Number(r.lat),
+      longitude: Number(r.lng),
     },
   }));
 

--- a/app/api/cron/update-cameras/lib/dbOperations.test.ts
+++ b/app/api/cron/update-cameras/lib/dbOperations.test.ts
@@ -26,6 +26,18 @@ describe('upsertTerminatorState', () => {
 
     // One call per row; rank is the array index
     expect(sqlMock).toHaveBeenCalledTimes(2);
+
+    // First call should carry webcamId=42 + rank=0 + phase='sunrise'.
+    const firstCallValues = sqlMock.mock.calls[0].slice(1);
+    expect(firstCallValues).toContain(42);
+    expect(firstCallValues).toContain('sunrise');
+    expect(firstCallValues).toContain(0);
+
+    // Second call should carry webcamId=7 + rank=1 + phase='sunrise'.
+    const secondCallValues = sqlMock.mock.calls[1].slice(1);
+    expect(secondCallValues).toContain(7);
+    expect(secondCallValues).toContain('sunrise');
+    expect(secondCallValues).toContain(1);
   });
 });
 

--- a/app/api/cron/update-cameras/lib/dbOperations.test.ts
+++ b/app/api/cron/update-cameras/lib/dbOperations.test.ts
@@ -55,4 +55,26 @@ describe('deactivateMissingTerminatorState', () => {
     const firstCallStrings = sqlMock.mock.calls[0][0] as readonly string[];
     expect(firstCallStrings.join(' ')).not.toContain("source = 'windy'");
   });
+
+  it('deactivates all rows for the phase when active set is empty', async () => {
+    await deactivateMissingTerminatorState('sunset', []);
+
+    expect(sqlMock).toHaveBeenCalledTimes(1);
+    const strings = sqlMock.mock.calls[0][0] as readonly string[];
+    const fullQuery = strings.join(' ');
+    expect(fullQuery).not.toContain("source = 'windy'");
+    // Empty-array fast path: no `<> all` filter.
+    expect(fullQuery).not.toContain('<> all');
+  });
+
+  it('passes the active ids array into the SQL parameters', async () => {
+    await deactivateMissingTerminatorState('sunrise', [42, 99]);
+
+    expect(sqlMock).toHaveBeenCalledTimes(1);
+    // Index 0 of the call is the TemplateStringsArray; rest are interpolated values.
+    const values = sqlMock.mock.calls[0].slice(1);
+    // The phase string and the active-ids array should both appear in values.
+    expect(values).toContain('sunrise');
+    expect(values.some((v) => Array.isArray(v) && (v as number[]).join(',') === '42,99')).toBe(true);
+  });
 });

--- a/app/api/cron/update-cameras/lib/dbOperations.test.ts
+++ b/app/api/cron/update-cameras/lib/dbOperations.test.ts
@@ -7,7 +7,27 @@ vi.mock('@/app/lib/db', () => ({
     sqlMock(strings, ...values),
 }));
 
-import { deactivateMissingTerminatorState } from './dbOperations';
+import { deactivateMissingTerminatorState, upsertTerminatorState } from './dbOperations';
+
+describe('upsertTerminatorState', () => {
+  beforeEach(() => {
+    sqlMock.mockReset();
+    sqlMock.mockResolvedValue(undefined);
+  });
+
+  it('upserts rows with pre-resolved DB webcam_id and array-index rank', async () => {
+    await upsertTerminatorState(
+      [
+        { webcamId: 42 },
+        { webcamId: 7 },
+      ],
+      'sunrise',
+    );
+
+    // One call per row; rank is the array index
+    expect(sqlMock).toHaveBeenCalledTimes(2);
+  });
+});
 
 describe('deactivateMissingTerminatorState', () => {
   beforeEach(() => {

--- a/app/api/cron/update-cameras/lib/dbOperations.test.ts
+++ b/app/api/cron/update-cameras/lib/dbOperations.test.ts
@@ -47,21 +47,12 @@ describe('deactivateMissingTerminatorState', () => {
     sqlMock.mockResolvedValue([]);
   });
 
-  it('only touches windy-sourced rows when active list is empty', async () => {
-    await deactivateMissingTerminatorState('sunset', []);
-
-    expect(sqlMock).toHaveBeenCalledTimes(1);
-    const [strings] = sqlMock.mock.calls[0];
-    const fullQuery = strings.join('?');
-    expect(fullQuery).toMatch(/source\s*=\s*'windy'/);
-  });
-
-  it('only touches windy-sourced rows when an active list is provided', async () => {
+  it('deactivates rows of any source not in the active set', async () => {
     await deactivateMissingTerminatorState('sunrise', [42, 99]);
 
     expect(sqlMock).toHaveBeenCalledTimes(1);
-    const [strings] = sqlMock.mock.calls[0];
-    const fullQuery = strings.join('?');
-    expect(fullQuery).toMatch(/source\s*=\s*'windy'/);
+    // The SQL template-tag invocation should NOT reference w.source = 'windy'.
+    const firstCallStrings = sqlMock.mock.calls[0][0] as readonly string[];
+    expect(firstCallStrings.join(' ')).not.toContain("source = 'windy'");
   });
 });

--- a/app/api/cron/update-cameras/lib/dbOperations.ts
+++ b/app/api/cron/update-cameras/lib/dbOperations.ts
@@ -153,6 +153,12 @@ export async function upsertTerminatorState(
  * Flip rows in this phase to active=false unless their webcam_id is in
  * activeWebcamIds. Source-agnostic: caller is responsible for unioning
  * active ids across Windy + custom (or any other source) before calling.
+ *
+ * WARNING: this function previously had a source='windy' guard. After its
+ * removal, passing an incomplete active set will deactivate rows of any
+ * source not in the set. Always pass the FULL union of active ids across
+ * every source the caller knows about — partial sets silently deactivate
+ * other-source rows.
  */
 export async function deactivateMissingTerminatorState(
   phase: 'sunrise' | 'sunset',

--- a/app/api/cron/update-cameras/lib/dbOperations.ts
+++ b/app/api/cron/update-cameras/lib/dbOperations.ts
@@ -125,18 +125,16 @@ export async function getWebcamIdMap(
 }
 
 /**
- * Upsert terminator state entries (upsert-only, no delete-all)
- * Uses last_seen_at for query-time filtering instead of bulk deletes
+ * Upsert terminator-state rows from pre-resolved DB webcam ids.
+ * Rank is the array index. Caller is responsible for any ordering
+ * decisions (sort, union, dedupe) before passing the array in.
  */
 export async function upsertTerminatorState(
-  webcams: WindyWebcam[],
+  rows: Array<{ webcamId: number }>,
   phase: 'sunrise' | 'sunset',
-  idByExternal: Map<string, number>
 ): Promise<void> {
-  const promises = webcams.map(async (w, rank) => {
-    const webcamId = idByExternal.get(String(w.webcamId));
-    if (!webcamId) return;
-
+  const promises = rows.map(async (row, rank) => {
+    const { webcamId } = row;
     await sql`
       insert into terminator_webcam_state (webcam_id, phase, rank, last_seen_at, updated_at, active)
       values (${webcamId}, ${phase}, ${rank}, now(), now(), true)

--- a/app/api/cron/update-cameras/lib/dbOperations.ts
+++ b/app/api/cron/update-cameras/lib/dbOperations.ts
@@ -150,35 +150,30 @@ export async function upsertTerminatorState(
 }
 
 /**
- * Deactivate terminator state entries that are no longer in the current ring results
- * This keeps "active" aligned with the latest ring-based fetch.
+ * Flip rows in this phase to active=false unless their webcam_id is in
+ * activeWebcamIds. Source-agnostic: caller is responsible for unioning
+ * active ids across Windy + custom (or any other source) before calling.
  */
 export async function deactivateMissingTerminatorState(
   phase: 'sunrise' | 'sunset',
-  activeWebcamIds: number[]
+  activeWebcamIds: number[],
 ): Promise<void> {
   if (activeWebcamIds.length === 0) {
     await sql`
-      update terminator_webcam_state s
+      update terminator_webcam_state
       set active = false, updated_at = now()
-      from webcams w
-      where s.webcam_id = w.id
-        and w.source = 'windy'
-        and s.phase = ${phase}
-        and s.active = true
+      where phase = ${phase}
+        and active = true
     `;
     return;
   }
 
   await sql`
-    update terminator_webcam_state s
+    update terminator_webcam_state
     set active = false, updated_at = now()
-    from webcams w
-    where s.webcam_id = w.id
-      and w.source = 'windy'
-      and s.phase = ${phase}
-      and s.active = true
-      and s.webcam_id <> all(${activeWebcamIds})
+    where phase = ${phase}
+      and active = true
+      and webcam_id <> all(${activeWebcamIds})
   `;
 }
 

--- a/app/api/cron/update-cameras/route.test.ts
+++ b/app/api/cron/update-cameras/route.test.ts
@@ -15,6 +15,7 @@ const scoreMock = vi.fn();
 const getHashMock = vi.fn();
 const setHashMock = vi.fn();
 const backfillMock = vi.fn();
+const customClassifyMock = vi.fn();
 const upsertStatsMock = vi.fn();
 const verifyAuthMock = vi.fn(() => true);
 const computeTickStatsMock = vi.fn();
@@ -56,6 +57,9 @@ vi.mock('./lib/aiScoring', () => ({
 vi.mock('./lib/customBackfill', () => ({
   backfillCustomSnapshotScores: (...a: unknown[]) => backfillMock(...a),
 }));
+vi.mock('./lib/customClassification', () => ({
+  classifyCustomCamerasForTick: (...a: unknown[]) => customClassifyMock(...a),
+}));
 vi.mock('./lib/dailyStats', () => ({
   computeTickStats: (...a: unknown[]) => computeTickStatsMock(...a),
   upsertDailyStats: (...a: unknown[]) => upsertStatsMock(...a),
@@ -89,6 +93,7 @@ beforeEach(() => {
     imageHash: 'newhash', source: 'windy', pathTaken: 'onnx',
   });
   backfillMock.mockReset().mockResolvedValue({ scored: 0, failed: 0, modelVersion: null, scores: [] });
+  customClassifyMock.mockReset().mockResolvedValue({ sunrise: [], sunset: [] });
   upsertStatsMock.mockReset().mockResolvedValue(undefined);
   setCachedMock.mockReset().mockResolvedValue(undefined);
   fetchTerminatorWebcamsMock.mockReset().mockResolvedValue([]);
@@ -147,5 +152,69 @@ describe('GET /api/cron/update-cameras', () => {
     expect(res.status).toBe(401);
     expect(scoreMock).not.toHaveBeenCalled();
     expect(backfillMock).not.toHaveBeenCalled();
+  });
+
+  it('unions custom cams into the upsert active set', async () => {
+    classifyMock.mockReturnValue({
+      sunrise: [{ webcamId: 'wA', location: { latitude: 0, longitude: 0 } }],
+      sunset: [],
+    });
+    getIdMapMock.mockResolvedValue(new Map([['wA', 1]]));
+    customClassifyMock.mockResolvedValue({
+      sunrise: [{ webcamId: 999 }],
+      sunset: [],
+    });
+
+    const res = await GET(makeReq());
+    expect(res.status).toBe(200);
+
+    const sunriseUpsertCall = upsertStateMock.mock.calls.find(
+      (c) => c[1] === 'sunrise',
+    );
+    expect(sunriseUpsertCall).toBeDefined();
+    const rows = sunriseUpsertCall![0] as Array<{ webcamId: number }>;
+    expect(rows.map((r) => r.webcamId).sort()).toEqual([1, 999]);
+  });
+
+  it('passes the union of ids to deactivateMissingTerminatorState', async () => {
+    classifyMock.mockReturnValue({
+      sunrise: [{ webcamId: 'wA', location: { latitude: 0, longitude: 0 } }],
+      sunset: [],
+    });
+    getIdMapMock.mockResolvedValue(new Map([['wA', 1]]));
+    customClassifyMock.mockResolvedValue({
+      sunrise: [{ webcamId: 999 }],
+      sunset: [],
+    });
+
+    const res = await GET(makeReq());
+    expect(res.status).toBe(200);
+
+    const sunriseDeactCall = deactivateMock.mock.calls.find(
+      (c) => c[0] === 'sunrise',
+    );
+    expect(sunriseDeactCall).toBeDefined();
+    expect((sunriseDeactCall![1] as number[]).sort()).toEqual([1, 999]);
+  });
+
+  it('skips upsert/deactivate for empty buckets gracefully', async () => {
+    classifyMock.mockReturnValue({ sunrise: [], sunset: [] });
+    getIdMapMock.mockResolvedValue(new Map());
+    customClassifyMock.mockResolvedValue({ sunrise: [], sunset: [] });
+
+    const res = await GET(makeReq());
+    expect(res.status).toBe(200);
+
+    // Empty buckets must still flow through upsert + deactivate — otherwise a
+    // future "optimize away empty arrays" change would silently break the
+    // deactivation contract (rows would never get flipped to active=false
+    // when the active set is empty).
+    const sunriseUpsertCall = upsertStateMock.mock.calls.find((c) => c[1] === 'sunrise');
+    expect(sunriseUpsertCall).toBeDefined();
+    expect(sunriseUpsertCall![0]).toEqual([]);
+
+    const sunriseDeactCall = deactivateMock.mock.calls.find((c) => c[0] === 'sunrise');
+    expect(sunriseDeactCall).toBeDefined();
+    expect(sunriseDeactCall![1]).toEqual([]);
   });
 });

--- a/app/api/cron/update-cameras/route.ts
+++ b/app/api/cron/update-cameras/route.ts
@@ -25,7 +25,9 @@ import {
   TERMINATOR_SUN_ALTITUDE_DEG,
   WINDY_FETCH_BATCH_SIZE,
   WINDY_FETCH_DELAY_BETWEEN_BATCHES_MS,
+  CUSTOM_CAM_FRESHNESS_WINDOW_MINUTES,
 } from '@/app/lib/masterConfig';
+import { classifyCustomCamerasForTick } from './lib/customClassification';
 import { verifyCronAuth } from './lib/auth';
 import {
   dedupeCoords,
@@ -214,15 +216,47 @@ export async function GET(req: Request) {
     customBackfill: backfillResult,
   });
 
-  // Resolve Windy external_id → DB webcam_id once for both upsert + deactivate
-  function toDbRows(list: typeof sunriseList) {
+  // Resolve Windy external_id → DB webcam_id rows
+  function toWindyDbRows(list: typeof sunriseList) {
     return list
       .map((w) => idByExternal.get(String(w.webcamId)))
       .filter((id): id is number => id !== undefined)
       .map((webcamId) => ({ webcamId }));
   }
-  const sunriseRows = toDbRows(sunriseList);
-  const sunsetRows = toDbRows(sunsetList);
+  const sunriseWindyRows = toWindyDbRows(sunriseList);
+  const sunsetWindyRows = toWindyDbRows(sunsetList);
+
+  // Classify custom cams against the same ring coords + freshness window
+  const customClassified = await classifyCustomCamerasForTick({
+    sunriseCoords,
+    sunsetCoords,
+    freshnessWindowMinutes: CUSTOM_CAM_FRESHNESS_WINDOW_MINUTES,
+    now,
+  });
+
+  // Union Windy + custom by webcamId, Windy first (preserves Windy lat-sorted rank).
+  function unionByWebcamId(
+    primary: Array<{ webcamId: number }>,
+    secondary: Array<{ webcamId: number }>,
+  ): Array<{ webcamId: number }> {
+    const seen = new Set<number>();
+    const out: Array<{ webcamId: number }> = [];
+    for (const r of primary) {
+      if (!seen.has(r.webcamId)) {
+        seen.add(r.webcamId);
+        out.push(r);
+      }
+    }
+    for (const r of secondary) {
+      if (!seen.has(r.webcamId)) {
+        seen.add(r.webcamId);
+        out.push(r);
+      }
+    }
+    return out;
+  }
+  const sunriseRows = unionByWebcamId(sunriseWindyRows, customClassified.sunrise);
+  const sunsetRows = unionByWebcamId(sunsetWindyRows, customClassified.sunset);
 
   await upsertTerminatorState(sunriseRows, 'sunrise');
   await upsertTerminatorState(sunsetRows, 'sunset');

--- a/app/api/cron/update-cameras/route.ts
+++ b/app/api/cron/update-cameras/route.ts
@@ -300,8 +300,8 @@ export async function GET(req: Request) {
 
   return NextResponse.json({
     ok: true,
-    sunrise: sunriseList.length,
-    sunset: sunsetList.length,
+    sunrise: sunriseRows.length,
+    sunset: sunsetRows.length,
     windyScored: windyScores.length,
     cacheHits,
     fallbacks,

--- a/app/api/cron/update-cameras/route.ts
+++ b/app/api/cron/update-cameras/route.ts
@@ -214,19 +214,21 @@ export async function GET(req: Request) {
     customBackfill: backfillResult,
   });
 
-  // Upsert terminator state for sunrise webcams
-  await upsertTerminatorState(sunriseList, 'sunrise', idByExternal);
+  // Resolve Windy external_id → DB webcam_id once for both upsert + deactivate
+  function toDbRows(list: typeof sunriseList) {
+    return list
+      .map((w) => idByExternal.get(String(w.webcamId)))
+      .filter((id): id is number => id !== undefined)
+      .map((webcamId) => ({ webcamId }));
+  }
+  const sunriseRows = toDbRows(sunriseList);
+  const sunsetRows = toDbRows(sunsetList);
 
-  // Upsert terminator state for sunset webcams
-  await upsertTerminatorState(sunsetList, 'sunset', idByExternal);
+  await upsertTerminatorState(sunriseRows, 'sunrise');
+  await upsertTerminatorState(sunsetRows, 'sunset');
 
-  // Deactivate entries that are no longer in the current ring results
-  const sunriseIds = sunriseList
-    .map((w) => idByExternal.get(String(w.webcamId)))
-    .filter((id): id is number => id !== undefined);
-  const sunsetIds = sunsetList
-    .map((w) => idByExternal.get(String(w.webcamId)))
-    .filter((id): id is number => id !== undefined);
+  const sunriseIds = sunriseRows.map((r) => r.webcamId);
+  const sunsetIds = sunsetRows.map((r) => r.webcamId);
   await deactivateMissingTerminatorState('sunrise', sunriseIds);
   await deactivateMissingTerminatorState('sunset', sunsetIds);
 


### PR DESCRIPTION
## Summary

Custom Pi cameras now appear/disappear on the map by the **exact same ring/radius predicate** as Windy webcams — plus a 90-minute snapshot-freshness window so stale/offline cams fall off cleanly. This collapses two visibility code paths into one.

The fix: a new `customClassification` module fetches `source='custom'` cams with fresh snapshots, shapes them through the same `classifyWebcamsByPhase` math against the same ring coords used for Windy, and returns DB-id rows. Those rows union with Windy results (Windy first, dedupe by `webcamId`) before upsert and deactivate.

Along the way, two `dbOperations.ts` functions that the spec called "unchanged" turned out to be Windy-coupled — `upsertTerminatorState` did internal external_id translation and `deactivateMissingTerminatorState` hardcoded `source='windy'`. Both are now source-agnostic. The cron route lifts external_id resolution into its own scope and unions all sources before any DB write.

- Spec: `docs/superpowers/specs/2026-05-15-custom-cam-visibility-single-source-of-truth-design.md`
- Plan: `docs/superpowers/plans/2026-05-16-custom-cam-visibility-single-source-of-truth.md`
- 244 tests pass on this branch (2 pre-existing failures on main: `useSetMarker.test.ts`, `terminatorRing.test.ts`, unrelated).

## Behavioral notes

- **Existing custom rows that were incorrectly `active=true` (i.e., visible at wrong times relative to the terminator) will flip to `active=false` on the first cron tick after deploy.** That's the bug fix this PR delivers — not a regression.
- Tick latency: the new SQL hits `idx_webcam_snapshots_webcam_captured_desc` from migration `20260514_webcam_snapshots_latest_idx.sql`. No new index required.
- Rollback: revert commit `0edb060bb` (the wiring); the helper modules and refactors (`11e392e5c`, `7d6cff07a`, `9cc532ef2`, `49a712cba`, `a5c477b9c`) leave Windy behavior identical and are independently safe to keep.

## Test plan

- [ ] `npx vitest run --exclude '.claude/**' --exclude 'node_modules/**'` — green (or only the 2 known pre-existing failures).
- [ ] `npx tsc --noEmit` — no new errors in `app/api/cron/**`, `app/lib/**`.
- [ ] **Manual smoke against deployed cron:** hit `/api/cron/update-cameras` with `Authorization: Bearer $CRON_SECRET` (or `?secret=$CRON_SECRET`); verify response is 200.
- [ ] Inspect `terminator_webcam_state` for the live test camera:
  ```sql
  select s.webcam_id, s.phase, s.rank, s.active, s.last_seen_at,
         w.source, w.lat, w.lng
  from terminator_webcam_state s
  join webcams w on w.id = s.webcam_id
  where w.source = 'custom'
  order by s.updated_at desc;
  ```
  Confirm test cam is `active=true` only when geometrically near the terminator AND has a snapshot within the last 90 minutes.
- [ ] Map UI sanity-check: test-cam dot only renders during its actual sun window.

## Follow-up items (deferred)

These are low-risk improvements flagged in code review but not blocking:

- Hoist `unionByWebcamId` (and possibly `toWindyDbRows`) to module scope so they can be unit-tested independently. Adding a `<T extends {webcamId: number}>` generic would future-proof the union helper.
- Doc comment on `unionByWebcamId` explaining the Windy-wins-on-collision policy.
- Rename `route.test.ts`'s "skips upsert/deactivate for empty buckets gracefully" — the body actually asserts upsert/deactivate are CALLED with empty arrays (the right contract), not skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)