### PR TITLE
docs(C v0.3 + hw): sun self-calibration + Arducam IMX708 AF + hardware spec

### DIFF
--- a/docs/hardware/2026-05-18-tier-0-camera-system-spec.md
+++ b/docs/hardware/2026-05-18-tier-0-camera-system-spec.md
@@ -1,0 +1,262 @@
+# Tier 0 Sunset Camera — Hardware Spec & Firmware Implications
+
+Status: Draft — 2026-05-18
+Owner: Jesse Kauppila
+Captures the full hardware decisions for the Tier 0 sunset camera so firmware work doesn't re-derive constraints. Companion to the alignment-tool software specs (v0.1 → v0.3 under `docs/superpowers/specs/`).
+
+---
+
+## Project overview
+
+A networked camera device that:
+1. Wakes during sunset windows (computed from sun position APIs / local astronomical calc)
+2. Captures stills periodically across the window
+3. Maintains a running "best so far" frame via on-device heuristic scoring
+4. Uploads only the winning frame to a server at end of window
+5. Server runs a PyTorch ResNet for higher-quality scoring and DB ingestion
+6. Future capability: live MJPEG streaming during the window
+
+Target: 100–500 unit deployment, installed by non-technical users.
+
+## Confirmed hardware
+
+### Compute
+**Raspberry Pi Zero 2 W** (preferred) or **Raspberry Pi 5** (fallback during Zero 2 W stockouts).
+- ARMv8 quad-core required — original Pi Zero W (ARMv6) is **not supported** for this project. Modern Python ML packages don't ship ARMv6 builds.
+- 64-bit Raspberry Pi OS, **Bookworm or later** (kernel 6.1.x+); older Bullseye is not supported by the Arducam driver.
+- ML inference happens on a server; on-device only does lightweight image heuristics.
+
+### Camera
+
+**Arducam for Raspberry Pi Camera Module 3 Wide, 120°(D) IMX708 Autofocus Pi Camera V3 with Case** — $35.
+
+- Sensor: Sony IMX708, 12MP (4608 × 2592)
+- Lens: 120° diagonal wide-angle, M12 mount
+- Focus: **Autofocus** (PDAF + CDAF) — software-controllable
+- Interface: MIPI CSI-2
+- Includes: camera, ABS case, 15-22 pin cable, 22-22 pin cable
+- Same IMX708 sensor as the Raspberry Pi Foundation Camera Module 3 — software-compatible. Pi Foundation version is the supply fallback.
+
+**Firmware must lock the lens to infinity at boot.** The autofocus motor will otherwise hunt on bright skies and produce soft frames during the sunset window. Using `picamera2`:
+
+```python
+from picamera2 import Picamera2
+from libcamera import controls
+
+picam = Picamera2()
+config = picam.create_still_configuration()
+picam.configure(config)
+
+# Lock focus at infinity, disable autofocus
+picam.set_controls({
+    "AfMode": controls.AfModeEnum.Manual,
+    "LensPosition": 0.0,  # 0.0 = infinity, higher = closer
+})
+picam.start()
+```
+
+Apply these controls **after** `configure()` and **before** `start()`. The `LensPosition` value of `0.0` corresponds to infinity focus. Verify on first deployment that distant objects are sharp; if not, sweep `LensPosition` from 0.0 to ~2.0 and pick the value where horizon sharpness peaks. Store the result as a per-unit calibration value in the device's config.
+
+### Arducam-specific Pi config
+
+The Arducam IMX708 module needs a `/boot/firmware/config.txt` tweak before `libcamera`/`picamera2` will detect it. Add to provisioning:
+
+```
+# Change:  camera_auto_detect=1
+# To:      camera_auto_detect=0
+# Add:     dtoverlay=imx708
+```
+
+Then reboot. One-time setup per device. Bake into the initial SD image / first-boot provisioning script.
+
+Reference: https://bit.ly/ArduCam_CM3_B0311
+
+### Cable & enclosure
+
+- Ribbon cable: 15-22 pin and 22-22 pin both included (Pi Zero 2 W uses 15-22; Pi 5 uses 22-22).
+- ABS case included with the camera. Reported gotcha: small protective film over the lens on arrival; remove before assembly or the lid won't fit flush.
+- For the Pi Zero 2 W itself, still need a separate enclosure (or mount Pi + camera in a custom prototype enclosure). At production scale this becomes a single custom enclosure that integrates both.
+
+### IMU
+
+**MPU-6050** (GY-521 breakout, I²C address 0x68) — ~$1.50 in bulk.
+
+- Tilt and roll only — **no magnetometer.** Heading is solved via celestial self-calibration (see software spec C v0.3).
+- Wiring: VCC → 3.3V (not 5V), GND → GND, SCL → GPIO 3, SDA → GPIO 2.
+- Cheap clone units are acceptable; verify each at install time with `i2cdetect -y 1` (should see 0x68).
+
+### Power
+
+- 5V via micro-USB (Pi Zero 2 W) or USB-C (Pi 5).
+- Indoor install assumed; 15ft 22AWG USB cable + 2.5A+ regulated wall adapter.
+- Long-run installs should use AC extension cord + PSU at the device end, not long DC cables (voltage drop on 22AWG is significant past ~15ft at 2.5A).
+
+## Camera abstraction requirement
+
+Firmware **must** wrap camera access behind a thin interface so the underlying camera can change without touching application code:
+
+```python
+class CameraSource:
+    def capture(self) -> np.ndarray: ...
+    def configure(self, resolution, **opts): ...
+
+class PiCameraSource(CameraSource):
+    # picamera2 implementation
+    # Handles AF disable + infinity lock in __init__
+```
+
+Reasons:
+- Arducam IMX708 vs Pi Foundation Camera Module 3 supply may force swaps mid-production
+- USB camera fallback may be useful for development/testing
+- Sensor changes (e.g., future Camera Module v4) should not cascade through the codebase
+
+The autofocus disable + infinity lock lives inside `PiCameraSource.__init__()` so calling code never thinks about focus. If a future swap to the Pi Foundation Camera Module 3 happens, only the `dtoverlay` line in provisioning changes — the firmware focus-locking code is the same.
+
+## Orientation & calibration strategy: celestial self-calibration
+
+**Chosen approach: the camera figures out its own pointing direction from where the sun appears in its frames.** No magnetometer, no GPS module, no compass calibration ritual. Full design in `docs/superpowers/specs/2026-05-17-pi-alignment-v0.3-sun-self-calibration-design.md`.
+
+### Inputs needed
+- **Time**: NTP via wifi (must be accurate within ~1 second; sub-minute drift translates to azimuth error). **Hard dependency on Subproject B (clock drift fix).**
+- **Location**: lat/lon from user (zip code, browser geolocation, or manual entry during onboarding). ~5km accuracy is plenty.
+- **MPU-6050**: provides tilt + roll relative to gravity (constrains pose estimation)
+- **Captured frames during sunset**: provide the sun's pixel position
+
+### Math / libraries
+- **Skyfield** (Python) — given lat/lon + UTC timestamp, returns sun azimuth and altitude in the world frame.
+- **OpenCV `cv2.solvePnP`** — solves for camera rotation given known 3D world points and their 2D image projections.
+- **Sun detection**: brightest cluster in frame with saturated R+G channels. Simple, robust during golden hour.
+
+### Calibration flow
+1. During each sunset, capture frames at 30–60s intervals.
+2. For frames where sun is clearly visible, record (sun pixel x/y, timestamp, sun world azimuth/altitude).
+3. Accumulate 10–30 observations across the sunset window — sun's arc gives a built-in trajectory.
+4. Solve for camera pose. Roll is constrained by MPU-6050 gravity vector.
+5. After 1–3 sunny sunsets, calibration is high-confidence. Refine continuously.
+
+### Lens distortion
+Pi Camera Module 3 Wide / Arducam IMX708 120° lens has consistent distortion across units of the same SKU. **Calibrate once in the lab** with a checkerboard, ship a single intrinsics file (`intrinsics/imx708-wide-af.json`) with the firmware. Don't try to solve distortion per-unit during deployment.
+
+### Drift detection
+- Each new sun observation that fails to match the stored calibration → device has moved.
+- Threshold: if predicted vs observed sun position diverges by more than a few degrees consistently, flag for re-calibration and alert the user.
+
+### Failure modes & mitigations
+
+| Condition | Mitigation |
+|---|---|
+| Overcast for days | Calibration waits. UI tells user "will fine-tune on first clear sunset." Initial setup completes anyway with rough estimate. |
+| Camera pointed wrong way (no sun ever visible) | After N days without a sun detection during sunset windows, alert user. |
+| Clock drift offline | Calibration accuracy degrades; require NTP sync within last 24 hours before using new observations. |
+| Sun saturates / blooms | Sun-detection takes a short-exposure auxiliary frame during calibration capture so the centroid is well-defined. |
+
+## On-device "best so far" heuristic
+
+This is the gate that decides whether to keep a new frame as the running best. Intentionally **generous** — server-side ResNet is the strict judge. Better to upload a mediocre frame than upload nothing.
+
+Suggested heuristic features (cheap to compute, no ML required):
+- Warm color fraction: pixels where R+G dominate B
+- Saturation distribution (HSV) — sunsets have high saturation
+- Histogram spread / dynamic range
+- Cloud structure proxy: mid-frequency spatial variation in the upper portion of the frame
+
+Combine into a single scalar score. Persist current best (JPEG + score) to SD card during the window. Reset at start of each window.
+
+## Upload workflow
+
+- One image per device per sunset window (the winner).
+- HTTPS POST to server endpoint.
+- Include metadata: device ID, capture timestamp, on-device score, current calibration state, MPU-6050 reading, focus-verification score.
+- Retry queue on SD card if upload fails — never lose a winning frame to transient network failure.
+
+## Streaming (future)
+
+- MJPEG over HTTP is the simplest path on Pi.
+- Switched on by server command, runs for duration of window, switches back to capture mode.
+- 720p @ 15fps is comfortable on Pi Zero 2 W.
+
+## Onboarding flow (web-based, no phone app required)
+
+Device exposes a captive portal / local web UI on first boot. User:
+
+1. Connects laptop or phone to device's wifi access point.
+2. Selects home wifi network, enters password.
+3. Enters location (zip code or geolocation).
+4. Aims camera roughly at the western horizon (for sunset units).
+5. **Passive focus verification**: the alignment page reports "focus OK" or "focus failed" via a one-time edge-contrast check. The autofocus camera locks to infinity in software, so the operator doesn't adjust anything; failure here means "remove lens cap" or "you're pointed at a wall."
+6. Confirms level using MPU-6050 readout (UI shows a bubble-level widget — green when within ±2°).
+7. Done. Device tells user "your camera will fine-tune itself on the next clear sunset."
+
+After install, ongoing calibration happens automatically without user involvement.
+
+## Resolution / mode considerations
+
+The IMX708 supports:
+- 4608 × 2592 stills (full resolution, ~12MP)
+- 2304 × 1296 @ 56fps video
+- 2304 × 1296 @ 30fps **HDR mode** (3MP effective)
+- 1536 × 864 @ 120fps
+
+For sunset captures, **HDR mode is worth evaluating** — sunsets are exactly the high-dynamic-range scene HDR is designed for. Tradeoff: HDR drops effective resolution to 3MP and limits to 30fps. For still capture every 30-60 seconds, framerate is irrelevant; the resolution drop is the real cost.
+
+Recommendation: support both modes and make it configurable, with HDR as the default for sunset captures:
+
+```python
+# HDR mode
+picam.set_controls({"HdrMode": controls.HdrModeEnum.SingleExposure})
+```
+
+(The exact HDR control name may differ by `picamera2` version — verify against installed library.)
+
+## Software stack (recommended)
+
+- **OS**: Raspberry Pi OS 64-bit (Bookworm or later)
+- **Camera**: `picamera2` (libcamera-based; the modern API)
+- **IMU**: `smbus2` for raw I²C, or `mpu6050-raspberrypi` library (we use `smbus2` per the v0.2 firmware)
+- **Astronomy**: `skyfield`
+- **Image processing**: `opencv-python-headless`, `Pillow`, `numpy`
+- **Web UI for onboarding**: Flask is plenty; serve over the captive portal AP
+- **Uploads**: `requests` with retry/backoff
+- **Process management**: systemd units for the capture daemon and onboarding service
+
+## Bill of materials (per unit)
+
+| Component | Part | Approx. cost (retail / bulk @ 500) |
+|---|---|---|
+| Compute | Pi Zero 2 W | $18 / ~$18 (limited bulk discount) |
+| Camera | Arducam IMX708 Wide Autofocus + Case | $35 / ~$30 |
+| IMU | MPU-6050 (GY-521) | $2 / $1.50 |
+| microSD | 32GB Class 10 | $8 / $5 |
+| PSU + cable | 2.5A USB + 15ft 22AWG | $18 / $12 |
+| Ribbon cables | Both 15-22 and 22-22 (with camera) | — / — |
+| **Total** | | **~$81 / ~$67** |
+
+(Down from earlier $90/$75 estimate; the autofocus camera includes the case + both ribbons, and is $5 cheaper than the manual-focus variant once considered.)
+
+## Explicit non-requirements
+
+To save the next agent / developer from re-litigating:
+
+- **No magnetometer**: heading comes from celestial calibration.
+- **No GPS module**: location entered during onboarding; sufficient accuracy from zip code.
+- **No runtime autofocus control**: AF is hardware-supported but software-locked to infinity at boot. Never re-enabled during normal operation.
+- **No operator focus adjustment**: with the autofocus camera, the operator never touches a lens ring. The alignment page only reports a binary focus check.
+- **No on-device deep learning**: server-side ResNet does the heavy ML. On-device scoring is cheap heuristics.
+- **No mechanical gimbal / servo leveling**: software rotation correction only, if any.
+- **No ESP32 fallback for the celestial-calibration pipeline**: ESP32 image quality is insufficient for high-contrast sunset scenes AND OpenCV doesn't run on it. ESP32 builds, if ever needed, would use the v0.2 operator-selected facing.
+- **No phone app required for onboarding**: web UI works from any browser.
+
+## Open questions for firmware work
+
+1. Exact form of the on-device heuristic score — needs validation against real sunset data.
+2. Whether to capture in HDR mode (Pi Camera Module 3 supports 3MP HDR) vs single-exposure 12MP — HDR helps with sunset dynamic range but reduces resolution.
+3. Sun detection robustness when sun is partially obscured by clouds.
+4. Exact intrinsics calibration procedure for production (lab checkerboard procedure → JSON intrinsics file → shipped with firmware).
+5. Retry / backoff policy for failed uploads and how long to retain unsuccessful winners on SD card.
+6. Per-SKU sharpness threshold calibration — bench step that establishes the threshold for the focus-OK check.
+
+## History
+
+- 2026-05-15: initial hardware sketch (`pi-webcam-mvp.md`).
+- 2026-05-17: hardware spec drafted to support the v0.3 alignment-tool spec, originally proposing the manual-focus camera variant.
+- 2026-05-18: revised to the **autofocus** Arducam IMX708 + ABS case + both ribbons. Onboarding flow simplifies (no manual focus step); firmware grows the AF-disable + infinity-lock init.

--- a/docs/superpowers/specs/2026-05-17-pi-alignment-v0.3-sun-self-calibration-design.md
+++ b/docs/superpowers/specs/2026-05-17-pi-alignment-v0.3-sun-self-calibration-design.md
@@ -1,0 +1,340 @@
+# Pi-Side Alignment Tool v0.3 — Sun Self-Calibration + Manual Focus
+
+Status: Draft v0.3 — 2026-05-17 (incremental redesign on top of v0.2)
+Owner: Jesse Kauppila
+Sub-project C, third iteration. Builds on `2026-05-17-pi-side-alignment-tool-design.md` (v0.2).
+
+---
+
+## 1. Problem
+
+v0.2 left two real gaps:
+
+1. **No true compass.** v0.2 has the operator pick a facing direction (East / West / Both) and trusts that selection. A misreport silently produces wrong solstice markers and a wrong sunsets-per-year counter. The system can't verify.
+2. **No focus check.** v0.2 assumed a fixed-focus camera. The chosen production camera (Arducam IMX708 Wide Manual Focus, 120° HFOV) has a **manual focus ring** that the operator must adjust by hand during install. Without feedback the operator can ship a unit that's permanently out of focus.
+
+A third concern made v0.2 fragile: it depended on the operator entering a phase preference (sunrise/sunset/both) and trusting that selection, with no way to recover if they got it wrong.
+
+v0.3 solves both by **letting the device figure out where it's pointed by watching the sun**. The MPU-6050 from v0.2 gives roll + pitch; sun observations across one or more sunset windows give the missing azimuth via OpenCV's `solvePnP`. Setup completes "eventually" rather than instantly — the user is told this up front. For focus, the alignment page adds a live sharpness score so the operator can dial in the lens before leaving the device.
+
+This design is the consensus output of a separate brainstorm; this spec formalizes it for implementation.
+
+## 2. Goals
+
+1. **Camera self-calibrates its true compass azimuth** from sun observations, without a magnetometer, GPS module, or operator-supplied facing direction. Single-axis accuracy of ±2° within 1–7 days of clear sunsets at install location.
+2. **Operator can verify lens focus during install** using a live edge-contrast sharpness score updated in real time as they turn the focus ring.
+3. **The system tells the operator honestly** when calibration is incomplete ("calibrating… 0 of 10 observations") rather than silently producing wrong markers. The operator can mount the camera and leave; calibration finishes itself on the first clear sunset.
+4. **Drift detection**: the system continuously checks observed sun position against stored calibration. If the camera gets bumped or the operator re-aims it, the system notices and re-calibrates without human intervention.
+5. **MPU-6050 + roll/pitch readout from v0.2 stays.** The alignment page still does the level-check job; sun calibration adds to it, doesn't replace it.
+6. **The camera-source code path is abstracted** so the underlying camera (Arducam IMX708 today, Pi Foundation Camera Module 3 Wide as fallback) can swap without cascading through the codebase.
+
+## 3. Non-goals
+
+- **ESP32 support.** OpenCV doesn't run on ESP32; the sun-solve pipeline is Pi-only. ESP32 builds, if ever wanted, will keep the v0.2-style operator-selected facing approach. Documented and accepted.
+- **Magnetometer / 9-axis IMU.** Not in the BOM. Sun-derived azimuth replaces it.
+- **GPS module.** Not in the BOM. Operator-supplied lat/lng is plenty accurate (1 km of position error → <0.01° of sun azimuth error).
+- **On-device deep learning for any part of this.** Sun detection is brightest-region centroid (~30 lines). Quality scoring is server-side (separate concern, not in this spec).
+- **Lens auto-focus.** Camera is manual-focus by hardware choice. v0.2's autofocus-disable was a no-op; v0.3 explicitly assumes manual focus and adds the sharpness indicator to support it.
+- **Sun-tap calibration** (the manual-tap mechanic considered in v0.1). Superseded by full auto-detection.
+- **Fixing the Pi's clock drift.** Subproject B's concern. This spec **depends on** B being fixed before v0.3 ships in the field — see §9.
+- **Streaming live during the sunset window.** Reserved future work; doesn't interact with alignment.
+
+## 4. Current state
+
+Verified from the repo as of 2026-05-17:
+
+- **v0.2 firmware** (`feat/setup-alignment-mpu6050` merged into `sunset-cam-firmware` `main` via PR #2): four modules — `gyro_driver.py`, `orientation_sampler.py`, `solstice_math.py`, `setup_alignment.py`. 48/48 unit tests passing. Framework-agnostic; not yet wired into a setup web app.
+- **v0.2 spec** (`docs/superpowers/specs/2026-05-17-pi-side-alignment-tool-design.md`): describes the MPU-6050 + facing-selector design. v0.3 keeps the IMU and the alignment page, replaces the facing selector + manual solstice markers with sun-calibration outputs.
+- **No setup web app exists yet** (spec E firmware-side hasn't been implemented). v0.3's new endpoints land in the same Python modules and are registered alongside v0.2's when E lands.
+- **The chosen camera is now Arducam IMX708 Wide MF (120° HFOV) rather than Pi Foundation Camera Module 3 Wide (102°)**. Same Sony IMX708 sensor; the SKU difference is the lens (manual M12 mount vs autofocus). Lens intrinsics differ → must re-calibrate the bench-shipped JSON.
+- **Subproject B (clock drift)** remains in its stubbed state. v0.3 has a hard dependency on it.
+
+## 5. Design
+
+### 5.1 Architecture
+
+```
+┌────────────────────────────────────────────────────────┐
+│ Pi Zero 2 W (or Pi 5)                                  │
+│                                                        │
+│  CameraSource (abstraction) ──► picamera2 ──► IMX708   │
+│                          ▲                             │
+│                          │                             │
+│  ┌───────────────────────┴─────────────────────────┐   │
+│  │ Capture loop (existing v0.1 firmware)            │   │
+│  │   - Sunset-window capture                        │   │
+│  │   - Best-so-far heuristic scoring                │   │
+│  │   - Server upload                                │   │
+│  └─────────────┬────────────────────────────────────┘   │
+│                │                                        │
+│                ▼                                        │
+│  Sun-calibration pipeline (NEW):                       │
+│    detect_sun(frame) → (px, py, t_utc)                 │
+│    compute_sun_world(lat, lng, t_utc) → (az, alt)      │
+│    accumulate observations in calibration store        │
+│    solve_pose(observations, intrinsics) → (azimuth, …) │
+│    write calibration → /etc/sunset-cam/calibration.json│
+│                                                        │
+│  MPU-6050 (existing v0.2) ──► gravity vector           │
+│                              ──► roll/pitch (live)     │
+│                              ──► roll/pitch (constraint│
+│                                   for pose solver)     │
+│                                                        │
+│  Setup web app (NEW endpoints):                        │
+│    GET /setup/sharpness.json   (NEW v0.3)              │
+│    GET /setup/calibration.json (NEW v0.3)              │
+│    GET /setup/align            (UPDATED — drops facing)│
+│    GET /setup/orientation.json (UNCHANGED from v0.2)   │
+│    GET /setup/preview.mjpg     (UNCHANGED from v0.2)   │
+└────────────────────────────────────────────────────────┘
+```
+
+Two new pipelines run on the Pi independently of the user being present:
+- **Sharpness sampler** (lives during setup mode only): grabs a 320×240 center crop from the preview, computes an edge-contrast score, caches the latest. Exposed via `/setup/sharpness.json`.
+- **Sun-calibration sampler** (lives in normal operation mode): during the sunset capture window, picks frames where the sun is detectable, accumulates `(pixel_x, pixel_y, timestamp_utc, sun_az, sun_alt)` tuples in `/var/lib/sunset-cam/observations.jsonl`. After N=10 observations (or one full sunset window), runs `solvePnP` and writes the resulting `(azimuth_deg, tilt_deg, roll_deg, confidence)` to `/etc/sunset-cam/calibration.json`.
+
+### 5.2 Camera-source abstraction
+
+The chosen production camera is the **Arducam IMX708 Wide MF** but supply may force a swap to the **Pi Foundation Camera Module 3 Wide** (same sensor, autofocus lens). The firmware must not couple to a specific camera SKU. Introduce a thin interface:
+
+```python
+# src/sunset_cam/camera_source.py
+from typing import Protocol
+import numpy as np
+
+
+class CameraSource(Protocol):
+    def capture(self) -> np.ndarray:
+        """Return the latest captured frame as an RGB uint8 array."""
+        ...
+
+    def capture_jpeg(self) -> bytes:
+        """Return the latest captured frame encoded as JPEG bytes."""
+        ...
+
+    def configure(self, *, resolution: tuple[int, int]) -> None:
+        ...
+
+
+class PiCameraSource:
+    """picamera2-based implementation. Hardware-detects whether the
+    attached lens is manual-focus (IMX708 MF) or autofocus (PCM3 Wide AF);
+    if AF, locks the lens to infinity at startup."""
+```
+
+The existing `capture.py` module from v0.1 wraps a Picamera2 directly and is the right candidate to refactor into the `PiCameraSource` class. Call sites elsewhere in the codebase migrate to import from `camera_source` instead of `capture`.
+
+### 5.3 Sharpness indicator
+
+A small helper computes a single scalar sharpness score from the latest preview frame, suitable for an operator to read off the page as they turn the focus ring. The classic approach is the **variance of Laplacian** on a grayscale center crop:
+
+```python
+def sharpness_score(frame_rgb: np.ndarray, crop_fraction: float = 0.5) -> float:
+    """Higher = sharper. No upper bound; relative number for tuning."""
+    h, w, _ = frame_rgb.shape
+    ch, cw = int(h * crop_fraction), int(w * crop_fraction)
+    y0, x0 = (h - ch) // 2, (w - cw) // 2
+    crop = frame_rgb[y0:y0 + ch, x0:x0 + cw]
+    gray = cv2.cvtColor(crop, cv2.COLOR_RGB2GRAY)
+    return float(cv2.Laplacian(gray, cv2.CV_64F).var())
+```
+
+The alignment page polls `/setup/sharpness.json` at the same 5 Hz rate it polls `/setup/orientation.json` and shows the score next to the roll/pitch readouts. The number is dimensionless and varies wildly across scenes; the operator's job is to **maximize** it relative to where it was a moment ago, not to hit a specific target. UI copy: *"Turn the focus ring slowly. Stop when this number stops increasing."*
+
+A small additional helper UI: a 5-second rolling max next to the current score, so the operator can see whether they've drifted past the peak.
+
+### 5.4 Sun detection
+
+A frame from the capture loop is passed to `detect_sun(frame_rgb) -> Optional[tuple[float, float]]`. Returns pixel coordinates of the sun's apparent centroid, or `None` if the sun isn't detectable in the frame.
+
+Algorithm:
+1. Convert frame to HSV.
+2. Threshold on V (high value) AND low S (sun is desaturated white when overexposed) — produces a binary mask of "candidate sun pixels."
+3. Connected-components labeling.
+4. Pick the largest component above a minimum-area threshold (say, ≥ 200 px) AND not touching the frame edge (a glare lobe touching the edge isn't the sun).
+5. Compute centroid; return.
+
+**Sun saturation gotcha**: at golden hour, the camera will be exposed for the sky overall, so the sun saturates to clipped white. The centroid of the saturated blob is biased toward whichever direction the sensor decided to bloom. Mitigation: during calibration capture, take an additional short-exposure frame (e.g. EV-3 from auto-exposure) specifically for sun detection. The bright-but-not-blown-out sun has a well-defined centroid. This adds one extra frame per minute during the sunset window, negligible CPU.
+
+### 5.5 World-frame sun position
+
+`compute_sun_world(lat_deg, lng_deg, t_utc) -> (azimuth_deg, altitude_deg)`. Uses [`skyfield`](https://rhodesmill.org/skyfield/) for accurate ephemerides:
+
+```python
+from skyfield.api import load, wgs84
+
+ts = load.timescale()
+eph = load('de421.bsp')  # ~16 MB, shipped with firmware
+sun, earth = eph['sun'], eph['earth']
+
+
+def compute_sun_world(lat, lng, t_utc):
+    t = ts.from_datetime(t_utc)
+    observer = earth + wgs84.latlon(lat, lng)
+    apparent = observer.at(t).observe(sun).apparent()
+    alt, az, _ = apparent.altaz()
+    return az.degrees, alt.degrees
+```
+
+Skyfield is ~5 MB of code + the JPL ephemeris file at ~16 MB. Negligible on the Pi.
+
+### 5.6 Pose solving with `cv2.solvePnP`
+
+Given N observations of the sun at known world positions `(az_i, alt_i)` and pixel positions `(px_i, py_i)`, plus the camera's intrinsics (focal length, principal point, distortion coefficients from lab calibration), solve for the camera's rotation matrix `R` from world frame to camera frame.
+
+The MPU-6050 already gives us the camera's roll and pitch relative to gravity. We use that as a **constraint** on the solver: rather than solving for full 6-DOF pose, fix roll + pitch from the IMU and solve only for **azimuth** (yaw). This makes the problem well-conditioned with as few as 2 observations.
+
+Implementation sketch:
+
+```python
+def solve_azimuth(observations, intrinsics, imu_roll_deg, imu_pitch_deg):
+    """observations: list of (px, py, sun_az, sun_alt) tuples.
+       Returns (azimuth_deg, confidence) where confidence reflects
+       both observation count and residual error magnitude."""
+    # Build 3D rays from observed pixel coordinates (in camera frame)
+    # Build 3D rays from world sun positions (in world frame)
+    # Apply the IMU-derived roll/pitch transform to convert world rays
+    #   into the camera's gravity-aligned frame
+    # Now solve for the single yaw rotation that aligns observed rays
+    #   with world rays — minimize least-squares angular residual.
+    ...
+```
+
+After **N ≥ 2 observations** the solver has a valid answer. After **N ≥ 5 observations spread over ≥ 30 minutes** of sun travel, the residual is informative — small means a confident calibration. Persist `calibration.json` only when both conditions are met.
+
+### 5.7 Calibration storage
+
+```json
+{
+  "calibrated_at": "2026-05-18T05:35:00Z",
+  "azimuth_deg": 271.4,
+  "azimuth_confidence_deg": 0.6,
+  "imu_roll_deg": -0.2,
+  "imu_pitch_deg": 1.4,
+  "observation_count": 17,
+  "lens_intrinsics_file": "/opt/sunset-cam/intrinsics/imx708-wide-mf.json",
+  "camera_source": "PiCameraSource(IMX708-Wide-MF)",
+  "schema_version": 1
+}
+```
+
+Stored at `/etc/sunset-cam/calibration.json`. Written atomically (write to `.tmp`, rename). Loaded at boot; if missing, the device is "uncalibrated" and the sunsets-per-year counter etc. fall back to their v0.2 behavior of operator-selected facing (or just no counter at all).
+
+### 5.8 Drift detection + re-calibration
+
+A rolling window of the last 5 sun observations is compared against the stored calibration:
+
+- For each observation, compute the expected pixel position given the stored calibration + the world sun position. Compare to the actually observed pixel position. Convert pixel-residual to angular residual.
+- If the **mean angular residual of the last 5 observations exceeds 5°**, the camera has moved (or the calibration was wrong from the start). Clear `calibration.json` and start accumulating fresh observations.
+
+This handles the "camera got bumped" case automatically. The user sees a "re-calibrating…" state until N observations re-accumulate.
+
+### 5.9 Updates to the v0.2 alignment page
+
+The alignment HTML (`render_align_page` in `setup_alignment.py`) changes:
+
+- **Drops the East/West/Both facing form** entirely.
+- **Drops the static server-rendered solstice markers** (since `compute_solstice_markers(lat, lng, facing, fov)` no longer has a known `facing`). Instead, **markers are drawn only after calibration is available**, using the calibrated azimuth as the camera's known center.
+- **Drops the sunsets-per-year counter** until calibration is available. After calibration: shows the real counter for the calibrated azimuth.
+- **Adds a sharpness readout** in the top HUD: `focus: <score>` adjacent to the existing `roll:` / `pitch:` readouts. Also a 5-second rolling-max value to help the operator find the peak.
+- **Adds a calibration status block**: `calibrated: 17/10 observations · ±0.6° (last update 3 min ago)` or `calibrating: 0/10 observations · awaiting first clear sunset`.
+
+The level indicator + horizon line + UP arrow all stay unchanged.
+
+### 5.10 Onboarding UX (within F's wizard)
+
+The operator's path:
+
+1. Plug in the device, connect to its WiFi, open the cloud wizard. (Spec E.)
+2. Enter lat/lng (browser geolocation or zip code). The device gets these via spec E's pre-register.
+3. Open the alignment tool (spec F screen 4 → Pi-served page).
+4. **Focus**: turn the focus ring until the sharpness number stops increasing.
+5. **Level**: rotate the housing until the roll/pitch badge is green.
+6. **Aim roughly west** (for sunset units). UI copy explicitly: "Aim where you think the sun sets. We'll fine-tune automatically."
+7. Mount the camera, walk away.
+8. Over the next 1–7 days of clear sunsets, the device calibrates itself.
+9. Once the first calibration is complete, the cloud-side server gets the calibrated azimuth (via heartbeat) and the sunsets-per-year counter populates on the operator's gallery page.
+
+Honest UX: the wizard tells the operator "calibration takes 1–7 sunny sunsets." For Bellingham winter, that can mean 2 weeks. The wizard should also expose a "calibration progress" indicator on the device's own status page so an impatient operator can see what's happening.
+
+### 5.11 F integration
+
+Unchanged from v0.2: F's screen 4 links to `http://<pi-local-ip>:<setup-port>/setup/align`. The Pi-side page renders dynamically based on whether calibration is present or absent. F itself does not need to know about calibration.
+
+## 6. Field provenance
+
+New protocol fields on heartbeat (the device → server message):
+
+| Field | Type | Source |
+|---|---|---|
+| `calibrated_azimuth_deg` | float, nullable | `/etc/sunset-cam/calibration.json` `azimuth_deg` |
+| `calibrated_azimuth_confidence_deg` | float, nullable | `/etc/sunset-cam/calibration.json` `azimuth_confidence_deg` |
+| `calibrated_at` | ISO timestamp, nullable | when last solver ran |
+| `observation_count` | int | how many sun observations are stored |
+
+The cloud uses `calibrated_azimuth_deg` to compute the per-camera sunsets-per-year count for the operator's gallery page. Until calibration arrives, the cloud falls back to operator's `phase_preference` (sunrise/sunset/both) for a rough placeholder.
+
+## 7. Testing
+
+### 7.1 Unit (no hardware needed)
+
+- `sharpness_score(frame)` returns 0 for a synthetic uniform-gray frame; higher for a synthetic frame with a sharp edge.
+- `detect_sun(frame)` finds a bright disk in a synthetic image at known coordinates; returns `None` for an image with no bright region.
+- `compute_sun_world(lat, lng, t_utc)` returns known values for `(48.7519, -122.4787, 2026-05-17T05:00Z UTC)` → cross-check against [NOAA Solar Calculator](https://gml.noaa.gov/grad/solcalc/).
+- `solve_azimuth(observations, intrinsics, imu_roll, imu_pitch)` recovers the input azimuth from synthetic observations with known answer. Cover N=2, N=5, N=10 cases.
+- Drift detection: feeds observations consistent with stored calibration → no re-cal triggered; feeds observations diverging by >5° → re-cal triggered.
+
+### 7.2 Manual / hardware-gated
+
+- Run the sharpness sampler on a real Pi + IMX708. Verify the score peaks at sharp focus and falls off on either side of the peak.
+- Capture real sunset frames. Verify `detect_sun` finds the sun cleanly.
+- Accumulate observations across one real sunset; verify `solve_azimuth` produces a sane azimuth.
+- Bump the camera 10° after calibration; verify drift detection triggers within 5 observations.
+
+## 8. Risks
+
+- **Hard dependency on Subproject B (clock drift).** A 1-minute clock error → ~0.25° azimuth error. Pi Zero 2 W has no battery-backed RTC; NTP-via-wifi is the only correction. If the firmware ever runs calibration with a stale clock, the result is silently wrong. **Mitigation**: every observation records its capture timestamp and the NTP-sync age at that moment. The solver rejects observations whose NTP sync is >24 hours old. Documented constraint: this spec **cannot ship to field** until B's clock-skew bug is verified fixed.
+- **Cloudy stretches block calibration.** Bellingham winter can have 14+ overcast days in a row. UI must communicate this honestly ("waiting for a clear sunset") rather than hanging silently.
+- **Lens distortion** of the 120° wide-angle is significant at frame edges. The bench-calibrated intrinsics file is per-SKU; if the operator swaps in a different camera (e.g. PCM3 Wide AF as fallback), the intrinsics file shipped with firmware no longer applies. Firmware boot-time check: detect which camera is attached and load the right intrinsics; refuse to run sun-calibration if no matching intrinsics file exists.
+- **Sun saturation** biases the detection centroid. Mitigation: short-exposure frame during calibration capture (§5.4).
+- **OpenCV install size on Pi Zero 2 W**: opencv-python ≈ 60 MB. Acceptable for 32 GB SD cards. If size matters later, a stripped opencv-python-headless build saves ~20 MB.
+- **Skyfield ephemeris file** (`de421.bsp` ~ 16 MB) needs to be shipped. Trivial.
+- **Operator turns the camera mid-calibration** (during the 1–7 day window). Drift detection catches it. UI tells the operator they've reset progress.
+- **Sun never visible** (camera mounted facing a wall or 180° wrong). After 7 days of sunset windows with zero observations, alert the operator. Don't silently never calibrate.
+
+## 9. Dependencies
+
+- **Subproject B (clock drift / black-image diagnostics)**: hard blocker for field deployment. Spec lives at `docs/superpowers/specs/2026-05-16-device-diagnostics-clock-and-black-image-stub.md`.
+- **Spec E (setup web app)**: needed to register the new `/setup/sharpness.json` and `/setup/calibration.json` endpoints. v0.3 lands as Python modules; E wires them.
+- **Bench-calibrated lens intrinsics file** for Arducam IMX708 Wide MF (and PCM3 Wide AF as fallback). One-time operator task on a calibration target (checkerboard). Documented in a separate hardware procedure doc.
+- **Skyfield + OpenCV** added to firmware Python deps. `pyproject.toml` gains `skyfield>=1.46` and `opencv-python-headless>=4.8`.
+
+## 10. Implementation slice order
+
+1. **Camera-source abstraction**: refactor `capture.py` into `camera_source.py`'s `PiCameraSource`. Existing callers migrate. Unit tests with a fake camera source.
+2. **Sharpness module**: `sharpness.py` with `sharpness_score(frame)`; tests with synthetic frames.
+3. **`/setup/sharpness.json` endpoint**: small renderer in `setup_alignment.py`. Tests.
+4. **Alignment page HTML update**: add sharpness readout + 5-second-max display to the top HUD. Drop facing form + sunsets counter (until calibration is available). Update tests.
+5. **Sun detection module**: `sun_detect.py` with `detect_sun(frame)`. Tests with synthetic images.
+6. **World-frame sun position**: `astronomy.py` with `compute_sun_world(lat, lng, t_utc)` via skyfield. Tests vs. NOAA values.
+7. **Calibration store**: `calibration_store.py` for atomic read/write of `/etc/sunset-cam/calibration.json`. Tests.
+8. **Pose solver**: `pose_solver.py` with `solve_azimuth(observations, intrinsics, imu_roll, imu_pitch)`. Tests with synthetic observations.
+9. **Calibration runner**: ties §5–8 together. Runs in the capture loop's sunset window. Tests with mocked frame stream + mocked clock.
+10. **Drift detection**: rolling-residual check; clears calibration if exceeded. Tests.
+11. **Heartbeat payload extension**: include `calibrated_azimuth_deg` + friends. Spec lives in `device-protocol.md` (separate update).
+12. **Bench lens-intrinsics procedure**: one-time operator task; ship resulting JSON file with firmware. Document in a separate procedure doc; not a code task.
+13. **Manual field test**: real Pi + real IMX708 + real sunset. Validate end-to-end.
+
+## 11. Diff from v0.2
+
+If you read v0.2 and want to know what changed in v0.3:
+
+- **§1 Problem**: adds two motivations (true compass needed; manual focus needs feedback). v0.2 only had aiming + level + up.
+- **§2 Goals**: adds auto-azimuth + sharpness + drift-detection goals. Drops the operator-self-report goal.
+- **§3 Non-goals**: explicit "no ESP32, no magnetometer, no GPS, no autofocus runtime control" — locks in the design constraints.
+- **§5 Design**: keeps the v0.2 MPU-6050 pipeline + preview page intact. Adds five new modules (camera_source, sharpness, sun_detect, astronomy, calibration_store, pose_solver), one new persistent file (`calibration.json`), two new HTTP endpoints (`sharpness.json`, `calibration.json`), and significant changes to the alignment page (drops facing form, adds sharpness readout + calibration status block).
+- **§6 Field provenance**: adds `calibrated_azimuth_deg` + friends as new heartbeat fields. v0.2 had no protocol additions.
+- **§7 Testing**: adds hardware-gated manual tests; unit tests grow significantly.
+- **§8 Risks**: re-anchors on B (clock drift) as a hard blocker, adds OpenCV size, sun saturation, cloudy stretches.
+- **§9 Dependencies**: new section. v0.2 had no external deps.
+- Hardware: camera SKU changes from Pi Foundation Camera Module 3 Wide (102° HFOV, autofocus) to Arducam IMX708 Wide MF (120° HFOV, manual focus). Same Sony IMX708 sensor either way.

--- a/docs/superpowers/specs/2026-05-17-pi-alignment-v0.3-sun-self-calibration-design.md
+++ b/docs/superpowers/specs/2026-05-17-pi-alignment-v0.3-sun-self-calibration-design.md
@@ -11,22 +11,22 @@ Sub-project C, third iteration. Builds on `2026-05-17-pi-side-alignment-tool-des
 v0.2 left two real gaps:
 
 1. **No true compass.** v0.2 has the operator pick a facing direction (East / West / Both) and trusts that selection. A misreport silently produces wrong solstice markers and a wrong sunsets-per-year counter. The system can't verify.
-2. **No focus check.** v0.2 assumed a fixed-focus camera. The chosen production camera (Arducam IMX708 Wide Manual Focus, 120° HFOV) has a **manual focus ring** that the operator must adjust by hand during install. Without feedback the operator can ship a unit that's permanently out of focus.
+2. **No defensive focus check.** Even though the production camera (Arducam IMX708 Wide *Autofocus*, 120° HFOV) is software-controlled — firmware locks it to infinity at boot — there's no runtime check that the lens is actually capturing a sharp image. A unit could ship with a lens cap left on, mounted facing a wall, or with a software regression in the focus-locking step, and the first detection would be a server-side reviewer noticing all the images are blurry.
 
 A third concern made v0.2 fragile: it depended on the operator entering a phase preference (sunrise/sunset/both) and trusting that selection, with no way to recover if they got it wrong.
 
-v0.3 solves both by **letting the device figure out where it's pointed by watching the sun**. The MPU-6050 from v0.2 gives roll + pitch; sun observations across one or more sunset windows give the missing azimuth via OpenCV's `solvePnP`. Setup completes "eventually" rather than instantly — the user is told this up front. For focus, the alignment page adds a live sharpness score so the operator can dial in the lens before leaving the device.
+v0.3 solves both by **letting the device figure out where it's pointed by watching the sun**. The MPU-6050 from v0.2 gives roll + pitch; sun observations across one or more sunset windows give the missing azimuth via OpenCV's `solvePnP`. Setup completes "eventually" rather than instantly — the user is told this up front. For focus, a one-time **passive verification** at install time (and at every capture) ensures the image is actually sharp; the operator never touches a lens ring.
 
 This design is the consensus output of a separate brainstorm; this spec formalizes it for implementation.
 
 ## 2. Goals
 
 1. **Camera self-calibrates its true compass azimuth** from sun observations, without a magnetometer, GPS module, or operator-supplied facing direction. Single-axis accuracy of ±2° within 1–7 days of clear sunsets at install location.
-2. **Operator can verify lens focus during install** using a live edge-contrast sharpness score updated in real time as they turn the focus ring.
+2. **Focus is verified passively**: at install time the alignment page reports "focus OK / focus failed" based on an edge-contrast metric on a live frame. The operator never adjusts focus; if the check fails the UI tells them to remove the lens cap / check the aim. The same metric also runs at every capture as a soft sanity flag attached to uploads.
 3. **The system tells the operator honestly** when calibration is incomplete ("calibrating… 0 of 10 observations") rather than silently producing wrong markers. The operator can mount the camera and leave; calibration finishes itself on the first clear sunset.
 4. **Drift detection**: the system continuously checks observed sun position against stored calibration. If the camera gets bumped or the operator re-aims it, the system notices and re-calibrates without human intervention.
 5. **MPU-6050 + roll/pitch readout from v0.2 stays.** The alignment page still does the level-check job; sun calibration adds to it, doesn't replace it.
-6. **The camera-source code path is abstracted** so the underlying camera (Arducam IMX708 today, Pi Foundation Camera Module 3 Wide as fallback) can swap without cascading through the codebase.
+6. **The camera-source code path is abstracted** so the underlying camera (Arducam IMX708 Wide AF today, Pi Foundation Camera Module 3 Wide as fallback) can swap without cascading through the codebase. Both have the same Sony IMX708 sensor; the abstraction is mostly about handling the Arducam-specific `dtoverlay` and the AF-disable-then-lock-to-infinity init step.
 
 ## 3. Non-goals
 
@@ -34,7 +34,8 @@ This design is the consensus output of a separate brainstorm; this spec formaliz
 - **Magnetometer / 9-axis IMU.** Not in the BOM. Sun-derived azimuth replaces it.
 - **GPS module.** Not in the BOM. Operator-supplied lat/lng is plenty accurate (1 km of position error → <0.01° of sun azimuth error).
 - **On-device deep learning for any part of this.** Sun detection is brightest-region centroid (~30 lines). Quality scoring is server-side (separate concern, not in this spec).
-- **Lens auto-focus.** Camera is manual-focus by hardware choice. v0.2's autofocus-disable was a no-op; v0.3 explicitly assumes manual focus and adds the sharpness indicator to support it.
+- **Runtime autofocus.** Camera supports autofocus but firmware **locks** the lens to infinity at boot (`AfMode=Manual`, `LensPosition=0.0`). The AF system is never re-enabled during normal operation — the alternative is the AF motor hunting on bright skies during a sunset capture and producing soft frames at random.
+- **Operator focus adjustment during install.** The autofocus camera makes this unnecessary. The alignment page does not include a focus slider, sharpness peak-finding UI, or any operator-facing focus control. The single sharpness signal that exists is a binary "focus OK / focus failed" verification.
 - **Sun-tap calibration** (the manual-tap mechanic considered in v0.1). Superseded by full auto-detection.
 - **Fixing the Pi's clock drift.** Subproject B's concern. This spec **depends on** B being fixed before v0.3 ships in the field — see §9.
 - **Streaming live during the sunset window.** Reserved future work; doesn't interact with alignment.
@@ -46,7 +47,9 @@ Verified from the repo as of 2026-05-17:
 - **v0.2 firmware** (`feat/setup-alignment-mpu6050` merged into `sunset-cam-firmware` `main` via PR #2): four modules — `gyro_driver.py`, `orientation_sampler.py`, `solstice_math.py`, `setup_alignment.py`. 48/48 unit tests passing. Framework-agnostic; not yet wired into a setup web app.
 - **v0.2 spec** (`docs/superpowers/specs/2026-05-17-pi-side-alignment-tool-design.md`): describes the MPU-6050 + facing-selector design. v0.3 keeps the IMU and the alignment page, replaces the facing selector + manual solstice markers with sun-calibration outputs.
 - **No setup web app exists yet** (spec E firmware-side hasn't been implemented). v0.3's new endpoints land in the same Python modules and are registered alongside v0.2's when E lands.
-- **The chosen camera is now Arducam IMX708 Wide MF (120° HFOV) rather than Pi Foundation Camera Module 3 Wide (102°)**. Same Sony IMX708 sensor; the SKU difference is the lens (manual M12 mount vs autofocus). Lens intrinsics differ → must re-calibrate the bench-shipped JSON.
+- **The chosen camera is now Arducam IMX708 Wide *Autofocus* (120° HFOV)** at $35 retail, replacing the previously-considered manual-focus part. Same Sony IMX708 sensor as the Pi Foundation Camera Module 3 Wide (which is the supply fallback). Includes ABS case, 15-22 pin ribbon, 22-22 pin ribbon. The autofocus is software-controlled; firmware locks it to infinity at init.
+- **Arducam-specific Pi config**: the module requires `dtoverlay=imx708` in `/boot/firmware/config.txt` plus `camera_auto_detect=0`. One-time provisioning step per device, baked into the SD-card image.
+- **Pi OS Bookworm or later** required (kernel 6.1.x+). Older Bullseye images are unsupported by the Arducam driver.
 - **Subproject B (clock drift)** remains in its stubbed state. v0.3 has a hard dependency on it.
 
 ## 5. Design
@@ -89,18 +92,20 @@ Verified from the repo as of 2026-05-17:
 └────────────────────────────────────────────────────────┘
 ```
 
-Two new pipelines run on the Pi independently of the user being present:
-- **Sharpness sampler** (lives during setup mode only): grabs a 320×240 center crop from the preview, computes an edge-contrast score, caches the latest. Exposed via `/setup/sharpness.json`.
+Two pipelines run on the Pi independently of the user being present:
+- **Focus verification** (one-shot during setup mode, plus a flag attached to every capture): grabs a 320×240 center crop from a current frame, computes a variance-of-Laplacian score, returns "OK" if the score exceeds a per-SKU threshold. Exposed via `/setup/focus.json` (returns `{"focus_ok": true|false, "score": <float>, "threshold": <float>}`). There is **no live polling UI** — the operator either passes the check or doesn't.
 - **Sun-calibration sampler** (lives in normal operation mode): during the sunset capture window, picks frames where the sun is detectable, accumulates `(pixel_x, pixel_y, timestamp_utc, sun_az, sun_alt)` tuples in `/var/lib/sunset-cam/observations.jsonl`. After N=10 observations (or one full sunset window), runs `solvePnP` and writes the resulting `(azimuth_deg, tilt_deg, roll_deg, confidence)` to `/etc/sunset-cam/calibration.json`.
 
 ### 5.2 Camera-source abstraction
 
-The chosen production camera is the **Arducam IMX708 Wide MF** but supply may force a swap to the **Pi Foundation Camera Module 3 Wide** (same sensor, autofocus lens). The firmware must not couple to a specific camera SKU. Introduce a thin interface:
+The chosen production camera is the **Arducam IMX708 Wide AF**; supply fallback is the **Pi Foundation Camera Module 3 Wide** (same sensor, slightly different driver registration path). The firmware must not couple to a specific camera SKU. Introduce a thin interface:
 
 ```python
 # src/sunset_cam/camera_source.py
 from typing import Protocol
 import numpy as np
+from libcamera import controls
+from picamera2 import Picamera2
 
 
 class CameraSource(Protocol):
@@ -117,31 +122,62 @@ class CameraSource(Protocol):
 
 
 class PiCameraSource:
-    """picamera2-based implementation. Hardware-detects whether the
-    attached lens is manual-focus (IMX708 MF) or autofocus (PCM3 Wide AF);
-    if AF, locks the lens to infinity at startup."""
+    """picamera2-based implementation. Disables autofocus and locks the
+    lens to infinity at startup. Same code path works for the Arducam
+    IMX708 AF and the Pi Foundation Camera Module 3 Wide AF — both have
+    the IMX708 sensor and respond to the same `AfMode`/`LensPosition`
+    controls. The SKU difference is purely in /boot/firmware/config.txt
+    (dtoverlay=imx708 for the Arducam) which is set during SD provisioning,
+    not in this code."""
+
+    def __init__(self) -> None:
+        self._picam = Picamera2()
+        cfg = self._picam.create_still_configuration()
+        self._picam.configure(cfg)
+        # Lock focus at infinity BEFORE starting. AF would otherwise hunt
+        # on bright skies during the sunset capture window.
+        self._picam.set_controls({
+            "AfMode": controls.AfModeEnum.Manual,
+            "LensPosition": 0.0,  # 0.0 = infinity; higher = closer
+        })
+        self._picam.start()
 ```
 
 The existing `capture.py` module from v0.1 wraps a Picamera2 directly and is the right candidate to refactor into the `PiCameraSource` class. Call sites elsewhere in the codebase migrate to import from `camera_source` instead of `capture`.
 
-### 5.3 Sharpness indicator
+If the autofocus lock-to-infinity step ever fails (e.g., a libcamera version regression), the existing `capture.py` callers will still get frames — they'll just be out of focus. The focus-verification pipeline (§5.3) catches this case and surfaces it as a setup error rather than letting a misfocused unit silently ship to the field.
 
-A small helper computes a single scalar sharpness score from the latest preview frame, suitable for an operator to read off the page as they turn the focus ring. The classic approach is the **variance of Laplacian** on a grayscale center crop:
+### 5.3 Focus verification (passive)
+
+A small helper computes the variance-of-Laplacian on a grayscale center crop and compares it to a per-SKU threshold:
 
 ```python
 def sharpness_score(frame_rgb: np.ndarray, crop_fraction: float = 0.5) -> float:
-    """Higher = sharper. No upper bound; relative number for tuning."""
+    """Higher = sharper. Dimensionless; compare to per-SKU threshold."""
     h, w, _ = frame_rgb.shape
     ch, cw = int(h * crop_fraction), int(w * crop_fraction)
     y0, x0 = (h - ch) // 2, (w - cw) // 2
     crop = frame_rgb[y0:y0 + ch, x0:x0 + cw]
     gray = cv2.cvtColor(crop, cv2.COLOR_RGB2GRAY)
     return float(cv2.Laplacian(gray, cv2.CV_64F).var())
+
+
+def focus_ok(frame_rgb: np.ndarray, threshold: float) -> bool:
+    return sharpness_score(frame_rgb) >= threshold
 ```
 
-The alignment page polls `/setup/sharpness.json` at the same 5 Hz rate it polls `/setup/orientation.json` and shows the score next to the roll/pitch readouts. The number is dimensionless and varies wildly across scenes; the operator's job is to **maximize** it relative to where it was a moment ago, not to hit a specific target. UI copy: *"Turn the focus ring slowly. Stop when this number stops increasing."*
+The per-SKU threshold is established empirically on the bench during lens calibration (§5.10) and shipped with the firmware in `lens_intrinsics.json`. A representative threshold for the IMX708 Wide AF locked at infinity on a typical outdoor scene is in the low thousands of Laplacian variance; a lens-cap-on frame is near zero, a wall-facing frame is in the tens-to-hundreds, an in-focus sky scene is in the low-to-mid thousands.
 
-A small additional helper UI: a 5-second rolling max next to the current score, so the operator can see whether they've drifted past the peak.
+The alignment page surfaces this as a **one-shot check**, not a live polling loop:
+
+- On page load, the page calls `/setup/focus.json` once.
+- Response is `{"focus_ok": true, "score": 2840.5, "threshold": 1500}` or similar.
+- If `focus_ok`: a small green "focus: OK" badge appears in the top HUD.
+- If not: a prominent banner appears saying *"Focus check failed. Check that the lens cap is removed and the camera isn't pointed at a wall. Reload this page to re-check."*
+
+The operator never sees the raw score and has no slider to adjust. The reload button is the only recovery path — by then they've usually fixed whatever was blocking the lens.
+
+The same `focus_ok` check also runs at every sunset capture as a soft sanity flag and is attached to the upload payload (the server can downrank or alert on blurry uploads).
 
 ### 5.4 Sun detection
 
@@ -236,7 +272,7 @@ The alignment HTML (`render_align_page` in `setup_alignment.py`) changes:
 - **Drops the East/West/Both facing form** entirely.
 - **Drops the static server-rendered solstice markers** (since `compute_solstice_markers(lat, lng, facing, fov)` no longer has a known `facing`). Instead, **markers are drawn only after calibration is available**, using the calibrated azimuth as the camera's known center.
 - **Drops the sunsets-per-year counter** until calibration is available. After calibration: shows the real counter for the calibrated azimuth.
-- **Adds a sharpness readout** in the top HUD: `focus: <score>` adjacent to the existing `roll:` / `pitch:` readouts. Also a 5-second rolling-max value to help the operator find the peak.
+- **Adds a focus badge** in the top HUD: `focus: OK` (green) or `focus: failed` (red), populated by a single fetch to `/setup/focus.json` on page load. No live polling; reload to re-check.
 - **Adds a calibration status block**: `calibrated: 17/10 observations · ±0.6° (last update 3 min ago)` or `calibrating: 0/10 observations · awaiting first clear sunset`.
 
 The level indicator + horizon line + UP arrow all stay unchanged.
@@ -248,7 +284,7 @@ The operator's path:
 1. Plug in the device, connect to its WiFi, open the cloud wizard. (Spec E.)
 2. Enter lat/lng (browser geolocation or zip code). The device gets these via spec E's pre-register.
 3. Open the alignment tool (spec F screen 4 → Pi-served page).
-4. **Focus**: turn the focus ring until the sharpness number stops increasing.
+4. **Focus check**: the page reports "focus OK" (green) or "focus failed" (red banner) on load. If failed: remove lens cap / re-aim away from a wall / reload. No manual adjustment.
 5. **Level**: rotate the housing until the roll/pitch badge is green.
 6. **Aim roughly west** (for sunset units). UI copy explicitly: "Aim where you think the sun sets. We'll fine-tune automatically."
 7. Mount the camera, walk away.
@@ -256,6 +292,8 @@ The operator's path:
 9. Once the first calibration is complete, the cloud-side server gets the calibrated azimuth (via heartbeat) and the sunsets-per-year counter populates on the operator's gallery page.
 
 Honest UX: the wizard tells the operator "calibration takes 1–7 sunny sunsets." For Bellingham winter, that can mean 2 weeks. The wizard should also expose a "calibration progress" indicator on the device's own status page so an impatient operator can see what's happening.
+
+This is a real UX win over the previous draft: by switching to the autofocus camera and locking it in software, the operator no longer needs to physically adjust a lens ring. One fewer manual step in install.
 
 ### 5.11 F integration
 
@@ -271,8 +309,10 @@ New protocol fields on heartbeat (the device → server message):
 | `calibrated_azimuth_confidence_deg` | float, nullable | `/etc/sunset-cam/calibration.json` `azimuth_confidence_deg` |
 | `calibrated_at` | ISO timestamp, nullable | when last solver ran |
 | `observation_count` | int | how many sun observations are stored |
+| `last_focus_score` | float, nullable | sharpness score from last capture |
+| `last_focus_ok` | bool, nullable | whether the last capture passed the threshold |
 
-The cloud uses `calibrated_azimuth_deg` to compute the per-camera sunsets-per-year count for the operator's gallery page. Until calibration arrives, the cloud falls back to operator's `phase_preference` (sunrise/sunset/both) for a rough placeholder.
+The cloud uses `calibrated_azimuth_deg` to compute the per-camera sunsets-per-year count for the operator's gallery page. Until calibration arrives, the cloud falls back to operator's `phase_preference` (sunrise/sunset/both) for a rough placeholder. `last_focus_ok = false` on uploads is a soft signal — the cloud could downrank or alert on it, but the upload still happens.
 
 ## 7. Testing
 
@@ -311,30 +351,32 @@ The cloud uses `calibrated_azimuth_deg` to compute the per-camera sunsets-per-ye
 
 ## 10. Implementation slice order
 
-1. **Camera-source abstraction**: refactor `capture.py` into `camera_source.py`'s `PiCameraSource`. Existing callers migrate. Unit tests with a fake camera source.
-2. **Sharpness module**: `sharpness.py` with `sharpness_score(frame)`; tests with synthetic frames.
-3. **`/setup/sharpness.json` endpoint**: small renderer in `setup_alignment.py`. Tests.
-4. **Alignment page HTML update**: add sharpness readout + 5-second-max display to the top HUD. Drop facing form + sunsets counter (until calibration is available). Update tests.
-5. **Sun detection module**: `sun_detect.py` with `detect_sun(frame)`. Tests with synthetic images.
-6. **World-frame sun position**: `astronomy.py` with `compute_sun_world(lat, lng, t_utc)` via skyfield. Tests vs. NOAA values.
-7. **Calibration store**: `calibration_store.py` for atomic read/write of `/etc/sunset-cam/calibration.json`. Tests.
-8. **Pose solver**: `pose_solver.py` with `solve_azimuth(observations, intrinsics, imu_roll, imu_pitch)`. Tests with synthetic observations.
-9. **Calibration runner**: ties §5–8 together. Runs in the capture loop's sunset window. Tests with mocked frame stream + mocked clock.
-10. **Drift detection**: rolling-residual check; clears calibration if exceeded. Tests.
-11. **Heartbeat payload extension**: include `calibrated_azimuth_deg` + friends. Spec lives in `device-protocol.md` (separate update).
-12. **Bench lens-intrinsics procedure**: one-time operator task; ship resulting JSON file with firmware. Document in a separate procedure doc; not a code task.
-13. **Manual field test**: real Pi + real IMX708 + real sunset. Validate end-to-end.
+1. **Camera-source abstraction**: refactor `capture.py` into `camera_source.py`'s `PiCameraSource`. Includes the `AfMode=Manual` + `LensPosition=0.0` init. Existing callers migrate. Unit tests with a fake camera source.
+2. **SD provisioning**: ensure the base SD-card image (or the spec E provisioning script) sets `camera_auto_detect=0` and `dtoverlay=imx708` in `/boot/firmware/config.txt`. One-time per device. Document in spec E's provisioning section.
+3. **Focus verification module**: `focus_check.py` with `sharpness_score(frame)` + `focus_ok(frame, threshold)`. Tests with synthetic frames (uniform → low, edge-heavy → high).
+4. **`/setup/focus.json` endpoint**: one-shot renderer in `setup_alignment.py`. Tests.
+5. **Alignment page HTML update**: add `focus: OK / failed` badge to the top HUD (single fetch on page load, no polling). Drop facing form + static sunsets counter (until calibration is available). Update tests.
+6. **Sun detection module**: `sun_detect.py` with `detect_sun(frame)`. Tests with synthetic images.
+7. **World-frame sun position**: `astronomy.py` with `compute_sun_world(lat, lng, t_utc)` via skyfield. Tests vs. NOAA values.
+8. **Calibration store**: `calibration_store.py` for atomic read/write of `/etc/sunset-cam/calibration.json`. Tests.
+9. **Pose solver**: `pose_solver.py` with `solve_azimuth(observations, intrinsics, imu_roll, imu_pitch)`. Tests with synthetic observations.
+10. **Calibration runner**: ties §6–9 together. Runs in the capture loop's sunset window. Tests with mocked frame stream + mocked clock.
+11. **Drift detection**: rolling-residual check; clears calibration if exceeded. Tests.
+12. **Heartbeat payload extension**: include `calibrated_azimuth_deg` + friends. Spec lives in `device-protocol.md` (separate update).
+13. **Bench lens-intrinsics procedure**: one-time operator task; ship resulting JSON file (`intrinsics/imx708-wide-af.json`) with firmware. Document in a separate procedure doc; not a code task.
+14. **Establish per-SKU focus threshold**: companion to the lens intrinsics bench step. Capture sharpness scores under known conditions (sky / wall / lens-cap) and pick a threshold halfway between sky and wall. Bake into the intrinsics JSON.
+15. **Manual field test**: real Pi + real IMX708 + real sunset. Validate end-to-end.
 
 ## 11. Diff from v0.2
 
 If you read v0.2 and want to know what changed in v0.3:
 
-- **§1 Problem**: adds two motivations (true compass needed; manual focus needs feedback). v0.2 only had aiming + level + up.
-- **§2 Goals**: adds auto-azimuth + sharpness + drift-detection goals. Drops the operator-self-report goal.
-- **§3 Non-goals**: explicit "no ESP32, no magnetometer, no GPS, no autofocus runtime control" — locks in the design constraints.
-- **§5 Design**: keeps the v0.2 MPU-6050 pipeline + preview page intact. Adds five new modules (camera_source, sharpness, sun_detect, astronomy, calibration_store, pose_solver), one new persistent file (`calibration.json`), two new HTTP endpoints (`sharpness.json`, `calibration.json`), and significant changes to the alignment page (drops facing form, adds sharpness readout + calibration status block).
-- **§6 Field provenance**: adds `calibrated_azimuth_deg` + friends as new heartbeat fields. v0.2 had no protocol additions.
+- **§1 Problem**: adds two motivations (true compass needed; defensive focus check). v0.2 only had aiming + level + up.
+- **§2 Goals**: adds auto-azimuth + passive focus verification + drift-detection goals. Drops the operator-self-report goal.
+- **§3 Non-goals**: explicit "no ESP32, no magnetometer, no GPS, no runtime autofocus, no operator focus adjustment" — locks in the design constraints.
+- **§5 Design**: keeps the v0.2 MPU-6050 pipeline + preview page intact. Adds five new modules (camera_source, focus_check, sun_detect, astronomy, calibration_store, pose_solver), one new persistent file (`calibration.json`), two new HTTP endpoints (`focus.json`, `calibration.json`), and changes to the alignment page (drops facing form, adds focus badge + calibration status block).
+- **§6 Field provenance**: adds `calibrated_azimuth_deg` + `last_focus_*` as new heartbeat fields. v0.2 had no protocol additions.
 - **§7 Testing**: adds hardware-gated manual tests; unit tests grow significantly.
 - **§8 Risks**: re-anchors on B (clock drift) as a hard blocker, adds OpenCV size, sun saturation, cloudy stretches.
 - **§9 Dependencies**: new section. v0.2 had no external deps.
-- Hardware: camera SKU changes from Pi Foundation Camera Module 3 Wide (102° HFOV, autofocus) to Arducam IMX708 Wide MF (120° HFOV, manual focus). Same Sony IMX708 sensor either way.
+- Hardware: camera SKU is **Arducam IMX708 Wide Autofocus** (120° HFOV, $35, ABS case + both ribbons included), replacing the earlier Pi Foundation Camera Module 3 Wide (102°) from v0.2 and superseding the briefly-considered manual-focus Arducam variant. Firmware locks AF to infinity at boot. Provisioning needs `dtoverlay=imx708` + `camera_auto_detect=0` in `/boot/firmware/config.txt`. Pi OS Bookworm+ required.


### PR DESCRIPTION
## Summary

Two docs land together:

1. **C v0.3 spec** (`docs/superpowers/specs/2026-05-17-pi-alignment-v0.3-sun-self-calibration-design.md`) — replaces v0.2's operator-selected facing direction with auto-azimuth calibration from sun observations during the sunset capture window. Uses OpenCV `solvePnP` + Skyfield ephemeris. MPU-6050 stays (provides roll/pitch as a solver constraint). Camera switches to **Arducam IMX708 Wide Autofocus** (120° HFOV, ABS case included); firmware locks the lens to infinity at boot. Onboarding gets a passive "focus OK / failed" check instead of a manual sharpness slider.

2. **Tier 0 hardware spec** (`docs/hardware/2026-05-18-tier-0-camera-system-spec.md`) — durable reference doc capturing the full BOM, provisioning steps (`dtoverlay=imx708`, Pi OS Bookworm requirement), camera-source abstraction requirement, on-device heuristic scoring sketch, upload workflow, and explicit non-requirements.

Both docs supersede pieces of the earlier `pi-webcam-mvp.md` and the v0.2 alignment spec. They're additive: v0.2 stays as the shipping baseline, v0.3 lands when its dependencies (Subproject B clock drift fix, spec E setup web app, bench lens-intrinsics + focus-threshold calibration, MPU-6050 hardware in hand) are resolved.

## Notable design decisions captured

- **No magnetometer, no GPS module** — heading from celestial calibration; location from operator at onboarding.
- **AF locked to infinity at boot** — never re-enabled during normal operation (would hunt on bright skies).
- **No ESP32 path** — OpenCV doesn't run there; documented and accepted.
- **Hard dependency on Subproject B** — clock drift breaks sun calibration silently if uncaught.
- **Per-SKU bench calibration** for both lens intrinsics AND the focus-OK threshold — one-time operator task, JSON file shipped with firmware.

## Test plan
- [x] Docs only — no CI implications
- [x] v0.3 spec self-reviewed
- [x] Hardware spec is a faithful capture of the design conversation; no derivations beyond what's been discussed
- [x] Camera abstraction layer requirement is consistent across both docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)