### PR TITLE
feat: auth foundation — owner login + server-side write gating (U1–U6)

### DIFF
--- a/app/HomeClient.tsx
+++ b/app/HomeClient.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import MainViewContainer from './components/MainViewContainer';
 import { useLoadTerminatorWebcams } from '@/app/store/useLoadTerminatorWebcams';
 import { useLoadAllWebcams } from '@/app/store/useLoadAllWebcams';
@@ -19,6 +19,8 @@ import { MapMosaicModeToggle } from '@/app/components/MapMosaicModeToggle';
 import type { ViewMode } from './components/MainViewContainer';
 import type { ManifestEntry } from '@/app/lib/modelRuns.types';
 import { ModelAnalysisTab } from './components/ModelAnalysis/ModelAnalysisTab';
+import { AuthControl } from './components/auth/AuthControl';
+import { useIsOperator } from './components/auth/useIsOperator';
 
 interface Props {
   manifestRuns: ManifestEntry[];
@@ -26,8 +28,33 @@ interface Props {
 
 export function HomeClient({ manifestRuns }: Props) {
   const [drawerOpen, setDrawerOpen] = useState(false);
-  const [tabValue, setTabValue] = useState(0); // Add tab state
+  const [tabKey, setTabKey] = useState<string>('current');
   const [mode, setMode] = useState<ViewMode>('globe');
+
+  const { isOperator } = useIsOperator();
+
+  // Stable-keyed tabs so hiding operator-only tabs for the public doesn't shift
+  // indices. Operator-only tabs (labeling + management) are removed entirely for
+  // the public, not disabled. The server (requireOwner) is the real gate; this
+  // is presentation.
+  const ALL_TABS = [
+    { key: 'current', label: 'Current Sunrises/Sunsets', operatorOnly: false },
+    { key: 'hard', label: '⚠ Hard Examples', operatorOnly: true },
+    { key: 'archive', label: 'Snapshot Archive', operatorOnly: false },
+    { key: 'curated', label: 'Curated', operatorOnly: false },
+    { key: 'unrated', label: 'Unrated Queue', operatorOnly: true },
+    { key: 'all', label: 'All Webcams', operatorOnly: true },
+    { key: 'models', label: 'Model Analysis', operatorOnly: false },
+  ] as const;
+  const visibleTabs = ALL_TABS.filter((t) => isOperator || !t.operatorOnly);
+
+  // If the active tab becomes hidden (e.g. operator signs out while on the
+  // Unrated Queue), fall back to the first public tab.
+  useEffect(() => {
+    if (!visibleTabs.some((t) => t.key === tabKey)) {
+      setTabKey('current');
+    }
+  }, [visibleTabs, tabKey]);
 
   // Bellingham, Washington location need to put in user's location eventually
   const userLocation = useMemo(
@@ -112,8 +139,10 @@ export function HomeClient({ manifestRuns }: Props) {
           >
             {/* Tabs Header */}
             <Tabs
-              value={tabValue}
-              onChange={(_, newValue) => setTabValue(newValue)}
+              value={tabKey}
+              onChange={(_, newValue) => setTabKey(newValue)}
+              variant="scrollable"
+              scrollButtons="auto"
               sx={{
                 borderBottom: 1,
                 borderColor: 'divider',
@@ -129,18 +158,14 @@ export function HomeClient({ manifestRuns }: Props) {
                 },
               }}
             >
-              <Tab label="Current Sunrises/Sunsets" />
-              <Tab label="⚠ Hard Examples" />
-              <Tab label="Snapshot Archive" />
-              <Tab label="Curated" />
-              <Tab label="Unrated Queue" />
-              <Tab label="All Webcams" />
-              <Tab label="Model Analysis" />
+              {visibleTabs.map((t) => (
+                <Tab key={t.key} value={t.key} label={t.label} />
+              ))}
             </Tabs>
 
             {/* Tab Content */}
             <Box sx={{ flex: 1, overflow: 'auto', p: 3 }}>
-              {tabValue === 0 && (
+              {tabKey === 'current' && (
                 // Current Terminator Tab
                 <Box
                   sx={{ display: 'flex', gap: 2, flexWrap: 'wrap' }}
@@ -161,7 +186,7 @@ export function HomeClient({ manifestRuns }: Props) {
                 </Box>
               )}
 
-              {tabValue === 1 && (
+              {tabKey === 'hard' && (
                 // Hard Examples — model-disagreement queue
                 <Box>
                   <SnapshotConsole
@@ -172,7 +197,7 @@ export function HomeClient({ manifestRuns }: Props) {
                 </Box>
               )}
 
-              {tabValue === 2 && (
+              {tabKey === 'archive' && (
                 // Snapshot Archive Tab
                 <Box>
                   <SnapshotConsole
@@ -182,7 +207,7 @@ export function HomeClient({ manifestRuns }: Props) {
                 </Box>
               )}
 
-              {tabValue === 3 && (
+              {tabKey === 'curated' && (
                 // Curated Tab
                 <Box>
                   <SnapshotConsole
@@ -192,7 +217,7 @@ export function HomeClient({ manifestRuns }: Props) {
                 </Box>
               )}
 
-              {tabValue === 4 && (
+              {tabKey === 'unrated' && (
                 // Unrated Queue Tab
                 <Box>
                   <SnapshotConsole
@@ -203,7 +228,7 @@ export function HomeClient({ manifestRuns }: Props) {
                 </Box>
               )}
 
-              {tabValue === 5 && (
+              {tabKey === 'all' && (
                 // All Webcams Tab
                 <Box>
                   <WebcamConsole
@@ -213,11 +238,27 @@ export function HomeClient({ manifestRuns }: Props) {
                 </Box>
               )}
 
-              {tabValue === 6 && (
+              {tabKey === 'models' && (
                 <Box sx={{ height: '100%' }}>
                   <ModelAnalysisTab runs={manifestRuns} />
                 </Box>
               )}
+            </Box>
+
+            {/* Auth affordance — pinned at the drawer bottom, always visible */}
+            <Box
+              sx={{
+                borderTop: 1,
+                borderColor: 'divider',
+                backgroundColor: '#374151', // gray-700
+                px: 2,
+                py: 1,
+                display: 'flex',
+                justifyContent: 'flex-end',
+                alignItems: 'center',
+              }}
+            >
+              <AuthControl />
             </Box>
           </Box>
         </Drawer>

--- a/app/api/auth/[...nextauth]/route.ts
+++ b/app/api/auth/[...nextauth]/route.ts
@@ -1,0 +1,3 @@
+import { handlers } from '@/auth';
+
+export const { GET, POST } = handlers;

--- a/app/api/snapshots/[id]/rate/route.test.ts
+++ b/app/api/snapshots/[id]/rate/route.test.ts
@@ -1,16 +1,25 @@
 // @vitest-environment node
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
+import { NextResponse } from 'next/server';
+
 const sqlMock = vi.fn();
+const requireOwnerMock = vi.fn();
 
 vi.mock('@/app/lib/db', () => ({
   sql: (...a: unknown[]) => sqlMock(...a),
+}));
+// Mock the owner guard so the test doesn't pull in real Auth.js/Google at import.
+vi.mock('@/app/lib/owner', () => ({
+  requireOwner: (...a: unknown[]) => requireOwnerMock(...a),
 }));
 
 import { POST } from './route';
 
 beforeEach(() => {
   sqlMock.mockReset();
+  requireOwnerMock.mockReset();
+  requireOwnerMock.mockResolvedValue(null); // default: authorized owner
 });
 
 function makeReq(body: Record<string, unknown>): Request {
@@ -104,5 +113,17 @@ describe('POST /api/snapshots/[id]/rate', () => {
   it('rejects missing userSessionId', async () => {
     const res = await POST(makeReq({ rating: 5 }), makeContext('1'));
     expect(res.status).toBe(400);
+  });
+
+  it('returns 401 when the caller is not the owner (gated, before any write)', async () => {
+    requireOwnerMock.mockResolvedValue(
+      NextResponse.json({ error: 'Not authenticated' }, { status: 401 }),
+    );
+    const res = await POST(
+      makeReq({ userSessionId: 's1', rating: 5 }),
+      makeContext('1'),
+    );
+    expect(res.status).toBe(401);
+    expect(sqlMock).not.toHaveBeenCalled();
   });
 });

--- a/app/api/snapshots/[id]/rate/route.ts
+++ b/app/api/snapshots/[id]/rate/route.ts
@@ -2,6 +2,7 @@
 
 import { NextResponse } from 'next/server';
 import { sql } from '@/app/lib/db';
+import { requireOwner } from '@/app/lib/owner';
 
 export const dynamic = 'force-dynamic';
 
@@ -19,6 +20,8 @@ export async function POST(
   request: Request,
   { params }: { params: Promise<{ id: string }> },
 ) {
+  const denied = await requireOwner();
+  if (denied) return denied;
   try {
     const { id } = await params;
     const snapshotId = parseInt(id, 10);
@@ -171,6 +174,8 @@ export async function DELETE(
   request: Request,
   { params }: { params: Promise<{ id: string }> },
 ) {
+  const denied = await requireOwner();
+  if (denied) return denied;
   try {
     const { id } = await params;
     const snapshotId = parseInt(id, 10);

--- a/app/api/snapshots/capture-and-rate/route.ts
+++ b/app/api/snapshots/capture-and-rate/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server';
 import { sql } from '@/app/lib/db';
 import { captureWebcamSnapshot } from '@/app/lib/webcamSnapshot';
 import { SNAPSHOTS_ENABLED_ON_RATING } from '@/app/lib/masterConfig';
+import { requireOwner } from '@/app/lib/owner';
 import type { WindyWebcam } from '@/app/lib/types';
 
 export const dynamic = 'force-dynamic';
@@ -166,6 +167,8 @@ async function upsertRating(
 }
 
 export async function POST(request: Request) {
+  const denied = await requireOwner();
+  if (denied) return denied;
   try {
     const body = (await request.json()) as CaptureAndRatePayload;
 

--- a/app/api/snapshots/capture/route.ts
+++ b/app/api/snapshots/capture/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server';
 import { sql } from '@/app/lib/db';
 import { captureWebcamSnapshot } from '@/app/lib/webcamSnapshot';
 import { SNAPSHOTS_ENABLED } from '@/app/lib/masterConfig';
+import { requireOwner } from '@/app/lib/owner';
 import type { WindyWebcam } from '@/app/lib/types';
 
 export const dynamic = 'force-dynamic';
@@ -26,6 +27,8 @@ interface CaptureResult {
 }
 
 export async function POST(request: Request) {
+  const denied = await requireOwner();
+  if (denied) return denied;
   try {
     const body = (await request.json()) as CaptureRequest;
     const { webcams } = body;

--- a/app/api/webcams/[id]/orientation/route.ts
+++ b/app/api/webcams/[id]/orientation/route.ts
@@ -3,6 +3,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { sql } from '@/app/lib/db';
 import type { Orientation } from '@/app/lib/types';
+import { requireOwner } from '@/app/lib/owner';
 
 const validOrientations: Orientation[] = [
   'N',
@@ -19,6 +20,8 @@ export async function PATCH(
   request: NextRequest,
   { params }: { params: Promise<{ id: string }> }
 ) {
+  const denied = await requireOwner();
+  if (denied) return denied;
   try {
     const { orientation } = await request.json();
     const { id } = await params;

--- a/app/api/webcams/[id]/rating/route.ts
+++ b/app/api/webcams/[id]/rating/route.ts
@@ -2,11 +2,14 @@
 
 import { NextRequest, NextResponse } from 'next/server';
 import { sql } from '@/app/lib/db';
+import { requireOwner } from '@/app/lib/owner';
 
 export async function PATCH(
   request: NextRequest,
   { params }: { params: Promise<{ id: string }> }
 ) {
+  const denied = await requireOwner();
+  if (denied) return denied;
   try {
     const { rating } = await request.json();
     const { id } = await params;

--- a/app/api/webcams/[id]/route.ts
+++ b/app/api/webcams/[id]/route.ts
@@ -5,6 +5,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { sql } from '@/app/lib/db';
 import type { Orientation } from '@/app/lib/types';
+import { requireOwner } from '@/app/lib/owner';
 
 const validOrientations: Orientation[] = [
   'N',
@@ -21,6 +22,8 @@ export async function PATCH(
   request: NextRequest,
   { params }: { params: Promise<{ id: string }> }
 ) {
+  const denied = await requireOwner();
+  if (denied) return denied;
   try {
     const body = await request.json();
     const { id } = await params;

--- a/app/components/Map/SimpleMap.tsx
+++ b/app/components/Map/SimpleMap.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import { useState, useEffect, useRef } from 'react';
-import {} from '@mui/icons-material';
 import { useMap } from './hooks/useMap';
 import { useSetWebcamMarkers } from './hooks/useSetWebcamMarkers';
 import { useUpdateTerminatorRing } from './hooks/useUpdateTerminatorRing';

--- a/app/components/auth/AuthControl.tsx
+++ b/app/components/auth/AuthControl.tsx
@@ -14,17 +14,25 @@ export function AuthControl() {
     return <CircularProgress size={16} sx={{ color: 'white' }} />;
   }
 
+  // Muted/secondary styling: subtle gray that still reads clearly against the
+  // gray-700 (#374151) drawer footer (gray-300 on gray-700 ≈ 5.9:1 contrast).
+  const subtleButton = {
+    color: '#d1d5db', // gray-300
+    textTransform: 'none' as const,
+    fontWeight: 400,
+    fontSize: '0.75rem',
+    minWidth: 'auto',
+    px: 1,
+    '&:hover': { color: '#f3f4f6', backgroundColor: 'rgba(255,255,255,0.06)' },
+  };
+
   if (status === 'authenticated') {
     return (
       <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
         <Typography variant="caption" sx={{ color: '#9ca3af' }}>
           {session.user?.email}
         </Typography>
-        <Button
-          size="small"
-          onClick={() => signOut()}
-          sx={{ color: '#60a5fa', textTransform: 'none' }}
-        >
+        <Button size="small" onClick={() => signOut()} sx={subtleButton}>
           Sign out
         </Button>
       </Box>
@@ -32,11 +40,7 @@ export function AuthControl() {
   }
 
   return (
-    <Button
-      size="small"
-      onClick={() => signIn('google')}
-      sx={{ color: '#60a5fa', textTransform: 'none' }}
-    >
+    <Button size="small" onClick={() => signIn('google')} sx={subtleButton}>
       Sign in
     </Button>
   );

--- a/app/components/auth/AuthControl.tsx
+++ b/app/components/auth/AuthControl.tsx
@@ -1,0 +1,43 @@
+'use client';
+
+import { signIn, signOut, useSession } from 'next-auth/react';
+import { Box, Button, Typography, CircularProgress } from '@mui/material';
+
+/**
+ * Sign-in / sign-out affordance. Shows "Sign in" to the public, the operator's
+ * email + "Sign out" when authenticated, and a small spinner while resolving.
+ */
+export function AuthControl() {
+  const { data: session, status } = useSession();
+
+  if (status === 'loading') {
+    return <CircularProgress size={16} sx={{ color: 'white' }} />;
+  }
+
+  if (status === 'authenticated') {
+    return (
+      <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+        <Typography variant="caption" sx={{ color: '#9ca3af' }}>
+          {session.user?.email}
+        </Typography>
+        <Button
+          size="small"
+          onClick={() => signOut()}
+          sx={{ color: '#60a5fa', textTransform: 'none' }}
+        >
+          Sign out
+        </Button>
+      </Box>
+    );
+  }
+
+  return (
+    <Button
+      size="small"
+      onClick={() => signIn('google')}
+      sx={{ color: '#60a5fa', textTransform: 'none' }}
+    >
+      Sign in
+    </Button>
+  );
+}

--- a/app/components/auth/SessionProviderWrapper.tsx
+++ b/app/components/auth/SessionProviderWrapper.tsx
@@ -1,0 +1,16 @@
+'use client';
+
+import { SessionProvider } from 'next-auth/react';
+
+/**
+ * Client wrapper so the server `app/layout.tsx` (which exports `metadata` and
+ * must stay a server component) can still provide the Auth.js session context
+ * to the client tree below it.
+ */
+export default function SessionProviderWrapper({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return <SessionProvider>{children}</SessionProvider>;
+}

--- a/app/components/auth/useIsOperator.ts
+++ b/app/components/auth/useIsOperator.ts
@@ -1,0 +1,23 @@
+'use client';
+
+import { useSession } from 'next-auth/react';
+
+/**
+ * Whether the current viewer is the operator (Jesse).
+ *
+ * A valid session is equivalent to "is the owner": the Auth.js `signIn`
+ * callback rejects every account except the OWNER_EMAILS allow-list, so any
+ * authenticated session can only belong to the owner. This is a UI convenience
+ * — the real authorization is the server-side `requireOwner` check on every
+ * mutating route (app/lib/owner.ts).
+ *
+ * `loading` is true while the session resolves; treat it as not-operator so we
+ * never flash operator controls before auth is known.
+ */
+export function useIsOperator(): { isOperator: boolean; loading: boolean } {
+  const { status } = useSession();
+  return {
+    isOperator: status === 'authenticated',
+    loading: status === 'loading',
+  };
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from 'next';
 import { Geist, Geist_Mono } from 'next/font/google';
 import './globals.css';
 import { Analytics } from '@vercel/analytics/next';
+import SessionProviderWrapper from './components/auth/SessionProviderWrapper';
 
 const geistSans = Geist({
   variable: '--font-geist-sans',
@@ -29,7 +30,7 @@ export default function RootLayout({
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
-        {children}
+        <SessionProviderWrapper>{children}</SessionProviderWrapper>
         <Analytics />
       </body>
     </html>

--- a/app/lib/owner.test.ts
+++ b/app/lib/owner.test.ts
@@ -1,0 +1,52 @@
+// @vitest-environment node
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// Replace the whole auth module so next-auth/Google never load in the test.
+vi.mock('@/auth', () => ({ auth: vi.fn() }));
+
+import { auth } from '@/auth';
+import { requireOwner, isOwner } from './owner';
+import type { Session } from 'next-auth';
+
+const mockAuth = vi.mocked(auth);
+const ORIG = process.env.OWNER_EMAILS;
+
+beforeEach(() => {
+  process.env.OWNER_EMAILS = 'owner@example.com';
+});
+afterEach(() => {
+  vi.clearAllMocks();
+  if (ORIG === undefined) delete process.env.OWNER_EMAILS;
+  else process.env.OWNER_EMAILS = ORIG;
+});
+
+const session = (email: string | null): Session =>
+  ({ user: { email }, expires: '' }) as Session;
+
+describe('requireOwner (route guard shared by every mutating route)', () => {
+  it('returns 401 when there is no session', async () => {
+    mockAuth.mockResolvedValue(null);
+    const res = await requireOwner();
+    expect(res?.status).toBe(401);
+  });
+
+  it('returns 403 when signed in but not the allow-listed owner', async () => {
+    mockAuth.mockResolvedValue(session('someone@else.com'));
+    const res = await requireOwner();
+    expect(res?.status).toBe(403);
+  });
+
+  it('allows (returns null) for the allow-listed owner, case-insensitively', async () => {
+    mockAuth.mockResolvedValue(session('Owner@Example.com'));
+    const res = await requireOwner();
+    expect(res).toBeNull();
+  });
+});
+
+describe('isOwner', () => {
+  it('is false for a null session and true for the allow-listed owner', () => {
+    expect(isOwner(null)).toBe(false);
+    expect(isOwner(session('owner@example.com'))).toBe(true);
+    expect(isOwner(session('nope@x.io'))).toBe(false);
+  });
+});

--- a/app/lib/owner.ts
+++ b/app/lib/owner.ts
@@ -1,0 +1,36 @@
+import 'server-only';
+import { NextResponse } from 'next/server';
+import type { Session } from 'next-auth';
+import { auth } from '@/auth';
+import { isAllowedOwnerEmail } from '@/app/lib/ownerEmails';
+
+/**
+ * The single authority for "who may write."
+ *
+ * `isOwner` is the pure session check; `requireOwner` is the route-handler guard
+ * — call it at the top of every mutating handler and return its result early
+ * when non-null. Hiding UI is cosmetic; this server-side check is the real gate.
+ *
+ * Flat by design: one operator role today. If trusted raters are added later,
+ * add a peer `requireRater` — do not grow this into a capability/role system.
+ */
+export function isOwner(session: Session | null): boolean {
+  return isAllowedOwnerEmail(session?.user?.email);
+}
+
+/**
+ * Returns a 401/403 NextResponse to return early, or null when the caller is the
+ * allow-listed owner. 401 = no session, 403 = signed in but not the owner. We do
+ * not 404-mask: the resources are public on the read side, so hiding existence
+ * buys nothing and only confuses clients.
+ */
+export async function requireOwner(): Promise<NextResponse | null> {
+  const session = await auth();
+  if (!session?.user) {
+    return NextResponse.json({ error: 'Not authenticated' }, { status: 401 });
+  }
+  if (!isOwner(session)) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+  return null;
+}

--- a/app/lib/ownerEmails.test.ts
+++ b/app/lib/ownerEmails.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { ownerEmails, isAllowedOwnerEmail } from './ownerEmails';
+
+const ORIG = process.env.OWNER_EMAILS;
+afterEach(() => {
+  if (ORIG === undefined) delete process.env.OWNER_EMAILS;
+  else process.env.OWNER_EMAILS = ORIG;
+});
+
+describe('owner allow-list', () => {
+  it('parses a comma-separated list, lowercasing and trimming whitespace', () => {
+    process.env.OWNER_EMAILS = ' Jesse@Example.com , second@x.io ';
+    expect(ownerEmails()).toEqual(['jesse@example.com', 'second@x.io']);
+  });
+
+  it('allows an allow-listed email case-insensitively (owner)', () => {
+    process.env.OWNER_EMAILS = 'jesse@example.com';
+    expect(isAllowedOwnerEmail('JESSE@Example.com')).toBe(true);
+  });
+
+  it('rejects a non-allow-listed email (signed in, not owner)', () => {
+    process.env.OWNER_EMAILS = 'jesse@example.com';
+    expect(isAllowedOwnerEmail('someone@else.com')).toBe(false);
+  });
+
+  it('rejects null/undefined/empty (no session, or session without an email)', () => {
+    process.env.OWNER_EMAILS = 'jesse@example.com';
+    expect(isAllowedOwnerEmail(null)).toBe(false);
+    expect(isAllowedOwnerEmail(undefined)).toBe(false);
+    expect(isAllowedOwnerEmail('')).toBe(false);
+  });
+
+  it('rejects everything when OWNER_EMAILS is unset', () => {
+    delete process.env.OWNER_EMAILS;
+    expect(ownerEmails()).toEqual([]);
+    expect(isAllowedOwnerEmail('jesse@example.com')).toBe(false);
+  });
+});

--- a/app/lib/ownerEmails.ts
+++ b/app/lib/ownerEmails.ts
@@ -1,0 +1,19 @@
+/**
+ * Owner allow-list parsing — the single source of truth for who counts as the
+ * operator. Pure (no `server-only`, no `next/server`) so it can be imported by
+ * both the Auth.js config (`auth.ts`, runs in middleware/edge too) and the
+ * server-side `requireOwner` guard.
+ *
+ * `OWNER_EMAILS` is a comma-separated list of allowed Google account emails.
+ */
+export function ownerEmails(): string[] {
+  return (process.env.OWNER_EMAILS ?? '')
+    .split(',')
+    .map((e) => e.trim().toLowerCase())
+    .filter(Boolean);
+}
+
+export function isAllowedOwnerEmail(email: string | null | undefined): boolean {
+  if (!email) return false;
+  return ownerEmails().includes(email.toLowerCase());
+}

--- a/auth.ts
+++ b/auth.ts
@@ -1,0 +1,28 @@
+import NextAuth from 'next-auth';
+import Google from 'next-auth/providers/google';
+import { isAllowedOwnerEmail } from '@/app/lib/ownerEmails';
+
+/**
+ * Auth.js v5 — single allow-listed Google account, JWT sessions (no DB adapter).
+ *
+ * Sign-in is rejected unless the Google profile has a verified email AND that
+ * email is in OWNER_EMAILS. This is the first of two defenses; every mutating
+ * route also re-checks via `requireOwner` (see app/lib/owner.ts), because UI/
+ * middleware gating is bypassable and the route handler is the real boundary.
+ *
+ * Env: AUTH_SECRET, AUTH_GOOGLE_ID, AUTH_GOOGLE_SECRET (auto-detected by the
+ * Google provider), OWNER_EMAILS. On Vercel, AUTH_TRUST_HOST/AUTH_URL are
+ * inferred and not needed.
+ */
+export const { handlers, auth, signIn, signOut } = NextAuth({
+  providers: [Google],
+  session: { strategy: 'jwt', maxAge: 60 * 60 * 8 }, // 8h — JWT can't be server-revoked, so keep it modest
+  callbacks: {
+    async signIn({ account, profile }) {
+      if (account?.provider !== 'google') return false;
+      const emailVerified =
+        (profile as { email_verified?: boolean } | undefined)?.email_verified === true;
+      return emailVerified && isAllowedOwnerEmail(profile?.email);
+    },
+  },
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "firebase-admin": "^13.5.0",
         "framer-motion": "^12.23.24",
         "mapbox-gl": "^3.14.0",
-        "next": "15.5.9",
+        "next": "^15.5.19",
         "onnxruntime-node": "^1.26.0",
         "react": "19.1.0",
         "react-dom": "19.1.0",
@@ -4139,9 +4139,9 @@
       }
     },
     "node_modules/@next/env": {
-      "version": "15.5.9",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-15.5.9.tgz",
-      "integrity": "sha512-4GlTZ+EJM7WaW2HEZcyU317tIQDjkQIyENDLxYJfSWlfqguN+dHkZgyQTV/7ykvobU7yEH5gKvreNrH4B6QgIg==",
+      "version": "15.5.19",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-15.5.19.tgz",
+      "integrity": "sha512-sWWluFvcv5v3Fxznmf2ZfjyoVQt/64oCnYqS90inQWGzMPK1VjvekPiz3OPHKmFT30EnHrjlbyaHLt3M0vWabw==",
       "license": "MIT"
     },
     "node_modules/@next/eslint-plugin-next": {
@@ -4155,9 +4155,9 @@
       }
     },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "15.5.7",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-15.5.7.tgz",
-      "integrity": "sha512-IZwtxCEpI91HVU/rAUOOobWSZv4P2DeTtNaCdHqLcTJU4wdNXgAySvKa/qJCgR5m6KI8UsKDXtO2B31jcaw1Yw==",
+      "version": "15.5.19",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-15.5.19.tgz",
+      "integrity": "sha512-jx9wWlTKueHKPvVOndyr7WuaevWCkuYqsQ8gC0TMPKAVWG3MhcdMrjfo9tvIZNXd0QOUYXXvAcZ325y8Uq7uzg==",
       "cpu": [
         "arm64"
       ],
@@ -4171,9 +4171,9 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "15.5.7",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-15.5.7.tgz",
-      "integrity": "sha512-UP6CaDBcqaCBuiq/gfCEJw7sPEoX1aIjZHnBWN9v9qYHQdMKvCKcAVs4OX1vIjeE+tC5EIuwDTVIoXpUes29lg==",
+      "version": "15.5.19",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-15.5.19.tgz",
+      "integrity": "sha512-291KFcsIQ3OenRdiUDFOR6W3wezzH4auENXm1gbm1Bjd4ANMMRgxPrWTUztQN43BnVoVuMnHCrLeECIMwgFKbA==",
       "cpu": [
         "x64"
       ],
@@ -4187,9 +4187,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "15.5.7",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-15.5.7.tgz",
-      "integrity": "sha512-NCslw3GrNIw7OgmRBxHtdWFQYhexoUCq+0oS2ccjyYLtcn1SzGzeM54jpTFonIMUjNbHmpKpziXnpxhSWLcmBA==",
+      "version": "15.5.19",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-15.5.19.tgz",
+      "integrity": "sha512-WeH+nelQyyMeE2f8FxBRZNrGipya5zHZV2vjzfCOAYyiI6am+NbnWAAldOBFQBB2w0DjJcsvrKqoFT2b7+5YoA==",
       "cpu": [
         "arm64"
       ],
@@ -4203,9 +4203,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "15.5.7",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-15.5.7.tgz",
-      "integrity": "sha512-nfymt+SE5cvtTrG9u1wdoxBr9bVB7mtKTcj0ltRn6gkP/2Nu1zM5ei8rwP9qKQP0Y//umK+TtkKgNtfboBxRrw==",
+      "version": "15.5.19",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-15.5.19.tgz",
+      "integrity": "sha512-5xTOE0lDlDCSSfp+BAif7j17VRRCjWp//ZPZy6NI0QpdrhxtQnsZguSx0xAAZ0c9XZLrLLwCe/XVe5YPrRilKw==",
       "cpu": [
         "arm64"
       ],
@@ -4219,9 +4219,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "15.5.7",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-15.5.7.tgz",
-      "integrity": "sha512-hvXcZvCaaEbCZcVzcY7E1uXN9xWZfFvkNHwbe/n4OkRhFWrs1J1QV+4U1BN06tXLdaS4DazEGXwgqnu/VMcmqw==",
+      "version": "15.5.19",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-15.5.19.tgz",
+      "integrity": "sha512-LTxRmMgqqMv05Had879W00Fm53quiJd3Zuz8h1JSNJ3nGSlbZ/7Tjs1tKyScgN3Au3t3MyPsjPlq60fMmSHLsg==",
       "cpu": [
         "x64"
       ],
@@ -4235,9 +4235,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "15.5.7",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-15.5.7.tgz",
-      "integrity": "sha512-4IUO539b8FmF0odY6/SqANJdgwn1xs1GkPO5doZugwZ3ETF6JUdckk7RGmsfSf7ws8Qb2YB5It33mvNL/0acqA==",
+      "version": "15.5.19",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-15.5.19.tgz",
+      "integrity": "sha512-eoNQSpA5PQfB9wBO4RA47MTDXWz1fizy9Y3Z6e4DetYIF3dvjuu8sj7aIGn/bFCU6lnFzTK34NtCaffP4NsQ7Q==",
       "cpu": [
         "x64"
       ],
@@ -4251,9 +4251,9 @@
       }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "15.5.7",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-15.5.7.tgz",
-      "integrity": "sha512-CpJVTkYI3ZajQkC5vajM7/ApKJUOlm6uP4BknM3XKvJ7VXAvCqSjSLmM0LKdYzn6nBJVSjdclx8nYJSa3xlTgQ==",
+      "version": "15.5.19",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-15.5.19.tgz",
+      "integrity": "sha512-6UNt2dFuCHOe446sm/Kp69nUe8/wIhnh9bm6Xcqw4qEWCOppLMOvhTBVgvM7invVUNr4SPpP6NOQsACtn2IN9Q==",
       "cpu": [
         "arm64"
       ],
@@ -4267,9 +4267,9 @@
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "15.5.7",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-15.5.7.tgz",
-      "integrity": "sha512-gMzgBX164I6DN+9/PGA+9dQiwmTkE4TloBNx8Kv9UiGARsr9Nba7IpcBRA1iTV9vwlYnrE3Uy6I7Aj6qLjQuqw==",
+      "version": "15.5.19",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-15.5.19.tgz",
+      "integrity": "sha512-PhmojAHyqMne56HBLGu9dhDnHPuFmEjrXSQMM/nW0J6j849lk3ESrVtqNJcCk8CKOV7brpTTbaYAjwKPzKM69w==",
       "cpu": [
         "x64"
       ],
@@ -12632,12 +12632,12 @@
       "license": "MIT"
     },
     "node_modules/next": {
-      "version": "15.5.9",
-      "resolved": "https://registry.npmjs.org/next/-/next-15.5.9.tgz",
-      "integrity": "sha512-agNLK89seZEtC5zUHwtut0+tNrc0Xw4FT/Dg+B/VLEo9pAcS9rtTKpek3V6kVcVwsB2YlqMaHdfZL4eLEVYuCg==",
+      "version": "15.5.19",
+      "resolved": "https://registry.npmjs.org/next/-/next-15.5.19.tgz",
+      "integrity": "sha512-xNOW6tYshGX1/Oi3F8uuk4gpDeWsSUE/1Z0G5uUMekIxaQ0xc03UXd9II0VQHYMWviMeA0OHpJFAKsHf8bTYVg==",
       "license": "MIT",
       "dependencies": {
-        "@next/env": "15.5.9",
+        "@next/env": "15.5.19",
         "@swc/helpers": "0.5.15",
         "caniuse-lite": "^1.0.30001579",
         "postcss": "8.4.31",
@@ -12650,14 +12650,14 @@
         "node": "^18.18.0 || ^19.8.0 || >= 20.0.0"
       },
       "optionalDependencies": {
-        "@next/swc-darwin-arm64": "15.5.7",
-        "@next/swc-darwin-x64": "15.5.7",
-        "@next/swc-linux-arm64-gnu": "15.5.7",
-        "@next/swc-linux-arm64-musl": "15.5.7",
-        "@next/swc-linux-x64-gnu": "15.5.7",
-        "@next/swc-linux-x64-musl": "15.5.7",
-        "@next/swc-win32-arm64-msvc": "15.5.7",
-        "@next/swc-win32-x64-msvc": "15.5.7",
+        "@next/swc-darwin-arm64": "15.5.19",
+        "@next/swc-darwin-x64": "15.5.19",
+        "@next/swc-linux-arm64-gnu": "15.5.19",
+        "@next/swc-linux-arm64-musl": "15.5.19",
+        "@next/swc-linux-x64-gnu": "15.5.19",
+        "@next/swc-linux-x64-musl": "15.5.19",
+        "@next/swc-win32-arm64-msvc": "15.5.19",
+        "@next/swc-win32-x64-msvc": "15.5.19",
         "sharp": "^0.34.3"
       },
       "peerDependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
         "framer-motion": "^12.23.24",
         "mapbox-gl": "^3.14.0",
         "next": "^15.5.19",
+        "next-auth": "^5.0.0-beta.31",
         "onnxruntime-node": "^1.26.0",
         "react": "19.1.0",
         "react-dom": "19.1.0",
@@ -153,6 +154,54 @@
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/@auth/core": {
+      "version": "0.41.2",
+      "resolved": "https://registry.npmjs.org/@auth/core/-/core-0.41.2.tgz",
+      "integrity": "sha512-Hx5MNBxN2fJTbJKGUKAA0wca43D0Akl3TvufY54Gn8lop7F+34vU1zA1pn0vQfIoVuLIrpfc2nkyjwIaPJMW7w==",
+      "license": "ISC",
+      "dependencies": {
+        "@panva/hkdf": "^1.2.1",
+        "jose": "^6.0.6",
+        "oauth4webapi": "^3.3.0",
+        "preact": "10.24.3",
+        "preact-render-to-string": "6.5.11"
+      },
+      "peerDependencies": {
+        "@simplewebauthn/browser": "^9.0.1",
+        "@simplewebauthn/server": "^9.0.2",
+        "nodemailer": "^7.0.7"
+      },
+      "peerDependenciesMeta": {
+        "@simplewebauthn/browser": {
+          "optional": true
+        },
+        "@simplewebauthn/server": {
+          "optional": true
+        },
+        "nodemailer": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@auth/core/node_modules/jose": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
+      "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/@auth/core/node_modules/preact": {
+      "version": "10.24.3",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.24.3.tgz",
+      "integrity": "sha512-Z2dPnBnMUfyQfSQ+GBdsGa16hz35YmLmtTLhM169uW944hYL6xzTYkJjC07j+Wosz733pMWx0fgON3JNw1jJQA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
+      }
     },
     "node_modules/@babel/code-frame": {
       "version": "7.27.1",
@@ -4357,6 +4406,15 @@
       "optional": true,
       "engines": {
         "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@panva/hkdf": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@panva/hkdf/-/hkdf-1.2.1.tgz",
+      "integrity": "sha512-6oclG6Y3PiDFcoyk8srjLfVKyMfVCKJ27JwNPViuXziFpmdz+MZnZN/aKY0JGXgYuO/VghU0jcOAZgWXZ1Dmrw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
       }
     },
     "node_modules/@parse5/tools": {
@@ -12683,6 +12741,33 @@
         }
       }
     },
+    "node_modules/next-auth": {
+      "version": "5.0.0-beta.31",
+      "resolved": "https://registry.npmjs.org/next-auth/-/next-auth-5.0.0-beta.31.tgz",
+      "integrity": "sha512-1OBgCKPzo+S7UWWMp3xgvGvIJ0OpV7B3vR4ZDRqD9a4Ch+OT6dakLXG9ivhtmIWVa71nTSXattOHyCg8sNi8/Q==",
+      "license": "ISC",
+      "dependencies": {
+        "@auth/core": "0.41.2"
+      },
+      "peerDependencies": {
+        "@simplewebauthn/browser": "^9.0.1",
+        "@simplewebauthn/server": "^9.0.2",
+        "next": "^14.0.0-0 || ^15.0.0 || ^16.0.0",
+        "nodemailer": "^7.0.7",
+        "react": "^18.2.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@simplewebauthn/browser": {
+          "optional": true
+        },
+        "@simplewebauthn/server": {
+          "optional": true
+        },
+        "nodemailer": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/next/node_modules/postcss": {
       "version": "8.4.31",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
@@ -12771,6 +12856,15 @@
       "integrity": "sha512-o6nIY3qwiSXl7/LuOU0Dmuctd34Yay0yeuZRLFmDPrrdHpXKFndPj3hM+YEPVHYC5fx2otBx4Ilc/gyYSAUaIA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/oauth4webapi": {
+      "version": "3.8.6",
+      "resolved": "https://registry.npmjs.org/oauth4webapi/-/oauth4webapi-3.8.6.tgz",
+      "integrity": "sha512-iwemM91xz8nryHti2yTmg5fhyEMVOkOXwHNqbvcATjyajb5oQxCQzrNOA6uElRHuMhQQTKUyFKV9y/CNyg25BQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
     },
     "node_modules/object-assign": {
       "version": "4.1.1",
@@ -13324,6 +13418,15 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/preact"
+      }
+    },
+    "node_modules/preact-render-to-string": {
+      "version": "6.5.11",
+      "resolved": "https://registry.npmjs.org/preact-render-to-string/-/preact-render-to-string-6.5.11.tgz",
+      "integrity": "sha512-ubnauqoGczeGISiOh6RjX0/cdaF8v/oDXIjO85XALCQjwQP+SB4RDXXtvZ6yTYSjG+PC1QRP2AhPgCEsM2EvUw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "preact": ">=10"
       }
     },
     "node_modules/prelude-ls": {

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "framer-motion": "^12.23.24",
     "mapbox-gl": "^3.14.0",
     "next": "^15.5.19",
+    "next-auth": "^5.0.0-beta.31",
     "onnxruntime-node": "^1.26.0",
     "react": "19.1.0",
     "react-dom": "19.1.0",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "firebase-admin": "^13.5.0",
     "framer-motion": "^12.23.24",
     "mapbox-gl": "^3.14.0",
-    "next": "15.5.9",
+    "next": "^15.5.19",
     "onnxruntime-node": "^1.26.0",
     "react": "19.1.0",
     "react-dom": "19.1.0",


### PR DESCRIPTION
The auth foundation for the public/private split. Plan: `docs/plans/2026-06-02-001-feat-public-private-split-plan.md` · Brainstorm: `docs/brainstorms/2026-06-02-public-private-split-requirements.md`. **Verified end-to-end locally** (Google sign-in completes, operator tabs gate correctly).

## What's in here
- **U1** — Next.js 15.5.9 → **15.5.19** (closes the CVE-2026-44575 middleware-bypass; middleware is treated as UX-only, the handler is the real gate).
- **U2/U3** — Auth.js v5 (Google, JWT sessions, no DB adapter). `signIn` rejects unless `email_verified` && email ∈ `OWNER_EMAILS`. Server-side `requireOwner` guard (`app/lib/owner.ts`), unit-tested.
- **U4** — **all 6 mutating routes gated** server-side before any DB work: snapshot rate (POST/DELETE), capture-and-rate, capture, webcam rating/orientation, and the generic `webcams/[id]` route. Anonymous rating writes are off. Reads + cron/device routes untouched.
- **U5** — `SessionProvider` (client wrapper; layout stays a server component), `useIsOperator` (authenticated session ⟺ owner), and a muted-gray sign-in/out control pinned at the drawer bottom.
- **U6** — drawer tabs re-keyed by stable id; **Hard Examples / Unrated Queue / All Webcams** are operator-only; falls back to a public tab on sign-out.
- Plus: fix a dead `@mui/icons-material` import that broke `next dev` (turbopack) after the bump.

## ⚠️ Deploy notes (this changes public behavior)
- Anonymous public rating turns **off**; the drawer slims for visitors. (Intended end-state per the brainstorm — "defer public rating".)
- Requires `AUTH_SECRET`, `AUTH_GOOGLE_ID`, `AUTH_GOOGLE_SECRET`, `OWNER_EMAILS` in Vercel + the prod redirect URI `https://www.sunrisesunset.studio/api/auth/callback/google` in the Google client.

## Deferred (next session, tracked in the plan)
- **Leaderboard (U7–U9)** — blocked on a real prerequisite: `webcam_snapshots.ai_rating` isn't broadly populated (only disagreement-flagged cron snapshots have it), so U7 (export the shared raw→rating mapping, score the custom-cam/capture paths, prod backfill) must come first.
- **Retention (U10/U11)** — mostly already on `main` (cleanup gated + excludes rated/disagreement); just the `ai_rating ≥ 4` class remains.
- Hiding inline rating/orientation controls in the *public* tabs (cosmetic — server already 401s every write).

🤖 Generated with [Claude Code](https://claude.com/claude-code)