### PR TITLE
fix(deploy): bundle ONNX models via next.config outputFileTracingIncl…

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -29,6 +29,22 @@ const nextConfig: NextConfig = {
       'node_modules/onnxruntime-node/bin/napi-v6/linux/x64/libnvinfer*',
     ],
   },
+  // Bundle the ONNX model files into the cron + smoke endpoints. The
+  // vercel.json `functions.includeFiles` field appears to silently not
+  // match `ml/artifacts/models/**` (logs show File doesn't exist at
+  // /var/task/ml/artifacts/models/...). Switch to Next's own tracing
+  // includes which DO work consistently. Route keys must NOT have the
+  // `.ts` suffix and must include the leading `app/` prefix.
+  outputFileTracingIncludes: {
+    '/api/cron/update-cameras': [
+      './ml/artifacts/models/regression_resnet18/**/*',
+      './ml/artifacts/models/binary_resnet18/**/*',
+    ],
+    '/api/debug/scoring-smoke': [
+      './ml/artifacts/models/regression_resnet18/**/*',
+      './ml/artifacts/models/binary_resnet18/**/*',
+    ],
+  },
 };
 
 export default nextConfig;


### PR DESCRIPTION
…udes

vercel.json's functions.includeFiles silently failed to match ml/artifacts/models/** — runtime logs showed 'File doesn't exist' at /var/task/ml/artifacts/models/.../model.onnx for both regression and binary heads, despite multiple glob patterns. Both fell back to baseline with latencyMs ~15 (no inference) and rawScore 0.21 (the deterministic baselineRaw output for the smoke endpoint's webcamId=0).

Switched to Next.js's outputFileTracingIncludes mechanism keyed by route path (NOT file path — the key '/api/cron/update-cameras' is what works; 'app/api/cron/update-cameras/route' is silently ignored).

Verified locally — .next/server/app/api/cron/update-cameras/route.js.nft.json now lists all four ONNX files; the smoke endpoint route's nft.json likewise.