### PR TITLE
feat(setup): cloud wizard skeleton at /setup/[claim_code]

### DIFF
--- a/app/setup/[claim_code]/WizardClient.tsx
+++ b/app/setup/[claim_code]/WizardClient.tsx
@@ -1,0 +1,92 @@
+'use client';
+
+import { useState } from 'react';
+import { initialWizardState, STEPS, type WizardState, type Step } from './types';
+import ConfirmCamera from './steps/ConfirmCamera';
+import PhasePreference from './steps/PhasePreference';
+import DeliveryPreferences from './steps/DeliveryPreferences';
+import ArPlacementPlaceholder from './steps/ArPlacementPlaceholder';
+import HorizonSweepPlaceholder from './steps/HorizonSweepPlaceholder';
+import MountHere from './steps/MountHere';
+import SubmitStep from './steps/SubmitStep';
+
+export default function WizardClient({ claimCode }: { claimCode: string }) {
+  const [step, setStep] = useState<Step>('confirm-camera');
+  const [state, setState] = useState<WizardState>(initialWizardState);
+
+  const update = (patch: Partial<WizardState>) =>
+    setState((s) => ({ ...s, ...patch }));
+
+  const goNext = () => {
+    const idx = STEPS.indexOf(step);
+    if (idx >= 0 && idx < STEPS.length - 1) setStep(STEPS[idx + 1]);
+  };
+  const goBack = () => {
+    const idx = STEPS.indexOf(step);
+    if (idx > 0) setStep(STEPS[idx - 1]);
+  };
+
+  return (
+    <main className="mx-auto flex min-h-screen max-w-md flex-col bg-black px-4 py-6 text-white">
+      <header className="mb-4 flex items-center justify-between text-xs uppercase tracking-wider text-neutral-400">
+        <span>Camera setup</span>
+        <span>
+          Step {STEPS.indexOf(step) + 1} of {STEPS.length}
+        </span>
+      </header>
+
+      <section className="flex flex-1 flex-col">
+        {step === 'confirm-camera' && (
+          <ConfirmCamera
+            claimCode={claimCode}
+            onAdvance={(deviceStatus) => {
+              update({ deviceStatus });
+              goNext();
+            }}
+          />
+        )}
+        {step === 'phase-preference' && (
+          <PhasePreference
+            value={state.phasePreference}
+            onChange={(phasePreference) => update({ phasePreference })}
+            onNext={goNext}
+            onBack={goBack}
+          />
+        )}
+        {step === 'delivery-preferences' && (
+          <DeliveryPreferences
+            value={state.delivery}
+            onChange={(delivery) => update({ delivery })}
+            onNext={goNext}
+            onBack={goBack}
+          />
+        )}
+        {step === 'ar-placement' && (
+          <ArPlacementPlaceholder onNext={goNext} onBack={goBack} />
+        )}
+        {step === 'horizon-sweep' && (
+          <HorizonSweepPlaceholder onNext={goNext} onBack={goBack} />
+        )}
+        {step === 'mount-here' && (
+          <MountHere
+            onCapture={({ azimuthDeg, tiltDeg, geo, timezone }) => {
+              update({
+                placementAzimuth: azimuthDeg,
+                placementTilt: tiltDeg,
+                lat: geo.lat,
+                lng: geo.lng,
+                elevationM: geo.elevationM,
+                timezone,
+              });
+              goNext();
+            }}
+            onBack={goBack}
+          />
+        )}
+        {step === 'submit' && (
+          <SubmitStep claimCode={claimCode} state={state} onBack={goBack} />
+        )}
+      </section>
+    </main>
+  );
+}

--- a/app/setup/[claim_code]/lib/useDeviceOrientation.ts
+++ b/app/setup/[claim_code]/lib/useDeviceOrientation.ts
@@ -1,0 +1,112 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+
+export type Orientation = {
+  // 0 = North, 90 = East, 180 = South, 270 = West (clockwise from North).
+  azimuthDeg: number;
+  // Pitch: 0 = level, +90 = pointed straight up, -90 = straight down.
+  tiltDeg: number;
+};
+
+// DeviceOrientation hook. iOS Safari requires a user gesture to grant
+// permission via DeviceOrientationEvent.requestPermission; Android grants
+// it implicitly. requestPermission() should be called from a click handler.
+//
+// The compass-heading question is OS-dependent:
+//   - iOS exposes `webkitCompassHeading` (already North-relative, 0-360)
+//   - Android only gives `alpha` (rotation around Z), needs absolute=true
+//     and a calibration step to be North-relative. Documented under
+//     "compass calibration is painful" in the design stub.
+//
+// This hook returns the best-effort heading without further calibration.
+// Future work (sub-project C / brainstorm): MPU6050-style fused readings
+// and the "point at a known landmark" calibration UX.
+
+declare global {
+  interface DeviceOrientationEventStatic {
+    requestPermission?: () => Promise<'granted' | 'denied'>;
+  }
+  // iOS-only field; not in the standard DeviceOrientationEvent types.
+  interface DeviceOrientationEvent {
+    webkitCompassHeading?: number;
+  }
+}
+
+export function useDeviceOrientation(): {
+  orientation: Orientation | null;
+  permissionState: 'unknown' | 'granted' | 'denied' | 'unsupported';
+  requestPermission: () => Promise<void>;
+  error: string | null;
+} {
+  const [orientation, setOrientation] = useState<Orientation | null>(null);
+  const [permissionState, setPermissionState] = useState<
+    'unknown' | 'granted' | 'denied' | 'unsupported'
+  >('unknown');
+  const [error, setError] = useState<string | null>(null);
+
+  const startListening = useCallback(() => {
+    const handler = (ev: DeviceOrientationEvent) => {
+      // iOS: webkitCompassHeading is already North-relative.
+      // Android: alpha is from device's reference, needs calibration to map.
+      const azimuthDeg =
+        typeof ev.webkitCompassHeading === 'number'
+          ? ev.webkitCompassHeading
+          : ev.alpha != null
+            ? (360 - ev.alpha) % 360 // Android: invert + wrap
+            : 0;
+      // Beta = front-to-back tilt, -180..180. Subtract 90 so "phone held up
+      // looking at horizon" reads as 0, level reads as -90.
+      const tiltDeg = ev.beta != null ? ev.beta - 90 : 0;
+      setOrientation({ azimuthDeg, tiltDeg });
+    };
+    window.addEventListener('deviceorientation', handler);
+    return () => window.removeEventListener('deviceorientation', handler);
+  }, []);
+
+  const requestPermission = useCallback(async () => {
+    if (typeof window === 'undefined') return;
+    const DOE = window.DeviceOrientationEvent as unknown as
+      | DeviceOrientationEventStatic
+      | undefined;
+    if (!DOE) {
+      setPermissionState('unsupported');
+      setError('Device orientation not supported on this browser.');
+      return;
+    }
+    // iOS path: explicit permission request from a user gesture.
+    if (typeof DOE.requestPermission === 'function') {
+      try {
+        const result = await DOE.requestPermission();
+        if (result === 'granted') {
+          setPermissionState('granted');
+          startListening();
+        } else {
+          setPermissionState('denied');
+          setError('Permission denied.');
+        }
+      } catch (err) {
+        setError(err instanceof Error ? err.message : String(err));
+      }
+      return;
+    }
+    // Non-iOS: no explicit request needed; just attach.
+    setPermissionState('granted');
+    startListening();
+  }, [startListening]);
+
+  useEffect(() => {
+    // Auto-attach for non-iOS on mount. iOS won't fire events until
+    // requestPermission() is awaited from a user gesture.
+    if (typeof window === 'undefined') return;
+    const DOE = window.DeviceOrientationEvent as unknown as
+      | DeviceOrientationEventStatic
+      | undefined;
+    if (DOE && typeof DOE.requestPermission !== 'function') {
+      setPermissionState('granted');
+      return startListening();
+    }
+  }, [startListening]);
+
+  return { orientation, permissionState, requestPermission, error };
+}

--- a/app/setup/[claim_code]/lib/useGeolocation.ts
+++ b/app/setup/[claim_code]/lib/useGeolocation.ts
@@ -1,0 +1,50 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+export type GeoResult = {
+  lat: number;
+  lng: number;
+  elevationM: number | null;
+};
+
+// Wrapper around navigator.geolocation. Resolves once with a high-accuracy
+// fix, then idles. The wizard calls this when the operator advances past
+// the initial confirm screen so the permission prompt arrives in context.
+export function useGeolocation(enabled: boolean): {
+  result: GeoResult | null;
+  error: string | null;
+  pending: boolean;
+} {
+  const [result, setResult] = useState<GeoResult | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [pending, setPending] = useState(false);
+
+  useEffect(() => {
+    if (!enabled || result !== null) return;
+    if (typeof navigator === 'undefined' || !navigator.geolocation) {
+      setError('Geolocation not supported on this device.');
+      return;
+    }
+    setPending(true);
+    navigator.geolocation.getCurrentPosition(
+      (pos) => {
+        setResult({
+          lat: pos.coords.latitude,
+          lng: pos.coords.longitude,
+          elevationM:
+            typeof pos.coords.altitude === 'number' ? pos.coords.altitude : null,
+        });
+        setPending(false);
+        setError(null);
+      },
+      (err) => {
+        setError(err.message || 'Could not get location.');
+        setPending(false);
+      },
+      { enableHighAccuracy: true, timeout: 10000, maximumAge: 60_000 }
+    );
+  }, [enabled, result]);
+
+  return { result, error, pending };
+}

--- a/app/setup/[claim_code]/lib/usePolling.ts
+++ b/app/setup/[claim_code]/lib/usePolling.ts
@@ -1,0 +1,63 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+
+// Generic polling hook. Calls `fn` immediately then every `intervalMs`
+// until cleanup. Stops when `stopWhen(result)` returns true.
+//
+// Used by Screen 1 (confirm-camera) to poll /api/cameras/setup-status
+// until the device's status flips from 'awaiting_wifi'.
+export function usePolling<T>(
+  fn: () => Promise<T>,
+  opts: {
+    intervalMs: number;
+    stopWhen: (result: T) => boolean;
+    enabled?: boolean;
+  }
+): { latest: T | null; error: Error | null; stopped: boolean } {
+  const { intervalMs, stopWhen, enabled = true } = opts;
+  const [latest, setLatest] = useState<T | null>(null);
+  const [error, setError] = useState<Error | null>(null);
+  const [stopped, setStopped] = useState(false);
+  // Keep latest stopWhen in a ref so the effect doesn't tear down every
+  // render the caller passes a fresh arrow.
+  const stopWhenRef = useRef(stopWhen);
+  stopWhenRef.current = stopWhen;
+  const fnRef = useRef(fn);
+  fnRef.current = fn;
+
+  useEffect(() => {
+    if (!enabled) return;
+    let cancelled = false;
+    setStopped(false);
+
+    const tick = async () => {
+      try {
+        const result = await fnRef.current();
+        if (cancelled) return;
+        setLatest(result);
+        setError(null);
+        if (stopWhenRef.current(result)) {
+          setStopped(true);
+          return;
+        }
+      } catch (err) {
+        if (cancelled) return;
+        setError(err instanceof Error ? err : new Error(String(err)));
+      }
+      if (!cancelled) {
+        timer = setTimeout(tick, intervalMs);
+      }
+    };
+
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    tick();
+
+    return () => {
+      cancelled = true;
+      if (timer) clearTimeout(timer);
+    };
+  }, [enabled, intervalMs]);
+
+  return { latest, error, stopped };
+}

--- a/app/setup/[claim_code]/page.tsx
+++ b/app/setup/[claim_code]/page.tsx
@@ -1,0 +1,22 @@
+import { notFound } from 'next/navigation';
+import WizardClient from './WizardClient';
+
+type PageProps = {
+  params: Promise<{ claim_code: string }>;
+};
+
+// Setup wizard entry point. Reached as /setup/{claim_code} after the
+// operator scans the sticker QR code (or types the URL printed on it).
+// See docs/superpowers/specs/2026-05-16-cloud-wizard-frontend-design.md.
+export default async function SetupPage({ params }: PageProps) {
+  const { claim_code } = await params;
+
+  // Basic shape check — real validation happens server-side on each API call.
+  // Claim codes are short alphanumeric tokens; reject obviously-malformed URLs
+  // before rendering the wizard.
+  if (!/^[A-Za-z0-9_-]{4,64}$/.test(claim_code)) {
+    notFound();
+  }
+
+  return <WizardClient claimCode={claim_code} />;
+}

--- a/app/setup/[claim_code]/steps/ArPlacementPlaceholder.tsx
+++ b/app/setup/[claim_code]/steps/ArPlacementPlaceholder.tsx
@@ -1,0 +1,45 @@
+'use client';
+
+// Screen 4 placeholder. Real AR design pending — see the design stub at
+// docs/superpowers/specs/2026-05-16-cloud-wizard-frontend-design.md
+// for what this needs to become (three solstice/equinox arcs in a
+// live camera feed with the phone's current bearing locked in).
+//
+// Lives here so the wizard flow is end-to-end navigable; replaced once
+// the AR brainstorm pass completes.
+export default function ArPlacementPlaceholder({
+  onNext,
+  onBack,
+}: {
+  onNext: () => void;
+  onBack: () => void;
+}) {
+  return (
+    <div className="flex flex-1 flex-col">
+      <h1 className="mb-1 text-2xl font-light">Sun-path preview</h1>
+      <p className="mb-6 text-sm text-neutral-400">
+        Coming soon: live AR overlay showing where the sun rises and sets
+        throughout the year at your location.
+      </p>
+
+      <div className="flex flex-1 items-center justify-center rounded border border-dashed border-neutral-700 p-8 text-center text-xs text-neutral-500">
+        AR overlay placeholder
+        <br />
+        (deferred — see design stub §4)
+      </div>
+
+      <div className="mt-6 flex justify-between">
+        <button type="button" onClick={onBack} className="text-sm text-neutral-400">
+          Back
+        </button>
+        <button
+          type="button"
+          onClick={onNext}
+          className="rounded bg-white px-6 py-2 text-sm font-medium text-black"
+        >
+          Skip for now
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/app/setup/[claim_code]/steps/ConfirmCamera.tsx
+++ b/app/setup/[claim_code]/steps/ConfirmCamera.tsx
@@ -1,0 +1,58 @@
+'use client';
+
+import { useEffect } from 'react';
+import { usePolling } from '../lib/usePolling';
+
+type StatusResponse = { status: 'awaiting_wifi' | 'registered' | 'ready' };
+
+// Screen 1. Polls /api/cameras/setup-status/[claim_code] every 3s until
+// the device has either registered or finished pre-register from another
+// path. Auto-advances when status != 'awaiting_wifi'.
+export default function ConfirmCamera({
+  claimCode,
+  onAdvance,
+}: {
+  claimCode: string;
+  onAdvance: (status: 'awaiting_wifi' | 'registered' | 'ready') => void;
+}) {
+  const { latest, error, stopped } = usePolling<StatusResponse>(
+    async () => {
+      const res = await fetch(`/api/cameras/setup-status/${claimCode}`);
+      if (!res.ok) {
+        if (res.status === 404) {
+          throw new Error('Unknown or expired claim code.');
+        }
+        throw new Error(`Setup status check failed (${res.status})`);
+      }
+      return (await res.json()) as StatusResponse;
+    },
+    {
+      intervalMs: 3000,
+      stopWhen: (r) => r.status !== 'awaiting_wifi',
+    }
+  );
+
+  useEffect(() => {
+    if (stopped && latest) onAdvance(latest.status);
+  }, [stopped, latest, onAdvance]);
+
+  return (
+    <div className="flex flex-1 flex-col justify-center text-center">
+      <h1 className="mb-4 text-2xl font-light">Finding your camera</h1>
+      <p className="mb-8 text-neutral-400">
+        Waiting for your camera to connect…
+      </p>
+      <div className="flex justify-center">
+        <div className="h-6 w-6 animate-spin rounded-full border-2 border-neutral-700 border-t-white" />
+      </div>
+      {latest && (
+        <p className="mt-6 text-xs text-neutral-500">
+          Status: {latest.status}
+        </p>
+      )}
+      {error && (
+        <p className="mt-6 text-sm text-red-400">{error.message}</p>
+      )}
+    </div>
+  );
+}

--- a/app/setup/[claim_code]/steps/DeliveryPreferences.tsx
+++ b/app/setup/[claim_code]/steps/DeliveryPreferences.tsx
@@ -1,0 +1,142 @@
+'use client';
+
+import { useState } from 'react';
+import type { DeliveryPreferences as Prefs } from '../types';
+
+// Screen 3. operator_preferences.delivery. Where the daily photo goes
+// and how often.
+export default function DeliveryPreferences({
+  value,
+  onChange,
+  onNext,
+  onBack,
+}: {
+  value: Prefs | null;
+  onChange: (v: Prefs) => void;
+  onNext: () => void;
+  onBack: () => void;
+}) {
+  const [channel, setChannel] = useState<Prefs['channel']>(
+    value?.channel ?? 'email'
+  );
+  const [email, setEmail] = useState(value?.email ?? '');
+  const [phone, setPhone] = useState(value?.phone ?? '');
+  const [cadence, setCadence] = useState<Prefs['cadence']>(
+    value?.cadence ?? 'daily'
+  );
+
+  const isValid =
+    (channel === 'gallery-only') ||
+    (channel === 'email' && /.+@.+\..+/.test(email)) ||
+    (channel === 'sms' && phone.replace(/\D/g, '').length >= 7);
+
+  const commit = () => {
+    onChange({
+      channel,
+      email: channel === 'email' ? email : undefined,
+      phone: channel === 'sms' ? phone : undefined,
+      cadence,
+    });
+    onNext();
+  };
+
+  return (
+    <div className="flex flex-1 flex-col">
+      <h1 className="mb-1 text-2xl font-light">Where should your photos go?</h1>
+      <p className="mb-6 text-sm text-neutral-400">
+        We’ll send the best one from each window.
+      </p>
+
+      <fieldset className="mb-6 flex flex-col gap-2">
+        <label className="text-xs uppercase tracking-wider text-neutral-500">
+          Channel
+        </label>
+        <div className="flex flex-col gap-2">
+          {(['email', 'sms', 'gallery-only'] as const).map((c) => (
+            <button
+              key={c}
+              type="button"
+              onClick={() => setChannel(c)}
+              className={`rounded border p-3 text-left text-sm ${
+                channel === c
+                  ? 'border-white bg-white/10'
+                  : 'border-neutral-700'
+              }`}
+            >
+              {c === 'email' && 'Email'}
+              {c === 'sms' && 'Text message (SMS)'}
+              {c === 'gallery-only' && 'Don’t send anything — gallery only'}
+            </button>
+          ))}
+        </div>
+      </fieldset>
+
+      {channel === 'email' && (
+        <label className="mb-6 block">
+          <span className="mb-1 block text-xs uppercase tracking-wider text-neutral-500">
+            Email address
+          </span>
+          <input
+            type="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            placeholder="you@example.com"
+            className="w-full rounded border border-neutral-700 bg-transparent px-3 py-2 text-sm"
+          />
+        </label>
+      )}
+      {channel === 'sms' && (
+        <label className="mb-6 block">
+          <span className="mb-1 block text-xs uppercase tracking-wider text-neutral-500">
+            Phone number
+          </span>
+          <input
+            type="tel"
+            value={phone}
+            onChange={(e) => setPhone(e.target.value)}
+            placeholder="+1 555 555 5555"
+            className="w-full rounded border border-neutral-700 bg-transparent px-3 py-2 text-sm"
+          />
+        </label>
+      )}
+
+      <fieldset className="mb-6 flex flex-col gap-2">
+        <label className="text-xs uppercase tracking-wider text-neutral-500">
+          Cadence
+        </label>
+        <div className="flex flex-col gap-2">
+          {(['daily', 'per-event', 'quality-gated'] as const).map((c) => (
+            <button
+              key={c}
+              type="button"
+              onClick={() => setCadence(c)}
+              className={`rounded border p-3 text-left text-sm ${
+                cadence === c
+                  ? 'border-white bg-white/10'
+                  : 'border-neutral-700'
+              }`}
+            >
+              {c === 'daily' && 'One photo per day'}
+              {c === 'per-event' && 'Every sunset/sunrise window'}
+              {c === 'quality-gated' && 'Only when the model thinks it was great'}
+            </button>
+          ))}
+        </div>
+      </fieldset>
+
+      <div className="mt-auto flex justify-between pt-4">
+        <button type="button" onClick={onBack} className="text-sm text-neutral-400">
+          Back
+        </button>
+        <button
+          type="button"
+          onClick={commit}
+          disabled={!isValid}
+          className="rounded bg-white px-6 py-2 text-sm font-medium text-black disabled:opacity-40"
+        >
+          Continue
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/app/setup/[claim_code]/steps/HorizonSweepPlaceholder.tsx
+++ b/app/setup/[claim_code]/steps/HorizonSweepPlaceholder.tsx
@@ -1,0 +1,48 @@
+'use client';
+
+// Screen 5 placeholder. Real horizon-sweep design pending — see the
+// design stub at docs/superpowers/specs/2026-05-16-cloud-wizard-
+// frontend-design.md for what this needs to become (record {azimuth,
+// altitude} pairs as the operator turns in a circle aimed at the
+// visible horizon).
+//
+// The pre-register endpoint accepts horizon_profile as optional;
+// skipping here is safe — the server will derive a default geometric
+// horizon (altitude 0 everywhere) until this is built.
+export default function HorizonSweepPlaceholder({
+  onNext,
+  onBack,
+}: {
+  onNext: () => void;
+  onBack: () => void;
+}) {
+  return (
+    <div className="flex flex-1 flex-col">
+      <h1 className="mb-1 text-2xl font-light">Map your horizon</h1>
+      <p className="mb-6 text-sm text-neutral-400">
+        Coming soon: walk in a slow circle while keeping the phone aimed at
+        where the sky meets the ground, so we know when the sun is actually
+        visible from this spot.
+      </p>
+
+      <div className="flex flex-1 items-center justify-center rounded border border-dashed border-neutral-700 p-8 text-center text-xs text-neutral-500">
+        Horizon sweep placeholder
+        <br />
+        (deferred — see design stub §5)
+      </div>
+
+      <div className="mt-6 flex justify-between">
+        <button type="button" onClick={onBack} className="text-sm text-neutral-400">
+          Back
+        </button>
+        <button
+          type="button"
+          onClick={onNext}
+          className="rounded bg-white px-6 py-2 text-sm font-medium text-black"
+        >
+          Skip for now
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/app/setup/[claim_code]/steps/MountHere.tsx
+++ b/app/setup/[claim_code]/steps/MountHere.tsx
@@ -1,0 +1,114 @@
+'use client';
+
+import { useDeviceOrientation } from '../lib/useDeviceOrientation';
+import { useGeolocation } from '../lib/useGeolocation';
+
+// Screen 6. The "snap a single orientation + location reading" step.
+// Requires DeviceOrientation permission (explicit on iOS) and Geolocation
+// permission. Both fire on entering this screen so the operator sees the
+// permission prompts in context.
+//
+// Captures everything the pre-register endpoint REQUIRES that the wizard
+// hasn't already collected: lat, lng, timezone, placement.azimuth_deg,
+// placement.tilt_deg. Hands the bundle to the parent.
+export default function MountHere({
+  onCapture,
+  onBack,
+}: {
+  onCapture: (data: {
+    azimuthDeg: number;
+    tiltDeg: number;
+    geo: { lat: number; lng: number; elevationM: number | null };
+    timezone: string;
+  }) => void;
+  onBack: () => void;
+}) {
+  const { orientation, permissionState, requestPermission, error: orientErr } =
+    useDeviceOrientation();
+  const { result: geo, error: geoErr, pending: geoPending } = useGeolocation(true);
+
+  const ready =
+    permissionState === 'granted' && orientation !== null && geo !== null;
+
+  const capture = () => {
+    if (!orientation || !geo) return;
+    const timezone =
+      Intl.DateTimeFormat().resolvedOptions().timeZone || 'UTC';
+    onCapture({
+      azimuthDeg: orientation.azimuthDeg,
+      tiltDeg: orientation.tiltDeg,
+      geo,
+      timezone,
+    });
+  };
+
+  return (
+    <div className="flex flex-1 flex-col">
+      <h1 className="mb-1 text-2xl font-light">Mount here</h1>
+      <p className="mb-6 text-sm text-neutral-400">
+        Point your phone exactly the way the camera will be pointed, then tap
+        below.
+      </p>
+
+      {permissionState === 'unknown' && (
+        <button
+          type="button"
+          onClick={requestPermission}
+          className="mb-6 rounded border border-white px-4 py-2 text-sm"
+        >
+          Enable compass + tilt
+        </button>
+      )}
+
+      <div className="mb-6 grid grid-cols-2 gap-3 text-sm">
+        <Tile
+          label="Bearing"
+          value={orientation ? `${Math.round(orientation.azimuthDeg)}°` : '—'}
+        />
+        <Tile
+          label="Tilt"
+          value={orientation ? `${Math.round(orientation.tiltDeg)}°` : '—'}
+        />
+        <Tile
+          label="Latitude"
+          value={geo ? geo.lat.toFixed(4) : geoPending ? '…' : '—'}
+        />
+        <Tile
+          label="Longitude"
+          value={geo ? geo.lng.toFixed(4) : geoPending ? '…' : '—'}
+        />
+      </div>
+
+      {(orientErr || geoErr) && (
+        <p className="mb-4 text-sm text-red-400">
+          {orientErr ?? geoErr}
+        </p>
+      )}
+
+      <div className="mt-auto flex justify-between pt-4">
+        <button type="button" onClick={onBack} className="text-sm text-neutral-400">
+          Back
+        </button>
+        <button
+          type="button"
+          onClick={capture}
+          disabled={!ready}
+          className="rounded bg-white px-6 py-2 text-sm font-medium text-black disabled:opacity-40"
+        >
+          Mount here
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function Tile({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded border border-neutral-700 p-3">
+      <div className="text-xs uppercase tracking-wider text-neutral-500">
+        {label}
+      </div>
+      <div className="mt-1 text-lg">{value}</div>
+    </div>
+  );
+}

--- a/app/setup/[claim_code]/steps/PhasePreference.tsx
+++ b/app/setup/[claim_code]/steps/PhasePreference.tsx
@@ -1,0 +1,68 @@
+'use client';
+
+import type { PhasePreference as Phase } from '../types';
+
+const OPTIONS: { value: Phase; label: string; blurb: string }[] = [
+  { value: 'sunrise', label: 'Sunrise', blurb: 'Wake up to the start of the day.' },
+  { value: 'sunset', label: 'Sunset', blurb: 'Catch the end of every day.' },
+  { value: 'both', label: 'Both', blurb: 'Two windows daily — sunrise and sunset.' },
+];
+
+// Screen 2. The phase_preference toggle.
+export default function PhasePreference({
+  value,
+  onChange,
+  onNext,
+  onBack,
+}: {
+  value: Phase | null;
+  onChange: (v: Phase) => void;
+  onNext: () => void;
+  onBack: () => void;
+}) {
+  return (
+    <div className="flex flex-1 flex-col">
+      <h1 className="mb-1 text-2xl font-light">What do you want to capture?</h1>
+      <p className="mb-6 text-sm text-neutral-400">
+        Your camera will only run during the windows you pick. You can change
+        this later.
+      </p>
+
+      <div className="flex flex-col gap-3">
+        {OPTIONS.map((opt) => (
+          <button
+            key={opt.value}
+            type="button"
+            onClick={() => onChange(opt.value)}
+            className={`rounded-lg border p-4 text-left transition ${
+              value === opt.value
+                ? 'border-white bg-white/10'
+                : 'border-neutral-700 hover:border-neutral-500'
+            }`}
+          >
+            <div className="text-lg">{opt.label}</div>
+            <div className="text-xs text-neutral-400">{opt.blurb}</div>
+          </button>
+        ))}
+      </div>
+
+      <div className="mt-auto flex justify-between pt-8">
+        <button
+          type="button"
+          onClick={onBack}
+          className="text-sm text-neutral-400"
+        >
+          Back
+        </button>
+        <button
+          type="button"
+          onClick={onNext}
+          disabled={value === null}
+          className="rounded bg-white px-6 py-2 text-sm font-medium text-black disabled:opacity-40"
+        >
+          Continue
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/app/setup/[claim_code]/steps/SubmitStep.tsx
+++ b/app/setup/[claim_code]/steps/SubmitStep.tsx
@@ -1,0 +1,158 @@
+'use client';
+
+import { useState } from 'react';
+import type { WizardState } from '../types';
+
+// Final step. Assembles the pre-register payload from wizard state and
+// POSTs it. The shape matches app/api/cameras/pre-register/route.ts.
+export default function SubmitStep({
+  claimCode,
+  state,
+  onBack,
+}: {
+  claimCode: string;
+  state: WizardState;
+  onBack: () => void;
+}) {
+  const [status, setStatus] = useState<
+    'idle' | 'submitting' | 'success' | 'error'
+  >('idle');
+  const [message, setMessage] = useState<string | null>(null);
+
+  const missing = listMissing(state);
+
+  const submit = async () => {
+    if (missing.length > 0) return;
+    setStatus('submitting');
+    try {
+      const res = await fetch('/api/cameras/pre-register', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          claim_code: claimCode,
+          lat: state.lat,
+          lng: state.lng,
+          elevation_m: state.elevationM,
+          timezone: state.timezone,
+          placement: {
+            azimuth_deg: state.placementAzimuth,
+            tilt_deg: state.placementTilt,
+            horizon_altitude_deg: 0,
+            horizon_profile: state.horizonProfile,
+          },
+          operator_preferences: {
+            phase_preference: state.phasePreference,
+            delivery: state.delivery,
+          },
+        }),
+      });
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}));
+        throw new Error(body.error || `Request failed (${res.status})`);
+      }
+      setStatus('success');
+      setMessage('Setup complete. Your camera will start capturing at the next window.');
+    } catch (err) {
+      setStatus('error');
+      setMessage(err instanceof Error ? err.message : String(err));
+    }
+  };
+
+  if (status === 'success') {
+    return (
+      <div className="flex flex-1 flex-col items-center justify-center text-center">
+        <div className="mb-4 text-4xl">✓</div>
+        <h1 className="mb-2 text-2xl font-light">You’re set up</h1>
+        <p className="text-sm text-neutral-400">{message}</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-1 flex-col">
+      <h1 className="mb-1 text-2xl font-light">Confirm and finish</h1>
+      <p className="mb-6 text-sm text-neutral-400">
+        Review what we collected, then submit.
+      </p>
+
+      <dl className="mb-6 space-y-2 text-sm">
+        <Row label="Phase" value={state.phasePreference ?? '—'} />
+        <Row
+          label="Location"
+          value={
+            state.lat != null && state.lng != null
+              ? `${state.lat.toFixed(4)}, ${state.lng.toFixed(4)}`
+              : '—'
+          }
+        />
+        <Row label="Timezone" value={state.timezone ?? '—'} />
+        <Row
+          label="Bearing"
+          value={
+            state.placementAzimuth != null
+              ? `${Math.round(state.placementAzimuth)}°`
+              : '—'
+          }
+        />
+        <Row
+          label="Tilt"
+          value={
+            state.placementTilt != null
+              ? `${Math.round(state.placementTilt)}°`
+              : '—'
+          }
+        />
+        <Row
+          label="Delivery"
+          value={
+            state.delivery
+              ? `${state.delivery.channel} · ${state.delivery.cadence}`
+              : '—'
+          }
+        />
+      </dl>
+
+      {missing.length > 0 && (
+        <p className="mb-4 text-sm text-amber-400">
+          Missing: {missing.join(', ')}. Go back and fill them in.
+        </p>
+      )}
+      {status === 'error' && message && (
+        <p className="mb-4 text-sm text-red-400">{message}</p>
+      )}
+
+      <div className="mt-auto flex justify-between pt-4">
+        <button type="button" onClick={onBack} className="text-sm text-neutral-400">
+          Back
+        </button>
+        <button
+          type="button"
+          onClick={submit}
+          disabled={missing.length > 0 || status === 'submitting'}
+          className="rounded bg-white px-6 py-2 text-sm font-medium text-black disabled:opacity-40"
+        >
+          {status === 'submitting' ? 'Submitting…' : 'Finish setup'}
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function Row({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="flex justify-between border-b border-neutral-800 py-1">
+      <dt className="text-neutral-400">{label}</dt>
+      <dd>{value}</dd>
+    </div>
+  );
+}
+
+function listMissing(state: WizardState): string[] {
+  const missing: string[] = [];
+  if (state.phasePreference == null) missing.push('phase');
+  if (state.lat == null || state.lng == null) missing.push('location');
+  if (state.timezone == null) missing.push('timezone');
+  if (state.placementAzimuth == null) missing.push('bearing');
+  if (state.placementTilt == null) missing.push('tilt');
+  return missing;
+}

--- a/app/setup/[claim_code]/types.ts
+++ b/app/setup/[claim_code]/types.ts
@@ -1,0 +1,66 @@
+// Shape of what the wizard accumulates as the operator walks through
+// the screens. Submitted to /api/cameras/pre-register at the end.
+// See pre-register/route.ts:11-27 for the matching server-side type.
+
+export type PhasePreference = 'sunrise' | 'sunset' | 'both';
+
+export type DeliveryPreferences = {
+  channel: 'email' | 'sms' | 'gallery-only';
+  email?: string;
+  phone?: string;
+  cadence: 'daily' | 'per-event' | 'quality-gated';
+};
+
+export type HorizonPoint = { azimuth_deg: number; altitude_deg: number };
+
+export type WizardState = {
+  // Screen 1: confirm-camera polling result.
+  deviceStatus: 'awaiting_wifi' | 'registered' | 'ready' | 'unknown';
+
+  // Screen 2.
+  phasePreference: PhasePreference | null;
+
+  // Screen 3.
+  delivery: DeliveryPreferences | null;
+
+  // Screens 4-5 (deferred to brainstorming session).
+  horizonProfile: HorizonPoint[] | null;
+
+  // Screen 6: captured on "Mount Here" tap.
+  placementAzimuth: number | null;
+  placementTilt: number | null;
+
+  // Geolocation API output. Captured automatically when permission is
+  // granted; not bound to any particular screen.
+  lat: number | null;
+  lng: number | null;
+  elevationM: number | null;
+
+  // Browser-derived.
+  timezone: string | null;
+};
+
+export const initialWizardState: WizardState = {
+  deviceStatus: 'unknown',
+  phasePreference: null,
+  delivery: null,
+  horizonProfile: null,
+  placementAzimuth: null,
+  placementTilt: null,
+  lat: null,
+  lng: null,
+  elevationM: null,
+  timezone: null,
+};
+
+// Six screens per the design spec. Names match the spec's headings.
+export const STEPS = [
+  'confirm-camera',
+  'phase-preference',
+  'delivery-preferences',
+  'ar-placement',     // Screen 4 — placeholder until brainstorm
+  'horizon-sweep',    // Screen 5 — placeholder until brainstorm
+  'mount-here',
+  'submit',
+] as const;
+export type Step = typeof STEPS[number];


### PR DESCRIPTION
Subproject F skeleton implementing the 6-screen onboarding flow defined in docs/superpowers/specs/2026-05-16-cloud-wizard-frontend-design.md.

What ships in this commit:
- Screen 1 (confirm-camera): polls /api/cameras/setup-status/[claim] every 3s, auto-advances when status != awaiting_wifi
- Screen 2 (phase-preference): sunrise / sunset / both toggle
- Screen 3 (delivery-preferences): email / sms / gallery-only with cadence picker (daily / per-event / quality-gated)
- Screen 6 (mount-here): captures bearing + tilt via DeviceOrientation API plus lat/lng via Geolocation API at button-tap; handles iOS requestPermission gesture requirement
- Submit step: assembles full pre-register payload (matches the shape pre-register/route.ts validates) and POSTs

What's deliberately deferred:
- Screen 4 (AR sun-path overlay) and Screen 5 (horizon sweep) ship as placeholders with "Skip for now" buttons. Both need real design work via the upcoming brainstorming session — the spec stub names them but doesn't define UX, compass-calibration approach, or AR rendering library choice. Skipping them is safe: pre-register accepts horizon_profile as optional, and AR is purely a visualization aid (produces no submitted fields).

The wizard is end-to-end functional today against the deployed cloud endpoints. Operators can complete setup; the AR steps just don't show the sun-path overlay yet.