### PR TITLE
fix(cron): map custom-camera raw score [0,1] → display [1,5] in sync SQL

### DIFF
--- a/app/api/cron/update-cameras/lib/dbOperations.backfill.test.ts
+++ b/app/api/cron/update-cameras/lib/dbOperations.backfill.test.ts
@@ -48,7 +48,7 @@ describe('updateSnapshotAiRegressionScore', () => {
 });
 
 describe('updateWebcamRegressionScoreFromLatestCustomSnapshot', () => {
-  it('copies the latest snapshot score into webcams.ai_rating_regression', async () => {
+  it('writes the latest snapshot score into webcams.ai_rating_regression', async () => {
     sqlMock.mockResolvedValue([]);
     await updateWebcamRegressionScoreFromLatestCustomSnapshot(42);
     const [strings, ...values] = sqlMock.mock.calls[0];
@@ -57,5 +57,16 @@ describe('updateWebcamRegressionScoreFromLatestCustomSnapshot', () => {
     expect(q).toMatch(/ai_rating_regression/);
     expect(q).toMatch(/order\s+by\s+captured_at\s+desc/i);
     expect(values).toContain(42);
+  });
+
+  it('maps the raw [0,1] snapshot score to the 1-5 display scale (1 + raw*4)', async () => {
+    sqlMock.mockResolvedValue([]);
+    await updateWebcamRegressionScoreFromLatestCustomSnapshot(42);
+    const [strings] = sqlMock.mock.calls[0];
+    const q = strings.join('?');
+    // The display column must be set from the mapping formula, not the
+    // raw score. Catches regressions like the 0.21/5 popup display bug.
+    expect(q).toMatch(/ai_rating_regression\s*=\s*1\s*\+\s*ls\.ai_regression_score\s*\*\s*4/i);
+    expect(q).not.toMatch(/ai_rating_regression\s*=\s*ls\.ai_regression_score\s*,/i);
   });
 });

--- a/app/api/cron/update-cameras/lib/dbOperations.ts
+++ b/app/api/cron/update-cameras/lib/dbOperations.ts
@@ -355,9 +355,13 @@ export async function updateSnapshotAiRegressionScore(
 export async function updateWebcamRegressionScoreFromLatestCustomSnapshot(
   webcamId: number
 ): Promise<void> {
+  // Map the raw [0,1] score into the 1-5 display scale (inverse of the
+  // (rating-1)/4 normalization applied at training time in ml/export_dataset.py).
+  // Windy path does this in aiScoring.ts/normalizeOnnxOutput; custom path
+  // persists the raw score per-snapshot and maps here at sync time.
   await sql`
     update webcams
-    set ai_rating_regression = ls.ai_regression_score,
+    set ai_rating_regression = 1 + ls.ai_regression_score * 4,
         ai_model_version_regression = ls.ai_model_version_regression,
         updated_at = now()
     from (


### PR DESCRIPTION
updateWebcamRegressionScoreFromLatestCustomSnapshot was copying the raw ai_regression_score (which is in [0,1]) directly into ai_rating_regression (which is the 1-5 display scale). Caused custom-camera popups to show values like "0.21 / 5" instead of "1.84 / 5".

Windy path mapped correctly (route.ts:175 uses scored.aiRating, already the [1,5] value from normalizeOnnxOutput). Only the custom path was affected.

Fix: apply the inverse of the (rating-1)/4 training normalization
directly in the sync SQL: ai_rating_regression = 1 + ls.ai_regression_score * 4.

Existing custom-camera rows will self-heal as new snapshots arrive.