### PR TITLE
fix(deploy): broaden vercel.json includeFiles glob (brace expansion i…

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -7,10 +7,10 @@
   ],
   "functions": {
     "app/api/cron/update-cameras/route.ts": {
-      "includeFiles": "ml/artifacts/models/{regression_resnet18,binary_resnet18}/**"
+      "includeFiles": "ml/artifacts/models/**"
     },
     "app/api/debug/scoring-smoke/route.ts": {
-      "includeFiles": "ml/artifacts/models/{regression_resnet18,binary_resnet18}/**"
+      "includeFiles": "ml/artifacts/models/**"
     }
   }
 }


### PR DESCRIPTION
…gnored)

PR #29 introduced 'ml/artifacts/models/{regression_resnet18,binary_resnet18}/**' to bundle both ONNX heads. Vercel's includeFiles globber doesn't expand the {a,b} brace syntax, so the pattern matched zero files — neither the regression NOR the binary model shipped in the function bundle. Both heads fell back to baseline silently (latencyMs 15 confirmed no ONNX inference ran).

Replace with the simpler 'ml/artifacts/models/**' that we know matches. This also picks up the unused v2 ONNX files (~86 MB extra), pushing the function bundle to ~218 MB — under Vercel's 250 MB hard limit but cutting it close. If a future deploy hits the size limit, trim the unused v2 ONNX files (they're not referenced by any env var; the .pt checkpoints stay around for rollback via re-export).

Diagnostic before fix:
  GET /api/debug/scoring-smoke
  -> pathTaken: 'baseline-fallback', binaryPathTaken: 'baseline-fallback'
  -> latencyMs: 15  (= no real inference)
  -> rawScore: 0.21 == baselineRaw(viewCount=0, manualRating=3) by design