### PR TITLE
docs(spec-stubs): Subproject B (clock drift + black image) + AI silhouette blind spot

### DIFF
--- a/docs/superpowers/specs/2026-05-16-ai-rating-silhouette-sunset-blind-spot-stub.md
+++ b/docs/superpowers/specs/2026-05-16-ai-rating-silhouette-sunset-blind-spot-stub.md
@@ -1,0 +1,52 @@
+# AI Rating — Silhouette-Sunset Blind Spot
+
+Status: Stub — 2026-05-16
+Owner: Jesse Kauppila
+Loosely connected to: `AI_RATINGS_V2_PLAN.md`, `ml/` training pipeline.
+
+---
+
+## Observation
+
+On 2026-05-16 at ~21:35 PDT, the Tier 0 test camera (Bellingham, WA — lat 48.7519, lng −122.4787) captured a sunset image with:
+
+- Sky filled with sunset colors (orange/red/gradient)
+- Dark foreground silhouettes (the typical "great sunset photo" composition)
+- The sun itself not in the frame (camera points at the horizon but not directly at the setting sun's azimuth)
+
+The AI rating returned was **0.21** (on whatever the active scoring scale is — regression model from `customBackfill.modelVersion: 20260315_003913_v2_regression_mild_crop`).
+
+By any photographic standard, this is a high-quality sunset image. The scoring model rated it badly anyway.
+
+## What this suggests
+
+The rating model is probably treating "sun visible in frame" as a strong positive signal — likely because most of the training labels for "good sunset" came from images where the sun is visible. Silhouette-and-color compositions, which are widely considered *better* photography (no blown highlights, more atmospheric gradients, more compositional interest), look feature-wise like "non-sunset" to a model trained that way.
+
+This is a **training distribution gap**, not an architecture gap. The model is doing its job for the labels it was given; the labels don't represent how humans actually judge sunset quality.
+
+## Why this matters
+
+The whole point of the AI ranker is to surface the *best* sunsets to the kiosk / mosaic / display. If a substantial fraction of objectively-great sunsets score low (because they happen to lack the sun's disk in frame), they'll be perpetually demoted in the queue and never surface, regardless of how stunning they are.
+
+Worse: this bias is invisible during normal operation — you'd only notice it by spot-checking low-scored images, which nobody is going to do at scale.
+
+## Possible directions (not yet a real spec)
+
+- **Re-label / augment training data** with explicit "silhouette sunset" examples scored highly by humans. Cheapest fix, biggest payoff if it works.
+- **Two-headed model:** one for "sunset content present at all" (binary), one for "quality of that sunset" (regression). Decouples detection from quality.
+- **Feature-level audit:** generate Grad-CAM or saliency maps for low-scored silhouette images and confirm the model is fixating on the missing sun rather than the sky color.
+- **Human-in-the-loop calibration:** when users star a sunset image highly, surface a few similar low-AI-rated images for label correction.
+
+## What this stub doesn't try to do
+
+Decide which of the above to pursue. Decide on a metric. Decide on a dataset. Decide on a model architecture. This is a flagged observation — turns into a real spec only after someone (probably you, when next looking at ML) decides this finding is worth a model iteration.
+
+## Linkage
+
+- [[2026-05-15-custom-cam-visibility-single-source-of-truth-design]] — the visibility fix that surfaced this image to the cron in the first place; without the fix, this image wouldn't have been observable.
+- [[2026-05-16-device-diagnostics-clock-and-black-image-stub]] — adjacent device-side concerns; orthogonal to this scoring issue.
+- `AI_RATINGS_V2_PLAN.md` — the existing roadmap for the rating model; this finding belongs in its backlog.
+
+## When this becomes a real spec
+
+When someone surveys ~50 low-rated images from the kiosk/mosaic candidate pool, finds that more than a handful are misjudged silhouette/color sunsets, and decides the fix is worth a training cycle.

--- a/docs/superpowers/specs/2026-05-16-device-diagnostics-clock-and-black-image-stub.md
+++ b/docs/superpowers/specs/2026-05-16-device-diagnostics-clock-and-black-image-stub.md
@@ -15,16 +15,18 @@ Two symptoms observed on the field-deployed Pi Zero 2 W test camera (lat 48.7519
 
 Both symptoms originate at the device, not in the cloud. Server-side accepts whatever the device sends.
 
-## Hypothesis: Single Root Cause
+## Hypothesis: Two Decoupled Problems
 
-The two symptoms are likely **the same bug** seen from two angles. The device firmware:
+**Updated 2026-05-16 22:00 PDT after a second sunset of observation.**
 
-- Computes its own local sunrise/sunset windows via an `astral`-style library against its onboard clock (see `pi-webcam-mvp.md` §2 — "Active window = 45 min before sunrise to 30 min after, etc.").
-- If the onboard clock is set ~7 hours ahead of real time, the device's "active window" maps to a real-world time that is fully dark.
-- The shutter opens; the sensor sees nothing; the snapshot is solid black.
-- The same skewed clock then stamps `captured_at` with a future ISO timestamp at upload time.
+The initial hypothesis was that both symptoms shared a root cause: a wrong clock would shift the active window into real-world darkness and produce black images, while also stamping uploads with future timestamps. Both predictions are *consistent* with the clock-drift hypothesis.
 
-**One hypothesis, two predictions, both consistent with what we observe.**
+But the second night of testing showed the camera producing real, well-exposed sunset imagery — *while still uploading future-stamped snapshots*. If clock drift caused the black images, every image should be black. They aren't. So:
+
+- **The clock drift is real and persistent.** Confirmed twice. Likely a `datetime.now()` vs `datetime.utcnow()` confusion in the upload path (the +7h offset matches PDT/UTC arithmetic exactly).
+- **The black image from 2026-05-15 was likely transient.** Probably weather (heavy overcast at golden hour), a startup driver glitch, or a one-off exposure error. Will know once we have several nights of observation under varied conditions.
+
+Treat these as two independent items. The clock fix is small and obvious. The intermittent black-image issue needs more data points before it's worth a real diagnosis — collect another week of snapshots and look for a pattern (does it correlate with weather, time-of-night, reboots, anything?).
 
 A secondary consequence: this also explains why the cam appeared at "wrong" times on the map before the visibility fix landed. The freshness predicate the cloud cron uses (`captured_at >= now - 90min`) is trivially satisfied by future timestamps, so the cam was "always fresh" regardless of when it actually captured. Once a real geometric predicate landed, the geographic gating started working — but freshness is still effectively a no-op for this device until the clock is fixed.
 

--- a/docs/superpowers/specs/2026-05-16-device-diagnostics-clock-and-black-image-stub.md
+++ b/docs/superpowers/specs/2026-05-16-device-diagnostics-clock-and-black-image-stub.md
@@ -1,0 +1,66 @@
+# Device Diagnostics — Clock Drift + Black Image
+
+Status: Stub — 2026-05-16
+Owner: Jesse Kauppila
+Subproject B of the post-MVP visibility/AR/hardware decomposition.
+
+---
+
+## Problem
+
+Two symptoms observed on the field-deployed Pi Zero 2 W test camera (lat 48.7519, lng −122.4787, "Tier 0 Test Camera — Jesse House"):
+
+1. **Black images.** Snapshots captured during the device's active window — uploaded to Firebase and scored normally — are visually solid black or near-black. AI scoring still runs but on no real content.
+2. **Future-stamped snapshots.** The `captured_at` value attached to uploaded snapshots is ~7 hours in the future. Observed example on 2026-05-16: device-side cron-tick payload showed `snapAt=2026-05-17T11:29:58.396Z` returned by the API while server-side `now()` was `2026-05-17T04:36Z` UTC.
+
+Both symptoms originate at the device, not in the cloud. Server-side accepts whatever the device sends.
+
+## Hypothesis: Single Root Cause
+
+The two symptoms are likely **the same bug** seen from two angles. The device firmware:
+
+- Computes its own local sunrise/sunset windows via an `astral`-style library against its onboard clock (see `pi-webcam-mvp.md` §2 — "Active window = 45 min before sunrise to 30 min after, etc.").
+- If the onboard clock is set ~7 hours ahead of real time, the device's "active window" maps to a real-world time that is fully dark.
+- The shutter opens; the sensor sees nothing; the snapshot is solid black.
+- The same skewed clock then stamps `captured_at` with a future ISO timestamp at upload time.
+
+**One hypothesis, two predictions, both consistent with what we observe.**
+
+A secondary consequence: this also explains why the cam appeared at "wrong" times on the map before the visibility fix landed. The freshness predicate the cloud cron uses (`captured_at >= now - 90min`) is trivially satisfied by future timestamps, so the cam was "always fresh" regardless of when it actually captured. Once a real geometric predicate landed, the geographic gating started working — but freshness is still effectively a no-op for this device until the clock is fixed.
+
+## Why the Pi clock would be wrong
+
+The Pi Zero 2 W has **no battery-backed RTC.** On boot it has no idea what time it is. The standard recovery is:
+
+- `systemd-timesyncd` polls NTP and sets the system clock.
+- If NTP is blocked by the local network, misconfigured in `/etc/systemd/timesyncd.conf`, or the service is failing, the clock stays at whatever the kernel decides on boot (often Jan 1 1970, but also sometimes whatever the filesystem mtime hints at).
+
+The **specific +7 hour skew** is suspicious. Possibilities, in rough order of likelihood:
+
+1. **Timezone double-conversion.** Pacific (PDT, UTC−7) is exactly 7 hours behind UTC. Code that takes a local-time wallclock value and stamps it as if it were UTC would produce snapshots 7 hours in the future during PDT. The arithmetic matches *exactly*.
+2. **NTP succeeded but UTC offset got added twice somewhere** in the capture-and-upload pipeline (Python's `datetime.now()` vs `datetime.utcnow()` confusion, or naive datetime → ISO string assuming local but treating as UTC).
+3. **Clock got set from an HTTP `Date` header in the wrong reference** — less likely, but the firmware does talk to the cloud on boot for registration.
+
+Hypothesis 1 is the most testable: if the device thinks "now" is 2026-05-17 04:30 PDT but the firmware stamps it as "2026-05-17T04:30Z UTC", the resulting timestamp will be 7 hours in the future of true UTC.
+
+## How to diagnose (in priority order)
+
+1. **SSH into the Pi.** Run `date`, `timedatectl`, and `cat /etc/timezone`. Compare to wallclock. If `date` reports the correct local time and `timedatectl` says NTP is synced and UTC is correct, then the bug is in the firmware's timestamp serialization (Hypothesis 1). If `date` is already wrong, then NTP is failing.
+2. **Look at the snapshot-emitting Python code.** Search the firmware repo for `datetime.now()`, `datetime.utcnow()`, `isoformat()`, `astimezone()`. Any path that builds the `captured_at` string from a naive datetime is a smoking gun.
+3. **If suspicion lands on the active-window math:** add a debug log line on the device that prints `[active-window-check] now={now_iso} sunrise_today={sunrise_iso} sunset_today={sunset_iso} in_window={bool}` once per tick. Watch for a tick where `now` and `in_window` disagree with real-world conditions.
+4. **Confirm black-image causality:** force the device to capture *outside* its computed active window (manual trigger). If the resulting image is well-exposed, the active-window math is the bug. If it's still black, the sensor / driver / lens is also at fault, separately.
+
+## Out of scope for this stub
+
+- **Image-quality tuning** (ISO, shutter, lens). Separate from the timing bug. Defer until clock is verified-correct and a real golden-hour snapshot is captured.
+- **Hardware mounting / orientation** ("which way is up"). That's Subproject C.
+- **Server-side guards** against future timestamps. Explicitly *not* fixing this in the cloud — masking the symptom would prevent diagnosis of the device-side root cause.
+
+## Linkage
+
+- [[2026-05-15-custom-cam-visibility-single-source-of-truth-design]] — the visibility fix that surfaced this bug. The freshness predicate is no-op'd by the clock skew but still correct in principle.
+- Future Subproject C ("which way is up") — black-image cause is split between *timing* (this spec) and *orientation* (subproject C). After timing is fixed, if the image is still bad, the orientation hypothesis becomes the leading one.
+
+## When this becomes a real spec
+
+When someone (probably you, with SSH access to the Pi) runs the diagnostic steps above and identifies which hypothesis is correct. The full spec then proposes the firmware-side fix (NTP enforcement, timestamp serialization correction, or both) and the verification plan (round-trip a known-good snapshot during a real golden hour).


### PR DESCRIPTION
## Summary

Three spec-stub commits from the 2026-05-16 testing-night observations, captured while running the test Pi camera through real sunset windows.

- **Subproject B (clock drift + black image)** — first hypothesis after night 1: the +7h future timestamps on uploaded snapshots and the black image content might share a single root cause (Pi clock skew firing the firmware's active window during real-world darkness).
- **Subproject B revised** — after night 2 produced real sunset imagery despite persistent clock drift, the "single root cause" hypothesis is wrong. Clock drift is real and probably a UTC/local datetime confusion in the firmware; black images are intermittent (likely weather or a different cause).
- **AI rating silhouette blind spot** — concrete data point from tonight: a beautiful Bellingham sunset (dark foreground silhouettes + sky color, no sun in frame) got rated 0.21 by the v2 regression model. Likely a training-label distribution problem, not architecture.

These stubs were drafted while a separate brainstorming session was running in a worktree; they're carried over to main here so they aren't lost when the worktree gets cleaned up.

## Files added

- `docs/superpowers/specs/2026-05-16-device-diagnostics-clock-and-black-image-stub.md`
- `docs/superpowers/specs/2026-05-16-ai-rating-silhouette-sunset-blind-spot-stub.md`

## Test plan

- [ ] Nothing to test — docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)