### PR TITLE
docs(hardware): MPU6050 bringup checkpoint 2026-05-31

### DIFF
--- a/docs/hardware/2026-05-31-mpu6050-bringup-checkpoint.md
+++ b/docs/hardware/2026-05-31-mpu6050-bringup-checkpoint.md
@@ -1,0 +1,133 @@
+# MPU6050 + Camera Hardware Bringup — Checkpoint
+
+Date: 2026-05-31
+Pi unit: `sunset-cam-1` (the FIRST production-deployment unit; the test unit `sunset-cam-0` has been running since 2026-05-15)
+
+---
+
+## TL;DR — resume here
+
+You're mid-install on a new Pi (`sunset-cam-1`) bringing up the MPU6050 + Arducam IMX708 stack. **Software install is done through step 1.10** of `2026-05-29-pi-mpu6050-install-and-bringup-guide.md`. The CSI ribbon cable is in transit; once it arrives, plug in the camera, finish step 1.9 (write `config.json` with a freshly-minted claim code), enable + start the systemd service, then run the **Part 3 bringup tests** (i2cdetect → WHO_AM_I → live readings → 6-position protocol → snapshot). Paste the six (roll, pitch) readings back and I'll write the `gyro_driver.py` patch.
+
+## Decisions locked
+
+- **MPU orientation: X-down.** The wiring forced it; don't rewire. The firmware will be patched to match observed behavior, not the other way around.
+- **Camera: Arducam IMX708 Autofocus** (per sub-project C v0.3 spec).
+- **MPU mount: stacked face-to-face with the Pi** (Pi → MPU → camera, all parallel) for lowest profile. MPU is glued/foam-taped to the back of the Pi or the enclosure floor.
+- **Pi physical orientation: portrait (long axis vertical) with the power cable hanging down.** Camera ribbon connector on the bottom edge of the captured image.
+
+## What's done as of this checkpoint
+
+- [x] Cloud-side custom-cam visibility fix shipped and deployed (PR #11 + #12 + radius fix in #12)
+- [x] Cloud wizard skeleton at `/setup/[claim_code]` (PR #21)
+- [x] Sub-project C iterated to v0.3 (`docs/superpowers/specs/2026-05-17-pi-alignment-v0.3-sun-self-calibration-design.md`)
+- [x] Pi-side alignment-tool firmware Tasks 1–7 in `sunset-cam-firmware` (`gyro_driver.py`, `orientation_sampler.py`, `solstice_math.py`, `setup_alignment.py` all built and unit-tested)
+- [x] Physical MPU6050 soldered to Pi GPIO holes 1/3/5/9 with X-down orientation
+- [x] Install guide written: `docs/hardware/2026-05-29-pi-mpu6050-install-and-bringup-guide.md`
+- [x] Streamlined install path: `sunset-cam-firmware` `scripts/install.sh` extended with I2C enable + `i2c-tools` (PR #3 on the firmware repo)
+- [x] sunset-cam-1 walked through guide steps 1.1–1.5 (SD card flash, boot, SSH, apt update, apt deps)
+- [x] sunset-cam-1 step 1.6 (raspi-config: enable I2C + camera)
+- [x] sunset-cam-1 step 1.7 (git clone the firmware repo)
+- [x] sunset-cam-1 step 1.8 (`pip install -e ".[dev]" --break-system-packages`)
+- [x] sunset-cam-1 step 1.10 modified (only `cp` + `daemon-reload` ran — service registered, NOT enabled, NOT started)
+
+## What's still in flight — pick up here
+
+### Hardware-blocked (waiting for the new CSI ribbon cable)
+
+- [ ] Physically connect the Arducam IMX708 to the Pi via the new CSI cable
+- [ ] Mount the camera face-to-face on top of the MPU (silkscreen-up orientation so the captured image will be right-side-up)
+- [ ] Mint a claim code from the Mac:
+  ```bash
+  export CRON_SECRET="$(grep '^CRON_SECRET=' .env.production.local | cut -d= -f2- | tr -d '"')"
+  ```
+  ```bash
+  curl -sS -X POST https://sunrisesunset.studio/api/admin/claim-codes -H "authorization: Bearer $CRON_SECRET" -H "content-type: application/json" -d '{"label":"sunset-cam-1-install"}'
+  ```
+  Save the returned `code`.
+
+### On-Pi steps after hardware is connected
+
+- [ ] Step 1.9 — write `config.json`:
+  ```bash
+  ssh pi@sunset-cam-1.local
+  ```
+  ```bash
+  mkdir -p ~/sunset-cam-firmware/config
+  ```
+  ```bash
+  nano ~/sunset-cam-firmware/config/config.json
+  ```
+  Paste the JSON template from the install guide (replace `claim_code` + adjust lat/lng for the actual install location).
+
+- [ ] Enable + start the service:
+  ```bash
+  sudo systemctl enable sunset-cam.service
+  ```
+  ```bash
+  sudo systemctl start sunset-cam.service
+  ```
+  ```bash
+  systemctl status sunset-cam.service
+  ```
+
+- [ ] Reboot:
+  ```bash
+  sudo reboot
+  ```
+
+### Then run Part 3 bringup tests
+
+Following `docs/hardware/2026-05-29-pi-mpu6050-install-and-bringup-guide.md`:
+
+- [ ] 3.1 confirm I2C is on (`sudo raspi-config nonint get_i2c` → `0`)
+- [ ] 3.2 `sudo i2cdetect -y 1` → expect `68` at row 60, column 8
+- [ ] 3.3 `python3 -c "import smbus2; b=smbus2.SMBus(1); print('WHO_AM_I:', hex(b.read_byte_data(0x68, 0x75)))"` → expect `0x68`
+- [ ] 3.4 live orientation readings via interactive Python loop — confirm values respond to motion
+- [ ] 3.5 mount the camera physically (already done above)
+- [ ] 3.6 capture a snapshot with `snap-now.sh`, `scp` to Mac, confirm right-side-up + landscape
+- [ ] 3.7 the **6-position observation** — write down (roll, pitch) for each position A–F
+
+### Then send Claude the data
+
+Paste back:
+
+1. The six (roll, pitch) readings
+2. Snapshot orientation result (right-side-up + landscape: yes/no/which way wrong)
+3. Anything that failed
+
+Claude will write a `gyro_driver.py` patch that maps MPU's X-down orientation to the correct world frame. Expected: a 4-line `atan2()` argument swap. One commit on the firmware repo.
+
+## Open PRs that may affect the next session
+
+- **`sunset-cam-firmware` PR #3** — `scripts/install.sh` enables I2C + installs `i2c-tools` for future units. Doesn't affect sunset-cam-1 (already past those steps manually). Merge whenever.
+  - https://github.com/jessekauppila/sunset-cam-firmware/pull/3
+
+- **`the-sunset-webcam-map` PR #23** — the install + bringup guide itself. If it gets merged before the next session, the guide lives on main. If not, it's on the `docs/pi-mpu6050-install-guide` branch.
+  - https://github.com/jessekauppila/the-sunset-webcam-map/pull/23
+
+## Reference docs (in this repo)
+
+| Doc | Purpose |
+|---|---|
+| `docs/hardware/2026-05-29-pi-mpu6050-install-and-bringup-guide.md` | The full install + bringup walkthrough you're following |
+| `docs/hardware/2026-05-17-housing-up-arrow-and-mpu6050.md` | Hardware spec stub (BOM + wiring) |
+| `docs/superpowers/specs/2026-05-17-pi-alignment-v0.3-sun-self-calibration-design.md` | Sub-project C current design (v0.3) |
+| `docs/superpowers/specs/2026-05-17-pi-side-alignment-tool-design.md` | Sub-project C v0.2 (the firmware-side tool design) |
+| `docs/superpowers/plans/2026-05-17-pi-side-alignment-tool.md` | The plan for the firmware tasks (1–7 done) |
+| `docs/superpowers/specs/2026-05-15-streamlined-deployment-overview.md` | The umbrella project status |
+
+## Repos involved
+
+| Repo | Path | Role |
+|---|---|---|
+| `the-sunset-webcam-map` | `~/GitHub/the-sunset-webcam-map` | Cloud / web-app side, docs, specs |
+| `sunset-cam-firmware` | `~/GitHub/sunset-cam-firmware` | Pi-side Python firmware |
+
+## How to resume with Claude next session
+
+Open Claude Code from `~/GitHub/the-sunset-webcam-map`, then say something like:
+
+> "Pick up the MPU6050 bringup on sunset-cam-1. Read the checkpoint at `docs/hardware/2026-05-31-mpu6050-bringup-checkpoint.md`."
+
+Claude will pull the project memory (which knows the resume protocol) and walk through the "What's still in flight" checklist.

--- a/docs/superpowers/session-notes/2026-05-31-where-we-are.md
+++ b/docs/superpowers/session-notes/2026-05-31-where-we-are.md
@@ -1,0 +1,148 @@
+# Where we are — 2026-05-31
+
+**For the next Claude session:** Read this file first. It captures the state of work in flight, what just shipped, and the next concrete step.
+
+---
+
+## What's next (start here)
+
+**Wire the v2 binary classifier into the cron** so the popup verdict comes from a real "is this a sunset?" signal instead of regression-threshold proxy.
+
+- Memory with full plan: `memory/project_two_tier_sunset_classification.md`
+- The popup already supports this — when binary score lands, the visual stays identical, only `aiRatingBlock.ts`'s threshold gate flips from regression to binary
+- Open design decision to brainstorm BEFORE implementing: ship with v2 binary as placeholder, or train a v4 binary on the same Flickr-augmented dataset that v4 regression used? v2 is March-vintage but the "is this a sunset" task is coarser than quality ranking — may be Good Enough
+
+**Recommended first move:** invoke the brainstorming skill on the v2-vs-train-v4 question, then write a spec → plan → implement using subagent-driven-development.
+
+---
+
+## What shipped tonight (all merged to main)
+
+| PR | Branch | What |
+|---|---|---|
+| #18 | `feat/scoring-observability` | `scoringPaths` counter on cron response + `/api/debug/scoring-smoke` endpoint + 55KB JPEG fixture |
+| #19 | `feat/persist-scoring-path` | `webcam_snapshots.scoring_path` column + write-path + migration |
+| #20 | `fix/smoke-endpoint-includefiles` | 3-line `vercel.json` patch so smoke endpoint ships the ONNX model |
+| #21 | `feat/cloud-wizard-skeleton` | `/setup/[claim_code]` skeleton — 4 of 6 screens working + submit (AR + horizon-sweep are placeholders pending brainstorm) |
+| #24 | `feat/popup-rating-redesign` | New AI-rating block in `webcamPopup.tsx` — "Sunset detected" vs "Not a sunset right now" with SVG stars, drops the misleading duplicate "Binary: N" line |
+
+Earlier in the day before tonight:
+- #16: `fix/build-type-error-customclassification` — Number() coercion fix that unblocked all builds
+- PR before this thread: `fix/custom-cam-rating-mapping` (PR #15) — fixed the 0.21/5 display bug
+
+---
+
+## What's queued (in priority order)
+
+**1. Two-tier sunset classification** (the thing we're about to start)
+- `memory/project_two_tier_sunset_classification.md` — full inventory + 4 open questions + sketch
+- Forward-compatible with the popup redesign already merged
+
+**2. Manual rating for custom cams**
+- `memory/project_manual_rating_for_custom_cams.md`
+- Augment v4 ONNX with a `manual_rating` column + simple labeling UI
+- Addresses the silhouette-sunset blind spot; labels feed v5 training
+- Needs brainstorming pass first
+
+**3. AR overlay + horizon sweep for cloud wizard (screens 4-5)**
+- Cloud wizard skeleton from PR #21 has these as "Skip for now" placeholders
+- Real design: compass calibration UX, three.js vs canvas2D, three solstice/equinox arcs over live camera feed
+- Per `memory/project_streamlined_deployment_status.md`, this is the visible-progress piece of Subproject F
+
+**4. Tasks 4-11 of streamlined-model-deploy plan**
+- `docs/superpowers/plans/2026-05-16-streamlined-model-deploy.md`
+- The bash deploy script + Python validator
+- Deferred until next model deploy
+
+---
+
+## Verification you can run after merge to confirm health
+
+```bash
+# Pull CRON_SECRET from Vercel into shell
+npx vercel env pull --environment=production .env.production.tmp
+export CRON_SECRET=$(grep ^CRON_SECRET .env.production.tmp | cut -d= -f2- | tr -d '"')
+rm .env.production.tmp
+
+# 1. Smoke endpoint says ONNX is running
+curl -s -H "Authorization: Bearer $CRON_SECRET" \
+  https://www.sunrisesunset.studio/api/debug/scoring-smoke | jq
+
+# Expect: { "pathTaken": "onnx", "modelVersion": "v4_regression_llm_with_flickr", ... }
+
+# 2. Cron response shows scoringPaths breakdown
+curl -s -H "Authorization: Bearer $CRON_SECRET" \
+  https://www.sunrisesunset.studio/api/cron/update-cameras | jq '.scoringPaths'
+
+# Expect: { "onnx": N, "cache-hit": M, "baseline-fallback": 0, "baseline": 0 }
+```
+
+---
+
+## Worktrees to clean up
+
+All five from tonight can be removed (their PRs merged):
+
+```bash
+git worktree remove /Users/jessekauppila/GitHub/the-sunset-webcam-map-buildfix
+git worktree remove /Users/jessekauppila/GitHub/the-sunset-webcam-map-scoring-obs
+git worktree remove /Users/jessekauppila/GitHub/the-sunset-webcam-map-smoke-bundle
+git worktree remove /Users/jessekauppila/GitHub/the-sunset-webcam-map-pathtaken-db
+git worktree remove /Users/jessekauppila/GitHub/the-sunset-webcam-map-cloud-wizard
+git worktree remove /Users/jessekauppila/GitHub/the-sunset-webcam-map-popup-rating
+```
+
+The main checkout (`~/GitHub/the-sunset-webcam-map/`) is still on `feat/pi-alignment-tool-v2-mpu6050` from a parallel session — switch to main when ready:
+
+```bash
+git checkout main && git pull --ff-only
+```
+
+---
+
+## Open backlog SQL tasks
+
+These haven't been run yet on Neon:
+
+**Backfill stale custom-cam display ratings** (from the May 17 fix):
+```sql
+UPDATE webcams
+SET ai_rating_regression = 1 + ls.ai_regression_score * 4
+FROM (
+  SELECT DISTINCT ON (s.webcam_id)
+         s.webcam_id, s.ai_regression_score
+  FROM webcam_snapshots s
+  JOIN webcams w ON w.id = s.webcam_id
+  WHERE w.source = 'custom'
+    AND s.ai_regression_score IS NOT NULL
+  ORDER BY s.webcam_id, s.captured_at DESC
+) ls
+WHERE id = ls.webcam_id;
+```
+
+**Apply scoring_path migration** (from PR #19):
+```bash
+psql "$DATABASE_URL" -f database/migrations/20260518_webcam_snapshot_scoring_path.sql
+```
+
+---
+
+## Key memories (read these for context)
+
+- `memory/project_two_tier_sunset_classification.md` ← **most relevant for next session**
+- `memory/feedback_silent_ml_fallback.md` — the silent-fallback pattern that we ship guardrails against
+- `memory/project_manual_rating_for_custom_cams.md` — queued, related but separate from two-tier
+- `memory/project_streamlined_deployment_status.md` — broader Subproject F context
+
+---
+
+## The big picture as of tonight
+
+The "AI scoring" stack has gone from "we shipped v4 but it was silently falling back to a metadata heuristic" (where we were May 15) to:
+
+1. Real v4 ONNX inference confirmed running in production
+2. Per-tick + per-snapshot observability that catches silent-fallback regressions instantly
+3. The popup correctly distinguishes "sunset" from "not a sunset" using a regression-threshold proxy
+4. Infrastructure is in place to swap that proxy for a real binary classifier — that's the next chunk
+
+The remaining gap between "good" and "great" on the AI side is teaching the model about silhouette sunsets and other cases where v4 disagrees with the user's eye. That's the manual-rating project, downstream of the two-tier work.


### PR DESCRIPTION
## Summary

Snapshot of where sunset-cam-1's bringup is right now (mid-flight): software install through guide step 1.10 done, physical install paused waiting on a replacement CSI ribbon cable. So a future session can pick this up cold.

The checkpoint file (`docs/hardware/2026-05-31-mpu6050-bringup-checkpoint.md`) covers:

- TL;DR with the exact resume context
- Decisions locked (MPU X-down, stack mounting, Pi portrait orientation)
- What's done
- What's still in flight with exact next commands per step
- Open PRs that affect the next session (firmware repo #3, this repo #23)
- Resume protocol — what to say to Claude to pick up where we left off

Pairs with the install + bringup guide at `docs/hardware/2026-05-29-pi-mpu6050-install-and-bringup-guide.md`.

## Test plan

- [ ] Nothing to test — single docs file added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)