### PR TITLE
docs(C v0.2): MPU6050 + facing selector + integration notes

### DIFF
--- a/docs/hardware/2026-05-17-housing-up-arrow-and-mpu6050.md
+++ b/docs/hardware/2026-05-17-housing-up-arrow-and-mpu6050.md
@@ -1,0 +1,31 @@
+# Housing UP-Arrow Marker + MPU6050 BOM Addition — Hardware Stub
+
+Status: Stub — 2026-05-17
+Owner: Jesse Kauppila
+Triggered by: software spec `docs/superpowers/specs/2026-05-17-pi-side-alignment-tool-design.md` (v0.2)
+
+## What
+
+Two hardware changes tracked here:
+
+1. **UP marker on the housing.** Sharpie ↑ arrow on the case for v1 (acceptable). Future: molded/etched ↑ as part of the STL.
+2. **MPU6050 / GY-521 IMU module** wired to the Pi via I2C. New BOM line item.
+
+## Requirements (UP marker)
+
+- Top-center of the front face, ≥3mm above the lens cutout, ≥3mm from the top edge
+- Relief or recess, 8–12mm tall, depth/height ≥0.4mm for weather resistance
+- v1: Sharpie applied during operator prep (accepts weathering risk; trivial to redo)
+
+## Requirements (MPU6050)
+
+- Part: MPU6050 / GY-521 breakout board ($3–8 single, ~$2/unit in bulk)
+- Pi Zero 2 W wiring: SDA→GPIO 2 (pin 3), SCL→GPIO 3 (pin 5), VCC→3.3V (pin 1), GND→GND (pin 9)
+- ESP32 wiring: SDA→GPIO 21, SCL→GPIO 22, same 3.3V + GND
+- I2C must be enabled in `raspi-config`
+- Soldering or hammer-header kit required for Pi Zero 2 W (non-WH variant)
+- Physical mount: needs to be rigidly fixed to the camera body so its gravity vector matches the camera's
+
+## Becomes a real spec when
+
+Units acquired, soldered onto a test Pi, software (this plan's output) verified to read live values. At that point the hardware spec graduates from stub to "production assembly procedure."

--- a/docs/superpowers/plans/2026-05-17-pi-side-alignment-tool.md
+++ b/docs/superpowers/plans/2026-05-17-pi-side-alignment-tool.md
@@ -1,140 +1,752 @@
-# Pi-Side Alignment Tool — Implementation Plan
+# Pi-Side Alignment Tool — Implementation Plan (v0.2)
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Build the framework-agnostic Pi-side alignment-tool logic — a render function for the HTML alignment page and a generator function for the MJPEG preview stream — with full unit-test coverage in the firmware repo, ready to be wired into spec E's setup web app whenever that lands.
+**Goal:** Build the framework-agnostic Pi-side alignment-tool logic — HTML rendering, MJPEG streaming, MPU6050 IMU driver, orientation sampler thread, and server-side solstice math — with full unit-test coverage in the firmware repo, ready to be wired into spec E's setup web app whenever that lands.
 
-**Architecture:** A single new module `setup_alignment.py` in the firmware repo exports two pure functions: `render_align_page() -> str` returns the static HTML+SVG for the alignment page, and `stream_mjpeg(frame_source, fps=4) -> Iterator[bytes]` produces multipart MJPEG bytes by polling a frame-source callable. Both are framework-agnostic — no Flask, no aiohttp, no FastAPI dependency. The eventual web-app integration (one task in spec E's firmware plan, not here) registers them as route handlers.
+**Architecture:** Three Python modules in the firmware: `setup_alignment.py` (HTML + MJPEG + orientation JSON renderers), `gyro_driver.py` (MPU6050 I2C reads), and `orientation_sampler.py` (background-thread cache of latest smoothed readings). All public functions are framework-agnostic (no Flask, no aiohttp). Solstice marker positions and sunsets-per-year counts are computed server-side and embedded in the HTML; the page itself does only one JS thing (poll the orientation JSON endpoint at 5 Hz and update the readout). The radio-toggle for facing direction (East/West/Both) is pure CSS — no JS state.
 
-**Tech Stack:** Python 3.11+ in `sunset-cam-firmware` repo. pytest for tests (already configured in `pyproject.toml`). Standard library only — no new dependencies.
+**Tech Stack:** Python 3.11+ in `sunset-cam-firmware` repo. pytest for tests. `smbus2` added as a new runtime dependency for I2C. Standard library otherwise.
 
-**Spec:** `docs/superpowers/specs/2026-05-17-pi-side-alignment-tool-design.md` (in the web-app repo at `the-sunset-webcam-map`).
+**Spec:** `docs/superpowers/specs/2026-05-17-pi-side-alignment-tool-design.md` v0.2 (in the web-app repo).
 
-**Working repo for this plan:** `/Users/jessekauppila/GitHub/sunset-cam-firmware`. All paths in this plan are relative to that root unless otherwise noted.
-
----
-
-## Dependency note
-
-This plan produces **functions** that the spec E firmware implementation will eventually call. Without spec E's setup web app, the functions land but aren't routed to URLs yet — that's deliberate. The functions are individually unit-testable; field verification (real Pi serving the page on real hardware) waits for spec E's web app to be built.
-
-A separate hardware ticket tracks the molded ↑ UP arrow on the housing STL — also out of scope for this plan.
+**Working repo for tasks 1–10:** `/Users/jessekauppila/GitHub/sunset-cam-firmware`. Tasks 11–12 live in the web-app repo.
 
 ---
 
-## File Structure
+## Dependency notes
 
-| Action | Path | Responsibility |
+- **Spec E's setup web app does not exist yet.** All tasks produce framework-agnostic functions and modules. Wiring into a real web framework is one task in spec E's firmware plan (when it's written), not here.
+- **MPU6050 hardware does not exist on the test Pi yet.** The user is acquiring units; soldering needed for non-WH Pi Zero 2 W. Tasks 3–4 are fully unit-testable with mocked I2C — they land before hardware arrives. Field verification (Task 13) gates on hardware.
+- **Spec E and F docs both need short integration notes** (Task 11) so the next implementer doesn't lose the thread.
+
+---
+
+## File structure
+
+| Action | Path (in `sunset-cam-firmware`) | Responsibility |
 |---|---|---|
-| Create | `src/sunset_cam/setup_alignment.py` | `render_align_page()`, `stream_mjpeg(frame_source, fps=4)` |
-| Create | `tests/test_setup_alignment.py` | Unit tests for both functions |
+| Modify | `pyproject.toml` | add `smbus2>=0.4` runtime dep |
+| Create | `src/sunset_cam/gyro_driver.py` | MPU6050 I2C reads + roll/pitch math |
+| Create | `src/sunset_cam/orientation_sampler.py` | background-thread sampler + smoothing + cache |
+| Create | `src/sunset_cam/solstice_math.py` | sun position + solstice azimuth + sunsets-per-year |
+| Create | `src/sunset_cam/setup_alignment.py` | `render_align_page()`, `render_orientation_json()`, `stream_mjpeg()` |
+| Create | `tests/test_gyro_driver.py` | unit tests w/ mocked I2C |
+| Create | `tests/test_orientation_sampler.py` | unit tests w/ fake clock + injected reader |
+| Create | `tests/test_solstice_math.py` | unit tests w/ known coordinates |
+| Create | `tests/test_setup_alignment.py` | unit tests for the three renderers |
 
-The module is small (target ~80 lines incl. the HTML template). Single responsibility: produce the alignment page content + stream bytes. No I/O, no framework binding, no global state.
+Each module is small (target ≤ 120 lines) and single-responsibility. No module imports a web framework. `setup_alignment.py` is the consumer of the others; the others know nothing about HTTP.
 
 ---
 
-## Task 1: Create `setup_alignment.py` skeleton + `render_align_page()`
+## Task 1: Add `smbus2` dependency
+
+**Files:**
+- Modify: `pyproject.toml`
+
+- [ ] **Step 1: Update `pyproject.toml`**
+
+Edit the `[project] dependencies` array to add `smbus2`:
+
+```toml
+[project]
+name = "sunset-cam"
+version = "0.0.1"
+description = "Firmware for the sunrise/sunset custom edge cameras (Tier 0)."
+requires-python = ">=3.11"
+dependencies = [
+  "requests>=2.31",
+  "smbus2>=0.4",
+]
+```
+
+- [ ] **Step 2: Install the dependency in the dev environment**
+
+Run: `cd /Users/jessekauppila/GitHub/sunset-cam-firmware && python -m pip install -e ".[dev]"`
+Expected: smbus2 installs cleanly.
+
+- [ ] **Step 3: Verify import**
+
+Run: `cd /Users/jessekauppila/GitHub/sunset-cam-firmware && python -c "import smbus2; print(smbus2.__version__)"`
+Expected: a version string prints. No error.
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd /Users/jessekauppila/GitHub/sunset-cam-firmware
+git add pyproject.toml
+git commit -m "build(deps): add smbus2 for MPU6050 I2C access"
+```
+
+---
+
+## Task 2: Create `gyro_driver.py` with `read_orientation()`
+
+**Files:**
+- Create: `src/sunset_cam/gyro_driver.py`
+- Create: `tests/test_gyro_driver.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/test_gyro_driver.py`:
+
+```python
+"""Tests for the MPU6050 driver — mocked I2C inputs."""
+from __future__ import annotations
+
+import math
+from sunset_cam.gyro_driver import read_orientation, accel_to_roll_pitch
+
+
+def test_accel_to_roll_pitch_returns_zero_when_flat():
+    # Phone flat: gravity is entirely along Z axis.
+    roll, pitch = accel_to_roll_pitch(0.0, 0.0, 1.0)
+    assert abs(roll) < 0.1
+    assert abs(pitch) < 0.1
+
+
+def test_accel_to_roll_pitch_returns_90_when_on_right_side():
+    # Phone on its right side: gravity along +Y → roll = 90°.
+    roll, pitch = accel_to_roll_pitch(0.0, 1.0, 0.0)
+    assert abs(roll - 90.0) < 0.5
+
+
+def test_accel_to_roll_pitch_returns_negative_90_when_on_left_side():
+    roll, pitch = accel_to_roll_pitch(0.0, -1.0, 0.0)
+    assert abs(roll - (-90.0)) < 0.5
+
+
+def test_accel_to_roll_pitch_pitch_when_tilted_forward():
+    # Phone tilted forward: gravity along +X → pitch ≈ -90°.
+    roll, pitch = accel_to_roll_pitch(1.0, 0.0, 0.0)
+    assert abs(pitch - (-90.0)) < 0.5
+
+
+def test_accel_to_roll_pitch_returns_180_or_negative_180_upside_down():
+    # Phone upside down: gravity along -Z. Roll wraps to ±180°.
+    roll, pitch = accel_to_roll_pitch(0.0, 0.0, -1.0)
+    assert abs(abs(roll) - 180.0) < 0.5
+
+
+def test_read_orientation_calls_smbus_with_correct_address():
+    # MPU6050 default address 0x68; accel registers start at 0x3B.
+    # The driver should issue an I2C read for 6 bytes starting at 0x3B.
+    calls = []
+
+    class FakeBus:
+        def read_i2c_block_data(self, addr, reg, length):
+            calls.append((addr, reg, length))
+            # 6 bytes of raw accel: 0x00 0x00 0x00 0x00 0x40 0x00
+            # → x=0, y=0, z=16384 (=1g for ±2g full scale)
+            return [0x00, 0x00, 0x00, 0x00, 0x40, 0x00]
+
+    bus = FakeBus()
+    roll, pitch = read_orientation(bus)
+
+    assert calls == [(0x68, 0x3B, 6)]
+    assert abs(roll) < 0.1
+    assert abs(pitch) < 0.1
+
+
+def test_read_orientation_handles_negative_raw_values():
+    # Two's-complement: raw=0xFFFF means -1, raw=0xC000 = -16384 (=-1g).
+    class FakeBus:
+        def read_i2c_block_data(self, addr, reg, length):
+            # x=0, y=0, z=-16384 → upside down
+            return [0x00, 0x00, 0x00, 0x00, 0xC0, 0x00]
+
+    bus = FakeBus()
+    roll, pitch = read_orientation(bus)
+    assert abs(abs(roll) - 180.0) < 0.5
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd /Users/jessekauppila/GitHub/sunset-cam-firmware && python -m pytest tests/test_gyro_driver.py -v`
+Expected: FAIL with `ModuleNotFoundError: No module named 'sunset_cam.gyro_driver'`
+
+- [ ] **Step 3: Create the module**
+
+Create `src/sunset_cam/gyro_driver.py`:
+
+```python
+"""MPU6050 / GY-521 6-axis IMU driver.
+
+Reads only the accelerometer for v0.2 (roll + pitch from the gravity vector).
+The gyro is on the chip but unused — it's reserved for a future sun-tap
+calibration spec.
+
+Spec: docs/superpowers/specs/2026-05-17-pi-side-alignment-tool-design.md §5.4
+
+Wiring (Pi Zero 2 W): VCC→3.3V, GND→GND, SDA→GPIO 2, SCL→GPIO 3.
+I2C bus 1, address 0x68 (default — AD0 pin tied low).
+"""
+from __future__ import annotations
+
+import math
+from typing import Protocol, Tuple
+
+
+MPU6050_ADDR = 0x68
+ACCEL_XOUT_H = 0x3B  # first byte of 6 accel registers (X H, X L, Y H, Y L, Z H, Z L)
+ACCEL_FS_LSB_PER_G = 16384.0  # ±2g full-scale → 16384 LSB / g
+
+
+class I2CBus(Protocol):
+    """Minimal protocol matching smbus2.SMBus.read_i2c_block_data."""
+
+    def read_i2c_block_data(self, addr: int, reg: int, length: int) -> list[int]: ...
+
+
+def _u8_pair_to_i16(high: int, low: int) -> int:
+    """Combine two unsigned bytes into a signed 16-bit integer (two's complement)."""
+    raw = (high << 8) | low
+    return raw - 0x10000 if raw & 0x8000 else raw
+
+
+def accel_to_roll_pitch(ax: float, ay: float, az: float) -> Tuple[float, float]:
+    """Convert accelerometer reading (in g, any consistent unit) to roll + pitch degrees.
+
+    Pure function — no I/O. Uses the standard atan2-based gravity-vector formulas:
+        roll  = atan2(ay, sqrt(ax² + az²))     — rotation around forward axis
+        pitch = atan2(-ax, sqrt(ay² + az²))    — rotation around right axis
+    Yaw is NOT recoverable from accelerometer alone (no horizontal reference).
+    """
+    roll_rad = math.atan2(ay, math.sqrt(ax * ax + az * az))
+    pitch_rad = math.atan2(-ax, math.sqrt(ay * ay + az * az))
+    return math.degrees(roll_rad), math.degrees(pitch_rad)
+
+
+def read_orientation(bus: I2CBus, addr: int = MPU6050_ADDR) -> Tuple[float, float]:
+    """Read accelerometer once over I2C and return (roll_deg, pitch_deg)."""
+    raw = bus.read_i2c_block_data(addr, ACCEL_XOUT_H, 6)
+    ax_lsb = _u8_pair_to_i16(raw[0], raw[1])
+    ay_lsb = _u8_pair_to_i16(raw[2], raw[3])
+    az_lsb = _u8_pair_to_i16(raw[4], raw[5])
+
+    ax_g = ax_lsb / ACCEL_FS_LSB_PER_G
+    ay_g = ay_lsb / ACCEL_FS_LSB_PER_G
+    az_g = az_lsb / ACCEL_FS_LSB_PER_G
+
+    return accel_to_roll_pitch(ax_g, ay_g, az_g)
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd /Users/jessekauppila/GitHub/sunset-cam-firmware && python -m pytest tests/test_gyro_driver.py -v`
+Expected: 7/7 PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /Users/jessekauppila/GitHub/sunset-cam-firmware
+git add src/sunset_cam/gyro_driver.py tests/test_gyro_driver.py
+git commit -m "feat(gyro): MPU6050 driver with read_orientation()"
+```
+
+---
+
+## Task 3: Create `orientation_sampler.py` with a background-thread cache
+
+**Files:**
+- Create: `src/sunset_cam/orientation_sampler.py`
+- Create: `tests/test_orientation_sampler.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/test_orientation_sampler.py`:
+
+```python
+"""Tests for the orientation sampler — uses an injected reader function
+plus a fake clock to verify smoothing math without real I2C or real time."""
+from __future__ import annotations
+
+import time
+from sunset_cam.orientation_sampler import OrientationSampler
+
+
+def test_initial_sample_is_none():
+    sampler = OrientationSampler(reader=lambda: (0.0, 0.0))
+    assert sampler.latest() is None
+
+
+def test_sample_once_caches_the_value():
+    sampler = OrientationSampler(reader=lambda: (1.0, 2.0))
+    sampler.sample_once()
+    latest = sampler.latest()
+    assert latest is not None
+    assert latest["roll_deg"] == 1.0
+    assert latest["pitch_deg"] == 2.0
+    assert "sampled_at" in latest
+
+
+def test_smoothing_with_default_alpha():
+    # alpha = 0.3 → first sample is the seed; second is 0.3*new + 0.7*prev
+    values = iter([(10.0, 0.0), (20.0, 0.0)])
+    sampler = OrientationSampler(reader=lambda: next(values), alpha=0.3)
+
+    sampler.sample_once()
+    assert abs(sampler.latest()["roll_deg"] - 10.0) < 0.001
+
+    sampler.sample_once()
+    expected = 0.3 * 20.0 + 0.7 * 10.0  # = 13.0
+    assert abs(sampler.latest()["roll_deg"] - expected) < 0.001
+
+
+def test_sample_once_handles_reader_exception():
+    # If the reader raises (e.g., I2C glitch), the cache stays at its
+    # previous value rather than corrupting to None.
+    sampler = OrientationSampler(reader=lambda: (5.0, 6.0))
+    sampler.sample_once()
+    sampled_before = sampler.latest()
+
+    def broken_reader() -> tuple[float, float]:
+        raise OSError("simulated I2C glitch")
+
+    sampler._reader = broken_reader
+    sampler.sample_once()  # Should not raise
+    assert sampler.latest() == sampled_before
+
+
+def test_start_stop_runs_sampling_loop():
+    # Background thread samples a few times then we stop it.
+    count = {"n": 0}
+
+    def counting_reader() -> tuple[float, float]:
+        count["n"] += 1
+        return (0.0, 0.0)
+
+    sampler = OrientationSampler(reader=counting_reader, hz=50)
+    sampler.start()
+    time.sleep(0.1)  # ~5 samples at 50 Hz
+    sampler.stop()
+    assert count["n"] >= 2
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd /Users/jessekauppila/GitHub/sunset-cam-firmware && python -m pytest tests/test_orientation_sampler.py -v`
+Expected: FAIL with `ModuleNotFoundError`.
+
+- [ ] **Step 3: Create the module**
+
+Create `src/sunset_cam/orientation_sampler.py`:
+
+```python
+"""Background-thread orientation sampler.
+
+Polls an injected reader callable at a fixed Hz, applies exponential
+smoothing, caches the latest result for synchronous access via ``latest()``.
+
+The reader is injected (not hard-coded to MPU6050) so the sampler can be
+unit-tested with a deterministic fake reader and so future hardware ports
+(ESP32, different IMU) don't need to fork this module.
+"""
+from __future__ import annotations
+
+import threading
+import time
+from datetime import datetime, timezone
+from typing import Callable, Optional, Tuple
+
+
+ReadingTuple = Tuple[float, float]  # (roll_deg, pitch_deg)
+
+
+class OrientationSampler:
+    """Polls a reader callable in a daemon thread; caches latest smoothed reading."""
+
+    def __init__(
+        self,
+        reader: Callable[[], ReadingTuple],
+        alpha: float = 0.3,
+        hz: int = 10,
+    ) -> None:
+        self._reader = reader
+        self._alpha = alpha
+        self._period_s = 1.0 / hz
+        self._smoothed: Optional[ReadingTuple] = None
+        self._sampled_at: Optional[str] = None
+        self._thread: Optional[threading.Thread] = None
+        self._stop_event = threading.Event()
+
+    def sample_once(self) -> None:
+        """Take one reading and update the cache (synchronous; for tests)."""
+        try:
+            raw = self._reader()
+        except Exception:
+            return  # keep previous cache
+
+        if self._smoothed is None:
+            self._smoothed = raw
+        else:
+            r_prev, p_prev = self._smoothed
+            r_new, p_new = raw
+            self._smoothed = (
+                self._alpha * r_new + (1.0 - self._alpha) * r_prev,
+                self._alpha * p_new + (1.0 - self._alpha) * p_prev,
+            )
+        self._sampled_at = datetime.now(timezone.utc).isoformat()
+
+    def latest(self) -> Optional[dict]:
+        """Return the latest cached reading as a JSON-serializable dict, or None."""
+        if self._smoothed is None:
+            return None
+        return {
+            "roll_deg": self._smoothed[0],
+            "pitch_deg": self._smoothed[1],
+            "sampled_at": self._sampled_at,
+        }
+
+    def start(self) -> None:
+        if self._thread is not None and self._thread.is_alive():
+            return
+        self._stop_event.clear()
+        self._thread = threading.Thread(target=self._run, daemon=True)
+        self._thread.start()
+
+    def stop(self) -> None:
+        self._stop_event.set()
+        if self._thread is not None:
+            self._thread.join(timeout=1.0)
+            self._thread = None
+
+    def _run(self) -> None:
+        while not self._stop_event.is_set():
+            self.sample_once()
+            self._stop_event.wait(timeout=self._period_s)
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd /Users/jessekauppila/GitHub/sunset-cam-firmware && python -m pytest tests/test_orientation_sampler.py -v`
+Expected: 5/5 PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /Users/jessekauppila/GitHub/sunset-cam-firmware
+git add src/sunset_cam/orientation_sampler.py tests/test_orientation_sampler.py
+git commit -m "feat(orientation): background sampler with smoothing + cache"
+```
+
+---
+
+## Task 4: Create `solstice_math.py` (server-side solstice + sunsets-per-year math)
+
+**Files:**
+- Create: `src/sunset_cam/solstice_math.py`
+- Create: `tests/test_solstice_math.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/test_solstice_math.py`:
+
+```python
+"""Tests for the solstice / sun-azimuth math.
+
+Uses NOAA-tabulated solstice sunset azimuths to validate the formula at a
+known latitude (Bellingham, WA: 48.7519°N).
+"""
+from __future__ import annotations
+
+from sunset_cam.solstice_math import (
+    sunset_azimuth_for_day,
+    az_to_pixel,
+    count_sunsets_in_fov,
+)
+
+
+# Bellingham, WA
+BELLINGHAM_LAT = 48.7519
+BELLINGHAM_LNG = -122.4787
+
+
+def test_sunset_azimuth_june_solstice_bellingham_is_northwest():
+    # June 21 sunset at 48.75°N is roughly 302° (just N of W).
+    az = sunset_azimuth_for_day(BELLINGHAM_LAT, 2026, 6, 21)
+    assert 295.0 <= az <= 310.0
+
+
+def test_sunset_azimuth_december_solstice_bellingham_is_southwest():
+    # Dec 21 sunset at 48.75°N is roughly 240° (S of W).
+    az = sunset_azimuth_for_day(BELLINGHAM_LAT, 2026, 12, 21)
+    assert 235.0 <= az <= 250.0
+
+
+def test_sunset_azimuth_equinox_bellingham_is_near_due_west():
+    # Mar/Sep equinox sunset is always ~270° (within ~1°).
+    az_sep = sunset_azimuth_for_day(BELLINGHAM_LAT, 2026, 9, 22)
+    assert 268.0 <= az_sep <= 272.0
+
+
+def test_az_to_pixel_center_when_target_equals_camera_center():
+    # If the target azimuth equals the camera's center, it maps to screen center.
+    px = az_to_pixel(az_deg=270.0, center_az=270.0, fov_deg=102.0, screen_width=1600)
+    assert abs(px - 800.0) < 1.0
+
+
+def test_az_to_pixel_wraps_signed_delta_correctly():
+    # Camera at 350°, target at 10°: signed delta should be +20°, not -340°.
+    px = az_to_pixel(az_deg=10.0, center_az=350.0, fov_deg=102.0, screen_width=1600)
+    # +20°/102° of full width → 800 + 1600*(20/102) ≈ 1114
+    assert 1100 <= px <= 1130
+
+
+def test_count_sunsets_in_fov_bellingham_west_returns_full_year():
+    # West-facing camera with 102° FOV centered on 270° covers
+    # roughly 219°–321°. Bellingham's sunset azimuth range over a year
+    # is roughly 240°–302°, fully inside the FOV → 365 days.
+    count = count_sunsets_in_fov(
+        BELLINGHAM_LAT, BELLINGHAM_LNG,
+        center_az=270.0, fov_deg=102.0, year=2026,
+    )
+    assert count == 365
+
+
+def test_count_sunsets_in_fov_bellingham_north_returns_few():
+    # North-facing camera misses every sunset. Expect 0.
+    count = count_sunsets_in_fov(
+        BELLINGHAM_LAT, BELLINGHAM_LNG,
+        center_az=0.0, fov_deg=60.0, year=2026,
+    )
+    assert count == 0
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd /Users/jessekauppila/GitHub/sunset-cam-firmware && python -m pytest tests/test_solstice_math.py -v`
+Expected: FAIL with `ModuleNotFoundError`.
+
+- [ ] **Step 3: Create the module**
+
+Create `src/sunset_cam/solstice_math.py`:
+
+```python
+"""Sun azimuth + sunsets-per-year computation, server-side.
+
+Pure math, no I/O, no external deps beyond stdlib. Uses NOAA's solar
+position approximation good to roughly ±0.5° for civil purposes — accurate
+enough for placement advice; not survey-grade.
+
+References:
+- NOAA Solar Calculator: https://gml.noaa.gov/grad/solcalc/
+- Equations (Spencer 1971 / Reda+Andreas refined) for declination + equation of time
+"""
+from __future__ import annotations
+
+import math
+from datetime import date, datetime, timedelta, timezone
+from typing import Iterable
+
+
+def _julian_day(year: int, month: int, day: int) -> float:
+    if month <= 2:
+        year -= 1
+        month += 12
+    a = year // 100
+    b = 2 - a + a // 4
+    return (
+        math.floor(365.25 * (year + 4716))
+        + math.floor(30.6001 * (month + 1))
+        + day + b - 1524.5
+    )
+
+
+def _solar_declination_deg(jd: float) -> float:
+    """Approximate solar declination, NOAA Spencer formula."""
+    n = jd - 2451545.0  # days since J2000.0
+    g_rad = math.radians((357.528 + 0.9856003 * n) % 360.0)
+    lam_rad = math.radians(
+        (280.460 + 0.9856474 * n + 1.915 * math.sin(g_rad) + 0.020 * math.sin(2 * g_rad))
+        % 360.0
+    )
+    eps_rad = math.radians(23.439 - 0.0000004 * n)
+    decl_rad = math.asin(math.sin(eps_rad) * math.sin(lam_rad))
+    return math.degrees(decl_rad)
+
+
+def sunset_azimuth_for_day(lat_deg: float, year: int, month: int, day: int) -> float:
+    """Approximate azimuth (degrees from North, clockwise) of the sun at sunset
+    on the given date at the given latitude.
+
+    Uses the closed-form solution from Duffie & Beckman (Solar Engineering of
+    Thermal Processes), §1.6: at sunset, the hour angle is the sunset hour
+    angle ωs satisfying cos(ωs) = -tan(φ)·tan(δ), and the azimuth (south=0
+    convention) is given by an arccosine of (sin(δ)·cos(φ) − cos(δ)·sin(φ)·cos(ωs))
+    over -1. We then convert to north=0 convention.
+    """
+    jd = _julian_day(year, month, day) + 0.5  # noon UT
+    decl_deg = _solar_declination_deg(jd)
+    decl_rad = math.radians(decl_deg)
+    lat_rad = math.radians(lat_deg)
+
+    # Sunset hour angle ωs (radians); guard against polar day/night where
+    # |tan(φ)·tan(δ)| > 1.
+    cos_ws = -math.tan(lat_rad) * math.tan(decl_rad)
+    if cos_ws >= 1.0:
+        cos_ws = 1.0  # polar night — no sunset; degenerate
+    elif cos_ws <= -1.0:
+        cos_ws = -1.0  # polar day
+    ws_rad = math.acos(cos_ws)
+
+    # Azimuth in south=0 west=positive convention
+    cos_az = (
+        (math.sin(decl_rad) * math.cos(lat_rad) - math.cos(decl_rad) * math.sin(lat_rad) * math.cos(ws_rad))
+        / max(1e-9, math.cos(math.asin(
+            math.sin(lat_rad) * math.sin(decl_rad)
+            + math.cos(lat_rad) * math.cos(decl_rad) * math.cos(ws_rad)
+        )))
+    )
+    cos_az = max(-1.0, min(1.0, cos_az))
+    az_from_south_rad = math.acos(cos_az)
+    # Sunset is always toward the west, so south=0 west=positive → az is positive.
+    az_from_south_deg = math.degrees(az_from_south_rad)
+    # Convert to compass (north=0, clockwise): compass = 180 + az_from_south for west
+    return (180.0 + az_from_south_deg) % 360.0
+
+
+def az_to_pixel(
+    az_deg: float, center_az: float, fov_deg: float, screen_width: int
+) -> float:
+    """Map an azimuth to a horizontal pixel coordinate on the preview frame."""
+    # Signed delta in [-180, 180]
+    delta = ((az_deg - center_az + 540.0) % 360.0) - 180.0
+    return screen_width * (0.5 + delta / fov_deg)
+
+
+def count_sunsets_in_fov(
+    lat_deg: float, lng_deg: float,
+    center_az: float, fov_deg: float,
+    year: int,
+) -> int:
+    """Count days in the given year where the sunset azimuth at (lat,lng)
+    falls within the camera's horizontal field-of-view centered on center_az."""
+    half_fov = fov_deg / 2.0
+    count = 0
+    d = date(year, 1, 1)
+    end = date(year, 12, 31)
+    while d <= end:
+        az = sunset_azimuth_for_day(lat_deg, d.year, d.month, d.day)
+        delta = ((az - center_az + 540.0) % 360.0) - 180.0
+        if -half_fov <= delta <= half_fov:
+            count += 1
+        d += timedelta(days=1)
+    return count
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd /Users/jessekauppila/GitHub/sunset-cam-firmware && python -m pytest tests/test_solstice_math.py -v`
+Expected: 7/7 PASS.
+
+If the Bellingham June/December solstice tests fail by a few degrees, that's a real signal — the closed-form formula above can be off by 2–3° at high latitudes. Acceptable for v1; tighten later if field data demands.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /Users/jessekauppila/GitHub/sunset-cam-firmware
+git add src/sunset_cam/solstice_math.py tests/test_solstice_math.py
+git commit -m "feat(solstice): sun azimuth + sunsets-per-year math"
+```
+
+---
+
+## Task 5: Create `setup_alignment.py` with `render_align_page()` (basic page, no live data yet)
 
 **Files:**
 - Create: `src/sunset_cam/setup_alignment.py`
 - Create: `tests/test_setup_alignment.py`
 
-- [ ] **Step 1: Write the failing test**
+This task lands the static page skeleton. Tasks 6–8 layer on the live readout, facing selector, and counter.
 
-Create `tests/test_setup_alignment.py` with the following content:
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/test_setup_alignment.py`:
 
 ```python
-"""Tests for the Pi-side alignment tool's render + stream functions."""
+"""Tests for setup_alignment.py — the alignment-page HTML renderer."""
 from __future__ import annotations
 
 from sunset_cam.setup_alignment import render_align_page
 
 
 def test_render_align_page_returns_string():
-    html = render_align_page()
+    html = render_align_page(lat=48.75, lng=-122.48)
     assert isinstance(html, str)
     assert html.startswith("<!doctype html>")
 
 
-def test_render_align_page_includes_preview_image_pointing_at_mjpeg_route():
-    html = render_align_page()
-    # The page contains an <img> whose src is the MJPEG stream route.
-    # The exact route path is part of the contract — downstream code
-    # in spec E's web app must register the stream at this URL.
+def test_render_align_page_embeds_preview_image_src():
+    html = render_align_page(lat=48.75, lng=-122.48)
     assert 'src="/setup/preview.mjpg"' in html
 
 
-def test_render_align_page_has_horizon_line_overlay():
-    html = render_align_page()
-    # A horizontal dashed line at the vertical center of the SVG overlay
-    # (viewBox is 1600x900, so y=450 is center).
+def test_render_align_page_has_horizon_line_at_center():
+    html = render_align_page(lat=48.75, lng=-122.48)
     assert '<line' in html
-    assert 'y1="450"' in html
-    assert 'y2="450"' in html
+    assert 'y1="450"' in html and 'y2="450"' in html
     assert 'stroke-dasharray' in html
 
 
-def test_render_align_page_has_up_arrow_label():
-    html = render_align_page()
-    # Top-center label showing which way is up
+def test_render_align_page_has_up_label():
+    html = render_align_page(lat=48.75, lng=-122.48)
     assert "UP" in html
-    # The arrow character or an HTML-entity equivalent
     assert ("↑" in html) or ("&uarr;" in html)
 
 
-def test_render_align_page_has_instructions():
-    html = render_align_page()
-    # Operator guidance text — at minimum mentions "horizon" and "mount"
-    assert "horizon" in html.lower()
-    assert "mount" in html.lower()
+def test_render_align_page_embeds_coordinates_in_data_attrs():
+    # lat/lng should be embedded so client-side JS (added in Task 6)
+    # can read them. v1: just data-attributes on the root element.
+    html = render_align_page(lat=48.75, lng=-122.48)
+    assert 'data-lat="48.75"' in html
+    assert 'data-lng="-122.48"' in html
 ```
 
 - [ ] **Step 2: Run test to verify it fails**
 
 Run: `cd /Users/jessekauppila/GitHub/sunset-cam-firmware && python -m pytest tests/test_setup_alignment.py -v`
-Expected: FAIL with `ModuleNotFoundError: No module named 'sunset_cam.setup_alignment'`
+Expected: FAIL with `ModuleNotFoundError`.
 
-- [ ] **Step 3: Create the module + implement `render_align_page()`**
+- [ ] **Step 3: Create the module**
 
-Create `src/sunset_cam/setup_alignment.py` with the following content:
+Create `src/sunset_cam/setup_alignment.py`:
 
 ```python
-"""Pi-side alignment tool: framework-agnostic helpers.
+"""Pi-side alignment tool: framework-agnostic page + stream renderers.
 
-Two public functions:
-- ``render_align_page()`` returns the static HTML for the alignment page
-  served at ``/setup/align``.
-- ``stream_mjpeg(frame_source, fps)`` returns a generator producing
-  multipart MJPEG bytes for ``/setup/preview.mjpg``.
+Public API:
+- ``render_align_page(lat, lng)`` → HTML for ``/setup/align``
+- ``render_orientation_json(sampler)`` → JSON for ``/setup/orientation.json``
+  (added in Task 7)
+- ``stream_mjpeg(frame_source, fps)`` → multipart MJPEG bytes for
+  ``/setup/preview.mjpg`` (added in Task 9)
 
-Both are pure: no framework binding, no global state, no I/O beyond what
-the caller provides via ``frame_source``. The eventual web-app integration
-(in spec E's setup web app) registers these as route handlers.
-
-Spec: docs/superpowers/specs/2026-05-17-pi-side-alignment-tool-design.md
-(in the the-sunset-webcam-map repo).
+Spec: docs/superpowers/specs/2026-05-17-pi-side-alignment-tool-design.md v0.2
 """
 from __future__ import annotations
 
-from typing import Callable, Iterator
 
-
-_ALIGN_HTML = """<!doctype html>
+def render_align_page(lat: float, lng: float) -> str:
+    """Render the alignment page HTML. Embeds the camera's lat/lng as
+    data-attributes for use by client-side scripts (added in Task 6)."""
+    return f"""<!doctype html>
 <html lang="en">
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width,initial-scale=1" />
   <title>Align your camera</title>
   <style>
-    body { background: #000; color: #fff; font: 14px system-ui, sans-serif; margin: 0; padding: 0; }
-    .preview-wrap { position: relative; width: 100%; max-width: 100vw; aspect-ratio: 16/9; margin: 0 auto; }
-    .preview-wrap img { width: 100%; display: block; }
-    .overlay { position: absolute; inset: 0; pointer-events: none; }
-    .instructions { padding: 16px 20px; line-height: 1.55; max-width: 560px; margin: 0 auto; }
-    .instructions ol { padding-left: 1.2em; }
+    body {{ background: #000; color: #fff; font: 14px system-ui, sans-serif; margin: 0; padding: 0; }}
+    .preview-wrap {{ position: relative; width: 100%; max-width: 100vw; aspect-ratio: 16/9; margin: 0 auto; }}
+    .preview-wrap img {{ width: 100%; display: block; }}
+    .overlay {{ position: absolute; inset: 0; pointer-events: none; }}
+    .instructions {{ padding: 16px 20px; line-height: 1.55; max-width: 560px; margin: 0 auto; }}
+    .instructions ol {{ padding-left: 1.2em; }}
   </style>
 </head>
-<body>
+<body data-lat="{lat}" data-lng="{lng}">
   <div class="preview-wrap">
     <img src="/setup/preview.mjpg" alt="camera preview" />
     <svg class="overlay" viewBox="0 0 1600 900" preserveAspectRatio="none">
@@ -148,34 +760,13 @@ _ALIGN_HTML = """<!doctype html>
     <p>Rotate the camera housing until:</p>
     <ol>
       <li>The real horizon lines up with the dashed line.</li>
-      <li>The &uarr; on screen points the same direction as the &uarr; molded on the housing.</li>
+      <li>The &uarr; on screen points the same direction as the &uarr; drawn on the housing.</li>
     </ol>
     <p>When both match, mount the camera in place. Then close this tab and return to setup.</p>
   </div>
 </body>
 </html>
 """
-
-
-def render_align_page() -> str:
-    """Return the static HTML for the alignment page.
-
-    Pure function — no I/O, no parameters. Callers (the web app) wrap the
-    return value in their framework's response object.
-    """
-    return _ALIGN_HTML
-
-
-def stream_mjpeg(
-    frame_source: Callable[[], bytes],
-    fps: int = 4,
-) -> Iterator[bytes]:
-    """Generator producing multipart MJPEG bytes.
-
-    Stub for Task 2 — placeholder body raises NotImplementedError so the
-    Task 1 import test passes without prematurely defining the contract.
-    """
-    raise NotImplementedError("stream_mjpeg lands in Task 2")
 ```
 
 - [ ] **Step 4: Run tests to verify they pass**
@@ -188,140 +779,79 @@ Expected: 5/5 PASS.
 ```bash
 cd /Users/jessekauppila/GitHub/sunset-cam-firmware
 git add src/sunset_cam/setup_alignment.py tests/test_setup_alignment.py
-git commit -m "feat(setup-align): render_align_page() with overlay + instructions"
+git commit -m "feat(setup-align): render_align_page() with horizon + UP marker"
 ```
 
 ---
 
-## Task 2: Implement `stream_mjpeg()` generator
+## Task 6: Extend `render_align_page()` with the live roll/pitch readout (polling JS)
 
 **Files:**
-- Modify: `src/sunset_cam/setup_alignment.py` (replace the stub body)
-- Modify: `tests/test_setup_alignment.py` (add streaming tests)
-
-The function produces a properly-formatted multipart/x-mixed-replace MJPEG stream by repeatedly calling a `frame_source` callable and yielding correctly-encoded bytes. Time pacing between frames is the caller's responsibility — Task 2 keeps the generator purely synchronous so unit tests can advance frames deterministically. Real-world rate limiting (sleep between frames) lands in a Task 3 helper or in the eventual web-app integration.
+- Modify: `src/sunset_cam/setup_alignment.py`
+- Modify: `tests/test_setup_alignment.py`
 
 - [ ] **Step 1: Add the failing tests**
 
 Append to `tests/test_setup_alignment.py`:
 
 ```python
-from sunset_cam.setup_alignment import stream_mjpeg, MJPEG_BOUNDARY
+def test_render_align_page_includes_orientation_readout_element():
+    html = render_align_page(lat=48.75, lng=-122.48)
+    # A specific element id the polling JS will update with the latest roll.
+    assert 'id="roll-readout"' in html
+    assert 'id="pitch-readout"' in html
 
 
-def test_mjpeg_boundary_is_exported_and_nontrivial():
-    # The boundary string used in the multipart payload must also be the
-    # one the web app advertises in its Content-Type header. Exporting it
-    # so the web app can read the same value avoids drift.
-    assert isinstance(MJPEG_BOUNDARY, str)
-    assert len(MJPEG_BOUNDARY) >= 8
+def test_render_align_page_includes_polling_script_targeting_orientation_endpoint():
+    html = render_align_page(lat=48.75, lng=-122.48)
+    # The script must fetch /setup/orientation.json on an interval.
+    assert "/setup/orientation.json" in html
+    assert "setInterval" in html
 
 
-def test_stream_mjpeg_yields_three_frames_from_a_three_call_source():
-    frames = [b"AAA", b"BBB", b"CCC"]
-    call_index = {"i": 0}
-
-    def source() -> bytes:
-        i = call_index["i"]
-        call_index["i"] += 1
-        if i >= len(frames):
-            raise StopIteration  # signals end of stream
-        return frames[i]
-
-    out = b"".join(stream_mjpeg(source))
-    # Each frame is wrapped in a multipart part with the boundary
-    assert out.count(f"--{MJPEG_BOUNDARY}".encode()) == 3
-    # Each part declares Content-Type: image/jpeg
-    assert out.count(b"Content-Type: image/jpeg") == 3
-    # Each part contains the frame body bytes
-    for frame in frames:
-        assert frame in out
-
-
-def test_stream_mjpeg_includes_content_length_per_part():
-    def source() -> bytes:
-        source.call_count = getattr(source, "call_count", 0) + 1
-        if source.call_count > 1:
-            raise StopIteration
-        return b"X" * 17
-
-    out = b"".join(stream_mjpeg(source))
-    # The part announces its body length so clients can frame correctly
-    assert b"Content-Length: 17" in out
-
-
-def test_stream_mjpeg_terminates_on_source_stopiteration():
-    def source() -> bytes:
-        raise StopIteration
-
-    # No frames produced — generator should complete cleanly without yielding
-    chunks = list(stream_mjpeg(source))
-    assert chunks == []
-
-
-def test_stream_mjpeg_swallows_source_exception_and_stops():
-    # A frame source that raises something other than StopIteration
-    # (e.g., a transient camera error) should NOT crash the stream;
-    # it should terminate cleanly as if EOF was reached.
-    def source() -> bytes:
-        raise RuntimeError("camera glitch")
-
-    chunks = list(stream_mjpeg(source))
-    assert chunks == []
+def test_render_align_page_includes_level_badge():
+    html = render_align_page(lat=48.75, lng=-122.48)
+    # The badge that lights up green when |roll| < 1°.
+    assert 'id="level-badge"' in html
 ```
 
 - [ ] **Step 2: Run tests to verify they fail**
 
-Run: `cd /Users/jessekauppila/GitHub/sunset-cam-firmware && python -m pytest tests/test_setup_alignment.py -v`
-Expected: the four new tests FAIL (the first because `MJPEG_BOUNDARY` doesn't exist, the others because `stream_mjpeg` raises `NotImplementedError`).
+Run: `cd /Users/jessekauppila/GitHub/sunset-cam-firmware && python -m pytest tests/test_setup_alignment.py::test_render_align_page_includes_orientation_readout_element -v`
+Expected: FAIL — `'id="roll-readout"' in html` is False.
 
-- [ ] **Step 3: Implement `stream_mjpeg()` + add `MJPEG_BOUNDARY` constant**
+- [ ] **Step 3: Extend `render_align_page()` in `setup_alignment.py`**
 
-In `src/sunset_cam/setup_alignment.py`, replace the placeholder body of `stream_mjpeg` and add the `MJPEG_BOUNDARY` constant. The full updated file:
+Replace the function body with a version that includes the readout + polling JS:
 
 ```python
-"""Pi-side alignment tool: framework-agnostic helpers.
-
-Two public functions:
-- ``render_align_page()`` returns the static HTML for the alignment page
-  served at ``/setup/align``.
-- ``stream_mjpeg(frame_source, fps)`` returns a generator producing
-  multipart MJPEG bytes for ``/setup/preview.mjpg``.
-
-Both are pure: no framework binding, no global state, no I/O beyond what
-the caller provides via ``frame_source``. The eventual web-app integration
-(in spec E's setup web app) registers these as route handlers.
-
-Spec: docs/superpowers/specs/2026-05-17-pi-side-alignment-tool-design.md
-(in the the-sunset-webcam-map repo).
-"""
-from __future__ import annotations
-
-from typing import Callable, Iterator
-
-
-MJPEG_BOUNDARY = "sunsetcamframe"
-"""The multipart boundary string. The web app must declare the same value
-in the response's Content-Type header (``multipart/x-mixed-replace; boundary=sunsetcamframe``)
-so clients frame parts correctly."""
-
-
-_ALIGN_HTML = """<!doctype html>
+def render_align_page(lat: float, lng: float) -> str:
+    """Render the alignment page HTML."""
+    return f"""<!doctype html>
 <html lang="en">
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width,initial-scale=1" />
   <title>Align your camera</title>
   <style>
-    body { background: #000; color: #fff; font: 14px system-ui, sans-serif; margin: 0; padding: 0; }
-    .preview-wrap { position: relative; width: 100%; max-width: 100vw; aspect-ratio: 16/9; margin: 0 auto; }
-    .preview-wrap img { width: 100%; display: block; }
-    .overlay { position: absolute; inset: 0; pointer-events: none; }
-    .instructions { padding: 16px 20px; line-height: 1.55; max-width: 560px; margin: 0 auto; }
-    .instructions ol { padding-left: 1.2em; }
+    body {{ background: #000; color: #fff; font: 14px system-ui, sans-serif; margin: 0; padding: 0; }}
+    .top-hud {{ display: flex; gap: 12px; align-items: center; justify-content: center; padding: 10px 16px; background: #111; }}
+    .readout {{ font-variant-numeric: tabular-nums; font-size: 16px; min-width: 80px; }}
+    .level-badge {{ padding: 4px 10px; border-radius: 12px; font-size: 11px; background: #444; color: #aaa; }}
+    .level-badge.ok {{ background: #265f2c; color: #d8ffd8; }}
+    .preview-wrap {{ position: relative; width: 100%; max-width: 100vw; aspect-ratio: 16/9; margin: 0 auto; }}
+    .preview-wrap img {{ width: 100%; display: block; }}
+    .overlay {{ position: absolute; inset: 0; pointer-events: none; }}
+    .instructions {{ padding: 16px 20px; line-height: 1.55; max-width: 560px; margin: 0 auto; }}
+    .instructions ol {{ padding-left: 1.2em; }}
   </style>
 </head>
-<body>
+<body data-lat="{lat}" data-lng="{lng}">
+  <div class="top-hud">
+    <span>roll: <span id="roll-readout" class="readout">—</span></span>
+    <span>pitch: <span id="pitch-readout" class="readout">—</span></span>
+    <span id="level-badge" class="level-badge">checking…</span>
+  </div>
   <div class="preview-wrap">
     <img src="/setup/preview.mjpg" alt="camera preview" />
     <svg class="overlay" viewBox="0 0 1600 900" preserveAspectRatio="none">
@@ -334,23 +864,456 @@ _ALIGN_HTML = """<!doctype html>
   <div class="instructions">
     <p>Rotate the camera housing until:</p>
     <ol>
-      <li>The real horizon lines up with the dashed line.</li>
-      <li>The &uarr; on screen points the same direction as the &uarr; molded on the housing.</li>
+      <li>The roll readout above is close to 0° and the badge shows green.</li>
+      <li>The &uarr; on screen points the same direction as the &uarr; drawn on the housing.</li>
     </ol>
     <p>When both match, mount the camera in place. Then close this tab and return to setup.</p>
   </div>
+  <script>
+    async function pollOrientation() {{
+      try {{
+        const r = await fetch('/setup/orientation.json', {{ cache: 'no-store' }});
+        if (!r.ok) return;
+        const j = await r.json();
+        if (j.roll_deg !== undefined) {{
+          document.getElementById('roll-readout').textContent = j.roll_deg.toFixed(1) + '°';
+        }}
+        if (j.pitch_deg !== undefined) {{
+          document.getElementById('pitch-readout').textContent = j.pitch_deg.toFixed(1) + '°';
+        }}
+        const badge = document.getElementById('level-badge');
+        const level = Math.abs(j.roll_deg || 99) < 1.0 && Math.abs(j.pitch_deg || 99) < 1.0;
+        badge.textContent = level ? 'level' : 'tilted';
+        badge.classList.toggle('ok', level);
+      }} catch (e) {{ /* swallow */ }}
+    }}
+    setInterval(pollOrientation, 200);
+    pollOrientation();
+  </script>
 </body>
 </html>
 """
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd /Users/jessekauppila/GitHub/sunset-cam-firmware && python -m pytest tests/test_setup_alignment.py -v`
+Expected: 8/8 PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /Users/jessekauppila/GitHub/sunset-cam-firmware
+git add src/sunset_cam/setup_alignment.py tests/test_setup_alignment.py
+git commit -m "feat(setup-align): live roll/pitch readout via polling JS"
+```
+
+---
+
+## Task 7: Add `render_orientation_json()`
+
+**Files:**
+- Modify: `src/sunset_cam/setup_alignment.py`
+- Modify: `tests/test_setup_alignment.py`
+
+- [ ] **Step 1: Add the failing tests**
+
+Append to `tests/test_setup_alignment.py`:
+
+```python
+import json
+from sunset_cam.orientation_sampler import OrientationSampler
+from sunset_cam.setup_alignment import render_orientation_json
 
 
-def render_align_page() -> str:
-    """Return the static HTML for the alignment page.
+def test_render_orientation_json_empty_when_sampler_has_no_reading():
+    sampler = OrientationSampler(reader=lambda: (0.0, 0.0))
+    body = render_orientation_json(sampler)
+    parsed = json.loads(body)
+    assert parsed == {}
 
-    Pure function — no I/O, no parameters. Callers (the web app) wrap the
-    return value in their framework's response object.
+
+def test_render_orientation_json_returns_latest_reading():
+    sampler = OrientationSampler(reader=lambda: (1.5, 2.5))
+    sampler.sample_once()
+    body = render_orientation_json(sampler)
+    parsed = json.loads(body)
+    assert abs(parsed["roll_deg"] - 1.5) < 0.001
+    assert abs(parsed["pitch_deg"] - 2.5) < 0.001
+    assert "sampled_at" in parsed
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd /Users/jessekauppila/GitHub/sunset-cam-firmware && python -m pytest tests/test_setup_alignment.py::test_render_orientation_json_empty_when_sampler_has_no_reading -v`
+Expected: FAIL with ImportError on `render_orientation_json`.
+
+- [ ] **Step 3: Add `render_orientation_json()` to `setup_alignment.py`**
+
+Append to `src/sunset_cam/setup_alignment.py`:
+
+```python
+import json
+from sunset_cam.orientation_sampler import OrientationSampler
+
+
+def render_orientation_json(sampler: OrientationSampler) -> str:
+    """Return the latest cached reading as a JSON string. Empty object when
+    the sampler has not yet captured anything (e.g., during the first 200 ms
+    after startup)."""
+    latest = sampler.latest()
+    return json.dumps(latest if latest is not None else {})
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd /Users/jessekauppila/GitHub/sunset-cam-firmware && python -m pytest tests/test_setup_alignment.py -v`
+Expected: 10/10 PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /Users/jessekauppila/GitHub/sunset-cam-firmware
+git add src/sunset_cam/setup_alignment.py tests/test_setup_alignment.py
+git commit -m "feat(setup-align): render_orientation_json() exposes sampler cache"
+```
+
+---
+
+## Task 8: Add facing selector + solstice markers + sunsets-per-year counter to the HTML
+
+**Files:**
+- Modify: `src/sunset_cam/setup_alignment.py`
+- Modify: `tests/test_setup_alignment.py`
+
+The markers and the counter are server-rendered (computed once per page-load in Python). The toggle is pure CSS via radio inputs + `:checked ~ ...` selectors — no JS state.
+
+- [ ] **Step 1: Add the failing tests**
+
+Append to `tests/test_setup_alignment.py`:
+
+```python
+def test_render_align_page_has_facing_selector_with_three_options():
+    html = render_align_page(lat=48.75, lng=-122.48)
+    # Radio inputs for east / west / both
+    assert 'value="east"' in html
+    assert 'value="west"' in html
+    assert 'value="both"' in html
+
+
+def test_render_align_page_embeds_per_facing_solstice_markers_and_counts():
+    html = render_align_page(lat=48.75, lng=-122.48)
+    # Each facing variant has its own marker x-positions + sunsets/year count
+    # rendered into the SVG. We check that the page contains three distinct
+    # sunsets-per-year values (one per facing).
+    # At Bellingham 48.75°N: west covers the year (365), east covers the year (365),
+    # both = 365. So a coarse check: the digit string "365" must appear ≥ 1 time
+    # in the body, and the markup must contain three labelled groups.
+    assert html.count('data-facing="east"') >= 1
+    assert html.count('data-facing="west"') >= 1
+    assert html.count('data-facing="both"') >= 1
+
+
+def test_render_align_page_default_facing_is_west():
+    html = render_align_page(lat=48.75, lng=-122.48)
+    # West radio input is checked by default
+    assert 'value="west" checked' in html or 'value="west"  checked' in html
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd /Users/jessekauppila/GitHub/sunset-cam-firmware && python -m pytest tests/test_setup_alignment.py -v -k "facing"`
+Expected: 3 FAIL.
+
+- [ ] **Step 3: Extend `render_align_page()` with the facing UI + server-computed markers + counter**
+
+Replace the function body of `render_align_page()` with the version below. This adds:
+- Server-side computation of solstice marker positions + sunsets-per-year count for each of three facings (East 90°, West 270°, Both — center at 180° with full FOV widened by adding the two halves).
+- Three sets of SVG `<g>` elements, one per facing, with `data-facing` attributes.
+- Three counter spans, similarly tagged.
+- A `<form>` with three radio inputs that drives CSS-only visibility of the per-facing elements.
+
+```python
+from sunset_cam.solstice_math import (
+    sunset_azimuth_for_day,
+    az_to_pixel,
+    count_sunsets_in_fov,
+)
+from datetime import date
+
+
+FOV_DEG = 102.0          # Camera Module 3 Wide horizontal FOV
+SCREEN_W = 1600          # Match SVG viewBox width
+SCREEN_H = 900           # Match SVG viewBox height
+HORIZON_Y = 450          # Vertical center
+
+
+def _facing_data(lat: float, lng: float, year: int) -> dict:
+    """Pre-compute marker positions + sunsets/year counts for each facing.
+
+    Returns a dict like:
+      {
+        "east":  {"jun_x": ..., "dec_x": ..., "count": N},
+        "west":  {"jun_x": ..., "dec_x": ..., "count": N},
+        "both":  {"jun_x": ..., "dec_x": ..., "count": N},
+      }
     """
-    return _ALIGN_HTML
+    jun_az = sunset_azimuth_for_day(lat, year, 6, 21)
+    dec_az = sunset_azimuth_for_day(lat, year, 12, 21)
+    out: dict[str, dict] = {}
+    for facing, center_az in (("east", 90.0), ("west", 270.0)):
+        out[facing] = {
+            "jun_x": az_to_pixel(jun_az, center_az, FOV_DEG, SCREEN_W),
+            "dec_x": az_to_pixel(dec_az, center_az, FOV_DEG, SCREEN_W),
+            "count": count_sunsets_in_fov(lat, lng, center_az, FOV_DEG, year),
+        }
+    # "both" = full panorama; we draw it as the same FOV but conceptually
+    # the operator is informed they're covering both phases.
+    out["both"] = {
+        "jun_x": out["west"]["jun_x"],
+        "dec_x": out["east"]["dec_x"],
+        "count": min(365, out["east"]["count"] + out["west"]["count"]),
+    }
+    return out
+
+
+def _marker_group(facing: str, data: dict) -> str:
+    """Render the SVG markers + shaded wedge for one facing."""
+    jx, dx = data["jun_x"], data["dec_x"]
+    lo, hi = sorted((jx, dx))
+    wedge = (
+        f'<rect x="{lo}" y="{HORIZON_Y - 30}" '
+        f'width="{hi - lo}" height="60" '
+        f'fill="#ffcc66" fill-opacity="0.18" />'
+    )
+    j_line = (
+        f'<line x1="{jx}" y1="{HORIZON_Y - 30}" x2="{jx}" y2="{HORIZON_Y + 30}" '
+        f'stroke="#ffd088" stroke-width="2" stroke-dasharray="6 4" />'
+    )
+    d_line = (
+        f'<line x1="{dx}" y1="{HORIZON_Y - 30}" x2="{dx}" y2="{HORIZON_Y + 30}" '
+        f'stroke="#ffaa55" stroke-width="2" stroke-dasharray="6 4" />'
+    )
+    return f'<g class="facing-group" data-facing="{facing}">{wedge}{j_line}{d_line}</g>'
+
+
+def render_align_page(lat: float, lng: float, year: int | None = None) -> str:
+    """Render the alignment page HTML. ``year`` defaults to the current year
+    for the sunsets-per-year counts."""
+    if year is None:
+        year = date.today().year
+    facing = _facing_data(lat, lng, year)
+    marker_groups = "\n".join(
+        _marker_group(name, facing[name]) for name in ("east", "west", "both")
+    )
+    counter_spans = "\n".join(
+        f'<span class="counter" data-facing="{name}">{facing[name]["count"]} sunsets/year</span>'
+        for name in ("east", "west", "both")
+    )
+
+    return f"""<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <title>Align your camera</title>
+  <style>
+    body {{ background: #000; color: #fff; font: 14px system-ui, sans-serif; margin: 0; padding: 0; }}
+    .top-hud {{ display: flex; gap: 12px; align-items: center; justify-content: center; padding: 10px 16px; background: #111; }}
+    .readout {{ font-variant-numeric: tabular-nums; font-size: 16px; min-width: 80px; }}
+    .level-badge {{ padding: 4px 10px; border-radius: 12px; font-size: 11px; background: #444; color: #aaa; }}
+    .level-badge.ok {{ background: #265f2c; color: #d8ffd8; }}
+    .preview-wrap {{ position: relative; width: 100%; max-width: 100vw; aspect-ratio: 16/9; margin: 0 auto; }}
+    .preview-wrap img {{ width: 100%; display: block; }}
+    .overlay {{ position: absolute; inset: 0; pointer-events: none; }}
+    .facing-form {{ display: flex; gap: 12px; justify-content: center; padding: 12px; background: #181818; }}
+    .facing-form label {{ padding: 6px 14px; border: 1px solid #444; border-radius: 16px; cursor: pointer; }}
+    .facing-form input {{ display: none; }}
+    .facing-form input:checked + label {{ background: #2a4a7a; border-color: #4a7acc; }}
+    /* CSS-only toggling of per-facing SVG groups and counters: */
+    .facing-group, .counter {{ display: none; }}
+    body[data-current-facing="east"] .facing-group[data-facing="east"],
+    body[data-current-facing="east"] .counter[data-facing="east"],
+    body[data-current-facing="west"] .facing-group[data-facing="west"],
+    body[data-current-facing="west"] .counter[data-facing="west"],
+    body[data-current-facing="both"] .facing-group[data-facing="both"],
+    body[data-current-facing="both"] .counter[data-facing="both"] {{ display: inline; }}
+    .counter-bar {{ text-align: center; padding: 10px; background: #181818; font-size: 18px; }}
+    .counter {{ color: #ffcc66; font-weight: 600; }}
+    .instructions {{ padding: 16px 20px; line-height: 1.55; max-width: 560px; margin: 0 auto; }}
+    .instructions ol {{ padding-left: 1.2em; }}
+  </style>
+</head>
+<body data-lat="{lat}" data-lng="{lng}" data-current-facing="west">
+  <div class="top-hud">
+    <span>roll: <span id="roll-readout" class="readout">—</span></span>
+    <span>pitch: <span id="pitch-readout" class="readout">—</span></span>
+    <span id="level-badge" class="level-badge">checking…</span>
+  </div>
+
+  <div class="preview-wrap">
+    <img src="/setup/preview.mjpg" alt="camera preview" />
+    <svg class="overlay" viewBox="0 0 {SCREEN_W} {SCREEN_H}" preserveAspectRatio="none">
+      <line x1="0" y1="{HORIZON_Y}" x2="{SCREEN_W}" y2="{HORIZON_Y}"
+            stroke="#ffcc66" stroke-width="2" stroke-dasharray="12 6" opacity="0.85" />
+      <text x="{SCREEN_W // 2}" y="60" fill="#ffcc66" font-size="36" text-anchor="middle"
+            font-family="system-ui, sans-serif">&uarr; UP</text>
+{marker_groups}
+    </svg>
+  </div>
+
+  <form class="facing-form" id="facing-form">
+    <input type="radio" name="facing" id="facing-east" value="east" />
+    <label for="facing-east">East (sunrise)</label>
+    <input type="radio" name="facing" id="facing-west" value="west" checked />
+    <label for="facing-west">West (sunset)</label>
+    <input type="radio" name="facing" id="facing-both" value="both" />
+    <label for="facing-both">Both</label>
+  </form>
+
+  <div class="counter-bar">
+{counter_spans}
+  </div>
+
+  <div class="instructions">
+    <p>Rotate the camera housing until:</p>
+    <ol>
+      <li>The roll readout is close to 0° and the badge shows green.</li>
+      <li>The &uarr; on screen matches the &uarr; on the housing.</li>
+      <li>The shaded wedge falls inside the visible preview.</li>
+    </ol>
+    <p>When all three match, mount the camera. Then close this tab and return to setup.</p>
+  </div>
+
+  <script>
+    // Orientation polling (Task 6).
+    async function pollOrientation() {{
+      try {{
+        const r = await fetch('/setup/orientation.json', {{ cache: 'no-store' }});
+        if (!r.ok) return;
+        const j = await r.json();
+        if (j.roll_deg !== undefined) {{
+          document.getElementById('roll-readout').textContent = j.roll_deg.toFixed(1) + '°';
+        }}
+        if (j.pitch_deg !== undefined) {{
+          document.getElementById('pitch-readout').textContent = j.pitch_deg.toFixed(1) + '°';
+        }}
+        const badge = document.getElementById('level-badge');
+        const level = Math.abs(j.roll_deg || 99) < 1.0 && Math.abs(j.pitch_deg || 99) < 1.0;
+        badge.textContent = level ? 'level' : 'tilted';
+        badge.classList.toggle('ok', level);
+      }} catch (e) {{ /* swallow */ }}
+    }}
+    setInterval(pollOrientation, 200);
+    pollOrientation();
+
+    // Facing selector — drives a body data-attribute that CSS uses to
+    // show/hide per-facing markers + counter.
+    document.getElementById('facing-form').addEventListener('change', (ev) => {{
+      if (ev.target && ev.target.name === 'facing') {{
+        document.body.dataset.currentFacing = ev.target.value;
+      }}
+    }});
+  </script>
+</body>
+</html>
+"""
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd /Users/jessekauppila/GitHub/sunset-cam-firmware && python -m pytest tests/test_setup_alignment.py -v`
+Expected: 13/13 PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /Users/jessekauppila/GitHub/sunset-cam-firmware
+git add src/sunset_cam/setup_alignment.py tests/test_setup_alignment.py
+git commit -m "feat(setup-align): facing selector + solstice markers + sunsets-per-year"
+```
+
+---
+
+## Task 9: Add `stream_mjpeg()` generator + `MJPEG_BOUNDARY` constant
+
+**Files:**
+- Modify: `src/sunset_cam/setup_alignment.py`
+- Modify: `tests/test_setup_alignment.py`
+
+Same as v0.1 plan's Task 2 — pure multipart-MJPEG generator. Included here for completeness.
+
+- [ ] **Step 1: Add the failing tests**
+
+Append to `tests/test_setup_alignment.py`:
+
+```python
+from sunset_cam.setup_alignment import stream_mjpeg, MJPEG_BOUNDARY
+
+
+def test_mjpeg_boundary_is_exported_and_nontrivial():
+    assert isinstance(MJPEG_BOUNDARY, str)
+    assert len(MJPEG_BOUNDARY) >= 8
+
+
+def test_stream_mjpeg_yields_three_frames_from_a_three_call_source():
+    frames = [b"AAA", b"BBB", b"CCC"]
+    call_index = {"i": 0}
+
+    def source() -> bytes:
+        i = call_index["i"]
+        call_index["i"] += 1
+        if i >= len(frames):
+            raise StopIteration
+        return frames[i]
+
+    out = b"".join(stream_mjpeg(source))
+    assert out.count(f"--{MJPEG_BOUNDARY}".encode()) == 3
+    assert out.count(b"Content-Type: image/jpeg") == 3
+    for f in frames:
+        assert f in out
+
+
+def test_stream_mjpeg_includes_content_length_per_part():
+    def source() -> bytes:
+        source.count = getattr(source, "count", 0) + 1
+        if source.count > 1:
+            raise StopIteration
+        return b"X" * 17
+
+    out = b"".join(stream_mjpeg(source))
+    assert b"Content-Length: 17" in out
+
+
+def test_stream_mjpeg_terminates_on_stopiteration():
+    def source() -> bytes:
+        raise StopIteration
+    assert list(stream_mjpeg(source)) == []
+
+
+def test_stream_mjpeg_swallows_source_exception_and_stops():
+    def source() -> bytes:
+        raise RuntimeError("glitch")
+    assert list(stream_mjpeg(source)) == []
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd /Users/jessekauppila/GitHub/sunset-cam-firmware && python -m pytest tests/test_setup_alignment.py -v -k "mjpeg"`
+Expected: 5 FAIL (one ImportError, 4 from missing function).
+
+- [ ] **Step 3: Add `stream_mjpeg()` + `MJPEG_BOUNDARY` to `setup_alignment.py`**
+
+At the top of `src/sunset_cam/setup_alignment.py`, near the other imports, add:
+
+```python
+from typing import Callable, Iterator
+```
+
+Append to the file:
+
+```python
+MJPEG_BOUNDARY = "sunsetcamframe"
 
 
 def stream_mjpeg(
@@ -359,14 +1322,9 @@ def stream_mjpeg(
 ) -> Iterator[bytes]:
     """Yield multipart-encoded MJPEG bytes by polling ``frame_source``.
 
-    The generator stops cleanly when ``frame_source()`` raises
-    ``StopIteration`` (end-of-stream) or any other exception (transient
-    camera error — terminate rather than poison the response).
-
-    ``fps`` is informational only here — the generator does NOT sleep
-    between frames. The caller (web app) is responsible for rate-limiting
-    if needed, since synchronous-vs-async scheduling depends on the
-    chosen framework.
+    Terminates cleanly on StopIteration (EOF) or any other exception
+    (transient camera glitch). The caller (web app) is responsible for
+    rate-limiting between frames; the ``fps`` parameter is informational.
     """
     boundary = MJPEG_BOUNDARY
     while True:
@@ -375,9 +1333,6 @@ def stream_mjpeg(
         except StopIteration:
             return
         except Exception:
-            # Any other failure terminates the stream cleanly. Logging is
-            # the caller's responsibility — we don't want to import logging
-            # into this framework-agnostic module.
             return
 
         header = (
@@ -391,157 +1346,131 @@ def stream_mjpeg(
         yield b"\r\n"
 ```
 
-- [ ] **Step 4: Run all module tests**
+- [ ] **Step 4: Run tests to verify they pass**
 
 Run: `cd /Users/jessekauppila/GitHub/sunset-cam-firmware && python -m pytest tests/test_setup_alignment.py -v`
-Expected: 9/9 PASS.
+Expected: 18/18 PASS.
 
 - [ ] **Step 5: Commit**
 
 ```bash
 cd /Users/jessekauppila/GitHub/sunset-cam-firmware
 git add src/sunset_cam/setup_alignment.py tests/test_setup_alignment.py
-git commit -m "feat(setup-align): stream_mjpeg() generator + MJPEG_BOUNDARY constant"
+git commit -m "feat(setup-align): stream_mjpeg() + MJPEG_BOUNDARY constant"
 ```
 
 ---
 
-## Task 3: Smoke test — full firmware test suite green
-
-The alignment module is fully covered by its own tests, but verify nothing else in the firmware regressed (the module is additive so this should be a fast pass).
+## Task 10: Full firmware test suite green
 
 - [ ] **Step 1: Run the entire firmware test suite**
 
 Run: `cd /Users/jessekauppila/GitHub/sunset-cam-firmware && python -m pytest -v`
-Expected: ALL pre-existing tests PASS + the 9 new alignment tests PASS.
+Expected: ALL pre-existing tests + 25+ new tests PASS.
 
-If any pre-existing test fails, it's a pre-existing baseline issue, NOT caused by this plan — note it in the task report but don't try to fix it as part of this plan.
+If any pre-existing test fails, note it as baseline; do not fix it as part of this plan.
 
-- [ ] **Step 2: Document the public API in the module docstring (already done in Task 2)**
-
-Verify the module docstring at the top of `src/sunset_cam/setup_alignment.py` accurately describes the contract (route paths, boundary string, sync vs async expectations). If the actual implementation drifted, update the docstring. No commit needed unless drift was found.
-
-- [ ] **Step 3: No new commits if no drift**
-
-If Step 2 produced no edits, this task closes with no commit. Otherwise:
-
-```bash
-cd /Users/jessekauppila/GitHub/sunset-cam-firmware
-git add src/sunset_cam/setup_alignment.py
-git commit -m "docs(setup-align): keep docstring aligned with implementation"
-```
+- [ ] **Step 2: No new commit unless something needed fixing**
 
 ---
 
-## Task 4: Integration note for downstream specs
+## Task 11: Integration notes in web-app repo
 
-The functions land; the actual route registration belongs to spec E's setup web app. Two specs need a one-line update so that the next implementer doesn't lose this thread.
+Update spec E and spec F so the next implementer of either knows to plug in C's three endpoints / link.
 
-**Files:**
-- Modify: `docs/superpowers/specs/2026-05-15-wifi-onboarding-and-provisioning-design.md` (in the `the-sunset-webcam-map` repo)
-- Modify: `docs/superpowers/specs/2026-05-16-cloud-wizard-frontend-design.md` (in the `the-sunset-webcam-map` repo)
+**Files (in `/Users/jessekauppila/GitHub/the-sunset-webcam-map`):**
+- Modify: `docs/superpowers/specs/2026-05-15-wifi-onboarding-and-provisioning-design.md`
+- Modify: `docs/superpowers/specs/2026-05-16-cloud-wizard-frontend-design.md`
 
-- [ ] **Step 1: Add an integration note to spec E**
+- [ ] **Step 1: Append the alignment-tool integration note to spec E**
 
-In the `the-sunset-webcam-map` repo, open `docs/superpowers/specs/2026-05-15-wifi-onboarding-and-provisioning-design.md`. Find the section where the setup web app's routes are listed (search for `iwlist` or `Submit`). Append the following paragraph at the end of that section:
-
-```markdown
-**Alignment-tool integration (sub-project C).** The setup web app must also register two routes from `sunset_cam.setup_alignment`:
-
-- `GET /setup/align` → response body = `render_align_page()`, `Content-Type: text/html; charset=utf-8`.
-- `GET /setup/preview.mjpg` → response body streams from `stream_mjpeg(frame_source=capture.capture_jpeg)`, `Content-Type: multipart/x-mixed-replace; boundary=sunsetcamframe` (use `setup_alignment.MJPEG_BOUNDARY`).
-
-These functions are framework-agnostic and pre-tested; this spec is responsible only for the framework wiring.
-```
-
-- [ ] **Step 2: Add an integration note to spec F**
-
-In the same repo, open `docs/superpowers/specs/2026-05-16-cloud-wizard-frontend-design.md`. Append a one-paragraph section at the end of the "What it does" section (after the numbered list of screens):
+In spec E (`docs/superpowers/specs/2026-05-15-wifi-onboarding-and-provisioning-design.md`), find the section listing the setup web app's routes (search for `iwlist`). Append:
 
 ```markdown
-**Screen 4 alignment-tool link (sub-project C).** Screen 4 renders a single button "Open the alignment tool" that opens `http://<pi-local-ip>:<setup-port>/setup/align` in a new browser tab (`target="_blank"`). The Pi's local IP + port are surfaced by the same setup-status polling spec E uses for the WiFi-handoff transition. The button is followed by a "Continue" button that advances the wizard with no state from the alignment tool — the alignment step is a one-way side trip with no protocol payload.
+**Alignment-tool integration (sub-project C, v0.2).** The setup web app must register three routes from `sunset_cam.setup_alignment`:
+
+- `GET /setup/align` → response body = `render_align_page(lat, lng)` with the camera's stored coordinates; `Content-Type: text/html; charset=utf-8`.
+- `GET /setup/preview.mjpg` → response body streams from `stream_mjpeg(frame_source=capture.capture_jpeg)`; `Content-Type: multipart/x-mixed-replace; boundary=sunsetcamframe`.
+- `GET /setup/orientation.json` → response body = `render_orientation_json(orientation_sampler)` where `orientation_sampler` is a singleton `OrientationSampler(reader=lambda: read_orientation(smbus2.SMBus(1)))` started at service boot. `Content-Type: application/json`.
+
+The MPU6050 / GY-521 IMU is required hardware for v0.2 (BOM addition). Wired via I2C on the Pi (SDA→GPIO 2, SCL→GPIO 3, VCC→3.3V, GND→GND).
 ```
 
-- [ ] **Step 3: Commit both edits in one commit in the web-app repo**
+- [ ] **Step 2: Append the alignment-tool link note to spec F**
+
+In spec F (`docs/superpowers/specs/2026-05-16-cloud-wizard-frontend-design.md`), append a paragraph at the end of the "What it does" section:
+
+```markdown
+**Screen 4 alignment-tool link (sub-project C, v0.2).** Screen 4 renders a single button "Open the alignment tool" that opens `http://<pi-local-ip>:<setup-port>/setup/align` in a new tab. The Pi's local IP + port are surfaced by the same setup-status polling spec E uses for the WiFi-handoff transition. The button is followed by a "Continue" button that advances the wizard with no protocol-payload state from the alignment tool — the alignment step is a one-way side trip.
+```
+
+- [ ] **Step 3: Commit both edits**
 
 ```bash
 cd /Users/jessekauppila/GitHub/the-sunset-webcam-map
 git add docs/superpowers/specs/2026-05-15-wifi-onboarding-and-provisioning-design.md \
         docs/superpowers/specs/2026-05-16-cloud-wizard-frontend-design.md
-git commit -m "docs(specs): wire alignment-tool integration notes into E + F"
-```
-
-- [ ] **Step 4: Push the web-app commit**
-
-If working on a feature branch in the web-app repo, push to origin:
-
-```bash
-cd /Users/jessekauppila/GitHub/the-sunset-webcam-map
+git commit -m "docs(specs): wire alignment-tool integration notes into E + F (v0.2)"
 git push
 ```
 
-If working directly on `main` (matches the user's pattern for doc updates), confirm with the user before pushing — this updates two PR-relevant specs that other branches may be reading.
-
 ---
 
-## Task 5: Hardware-side tracking note
+## Task 12: Hardware tracking stub
 
-The molded ↑ UP arrow on the housing is not implementable in code. It's a hardware/STL change tracked by a separate hardware spec. Make sure that ticket exists.
+**Files (in `/Users/jessekauppila/GitHub/the-sunset-webcam-map`):**
+- Create: `docs/hardware/2026-05-17-housing-up-arrow-and-mpu6050.md`
 
-- [ ] **Step 1: Check for an existing hardware tracking doc**
-
-Run: `cd /Users/jessekauppila/GitHub/the-sunset-webcam-map && find docs -iname "*hardware*" -o -iname "*housing*" -o -iname "*enclosure*" -o -iname "*stl*" 2>/dev/null`
-
-- [ ] **Step 2: If nothing exists, create a hardware-tracking stub**
-
-If the previous command returned no matches, create `docs/hardware/2026-05-17-housing-up-arrow-stub.md` (note: hardware docs go in `docs/hardware/`, not `docs/superpowers/specs/` — the latter is for software specs only):
+- [ ] **Step 1: Create the hardware stub**
 
 ```markdown
-# Housing UP-Arrow Marker — Hardware Stub
+# Housing UP-Arrow Marker + MPU6050 BOM Addition — Hardware Stub
 
 Status: Stub — 2026-05-17
 Owner: Jesse Kauppila
-Triggered by: software spec `docs/superpowers/specs/2026-05-17-pi-side-alignment-tool-design.md`
+Triggered by: software spec `docs/superpowers/specs/2026-05-17-pi-side-alignment-tool-design.md` (v0.2)
 
 ## What
 
-Add a molded or recessed ↑ UP arrow to the camera housing's front face, above the lens.
+Two hardware changes tracked here:
 
-## Requirements (from the software spec §5.3)
+1. **UP marker on the housing.** Sharpie ↑ arrow on the case for v1 (acceptable). Future: molded/etched ↑ as part of the STL.
+2. **MPU6050 / GY-521 IMU module** wired to the Pi via I2C. New BOM line item.
+
+## Requirements (UP marker)
 
 - Top-center of the front face, ≥3mm above the lens cutout, ≥3mm from the top edge
-- Relief or recess, 8–12mm tall, depth/height ≥0.4mm so it survives weathering
-- Same material as the housing — no painted/printed labels (they weather poorly)
-- Either a flat ▲ triangle or stylized ↑ acceptable; pick one design and apply consistently
-- Must remain visible when mounted with any reasonable tape/screw fixture
+- Relief or recess, 8–12mm tall, depth/height ≥0.4mm for weather resistance
+- v1: Sharpie applied during operator prep (accepts weathering risk; trivial to redo)
 
-## Why
+## Requirements (MPU6050)
 
-The software alignment tool relies on operators reading this physical marker to know which way to mount the housing. Without it, the on-screen "↑ UP" label has no anchor in the real world.
+- Part: MPU6050 / GY-521 breakout board ($3–8 single, ~$2/unit in bulk)
+- Pi Zero 2 W wiring: SDA→GPIO 2 (pin 3), SCL→GPIO 3 (pin 5), VCC→3.3V (pin 1), GND→GND (pin 9)
+- ESP32 wiring: SDA→GPIO 21, SCL→GPIO 22, same 3.3V + GND
+- I2C must be enabled in `raspi-config`
+- Soldering or hammer-header kit required for Pi Zero 2 W (non-WH variant)
+- Physical mount: needs to be rigidly fixed to the camera body so its gravity vector matches the camera's
 
 ## Becomes a real spec when
 
-Someone picks up the housing STL to apply the change. The STL update is one CAD edit; this stub becomes a real spec when it's time to schedule that work.
+Units acquired, soldered onto a test Pi, software (this plan's output) verified to read live values. At that point the hardware spec graduates from stub to "production assembly procedure."
 ```
 
-If hardware docs already exist somewhere, add the marker requirements to the appropriate existing doc instead.
-
-- [ ] **Step 3: Commit (if a file was created)**
+- [ ] **Step 2: Commit + push**
 
 ```bash
 cd /Users/jessekauppila/GitHub/the-sunset-webcam-map
-git add docs/hardware/2026-05-17-housing-up-arrow-stub.md
-git commit -m "docs(hardware): stub for housing UP-arrow marker (C dependency)"
+git add docs/hardware/2026-05-17-housing-up-arrow-and-mpu6050.md
+git commit -m "docs(hardware): stub for housing UP-arrow + MPU6050 BOM (C v0.2)"
 git push
 ```
 
 ---
 
-## Task 6: Push the firmware commits
+## Task 13: Push firmware feature branch + open PR
 
-The firmware commits from Tasks 1–3 live in `/Users/jessekauppila/GitHub/sunset-cam-firmware`. Push them to origin so future spec-E implementers can pick them up.
-
-- [ ] **Step 1: Identify the firmware branch state**
+- [ ] **Step 1: Identify firmware branch state**
 
 ```bash
 cd /Users/jessekauppila/GitHub/sunset-cam-firmware
@@ -549,47 +1478,55 @@ git branch --show-current
 git log origin/main..HEAD --oneline
 ```
 
-- [ ] **Step 2: Create a feature branch if currently on main, otherwise reuse**
+- [ ] **Step 2: Create a feature branch if on main**
 
-If the current branch is `main`, do not push directly. Create a feature branch first:
+If currently on `main`, create a feature branch:
 
 ```bash
 cd /Users/jessekauppila/GitHub/sunset-cam-firmware
-git checkout -b feat/setup-alignment-module
+git checkout -b feat/setup-alignment-mpu6050
 ```
 
-If the current branch is already a feature branch with the Task 1–3 commits, skip this step.
-
-- [ ] **Step 3: Push the branch**
+- [ ] **Step 3: Push**
 
 ```bash
 cd /Users/jessekauppila/GitHub/sunset-cam-firmware
 git push -u origin HEAD
 ```
 
-- [ ] **Step 4: Open a PR (manual)**
+- [ ] **Step 4: Open PR (manual)**
 
-The plan does not auto-create the PR. The implementer opens it with the title `feat(setup-align): framework-agnostic alignment-tool functions` and a body summarizing: "Two pure functions (HTML render + MJPEG generator) plus 9 unit tests. Framework-agnostic — landing now so spec E's setup web app can register them as routes when it's built." Link to the spec at `docs/superpowers/specs/2026-05-17-pi-side-alignment-tool-design.md` in the web-app repo.
+Open the PR with:
+- Title: `feat(setup-align): alignment tool + MPU6050 (sub-project C v0.2)`
+- Body: summarize the four new modules + 25+ unit tests + that field validation gates on MPU6050 acquisition.
+- Link to the spec in the web-app repo.
 
 ---
 
 ## Self-review
 
-Mapping the spec to tasks:
+Mapping the spec v0.2 to tasks:
 
 | Spec section | Task(s) |
 |---|---|
-| §5.1 Architecture (two routes served by Pi web app) | 1, 2 produce the handlers; 4 wires them via spec E |
-| §5.2 Alignment page (HTML structure, SVG overlay) | 1 (`render_align_page` with 5 unit tests) |
-| §5.2 MJPEG stream | 2 (`stream_mjpeg` with 4 unit tests + boundary constant) |
-| §5.3 Hardware UP arrow | 5 (hardware stub doc) |
-| §5.4 F integration (screen 4 link) | 4 step 2 (spec F note) |
-| §6 No new protocol fields | Confirmed — no protocol code in this plan |
-| §7.1 Unit testing | 1, 2 |
-| §7.2 Manual testing | Deferred to spec E's web-app field-testing — noted explicitly in plan header |
-| §8 Risks | MJPEG latency: handled by the `fps` parameter being caller-controlled; rate limiting is caller's responsibility |
-| §10 Open question (concurrent encoders) | Sidestepped: in setup mode the production capture loop is idle, so `frame_source=capture.capture_jpeg` has exclusive picamera2 access. Documented in stream_mjpeg's docstring. |
+| §1 Problem (level / up / aim) | Goals addressed in Tasks 2 (level), 5 (up), 8 (aim) |
+| §2 Goals 1–3 | 2, 5, 8 |
+| §3 Non-goals | No tasks (deliberate) |
+| §5.1 Architecture (three endpoints) | 5/7/9 |
+| §5.2 Alignment page (HUD + facing + counter) | 5, 6, 8 |
+| §5.3 Hardware | 12 |
+| §5.4 Reading orientation (math) | 2 |
+| §5.5 Facing selector + solstice math | 4, 8 |
+| §5.6 F integration | 11 |
+| §7.1 Unit testing | 2, 3, 4, 5, 6, 7, 8, 9 |
+| §7.2 Manual testing | Deferred — gates on MPU6050 hardware |
+| §8 Risks | Each task documents its specific risks via comments + tests |
+| §10 Open questions / future | Documented in spec, no code tasks |
 
-No spec section maps to "nothing" — every requirement that's implementable in software has a task. Hardware (§5.3) is correctly scoped out to a separate ticket.
+**Type consistency check:**
+- `OrientationSampler.latest()` returns `Optional[dict]` everywhere (Tasks 3, 7).
+- `render_orientation_json(sampler)` consumes an `OrientationSampler` (Task 7).
+- `read_orientation(bus)` returns `Tuple[float, float]` (Task 2); injected as `reader` into `OrientationSampler` (Task 3).
+- `MJPEG_BOUNDARY` referenced consistently in Task 9.
 
-**Open dependency:** Task 4 step 2 updates F's stub spec doc, but F is doc-only today. When F's implementation plan is written, that plan should reference this integration note. No coordination needed in the meantime.
+No placeholders, no "TBD." Every code step has full code. Every test step has a runnable command + expected outcome.

--- a/docs/superpowers/specs/2026-05-15-wifi-onboarding-and-provisioning-design.md
+++ b/docs/superpowers/specs/2026-05-15-wifi-onboarding-and-provisioning-design.md
@@ -198,6 +198,14 @@ The existing heartbeat response (`device-protocol.md` §6.4) already returns a `
 
 The setup service's footprint should be small enough that it can ship in the same image as the capture firmware and add no boot-time cost on already-provisioned units (it doesn't start unless the boot check finds no WiFi creds).
 
+**Alignment-tool integration (sub-project C, v0.2).** The setup web app must register three routes from `sunset_cam.setup_alignment`:
+
+- `GET /setup/align` → response body = `render_align_page(lat, lng)` with the camera's stored coordinates; `Content-Type: text/html; charset=utf-8`.
+- `GET /setup/preview.mjpg` → response body streams from `stream_mjpeg(frame_source=capture.capture_jpeg)`; `Content-Type: multipart/x-mixed-replace; boundary=sunsetcamframe`.
+- `GET /setup/orientation.json` → response body = `render_orientation_json(orientation_sampler)` where `orientation_sampler` is a singleton `OrientationSampler(reader=lambda: read_orientation(smbus2.SMBus(1)))` started at service boot. `Content-Type: application/json`.
+
+The MPU6050 / GY-521 IMU is required hardware for v0.2 (BOM addition). Wired via I2C on the Pi (SDA→GPIO 2, SCL→GPIO 3, VCC→3.3V, GND→GND).
+
 ### 5.6 Cloud-side endpoints touched
 
 Existing endpoints, used as-is:

--- a/docs/superpowers/specs/2026-05-16-cloud-wizard-frontend-design.md
+++ b/docs/superpowers/specs/2026-05-16-cloud-wizard-frontend-design.md
@@ -28,6 +28,8 @@ After granting camera + location + device-orientation permission, the wizard wal
 
 6. **Mount here.** Operator aims the phone at the desired mounting direction and taps "Mount Here." Final `azimuth_deg` + `tilt_deg` snapshot from the DeviceOrientation API at tap time. Sub-project C will add `roll_deg` here plus a "which way is up" overlay on the housing.
 
+**Screen 4 alignment-tool link (sub-project C, v0.2).** Screen 4 renders a single button "Open the alignment tool" that opens `http://<pi-local-ip>:<setup-port>/setup/align` in a new tab. The Pi's local IP + port are surfaced by the same setup-status polling spec E uses for the WiFi-handoff transition. The button is followed by a "Continue" button that advances the wizard with no protocol-payload state from the alignment tool — the alignment step is a one-way side trip.
+
 The wizard then submits the assembled blob to `POST /api/cameras/pre-register` with the claim code. Per spec E's protocol Amendment A, this works whether the device has registered yet or not.
 
 ## Field provenance

--- a/docs/superpowers/specs/2026-05-17-pi-side-alignment-tool-design.md
+++ b/docs/superpowers/specs/2026-05-17-pi-side-alignment-tool-design.md
@@ -77,7 +77,7 @@ The page contains:
   - Two solstice azimuth markers as dashed vertical lines, positioned client-side based on lat/lng + facing.
   - Shaded wedge between the solstice markers labeled "where the sun ever is."
 - **Facing selector**: a 3-state toggle (East / West / Both) below the preview. Default value is suggested by the operator's earlier phase preference from F (sunrise → East, sunset → West, both → Both).
-- **Bottom counter**: "N sunsets/year fall in this azimuth wedge" — astronomy only, recomputed client-side when the facing selector changes.
+- **Bottom counter**: "N sunsets/year fall in this azimuth wedge" — astronomy only, recomputed client-side when the facing selector changes. **v0.2 limitation**: the counter only tracks *sunset* azimuths, so an East-facing camera (which actually captures sunrises) shows "0 sunsets/year." A future spec adds a `count_sunrises_in_fov` companion and routes East to the sunrise count + sunrise-azimuth markers; until then, the East option produces a misleading display and is best treated as a placeholder for future v0.3.
 - **Instructions** (below the preview):
   > Rotate the camera housing until:
   > 1. The roll readout reads close to 0° and the "level" badge is green.
@@ -112,11 +112,13 @@ Only the accelerometer is used for v1 (roll + pitch from the gravity vector). Th
 Roll and pitch derived from the accelerometer's gravity vector:
 
 ```
-roll_rad  = atan2(accel_y, sqrt(accel_x² + accel_z²))
-pitch_rad = atan2(-accel_x, sqrt(accel_y² + accel_z²))
+roll_rad  = atan2(accel_y, accel_z)                  # range [-180°, 180°]
+pitch_rad = atan2(-accel_x, sqrt(accel_y² + accel_z²))   # range [-90°, 90°]
 ```
 
 Convert to degrees. **Yaw (compass direction) is not derivable from accelerometer alone** — requires a magnetometer, which we don't have. Out of scope, explicitly.
+
+Note on roll formula: the simpler `atan2(ay, sqrt(ax² + az²))` form returns the range [-90°, 90°] and cannot distinguish "flat" from "upside-down" (both give roll = 0°). The full `atan2(ay, az)` form returns the full [-180°, 180°] range and correctly returns ±180° when the device is upside-down. We want the full range so the operator can confirm orientation across any mounting position; the test suite asserts this explicitly.
 
 Implementation:
 - Background thread samples at 10 Hz.

--- a/docs/superpowers/specs/2026-05-17-pi-side-alignment-tool-design.md
+++ b/docs/superpowers/specs/2026-05-17-pi-side-alignment-tool-design.md
@@ -1,6 +1,6 @@
 # Pi-Side Alignment Tool
 
-Status: Draft v0.1 — 2026-05-17
+Status: Draft v0.2 — 2026-05-17 (revised to add MPU6050 + facing selector)
 Owner: Jesse Kauppila
 Sub-project C of the streamlined-deployment umbrella (`2026-05-15-streamlined-deployment-overview.md`).
 
@@ -8,175 +8,210 @@ Sub-project C of the streamlined-deployment umbrella (`2026-05-15-streamlined-de
 
 ## 1. Problem
 
-A non-technical recipient mounting a Pi camera at home needs to know two things during install:
+A non-technical recipient mounting a Pi camera at home needs to know three things during install:
+
 1. **Is the camera level?** A mounted-sideways camera produces a tilted horizon, which all downstream consumers (the AI ranker, the mosaic display, human viewers) implicitly assume is horizontal. There is no automatic recovery — a sideways image stays sideways.
 2. **Which way is up on the device?** The housing is symmetric enough that an operator without guidance can mount it 90° or 180° from the intended orientation. The lens is offset on the front face; "up" has to be communicated.
+3. **Is the camera pointed at where the sun actually sets or rises over the year?** An operator can mount the camera perfectly level but aimed at a wall, or at a compass direction the sun never visits. The 2026-05-16 field test of the Tier 0 Bellingham unit demonstrated this exact failure mode — the captured images were technically valid (level, well-exposed) but framed away from the sun's actual path.
 
-Today, neither is solved. The cloud wizard's sub-project F stub (`2026-05-16-cloud-wizard-frontend-design.md`) assumes phone-side AR will guide the operator, but the Pi Zero 2 W has no gyroscope, magnetometer, or GPS, and phone compasses are unreliable. The F stub's risk section already flags this as the painful part.
-
-A simpler tool, owned by the Pi itself, solves both problems with no sensors and no math.
+Today, none of these are solved. The cloud wizard's sub-project F stub (`2026-05-16-cloud-wizard-frontend-design.md`) assumes phone-side AR will guide the operator, but the Pi Zero 2 W ships with no inertial sensors and phone compasses are unreliable. Spec v0.1 punted #3 entirely; v0.2 adds a low-cost MPU6050 6-axis IMU to the device BOM ($2–8/unit) and an operator-selected facing direction, which together get us most of the way to #3 without requiring a magnetometer.
 
 ## 2. Goals
 
-1. The recipient can level their camera within ±2° of horizontal using only their phone browser and the Pi's own camera feed.
-2. The recipient cannot accidentally mount the housing upside down or sideways — both the hardware marker and the on-screen overlay confirm orientation independently.
-3. No phone sensors, no astronomy math, no AI, no calibration step. If the live preview shows a level horizon and the housing marker points up, alignment is complete.
-4. The tool runs entirely on the Pi, served to the phone over the Pi's local WiFi (already established by sub-project E's captive-portal flow). No cloud round-trip required for the alignment step itself.
+1. The recipient can level their camera within ±2° of horizontal using a live roll readout from the MPU6050. Tighter precision than v0.1's "eyeball the horizon line" approach.
+2. The recipient cannot accidentally mount the housing upside down or sideways — three independent signals confirm orientation: the Sharpie-drawn (later molded) ↑ on the housing, the on-screen ↑ UP label, and the live roll/pitch readout from the IMU.
+3. The operator can aim the camera within the **year-round sun-azimuth wedge** during install, approximately. v1 supports this via operator-selected facing direction (east/west) + lat/lng + computed solstice azimuth markers drawn on the preview. True compass-based azimuth (requiring a magnetometer or sun-tap calibration) is a future spec.
+4. The tool runs entirely on the Pi, served to the phone over local WiFi (already established by sub-project E's captive-portal flow). No cloud round-trip for the alignment step itself.
 
 ## 3. Non-goals
 
-- Sensor-based directional guidance (no compass, no gyroscope on Pi; phone sensors not used).
-- Sun-path overlays, solstice azimuth markers, "sunsets/year captured" counters. Considered and explicitly deferred — the calibration mechanic that would make them possible has too many failure modes for v1.
-- AI / CV detection of walls, sky coverage, or scene quality. The live camera view solves "you're pointed at a wall" by being visible to the operator.
-- Weather-based quality prediction. The whole sub-project D, deferred.
-- Detecting post-install camera movement. Instruction: if you bump the camera after install, restart this tool.
-- Fixing the **"aimed at the wrong compass direction"** failure mode. Explicitly out of scope. Operator's responsibility to point the camera roughly toward the sunset/sunrise direction; this tool only verifies level and up.
-- Fixing the Pi's onboard clock skew (Subproject B). Unrelated to this tool — the alignment step doesn't depend on the Pi's clock at all.
-- Rewriting F's other screens. Only screen 4 (the AR/placement step) changes shape; the rest stay.
+- **True compass / absolute azimuth measurement.** Requires a magnetometer (MPU9250 or similar) which is not in the BOM. v1 approximates via operator-selected east/west facing. Sun-tap calibration with the gyro is the planned future path.
+- **Sun-tap calibration mechanic itself.** Considered for v1, deferred — the calibration UX adds complexity that the simpler approximation doesn't need yet.
+- **AI / CV detection of walls, sky coverage, or scene quality.** The live camera view solves "you're pointed at a wall" by being visible to the operator.
+- **Weather-based quality prediction.** Sub-project D, deferred.
+- **Detecting post-install camera movement.** The accelerometer could detect this; out of scope for the install flow. Instruction: if you bump the camera, restart this tool.
+- **Fixing the Pi's onboard clock skew (Subproject B).** Unrelated — this tool doesn't depend on the Pi's clock at all.
+- **Rewriting F's other screens.** Only screen 4 (the AR/placement step) changes shape; the rest stay.
 
 ## 4. Current state
 
 Verified from the repo as of 2026-05-17:
 
-- The Pi's firmware (per `pi-webcam-mvp.md`) runs picamera2 + FFmpeg for capture/streaming. No setup-mode web server currently exists for non-captive-portal use, but spec E (`2026-05-15-wifi-onboarding-and-provisioning-design.md`) introduces a `sunset-cam-setup` systemd service that runs a local HTTP server during setup mode. **This spec extends that web app with two new routes (one HTML page, one MJPEG stream).**
+- The Pi's firmware (per `pi-webcam-mvp.md`) runs picamera2 + FFmpeg for capture/streaming. No setup-mode web server currently exists for non-captive-portal use, but spec E (`2026-05-15-wifi-onboarding-and-provisioning-design.md`) introduces a `sunset-cam-setup` systemd service that runs a local HTTP server during setup mode. **This spec extends that web app with three new routes (one HTML page, one MJPEG stream, one JSON readings endpoint).**
+- The Pi BOM today does not include any sensors. **This spec adds an MPU6050 / GY-521 module** ($3–8 single, ~$2 bulk) wired via I2C. ESP32-S3 equivalent works identically with different GPIO pins.
 - The cloud wizard (`2026-05-16-cloud-wizard-frontend-design.md`) has a 6-screen flow; screen 4 is "AR placement" and assumes phone-side AR. This spec replaces the phone-AR mechanism for screen 4 with a link to a Pi-served page.
-- The hardware case is currently an "IP65 weatherproof box w/ clear lid + cable glands" (`pi-webcam-mvp.md` §Hardware). No orientation markings exist on it today. This spec adds a molded ↑ arrow to the housing.
-- The Pi has no gyroscope, magnetometer, GPS, or accelerometer in the BOM. No software workaround changes that.
+- The hardware case has no orientation marking today. v1 acceptable solution: Sharpie ↑ on the case during operator prep. A future hardware spec covers molded/etched markers.
 
 ## 5. Design
 
 ### 5.1 Architecture
 
 ```
-┌─────────────┐  WiFi (Pi's local AP or joined home WiFi)  ┌──────────────┐
-│ Pi Zero 2 W │ ◀──────────────────────────────────────── │ Operator's   │
-│             │                                            │ phone        │
-│  picamera2 ─┼──► MJPEG stream                            │              │
-│             │     /setup/preview.mjpg                    │  Browser     │
-│  setup web ─┼──► alignment page                          │   <img       │
-│  app        │     /setup/align                           │    src=…/…   │
-│             │     (returns HTML + static overlay SVG)    │    .mjpg>    │
-└─────────────┘                                            └──────────────┘
+┌─────────────────┐  WiFi (Pi's local AP or joined home WiFi)  ┌──────────────┐
+│ Pi Zero 2 W     │ ◀──────────────────────────────────────── │ Operator's   │
+│                 │                                            │ phone        │
+│  picamera2 ─────┼──► MJPEG stream  /setup/preview.mjpg       │              │
+│  MPU6050 (I2C) ─┼──► readings      /setup/orientation.json   │  Browser     │
+│  setup web app ─┼──► align page    /setup/align              │  fetch loop  │
+│                 │     (HTML + JS that fetches readings ~5 Hz)│  + live <img>│
+└─────────────────┘                                            └──────────────┘
 ```
 
-- The Pi's existing `sunset-cam-setup` service (introduced in spec E) gains two new endpoints:
-  - `GET /setup/preview.mjpg` — returns the multipart MJPEG stream from `picamera2`.
-  - `GET /setup/align` — returns the alignment HTML page with the overlay rendered as inline SVG over an `<img>` pointing at the MJPEG stream.
-- The cloud wizard (F) provides the URL of `/setup/align` on the Pi's local IP to the operator. Operator opens it in a new browser tab, performs the alignment, closes the tab, returns to F, advances.
-- All overlay rendering is static (server-rendered SVG inlined into the page). No JS interactivity required for v1. No tap handlers, no recalculation, no state.
+- Pi's existing `sunset-cam-setup` service (from spec E) gains three new endpoints:
+  - `GET /setup/preview.mjpg` — multipart MJPEG stream from picamera2.
+  - `GET /setup/align` — the alignment HTML page (with embedded JS to poll for live readings).
+  - `GET /setup/orientation.json` — latest accelerometer-derived roll + pitch as JSON: `{"roll_deg": -0.4, "pitch_deg": 1.2, "sampled_at": "..."}`.
+- The Pi reads the MPU6050 at ~10 Hz in a background thread, exponentially smooths the readings, exposes the latest via the JSON endpoint.
+- The alignment page polls the JSON endpoint at ~5 Hz via `fetch()` and updates the on-screen roll readout. East/west facing selector is a client-side toggle; solstice marker computation is client-side using `suncalc` (or equivalent astronomical formula) given lat/lng + the selected facing.
+- Operator's lat/lng is embedded in the served HTML page as a JS constant (the Pi knows it from the pre-register flow per spec E).
 
 ### 5.2 The alignment page
 
-`GET /setup/align` returns the following minimal page (sketched, not literal HTML):
+The page contains:
+
+- **Top HUD**: live roll readout (e.g. "−0.4°"), updated 5 Hz via fetch. Adjacent: pitch readout. Both have a "level" badge that lights up green when |angle| < 1°.
+- **Live MJPEG preview** (`<img src="/setup/preview.mjpg">`).
+- **Overlay layer (SVG, on top of the preview)**:
+  - Dashed horizontal line at the vertical center of the preview frame.
+  - `↑ UP` label at top center.
+  - Two solstice azimuth markers as dashed vertical lines, positioned client-side based on lat/lng + facing.
+  - Shaded wedge between the solstice markers labeled "where the sun ever is."
+- **Facing selector**: a 3-state toggle (East / West / Both) below the preview. Default value is suggested by the operator's earlier phase preference from F (sunrise → East, sunset → West, both → Both).
+- **Bottom counter**: "N sunsets/year fall in this azimuth wedge" — astronomy only, recomputed client-side when the facing selector changes.
+- **Instructions** (below the preview):
+  > Rotate the camera housing until:
+  > 1. The roll readout reads close to 0° and the "level" badge is green.
+  > 2. The ↑ on screen points the same direction as the ↑ on the housing.
+  > 3. The shaded wedge (where the sun travels) falls inside the visible preview — if it doesn't, swivel the camera left or right until it does.
+  >
+  > When all three match, mount the camera in place. Then close this tab and return to setup.
+
+### 5.3 Hardware
+
+#### 5.3.1 UP marker on the housing
+
+**v1 (now)**: Sharpie ↑ arrow on the case, drawn by hand during operator prep. No tooling, no STL update; accepts that the marker will fade over time.
+
+**Future hardware spec**: Molded/etched ↑ on the housing STL. Tracked in `docs/hardware/...` per the existing stub. Not blocking C.
+
+#### 5.3.2 MPU6050 / GY-521 IMU (NEW v1 BOM addition)
+
+- **Part**: MPU6050 6-axis IMU (3-axis gyro + 3-axis accelerometer) on a GY-521 breakout. Ships under several brand names; all are the same chip.
+- **Cost**: $3–8 per single unit on Amazon; ~$8–15 for multi-packs of 3–6; effectively under $2/unit in bulk.
+- **Bus**: I2C, default address `0x68`.
+- **Pi Zero 2 W wiring**: VCC → 3.3V (pin 1), GND → GND (pin 9), SDA → GPIO 2 (pin 3), SCL → GPIO 3 (pin 5). I2C must be enabled in `raspi-config`.
+- **ESP32 wiring**: VCC → 3.3V, GND → GND, SDA → GPIO 21, SCL → GPIO 22. Same chip; portable across hardware targets.
+- **Soldering**: Pi Zero 2 W without the "WH" suffix has no pre-soldered headers. Requires either soldering or a hammer-header kit.
+- **Driver**: `smbus2` on Pi (stdlib-adjacent Python). `Adafruit_MPU6050` or `MPU6050_light` on ESP32/ESP8266.
+- **Power**: ~3.6 mA active; negligible.
+
+Only the accelerometer is used for v1 (roll + pitch from the gravity vector). The gyro lives in the BOM for a future sun-tap calibration spec.
+
+### 5.4 Reading orientation
+
+Roll and pitch derived from the accelerometer's gravity vector:
 
 ```
-<!doctype html>
-<title>Align your camera</title>
-<style>
-  body { background: #000; color: #fff; font: 14px system-ui; margin: 0; }
-  .preview-wrap { position: relative; max-width: 100vw; aspect-ratio: 16/9; margin: 0 auto; }
-  .preview-wrap img { width: 100%; display: block; }
-  .overlay { position: absolute; inset: 0; pointer-events: none; }
-  .instructions { padding: 16px; text-align: center; }
-</style>
-<div class="preview-wrap">
-  <img src="/setup/preview.mjpg" alt="camera preview" />
-  <svg class="overlay" viewBox="0 0 1600 900" preserveAspectRatio="none">
-    <!-- horizon line at vertical center -->
-    <line x1="0" y1="450" x2="1600" y2="450"
-          stroke="#ffcc66" stroke-width="2" stroke-dasharray="12 6" opacity="0.85" />
-    <!-- up arrow + label, top center -->
-    <text x="800" y="40" fill="#ffcc66" font-size="32" text-anchor="middle">↑ UP</text>
-  </svg>
-</div>
-<div class="instructions">
-  <p>Rotate the camera housing until:</p>
-  <p>1. The real horizon lines up with the dashed line.</p>
-  <p>2. The ↑ on screen points the same direction as the ↑ molded on the housing.</p>
-  <p>When both match, mount the camera in place. Then close this tab and return to setup.</p>
-</div>
+roll_rad  = atan2(accel_y, sqrt(accel_x² + accel_z²))
+pitch_rad = atan2(-accel_x, sqrt(accel_y² + accel_z²))
 ```
 
-Two overlay elements, both static:
-- A horizontal dashed line at the vertical center of the preview frame
-- A label `↑ UP` at the top center, matching the molded marker on the housing
+Convert to degrees. **Yaw (compass direction) is not derivable from accelerometer alone** — requires a magnetometer, which we don't have. Out of scope, explicitly.
 
-The page contains no JavaScript. No state. If the operator reloads, they get the same page. If the operator navigates back to the cloud wizard, the wizard advances on a button click — no Pi-side handoff needed.
+Implementation:
+- Background thread samples at 10 Hz.
+- Exponentially smoothed: `smoothed = α × raw + (1−α) × prev`, α = 0.3.
+- Latest smoothed values cached in a single `(roll_deg, pitch_deg, sampled_at)` tuple, lock-free since reads are atomic at this size.
+- `/setup/orientation.json` returns the cached tuple.
 
-### 5.3 Hardware: molded UP arrow
+### 5.5 Facing selector + approximate solstice math
 
-The housing's STL (or injection-mold tooling, if/when the project moves past 3D printing) gains a single molded ↑ arrow on the face above the lens. Specifics:
-- Placement: top-center of the front face, ≥3mm above the lens cutout, ≥3mm from the top edge of the case
-- Form: relief or recess, 8–12mm tall, depth/height ≥0.4mm to remain visible after weathering
-- Material: same as the housing — no painted/printed labels (those weather poorly)
-- A flat ▲ triangle or stylized ↑ are both acceptable; one design, picked once, applied to every unit thereafter
-- The arrow must remain visible when the case is mounted with any reasonable tape/screw fixture — so don't put it where the mounting bracket covers it
+The operator's facing direction (East / West / Both) supplies the assumed center azimuth of the camera's view: 90°, 270°, or both. Without a magnetometer the Pi cannot verify this; the operator's selection is taken on trust and caught downstream by sub-project G (first-image verification).
 
-A separate hardware spec (`docs/specs/hardware/...`, not part of this software project) tracks the STL update. This software spec assumes the marker exists from the operator's perspective; if it doesn't yet, the install instructions can substitute "the side with the lens visible at the bottom and the cable port at the bottom" with the same effect.
+Client-side JS:
 
-### 5.4 F integration
+```javascript
+// On page load, given lat/lng (from server) + selected facing:
+const jun_sunset_az = computeSunsetAzimuth(lat, lng, jun21);
+const dec_sunset_az = computeSunsetAzimuth(lat, lng, dec21);
 
-F's screen 4 (the former "AR placement" step) becomes:
-
-```
-+---------------------------------------+
-|  Align your camera                    |
-|                                       |
-|  Open the alignment tool to level     |
-|  your camera using its live preview:  |
-|                                       |
-|  [ Open alignment tool ]              |
-|  (opens http://<pi-local-ip>:8080/    |
-|   setup/align in a new tab)           |
-|                                       |
-|  When you're done, come back here     |
-|  and click Continue.                  |
-|                                       |
-|  [ Continue ]                         |
-+---------------------------------------+
+// Map azimuth → horizontal pixel on the preview
+function azToPixel(az_deg, center_az, fov_deg, screen_width) {
+  const offset = ((az_deg - center_az + 540) % 360) - 180; // signed delta in [-180,180]
+  return screen_width * (0.5 + offset / fov_deg);
+}
 ```
 
-The Pi's local IP is discovered the same way F's other screens reach the Pi — via spec E's setup-status polling, which already returns the Pi's local network info to the wizard. The wizard renders the `Open alignment tool` button as an anchor with `target="_blank"`.
+`fov_deg` = 102° for the Camera Module 3 Wide (existing BOM). Markers drawn at the computed pixel positions; shaded wedge between them; counter computed as `count(days where sunset_azimuth(day) is within camera_fov_centered_on selected_facing)`.
 
-Continuing on F's screen 4 advances to screen 5 (horizon sweep) with no state from this tool — the alignment tool is a one-way side trip and has no protocol payload.
+The simplification: this assumes the operator aims roughly at due-east or due-west, off by a few tens of degrees at most. If the operator aims at, say, NNW (315°) and selects "West (270°)," the markers will be drawn off-center — operator's responsibility to swivel until the wedge is inside the visible preview. The system can't tell them they're wrong; it can only tell them where they SHOULD be looking if the assumption holds.
+
+### 5.6 F integration
+
+Same as v0.1 — F's screen 4 becomes a link "Open the alignment tool" pointing to `http://<pi-local-ip>:<setup-port>/setup/align`, opened in a new tab. Operator does the alignment, returns, clicks Continue to advance.
+
+The facing direction selected on the alignment page is **not** submitted to F or the protocol — it's a local computation only, used for drawing the markers. The actual `placement.azimuth_deg` submitted by F's screen 6 ("Mount Here") remains the canonical record.
 
 ## 6. Field provenance
 
-This tool produces **no new protocol fields**. The orientation/roll-capture concern that the umbrella spec assigned to sub-project C is solved here by hardware + human verification, not by a new sensor reading. The protocol's existing `placement.azimuth_deg` and `placement.tilt_deg` (from F's screen 6 "Mount Here") are unchanged.
+No new protocol fields. The operator's facing selection is local to the alignment tool. Roll/pitch from the IMU is local too (not sent to the cloud). The cloud sees only the final `placement.azimuth_deg / tilt_deg` from F's screen 6, unchanged.
 
-Notably absent: `placement.roll_deg`. The umbrella spec listed this as a Sub-project C deliverable. We don't capture it — the alignment step verifies roll=0 by visual inspection, and storing the visually-verified value adds no value to the cloud (no consumer reads it).
+Future v2 of the protocol may add `placement.roll_deg` (now measurable!) and `placement.calibrated_azimuth_deg` (from sun-tap calibration) — out of scope here.
 
 ## 7. Testing
 
 ### 7.1 Unit
 
-- `GET /setup/align` returns 200 with the expected HTML structure (horizon line at midpoint, UP label at top, image src pointing at `/setup/preview.mjpg`).
-- `GET /setup/preview.mjpg` returns `Content-Type: multipart/x-mixed-replace; boundary=...` and a steady stream of JPEG frames from picamera2.
-- The setup web app's existing tests (from spec E) need a new case: while in setup mode, `/setup/align` is reachable; while NOT in setup mode, it returns 404 or redirects.
+- `read_orientation(i2c_bus)` returns the expected (roll, pitch) for known accelerometer readings (gravity along each axis). Cover: flat, on its side both ways, upside down.
+- `compute_solstice_markers(lat, lng, facing, fov)` returns the expected pixel offsets for known coordinates (Bellingham 48.75°N: Jun sunset ~295°, Dec sunset ~248°).
+- `count_sunsets_in_fov(lat, lng, facing, fov)` returns 100–365 days/year for mid-latitudes; 365 for equator.
+- `GET /setup/align` returns HTML containing the polling script and the embedded lat/lng.
+- `GET /setup/orientation.json` returns the latest cached reading; mocked I2C inputs verify smoothing math.
 
-### 7.2 Manual
+### 7.2 Manual (gated on MPU6050 acquisition + soldering)
 
-- Open `/setup/align` from a phone connected to the Pi's local network. Confirm the live preview is visible, the horizon line is at vertical center, the ↑ UP label is at top.
-- Rotate the Pi housing physically through all 4 cardinal orientations (upright, 90° left, 180°, 90° right). Confirm the preview rotates correspondingly in the browser, and that levelling at "upright" produces a horizontal real-world horizon visible in the preview.
-- With the housing mounted upright and level, confirm the molded ↑ arrow on the housing aligns visually with the ↑ on screen.
+- Wire an MPU6050 to a test Pi. Run the orientation read loop; rotate the Pi by hand and observe live readings change.
+- Open `/setup/align` from a phone connected to the Pi's local network. Confirm the roll readout updates in real time as the Pi is rotated.
+- Toggle East/West/Both; confirm solstice markers and the sunsets-per-year counter update.
+- Install the camera in field at a known good location; confirm the live preview, roll readout, and markers are all usable together.
 
 ## 8. Risks
 
-- **MJPEG latency on Pi Zero 2 W.** Targeting a 4–8 fps preview at 640×480 to stay under 5 Mbps; acceptable for static alignment but not for any future real-time interactive overlay. If latency feels noticeably bad in field testing, the preview resolution drops first before any architectural change.
-- **Phone-screen rendering of overlay at edge zoom levels.** The static SVG should remain visible at thumb-zoom; the design uses thick strokes and large text to mitigate.
-- **Operator misreads "up."** Belt-and-suspenders: the live preview shows the real world (so the operator can see if it's upside-down), the molded arrow is permanent reference, and the on-screen `↑ UP` label is visible above the preview. Three independent signals.
-- **The known gap: this does not catch "aimed at the wrong compass direction."** Explicitly accepted limitation. A future spec can revisit if the failure pattern becomes common.
+- **MPU6050 sourcing + soldering blocks first field test.** Operator must acquire units and install them before any field validation. Accepted as a one-time setup cost.
+- **Operator misreports facing direction.** Solstice markers drawn wrong. Mitigation: G (first-image verification) catches it; operator can also see the wedge "looks wrong" on the live preview if their actual aim differs from what they reported.
+- **MPU6050 calibration drift / DC bias.** Cheap parts have ±2° accelerometer accuracy out of the box. Mitigation: the level badge tolerates ±1° "good enough"; precision-critical scenarios out of v1 scope.
+- **I2C contention with other peripherals.** None expected — picamera2 uses CSI bus, MPU6050 uses I2C; independent.
+- **MJPEG latency on Pi Zero 2 W** — same as v0.1, mitigated by low fps (~4–8 fps target).
+- **No magnetometer = no true compass.** Operator self-report is the v1 workaround. Future specs (sun-tap calibration, 9-axis upgrade) are paths to fix this if it becomes a real problem.
+- **"Looking at the wedge wrong" failure mode** (operator says West, mounts NW). The shaded wedge will be off-center on the preview. Operator can self-correct by panning until the wedge looks centered — but the system can't enforce it.
 
 ## 9. Implementation slice order
 
-1. Add the `/setup/align` route to the setup web app (one HTML response, inline SVG, no JS).
-2. Add the `/setup/preview.mjpg` route. The picamera2 capture loop is already running for the normal capture-streaming path; this is a second consumer subscribing to the same frames. (Engineer should confirm whether picamera2 supports concurrent encoders; if not, the setup mode runs a dedicated low-fps preview.)
-3. Update F's screen 4 (in the cloud wizard frontend) to a link-to-Pi-IP button instead of the prior AR placeholder.
-4. Update the hardware STL with the molded ↑ arrow (separate hardware spec, but file the issue and link from the install instructions).
-5. Manual install test with a real Pi at the test location.
+1. Add MPU6050 driver module + unit tests (mocked I2C inputs).
+2. Add `/setup/orientation.json` endpoint + background sampler thread.
+3. Extend `setup_alignment.py`'s HTML to include the polling JS + readout.
+4. Add the facing selector + client-side solstice math.
+5. Add the sunsets-per-year counter (suncalc-based).
+6. Wire all into the spec E setup web app once that lands.
+7. Field test with real MPU6050 hardware + real install location.
 
-## 10. Open questions
+## 10. Open questions / future directions
 
-- Does picamera2 support concurrent encoders (one for the production MJPEG capture loop, one for the setup-preview stream), or do they need to serialize? Resolves at implementation time.
-- Should the alignment page include a "freeze frame / unfreeze" button so the operator can pause the stream to align without their motion shaking the preview? Probably not — they need it live to see the result of their physical rotation. Defer until field testing surfaces a need.
-- After mount, should the cloud wizard show a confirmation thumbnail captured from the Pi as proof of alignment? Pulled into sub-project G (first-image verification), out of scope here.
+- **Sun-Seeker-style placement app**: a separate phone-side scouting app inspired by [Sun Seeker](https://profilmmakerapps.com/app/sun-seeker/). The operator attaches the Pi case to their phone (magnetic mount, strap, or a printed cradle), then walks around the install location with the phone running an AR view that uses the phone's full sensor suite — including a real compass — to predict where the sun will travel relative to the Pi's eventual mounted position. No Pi changes needed; pure phone-side software. Worth a separate spec.
+- **Sun-tap calibration with the MPU6050 gyro**: with the IMU in place, a future spec adds a one-time tap-the-sun calibration. Operator taps the sun on the preview during install; the Pi computes the sun's true azimuth at that timestamp + lat/lng; the gyro integrates rotation rates to track subsequent azimuth changes. Effective compass without a magnetometer. Deferred from v0.1 because the UX was complex; revisit when the simpler v0.2 approach proves insufficient.
+- **9-axis upgrade** (MPU9250 or MPU6050 + QMC5883L magnetometer): if operator-self-report turns out to be unreliable in the field, an upgrade to a magnetometer-equipped IMU gives true compass. Adds $3–5 per unit. Defer until v0.2 ships and we have field data.
+- **Confirmation thumbnail in the cloud wizard**: after mounting, sub-project G's first-image-verification step shows the operator the actual first captured frame from their Pi. If the sun-wedge isn't visible in it, they know they aimed wrong and can recalibrate. Out of scope here; lives in G.
+- **Concurrent MJPEG encoders on Pi Zero 2 W** (legacy open question from v0.1): in setup mode the production capture loop is idle, so the setup web app has exclusive picamera2 access. Sidesteps the contention question.
+
+---
+
+## Diff from v0.1
+
+If you read v0.1 and want to know what changed:
+
+- **§1 Problem**: added a 3rd item (compass-aim failure) motivated by the 2026-05-16 field observation.
+- **§2 Goals**: added goal 3 (year-round sun-azimuth wedge alignment) + tighter level precision via real sensor.
+- **§3 Non-goals**: removed "no sensor-based directional guidance" — we now have an IMU. Added "no magnetometer" + "no sun-tap calibration" to make the new boundary explicit.
+- **§5 Design**: §5.2 grew (polling JS, facing selector, counter); §5.3 split into UP-marker subsection (now: Sharpie OK) + MPU6050 BOM addition; §5.4 new (sensor read math); §5.5 new (facing-selector + solstice math); §5.6 unchanged.
+- **§7 Risks**: added MPU6050 sourcing risk, facing-misreport risk, sensor accuracy risk.
+- **§10 Open questions**: added Sun-Seeker app pattern, sun-tap calibration as future spec, 9-axis upgrade path.


### PR DESCRIPTION
## Summary

Sub-project C v0.2 — adds MPU6050 to the device BOM and an operator-selected facing direction (East/West/Both) to the alignment tool. Companion to firmware PR `jessekauppila/sunset-cam-firmware#2`.

This PR is **docs-only** in this repo. All code lives in the firmware repo.

### Files changed

- `docs/superpowers/specs/2026-05-17-pi-side-alignment-tool-design.md` — v0.1 → v0.2 rewrite (added IMU goals, facing selector, solstice markers, sun-Seeker pattern as future, sun-tap calibration as future, 9-axis upgrade path).
- `docs/superpowers/plans/2026-05-17-pi-side-alignment-tool.md` — v0.1 (6 tasks) → v0.2 (13 tasks). Plan was executed during the late-night session — see firmware PR #2.
- `docs/superpowers/specs/2026-05-15-wifi-onboarding-and-provisioning-design.md` — integration note added so spec E's implementer knows to register C's 3 routes.
- `docs/superpowers/specs/2026-05-16-cloud-wizard-frontend-design.md` — integration note added so spec F's screen 4 links to the Pi-served alignment tool.
- `docs/hardware/2026-05-17-housing-up-arrow-and-mpu6050.md` — new hardware tracking stub (UP marker + MPU6050 BOM).

### Notes carried over from execution

- Spec §5.4 roll formula was corrected to `atan2(ay, az)` after the implementer caught that the original `atan2(ay, sqrt(ax²+az²))` form couldn't distinguish flat from upside-down.
- East-facing counter shows 0 (we only track sunsets); documented as a known v0.2 limitation, future spec adds sunrise tracking.

## Test plan
- [x] Docs only — no CI implications
- [x] Spec self-reviewed
- [x] Plan self-reviewed against spec
- [x] Companion firmware PR has 48/48 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)