### PR TITLE
feat(cron): persist scoring_path on webcam_snapshots

### DIFF
--- a/app/api/cron/update-cameras/lib/customBackfill.test.ts
+++ b/app/api/cron/update-cameras/lib/customBackfill.test.ts
@@ -60,8 +60,8 @@ describe('backfillCustomSnapshotScores', () => {
     expect(result.modelVersion).toBe('v4');
     expect(result.scores).toEqual([0.82, 0.82]);
     expect(updateSnapMock).toHaveBeenCalledTimes(2);
-    expect(updateSnapMock).toHaveBeenCalledWith(11, 0.82, 'v4');
-    expect(updateSnapMock).toHaveBeenCalledWith(12, 0.82, 'v4');
+    expect(updateSnapMock).toHaveBeenCalledWith(11, 0.82, 'v4', 'onnx');
+    expect(updateSnapMock).toHaveBeenCalledWith(12, 0.82, 'v4', 'onnx');
     // Webcam sync runs once per unique webcam_id (42 appears twice -> 1 call).
     expect(syncWebcamMock).toHaveBeenCalledTimes(1);
     expect(syncWebcamMock).toHaveBeenCalledWith(42);

--- a/app/api/cron/update-cameras/lib/customBackfill.ts
+++ b/app/api/cron/update-cameras/lib/customBackfill.ts
@@ -45,7 +45,8 @@ export async function backfillCustomSnapshotScores(opts: {
       await updateSnapshotAiRegressionScore(
         row.snapshotId,
         result.rawScore,
-        result.modelVersion
+        result.modelVersion,
+        result.pathTaken
       );
       modelVersion = result.modelVersion;
       touchedWebcamIds.add(row.webcamId);

--- a/app/api/cron/update-cameras/lib/dbOperations.backfill.test.ts
+++ b/app/api/cron/update-cameras/lib/dbOperations.backfill.test.ts
@@ -35,7 +35,7 @@ describe('findCustomSnapshotsNeedingScore', () => {
 describe('updateSnapshotAiRegressionScore', () => {
   it('writes ai_regression_score + ai_model_version_regression for a snapshot id', async () => {
     sqlMock.mockResolvedValue([]);
-    await updateSnapshotAiRegressionScore(7, 0.812, 'v4');
+    await updateSnapshotAiRegressionScore(7, 0.812, 'v4', 'onnx');
     const [strings, ...values] = sqlMock.mock.calls[0];
     const q = strings.join('?');
     expect(q).toMatch(/update\s+webcam_snapshots/i);
@@ -44,6 +44,22 @@ describe('updateSnapshotAiRegressionScore', () => {
     expect(values).toContain(7);
     expect(values).toContain(0.812);
     expect(values).toContain('v4');
+  });
+
+  it('also writes scoring_path so contaminated rows are queryable later', async () => {
+    sqlMock.mockResolvedValue([]);
+    await updateSnapshotAiRegressionScore(7, 0.812, 'v4', 'onnx');
+    const [strings, ...values] = sqlMock.mock.calls[0];
+    const q = strings.join('?');
+    expect(q).toMatch(/scoring_path/);
+    expect(values).toContain('onnx');
+  });
+
+  it('persists baseline-fallback when the scoring path was a fallback', async () => {
+    sqlMock.mockResolvedValue([]);
+    await updateSnapshotAiRegressionScore(7, 0.5, 'v4', 'baseline-fallback');
+    const [, ...values] = sqlMock.mock.calls[0];
+    expect(values).toContain('baseline-fallback');
   });
 });
 

--- a/app/api/cron/update-cameras/lib/dbOperations.ts
+++ b/app/api/cron/update-cameras/lib/dbOperations.ts
@@ -337,12 +337,14 @@ export async function findCustomSnapshotsNeedingScore(
 export async function updateSnapshotAiRegressionScore(
   snapshotId: number,
   score: number,
-  modelVersion: string
+  modelVersion: string,
+  scoringPath: string
 ): Promise<void> {
   await sql`
     update webcam_snapshots
     set ai_regression_score = ${score},
-        ai_model_version_regression = ${modelVersion}
+        ai_model_version_regression = ${modelVersion},
+        scoring_path = ${scoringPath}
     where id = ${snapshotId}
   `;
 }

--- a/database/migrations/20260518_webcam_snapshot_scoring_path.sql
+++ b/database/migrations/20260518_webcam_snapshot_scoring_path.sql
@@ -1,0 +1,17 @@
+-- Add per-snapshot scoring_path so the actual code path (onnx vs
+-- baseline-fallback vs baseline) is queryable historically. Companion
+-- to the per-tick scoringPaths counter shipped on 2026-05-18 — that
+-- one shows live state, this one captures it on every row written.
+--
+-- Motivated by the v4 deploy on 2026-05-15: scoring_path would have
+-- let a single SQL query find every contaminated row instead of
+-- requiring a week of investigation.
+--
+-- Forward-only, idempotent. Apply manually via:
+--   psql "$DATABASE_URL" -f database/migrations/20260518_webcam_snapshot_scoring_path.sql
+--
+-- Historical rows stay NULL (= "we don't know") rather than backfilled —
+-- false-attestation would be worse than absence here.
+
+ALTER TABLE webcam_snapshots
+  ADD COLUMN IF NOT EXISTS scoring_path TEXT;


### PR DESCRIPTION
Adds scoring_path TEXT column to webcam_snapshots and writes scored.pathTaken into it from the custom-camera backfill path.

Companion to the per-tick scoringPaths counter shipped in PR #18:
- scoringPaths shows live state per tick
- scoring_path captures it on every row written

After any future broken-ONNX deploy, contaminated rows become queryable:
  SELECT scoring_path, COUNT(*) FROM webcam_snapshots
  WHERE captured_at > '...' GROUP BY scoring_path;

Tonight's 2026-05-15 investigation would have been a 10-second query instead of a week of detective work.

Historical rows stay NULL (= 'we don't know') — false attestation would be worse than absence here. Migration is idempotent.

Only the custom-camera path writes per-snapshot today. The windy path writes to the webcams table (top-level), not webcam_snapshots — if/when winder snapshots get their own AI scoring (Phase 2 winner-selection), they'll write scoring_path the same way.