### PR TITLE
fix(deploy): bundle ONNX model into scoring-smoke function

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -8,6 +8,9 @@
   "functions": {
     "app/api/cron/update-cameras/route.ts": {
       "includeFiles": "ml/artifacts/models/regression_resnet18/**"
+    },
+    "app/api/debug/scoring-smoke/route.ts": {
+      "includeFiles": "ml/artifacts/models/regression_resnet18/**"
     }
   }
 }


### PR DESCRIPTION
The new /api/debug/scoring-smoke endpoint calls scoreImage which loads model.onnx at runtime. Without listing the route in vercel.json's functions.includeFiles map, Vercel's tracer doesn't include the model file — scoreImage falls through to baseline-fallback path, defeating the whole 'is ONNX really running' check.

Same includeFiles glob as the cron route so both functions ship the same model artifact.