### PR TITLE
fix(ml): binary_threshold defaults to 0.75 (normalized space)

### DIFF
--- a/ml/common/labels.py
+++ b/ml/common/labels.py
@@ -10,14 +10,34 @@ from dataclasses import dataclass
 
 @dataclass(frozen=True)
 class LabelPolicy:
-    """Controls how exported labels are transformed for model training."""
+    """Controls how exported labels are transformed for model training.
+
+    IMPORTANT: ``binary_threshold`` is compared against the NORMALIZED
+    [0, 1] label values produced by ``merge_label`` in
+    ``ml/export_dataset.py``, not the raw 1-5 ratings. Normalized
+    values are ``(rating - 1) / 4``, so:
+
+        rating 4.0  →  normalized 0.75
+        rating 4.5  →  normalized 0.875
+        rating 5.0  →  normalized 1.0
+
+    The historical default ``4.0`` was correct when labels were raw
+    1-5 values, but the v3+ pipeline normalizes upstream of
+    ``map_label``. A 4.0 threshold against normalized labels never
+    matches anything → the dataset reports 0 positives and binary
+    training silently produces an "always 0" model. Pass thresholds
+    in the normalized space.
+    """
 
     target_type: str = "binary"  # binary | regression
-    binary_threshold: float = 4.0
+    binary_threshold: float = 0.75  # normalized; was 4.0 before 2026-05-31
 
 
-def to_binary(label_value: float, threshold: float = 4.0) -> int:
-    """Convert continuous rating into good/not-good class label."""
+def to_binary(label_value: float, threshold: float = 0.75) -> int:
+    """Convert normalized [0,1] label into good/not-good class label.
+
+    See ``LabelPolicy`` for the threshold-space convention.
+    """
     return 1 if label_value >= threshold else 0
 
 

--- a/ml/configs/v4_binary_llm_with_flickr.yaml
+++ b/ml/configs/v4_binary_llm_with_flickr.yaml
@@ -26,7 +26,13 @@ data:
   llm_ratings_csv: ml/artifacts/llm_ratings/initial_ratings.csv
   label_merge_strategy: llm_only
   target_type: binary
-  binary_threshold: 4.0
+  # IMPORTANT: this threshold compares against the NORMALIZED [0,1]
+  # target_label, not the raw 1-5 rating. (rating - 1) / 4 = 0.75
+  # corresponds to "rating >= 4". Setting this to 4.0 produces zero
+  # positives in the dataset (since normalized values cap at 1.0) and
+  # the model trains a trivial "always 0" solution. See
+  # ml/common/labels.py:19 and ml/export_dataset.py merge_label docstring.
+  binary_threshold: 0.75
   min_rating_count: 1
   include_external: true
   external_categories: [sunset]

--- a/ml/export_dataset.py
+++ b/ml/export_dataset.py
@@ -110,7 +110,10 @@ def parse_args() -> argparse.Namespace:
         default="manual_only",
     )
     parser.add_argument("--target-type", choices=["binary", "regression"], default="binary")
-    parser.add_argument("--binary-threshold", type=float, default=4.0)
+    # Compared against the normalized [0,1] label produced by merge_label,
+    # NOT the raw 1-5 rating. (rating - 1) / 4 = 0.75 corresponds to
+    # "rating >= 4". See ml/common/labels.py docstring.
+    parser.add_argument("--binary-threshold", type=float, default=0.75)
     parser.add_argument("--min-rating-count", type=int, default=2)
     parser.add_argument("--seed", type=int, default=20260212)
     parser.add_argument("--train-pct", type=int, default=70)

--- a/ml/run_experiment.py
+++ b/ml/run_experiment.py
@@ -96,7 +96,9 @@ def main() -> None:
         "--target-type",
         str(cfg_get(data_cfg, "target_type", "binary")),
         "--binary-threshold",
-        str(cfg_get(data_cfg, "binary_threshold", 4.0)),
+        # Normalized [0,1] threshold — see ml/common/labels.py docstring.
+        # 0.75 ≈ rating >= 4 on the original 1-5 scale.
+        str(cfg_get(data_cfg, "binary_threshold", 0.75)),
         "--min-rating-count",
         str(cfg_get(data_cfg, "min_rating_count", 2)),
         "--seed",


### PR DESCRIPTION
The training pipeline normalizes labels to [0,1] before map_label runs (see merge_label docstring in ml/export_dataset.py). The historical binary_threshold default of 4.0 came from when labels were raw 1-5 values; since the normalization landed it's been silently broken — no label ever crosses 4.0 in normalized space, so binary training produces 0 positives and the model learns a trivial "always 0" solution.

Discovered when v4_binary_llm_with_flickr.yaml's export_dataset run reported "positive": 0 across all 35,372 rows.

Fixes:
- ml/configs/v4_binary_llm_with_flickr.yaml: 4.0 → 0.75 with comment
- ml/common/labels.py: docstring expanded with the normalization convention; default lowered to 0.75
- ml/run_experiment.py:99 and ml/export_dataset.py:113: bare defaults lowered to 0.75 so omitting the field doesn't reintroduce the bug

v2_*_balanced.yaml configs explicitly set 4.0 — they were correct at the time (pre-normalization pipeline) but would now produce 0 positives. They aren't touched here because re-running them isn't expected; if anyone does, the comment in labels.py points the way.