### PR TITLE
fix(build): coerce row.lat/lng to Number in custom-cam distance filter

### DIFF
--- a/app/api/cron/update-cameras/lib/customClassification.ts
+++ b/app/api/cron/update-cameras/lib/customClassification.ts
@@ -75,16 +75,18 @@ export async function classifyCustomCamerasForTick(opts: {
     );
   }
 
+  // Same Number() coercion as the `shaped` mapping above — row.lat/lng come
+  // off the Neon driver as `number | string` for NUMERIC columns.
   const filteredSunrise = sunrise.filter((w) => {
     const row = rows.find((r) => r.webcam_id === (w.webcamId as number));
     if (!row) return false;
-    return minDistToCoords(row.lat, row.lng, opts.sunriseCoords) <= SEARCH_RADIUS_DEG;
+    return minDistToCoords(Number(row.lat), Number(row.lng), opts.sunriseCoords) <= SEARCH_RADIUS_DEG;
   });
 
   const filteredSunset = sunset.filter((w) => {
     const row = rows.find((r) => r.webcam_id === (w.webcamId as number));
     if (!row) return false;
-    return minDistToCoords(row.lat, row.lng, opts.sunsetCoords) <= SEARCH_RADIUS_DEG;
+    return minDistToCoords(Number(row.lat), Number(row.lng), opts.sunsetCoords) <= SEARCH_RADIUS_DEG;
   });
 
   return {


### PR DESCRIPTION
customClassification.ts:81/87 passed CustomCamRow.lat/lng directly into minDistToCoords, which expects (number, number). The row fields are typed `number | string` because the Neon driver returns NUMERIC columns as strings. The shaped array at line 57-58 already does Number(r.lat) coercion — the filter call sites missed it.

Result: every Vercel build since this file landed has failed with 'Argument of type string | number is not assignable to parameter of type number'.