### PR TITLE
feat: Best Sunsets leaderboard (Claude-ranked) + snapshot capture toggles + retention

### DIFF
--- a/app/HomeClient.tsx
+++ b/app/HomeClient.tsx
@@ -21,6 +21,7 @@ import type { ManifestEntry } from '@/app/lib/modelRuns.types';
 import { ModelAnalysisTab } from './components/ModelAnalysis/ModelAnalysisTab';
 import { AuthControl } from './components/auth/AuthControl';
 import { useIsOperator } from './components/auth/useIsOperator';
+import { LeaderboardTab } from './components/Leaderboard/LeaderboardTab';
 
 interface Props {
   manifestRuns: ManifestEntry[];
@@ -39,6 +40,7 @@ export function HomeClient({ manifestRuns }: Props) {
   // is presentation.
   const ALL_TABS = [
     { key: 'current', label: 'Current Sunrises/Sunsets', operatorOnly: false },
+    { key: 'best', label: '🌅 Best Sunsets', operatorOnly: false },
     { key: 'hard', label: '⚠ Hard Examples', operatorOnly: true },
     { key: 'archive', label: 'Snapshot Archive', operatorOnly: false },
     { key: 'curated', label: 'Curated', operatorOnly: false },
@@ -183,6 +185,13 @@ export function HomeClient({ manifestRuns }: Props) {
                       title={'Current Sunrises'}
                     />
                   </Box>
+                </Box>
+              )}
+
+              {tabKey === 'best' && (
+                // Best Sunsets leaderboard (public)
+                <Box>
+                  <LeaderboardTab />
                 </Box>
               )}
 

--- a/app/api/cron/update-cameras/lib/dbOperations.ts
+++ b/app/api/cron/update-cameras/lib/dbOperations.ts
@@ -315,7 +315,9 @@ export async function insertWindyDisagreementSnapshot(opts: {
   aiRegressionScore: number;
   aiModelVersionRegression: string;
   scoringPath: string;
-  disagreementKind: string;
+  // null when the frame is persisted for a non-disagreement reason
+  // (high-rated or all-rated capture toggles), not the Hard Examples queue.
+  disagreementKind: string | null;
 }): Promise<number> {
   const [row] = (await sql`
     insert into webcam_snapshots (

--- a/app/api/cron/update-cameras/route.test.ts
+++ b/app/api/cron/update-cameras/route.test.ts
@@ -80,6 +80,23 @@ vi.mock('@/app/components/Map/lib/terminatorRing', () => ({
   createTerminatorQueryRing: () => ({ sunriseCoords: [], sunsetCoords: [] }),
 }));
 
+// Mutable capture toggles — keep the real masterConfig values, override only
+// the two flags so each test can flip them (getters re-read per access).
+const toggles = vi.hoisted(() => ({ high: false, all: false }));
+vi.mock('@/app/lib/masterConfig', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('@/app/lib/masterConfig')>();
+  return {
+    ...actual,
+    get SAVE_HIGH_RATED_SNAPSHOTS() {
+      return toggles.high;
+    },
+    get SAVE_ALL_RATED_SNAPSHOTS() {
+      return toggles.all;
+    },
+  };
+});
+
 import { GET } from './route';
 
 beforeEach(() => {
@@ -113,6 +130,8 @@ beforeEach(() => {
     path: 'snapshots/0/test.jpg',
   });
   insertWindyDisagreementSnapshotMock.mockReset().mockReturnValue(999);
+  toggles.high = false;
+  toggles.all = false;
 });
 
 function makeReq(): Request {
@@ -286,5 +305,38 @@ describe('GET /api/cron/update-cameras', () => {
     await GET(makeReq());
     expect(uploadToFirebaseMock).not.toHaveBeenCalled();
     expect(insertWindyDisagreementSnapshotMock).not.toHaveBeenCalled();
+  });
+
+  it('persists a high-scoring frame when SAVE_HIGH_RATED_SNAPSHOTS is on (no disagreement)', async () => {
+    toggles.high = true;
+    scoreMock.mockResolvedValue({
+      rawScore: 0.95, aiRating: 4.8, modelVersion: 'v4',
+      imageHash: 'h', source: 'windy', pathTaken: 'onnx',
+    });
+    await GET(makeReq());
+    expect(insertWindyDisagreementSnapshotMock).toHaveBeenCalledTimes(1);
+    expect(insertWindyDisagreementSnapshotMock.mock.calls[0][0]).toMatchObject({
+      disagreementKind: null,
+      aiRating: 4.8,
+    });
+  });
+
+  it('does NOT persist a high-scoring frame when the toggle is off', async () => {
+    scoreMock.mockResolvedValue({
+      rawScore: 0.95, aiRating: 4.8, modelVersion: 'v4',
+      imageHash: 'h', source: 'windy', pathTaken: 'onnx',
+    });
+    await GET(makeReq());
+    expect(insertWindyDisagreementSnapshotMock).not.toHaveBeenCalled();
+  });
+
+  it('persists every scored frame when SAVE_ALL_RATED_SNAPSHOTS is on, even a low score', async () => {
+    toggles.all = true;
+    scoreMock.mockResolvedValue({
+      rawScore: 0.1, aiRating: 1.4, modelVersion: 'v4',
+      imageHash: 'h', source: 'windy', pathTaken: 'onnx',
+    });
+    await GET(makeReq());
+    expect(insertWindyDisagreementSnapshotMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/app/api/cron/update-cameras/route.ts
+++ b/app/api/cron/update-cameras/route.ts
@@ -22,6 +22,9 @@ import {
   WINDY_FETCH_BATCH_SIZE,
   WINDY_FETCH_DELAY_BETWEEN_BATCHES_MS,
   CUSTOM_CAM_FRESHNESS_WINDOW_MINUTES,
+  SAVE_HIGH_RATED_SNAPSHOTS,
+  SAVE_ALL_RATED_SNAPSHOTS,
+  AI_SNAPSHOT_MIN_RATING_THRESHOLD,
 } from '@/app/lib/masterConfig';
 import { classifyCustomCamerasForTick } from './lib/customClassification';
 import { verifyCronAuth } from './lib/auth';
@@ -210,15 +213,24 @@ export async function GET(req: Request) {
       ]);
 
       // Windy webcams don't normally create webcam_snapshots rows
-      // (SNAPSHOTS_ENABLED=false), so disagreement frames would otherwise
-      // be lost on the next tick. Persist them here so they show up in
-      // the Hard Examples drawer queue. Best-effort: a Firebase upload
-      // failure logs but doesn't fail the cron tick.
+      // (SNAPSHOTS_ENABLED=false). We persist a row here when ANY of:
+      //   - the two heads disagree (Hard Examples queue), OR
+      //   - SAVE_HIGH_RATED_SNAPSHOTS && this frame scored highly (best-of /
+      //     leaderboard archive), OR
+      //   - SAVE_ALL_RATED_SNAPSHOTS (bring in every scored frame).
+      // Persisted rows carry ai_rating, so they feed the Best Sunsets
+      // leaderboard. Best-effort: a Firebase upload failure logs but doesn't
+      // fail the cron tick.
       const disagreementKind = computeDisagreementKind({
         binaryIsSunset: scored.binaryIsSunset,
         aiRating: scored.aiRating,
       });
-      if (disagreementKind !== null) {
+      const isHighRated =
+        SAVE_HIGH_RATED_SNAPSHOTS &&
+        scored.aiRating >= AI_SNAPSHOT_MIN_RATING_THRESHOLD;
+      const shouldPersist =
+        disagreementKind !== null || isHighRated || SAVE_ALL_RATED_SNAPSHOTS;
+      if (shouldPersist) {
         try {
           const capturedAt = new Date();
           const upload = await uploadToFirebase(bytes, webcamId, capturedAt);

--- a/app/api/leaderboards/route.test.ts
+++ b/app/api/leaderboards/route.test.ts
@@ -1,0 +1,70 @@
+// @vitest-environment node
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const sqlQueryMock = vi.fn();
+vi.mock('@/app/lib/db', () => ({
+  sql: { query: (...a: unknown[]) => sqlQueryMock(...a) },
+}));
+
+import { GET } from './route';
+
+beforeEach(() => {
+  sqlQueryMock.mockReset().mockResolvedValue([]);
+});
+
+const req = (qs = '') => new Request(`http://test/api/leaderboards${qs}`);
+
+describe('GET /api/leaderboards', () => {
+  it('defaults to overall / all-time, ranks by ai_rating, excludes NULL', async () => {
+    const res = await GET(req());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.grouping).toBe('overall');
+    expect(body.window).toBe('all-time');
+    const [text, params] = sqlQueryMock.mock.calls[0];
+    expect(text).toMatch(/ORDER BY s\.ai_rating DESC/i);
+    expect(text).toMatch(/ai_rating IS NOT NULL/i);
+    expect(params).toEqual([50]);
+  });
+
+  it('never selects sensitive columns (allow-list is structural)', async () => {
+    await GET(req());
+    const [text] = sqlQueryMock.mock.calls[0];
+    expect(text).not.toMatch(/user_session_id/i);
+    expect(text).not.toMatch(/device_token_hash/i);
+    expect(text).not.toMatch(/select\s+\*\s+from\s+webcam_snapshots/i);
+  });
+
+  it('uses DISTINCT ON for per-webcam grouping (best frame per webcam)', async () => {
+    await GET(req('?grouping=webcam'));
+    const [text] = sqlQueryMock.mock.calls[0];
+    expect(text).toMatch(/DISTINCT ON \(s\.webcam_id\)/i);
+  });
+
+  it('groups per country with an Unknown bucket', async () => {
+    await GET(req('?grouping=country'));
+    const [text] = sqlQueryMock.mock.calls[0];
+    expect(text).toMatch(/DISTINCT ON \(w\.country\)/i);
+    expect(text).toMatch(/COALESCE\(w\.country, 'Unknown'\)/i);
+  });
+
+  it('applies the today window filter', async () => {
+    await GET(req('?window=today'));
+    const [text] = sqlQueryMock.mock.calls[0];
+    expect(text).toMatch(/date_trunc\('day', NOW\(\)\)/i);
+  });
+
+  it('ignores invalid grouping/window and clamps limit to 100', async () => {
+    const res = await GET(req('?grouping=bogus&window=bogus&limit=9999'));
+    const body = await res.json();
+    expect(body.grouping).toBe('overall');
+    expect(body.window).toBe('all-time');
+    const [, params] = sqlQueryMock.mock.calls[0];
+    expect(params).toEqual([100]);
+  });
+
+  it('sets a CDN cache header', async () => {
+    const res = await GET(req());
+    expect(res.headers.get('cache-control')).toMatch(/s-maxage=60/);
+  });
+});

--- a/app/api/leaderboards/route.test.ts
+++ b/app/api/leaderboards/route.test.ts
@@ -24,7 +24,7 @@ describe('GET /api/leaderboards', () => {
     const [text, params] = sqlQueryMock.mock.calls[0];
     expect(text).toMatch(/ORDER BY s\.ai_rating DESC/i);
     expect(text).toMatch(/ai_rating IS NOT NULL/i);
-    expect(params).toEqual([50]);
+    expect(params).toEqual([60]);
   });
 
   it('never selects sensitive columns (allow-list is structural)', async () => {
@@ -54,13 +54,13 @@ describe('GET /api/leaderboards', () => {
     expect(text).toMatch(/date_trunc\('day', NOW\(\)\)/i);
   });
 
-  it('ignores invalid grouping/window and clamps limit to 100', async () => {
+  it('ignores invalid grouping/window and clamps limit to 500', async () => {
     const res = await GET(req('?grouping=bogus&window=bogus&limit=9999'));
     const body = await res.json();
     expect(body.grouping).toBe('overall');
     expect(body.window).toBe('all-time');
     const [, params] = sqlQueryMock.mock.calls[0];
-    expect(params).toEqual([100]);
+    expect(params).toEqual([500]);
   });
 
   it('sets a CDN cache header', async () => {

--- a/app/api/leaderboards/route.test.ts
+++ b/app/api/leaderboards/route.test.ts
@@ -15,15 +15,16 @@ beforeEach(() => {
 const req = (qs = '') => new Request(`http://test/api/leaderboards${qs}`);
 
 describe('GET /api/leaderboards', () => {
-  it('defaults to overall / all-time, ranks by ai_rating, excludes NULL', async () => {
+  it('defaults to overall / all-time, ranks by llm_quality, filters to sunsets', async () => {
     const res = await GET(req());
     expect(res.status).toBe(200);
     const body = await res.json();
     expect(body.grouping).toBe('overall');
     expect(body.window).toBe('all-time');
     const [text, params] = sqlQueryMock.mock.calls[0];
-    expect(text).toMatch(/ORDER BY s\.ai_rating DESC/i);
-    expect(text).toMatch(/ai_rating IS NOT NULL/i);
+    expect(text).toMatch(/ORDER BY s\.llm_quality DESC/i);
+    expect(text).toMatch(/llm_quality IS NOT NULL/i);
+    expect(text).toMatch(/llm_is_sunset = true/i);
     expect(params).toEqual([60]);
   });
 

--- a/app/api/leaderboards/route.ts
+++ b/app/api/leaderboards/route.ts
@@ -1,0 +1,108 @@
+import { NextResponse } from 'next/server';
+import { sql } from '@/app/lib/db';
+
+export const dynamic = 'force-dynamic';
+
+// Public, read-only "Best Sunsets" leaderboard. Ranks webcam_snapshots by the
+// per-snapshot ai_rating the cron stamps (NOT the human calculated_rating).
+// No auth — it's a public surface; cached at the CDN.
+//
+// Coverage caveat (surfaced in the UI): ai_rating is only populated for frames
+// the cron persisted (disagreement queue + the SAVE_HIGH_RATED / SAVE_ALL_RATED
+// capture toggles), so the board is sparse until those toggles have run a while.
+
+type Grouping = 'overall' | 'webcam' | 'country';
+type Window = 'now' | 'today' | 'all-time';
+
+const GROUPINGS: Grouping[] = ['overall', 'webcam', 'country'];
+const WINDOWS: Window[] = ['now', 'today', 'all-time'];
+
+// Fixed, non-user-controlled SQL fragments — safe to inline (no user input).
+const WINDOW_SQL: Record<Window, string> = {
+  now: "AND s.captured_at >= NOW() - INTERVAL '120 minutes'",
+  today: "AND s.captured_at >= date_trunc('day', NOW())",
+  'all-time': '',
+};
+
+export interface LeaderboardEntry {
+  id: number;
+  aiRating: number;
+  firebaseUrl: string | null;
+  capturedAt: string;
+  webcamId: number;
+  webcamTitle: string | null;
+  country: string;
+}
+
+function pick<T>(value: string | null, allowed: readonly T[], fallback: T): T {
+  return (allowed as readonly unknown[]).includes(value) ? (value as T) : fallback;
+}
+
+export async function GET(request: Request) {
+  try {
+    const { searchParams } = new URL(request.url);
+    const grouping = pick(searchParams.get('grouping'), GROUPINGS, 'overall');
+    const window = pick(searchParams.get('window'), WINDOWS, 'all-time');
+    const limit = Math.min(
+      Math.max(parseInt(searchParams.get('limit') ?? '50', 10) || 50, 1),
+      100,
+    );
+
+    const windowSql = WINDOW_SQL[window];
+
+    // Explicit column allow-list — never expose user_session_id / device_token_hash.
+    const cols = `
+      s.id,
+      s.ai_rating AS "aiRating",
+      s.firebase_url AS "firebaseUrl",
+      s.captured_at AS "capturedAt",
+      s.webcam_id AS "webcamId",
+      w.title AS "webcamTitle",
+      COALESCE(w.country, 'Unknown') AS country
+    `;
+    const base = `
+      FROM webcam_snapshots s
+      JOIN webcams w ON w.id = s.webcam_id
+      WHERE s.ai_rating IS NOT NULL
+      ${windowSql}
+    `;
+
+    let queryText: string;
+    if (grouping === 'overall') {
+      // Top frames overall.
+      queryText = `SELECT ${cols} ${base} ORDER BY s.ai_rating DESC, s.captured_at DESC LIMIT $1`;
+    } else {
+      // Best single frame per webcam / per country, then ranked.
+      const distinctCol = grouping === 'webcam' ? 's.webcam_id' : 'w.country';
+      queryText = `
+        SELECT * FROM (
+          SELECT DISTINCT ON (${distinctCol}) ${cols}
+          ${base}
+          ORDER BY ${distinctCol}, s.ai_rating DESC, s.captured_at DESC
+        ) best
+        ORDER BY best."aiRating" DESC
+        LIMIT $1
+      `;
+    }
+
+    const rows = (await sql.query(queryText, [limit])) as LeaderboardEntry[];
+
+    return NextResponse.json(
+      { grouping, window, count: rows.length, entries: rows },
+      {
+        headers: {
+          'Cache-Control': 's-maxage=60, stale-while-revalidate=120',
+        },
+      },
+    );
+  } catch (error) {
+    console.error('Error in leaderboards route:', error);
+    return NextResponse.json(
+      {
+        error: 'Internal server error',
+        details: error instanceof Error ? error.message : 'Unknown error',
+      },
+      { status: 500 },
+    );
+  }
+}

--- a/app/api/leaderboards/route.ts
+++ b/app/api/leaderboards/route.ts
@@ -3,13 +3,12 @@ import { sql } from '@/app/lib/db';
 
 export const dynamic = 'force-dynamic';
 
-// Public, read-only "Best Sunsets" leaderboard. Ranks webcam_snapshots by the
-// per-snapshot ai_rating the cron stamps (NOT the human calculated_rating).
-// No auth — it's a public surface; cached at the CDN.
-//
-// Coverage caveat (surfaced in the UI): ai_rating is only populated for frames
-// the cron persisted (disagreement queue + the SAVE_HIGH_RATED / SAVE_ALL_RATED
-// capture toggles), so the board is sparse until those toggles have run a while.
+// Public, read-only "Best Sunsets" leaderboard. Ranks by the anthropic LLM
+// analysis (llm_quality from claude-sonnet-4-5), filtered to frames the LLM
+// judged to be a sunrise/sunset (llm_is_sunset = true). This is the meaningful
+// signal — the legacy ai_rating column has no model provenance. We also return
+// ai_rating so the UI can show the model-vs-LLM mismatch. No auth (public),
+// CDN-cached.
 
 type Grouping = 'overall' | 'webcam' | 'country';
 type Window = 'now' | 'today' | 'all-time';
@@ -26,7 +25,13 @@ const WINDOW_SQL: Record<Window, string> = {
 
 export interface LeaderboardEntry {
   id: number;
-  aiRating: number;
+  llmQuality: number | string;
+  llmIsSunset: boolean;
+  llmIsSunrise: boolean | null;
+  llmExplanation: string | null;
+  llmModel: string | null;
+  llmProvider: string | null;
+  aiRating: number | string | null; // legacy, shown for comparison
   firebaseUrl: string | null;
   capturedAt: string;
   webcamId: number;
@@ -53,6 +58,12 @@ export async function GET(request: Request) {
     // Explicit column allow-list — never expose user_session_id / device_token_hash.
     const cols = `
       s.id,
+      s.llm_quality AS "llmQuality",
+      s.llm_is_sunset AS "llmIsSunset",
+      s.llm_is_sunrise AS "llmIsSunrise",
+      s.llm_rating_explanation AS "llmExplanation",
+      s.llm_model AS "llmModel",
+      s.llm_provider AS "llmProvider",
       s.ai_rating AS "aiRating",
       s.firebase_url AS "firebaseUrl",
       s.captured_at AS "capturedAt",
@@ -60,17 +71,18 @@ export async function GET(request: Request) {
       w.title AS "webcamTitle",
       COALESCE(w.country, 'Unknown') AS country
     `;
+    // Rank by the anthropic analysis; only frames the LLM judged a sunrise/sunset.
     const base = `
       FROM webcam_snapshots s
       JOIN webcams w ON w.id = s.webcam_id
-      WHERE s.ai_rating IS NOT NULL
+      WHERE s.llm_quality IS NOT NULL AND s.llm_is_sunset = true
       ${windowSql}
     `;
 
     let queryText: string;
     if (grouping === 'overall') {
       // Top frames overall.
-      queryText = `SELECT ${cols} ${base} ORDER BY s.ai_rating DESC, s.captured_at DESC LIMIT $1`;
+      queryText = `SELECT ${cols} ${base} ORDER BY s.llm_quality DESC, s.captured_at DESC LIMIT $1`;
     } else {
       // Best single frame per webcam / per country, then ranked.
       const distinctCol = grouping === 'webcam' ? 's.webcam_id' : 'w.country';
@@ -78,9 +90,9 @@ export async function GET(request: Request) {
         SELECT * FROM (
           SELECT DISTINCT ON (${distinctCol}) ${cols}
           ${base}
-          ORDER BY ${distinctCol}, s.ai_rating DESC, s.captured_at DESC
+          ORDER BY ${distinctCol}, s.llm_quality DESC, s.captured_at DESC
         ) best
-        ORDER BY best."aiRating" DESC
+        ORDER BY best."llmQuality" DESC
         LIMIT $1
       `;
     }

--- a/app/api/leaderboards/route.ts
+++ b/app/api/leaderboards/route.ts
@@ -44,8 +44,8 @@ export async function GET(request: Request) {
     const grouping = pick(searchParams.get('grouping'), GROUPINGS, 'overall');
     const window = pick(searchParams.get('window'), WINDOWS, 'all-time');
     const limit = Math.min(
-      Math.max(parseInt(searchParams.get('limit') ?? '50', 10) || 50, 1),
-      100,
+      Math.max(parseInt(searchParams.get('limit') ?? '60', 10) || 60, 1),
+      500,
     );
 
     const windowSql = WINDOW_SQL[window];

--- a/app/api/snapshots/cleanup/route.test.ts
+++ b/app/api/snapshots/cleanup/route.test.ts
@@ -15,6 +15,7 @@ vi.mock('@/app/lib/masterConfig', () => ({
   get CLEANUP_ENABLED() {
     return cleanupEnabledMock.value;
   },
+  AI_SNAPSHOT_MIN_RATING_THRESHOLD: 4.0,
 }));
 
 import { GET } from './route';
@@ -68,5 +69,14 @@ describe('GET /api/snapshots/cleanup', () => {
     const q = strings.join('?');
     expect(q).toMatch(/webcam_snapshot_ratings/i);
     expect(q).toMatch(/rating\s+is\s+not\s+null\s+or\s+is_sunset_verdict\s+is\s+not\s+null/i);
+  });
+
+  it('excludes high-ai_rating snapshots (best-of frames the leaderboard ranks)', async () => {
+    cleanupEnabledMock.value = true;
+    sqlMock.mockResolvedValueOnce([]);
+    await GET(makeReq());
+    const [strings] = sqlMock.mock.calls[0];
+    const q = strings.join('?');
+    expect(q).toMatch(/ai_rating\s+is\s+null\s+or\s+ai_rating\s*</i);
   });
 });

--- a/app/api/snapshots/cleanup/route.ts
+++ b/app/api/snapshots/cleanup/route.ts
@@ -1,7 +1,10 @@
 import { NextResponse } from 'next/server';
 import { sql } from '@/app/lib/db';
 import { deleteFromFirebase } from '@/app/lib/webcamSnapshot';
-import { CLEANUP_ENABLED } from '@/app/lib/masterConfig';
+import {
+  CLEANUP_ENABLED,
+  AI_SNAPSHOT_MIN_RATING_THRESHOLD,
+} from '@/app/lib/masterConfig';
 
 export const dynamic = 'force-dynamic';
 export const maxDuration = 300; // 5 minutes
@@ -16,6 +19,8 @@ export const maxDuration = 300; // 5 minutes
 //      survive forever — they're training data
 //   3. Snapshots with model_disagreement_kind != NULL survive — they're on
 //      the Hard Examples queue waiting for a verdict
+//   4. Snapshots with a high ai_rating (>= AI_SNAPSHOT_MIN_RATING_THRESHOLD)
+//      survive — they're the best-of frames the leaderboard ranks
 //
 // Before adding this endpoint to vercel.json's crons or POSTing to it
 // manually, re-read the retention rules above. The archive contained
@@ -55,16 +60,19 @@ async function cleanup(request: Request) {
 
     console.log('Starting snapshot cleanup...');
 
-    // Three classes of snapshots are NEVER cleaned up:
-    //   1. Anything older than 7 days that has no human signal and no
-    //      model-disagreement signal — that's the only thing we drop.
-    //   2. Anything with model_disagreement_kind set (queued for triage).
-    //   3. Anything that any user ever rated or verdicted (training data).
+    // Four classes of snapshots are NEVER cleaned up — we only drop a frame
+    // older than 7 days that has none of these signals:
+    //   1. model_disagreement_kind set (queued for Hard Examples triage).
+    //   2. Any user ever rated or verdicted it (training data).
+    //   3. A high AI score (ai_rating >= AI_SNAPSHOT_MIN_RATING_THRESHOLD) —
+    //      the best-of frames the Best Sunsets leaderboard ranks. NULL ai_rating
+    //      counts as "not high" and is eligible for deletion.
     const oldSnapshots = await sql`
       SELECT id, firebase_path, captured_at
       FROM webcam_snapshots
       WHERE captured_at < NOW() - INTERVAL '7 days'
         AND model_disagreement_kind IS NULL
+        AND (ai_rating IS NULL OR ai_rating < ${AI_SNAPSHOT_MIN_RATING_THRESHOLD})
         AND id NOT IN (
           SELECT DISTINCT snapshot_id FROM webcam_snapshot_ratings
           WHERE rating IS NOT NULL OR is_sunset_verdict IS NOT NULL

--- a/app/components/Leaderboard/LeaderboardTab.tsx
+++ b/app/components/Leaderboard/LeaderboardTab.tsx
@@ -19,7 +19,13 @@ type Win = 'now' | 'today' | 'all-time';
 
 interface Entry {
   id: number;
-  aiRating: number | string;
+  llmQuality: number | string;
+  llmIsSunset: boolean;
+  llmIsSunrise: boolean | null;
+  llmExplanation: string | null;
+  llmModel: string | null;
+  llmProvider: string | null;
+  aiRating: number | string | null; // legacy, for comparison
   firebaseUrl: string | null;
   capturedAt: string;
   webcamId: number;
@@ -78,8 +84,10 @@ export function LeaderboardTab() {
         variant="caption"
         sx={{ color: '#9ca3af', display: 'block', mb: 1.5 }}
       >
-        Best sunrises &amp; sunsets, ranked by AI score. Shows AI-scored frames
-        only — sparse until snapshot capture has run a while.
+        Best sunrises &amp; sunsets, ranked by Claude&apos;s quality analysis
+        (claude-sonnet-4-5) — only frames Claude judged a real sunrise/sunset.
+        The small &ldquo;legacy ai&rdquo; value is the old model score, shown so
+        you can see where it disagrees.
       </Typography>
 
       <Box sx={{ display: 'flex', gap: 2, flexWrap: 'wrap', mb: 2 }}>
@@ -161,12 +169,30 @@ export function LeaderboardTab() {
                 </Box>
               )}
               <Box sx={{ p: 1 }}>
-                <Typography
-                  variant="body2"
-                  sx={{ color: 'white', fontWeight: 600 }}
+                <Box
+                  sx={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'space-between',
+                  }}
                 >
-                  #{i + 1} · ★ {Number(e.aiRating).toFixed(1)}
-                </Typography>
+                  <Typography
+                    variant="caption"
+                    sx={{
+                      color: '#fb923c',
+                      fontWeight: 700,
+                      letterSpacing: '0.08em',
+                    }}
+                  >
+                    #{i + 1} · {e.llmIsSunrise ? 'SUNRISE' : 'SUNSET'} ✓
+                  </Typography>
+                  <Typography
+                    variant="caption"
+                    sx={{ color: '#fbbf24', fontFamily: 'monospace' }}
+                  >
+                    {(Number(e.llmQuality) * 100).toFixed(0)}%
+                  </Typography>
+                </Box>
                 <Typography
                   variant="caption"
                   sx={{
@@ -175,12 +201,40 @@ export function LeaderboardTab() {
                     whiteSpace: 'nowrap',
                     overflow: 'hidden',
                     textOverflow: 'ellipsis',
+                    mt: 0.5,
                   }}
                 >
-                  {e.webcamTitle ?? `Webcam ${e.webcamId}`}
+                  {e.webcamTitle ?? `Webcam ${e.webcamId}`} · {e.country}
                 </Typography>
-                <Typography variant="caption" sx={{ color: '#6b7280' }}>
-                  {e.country}
+                {e.llmExplanation && (
+                  <Typography
+                    variant="caption"
+                    sx={{
+                      color: '#cbd5e1',
+                      mt: 0.5,
+                      fontSize: '10px',
+                      lineHeight: 1.3,
+                      display: '-webkit-box',
+                      WebkitLineClamp: 3,
+                      WebkitBoxOrient: 'vertical',
+                      overflow: 'hidden',
+                    }}
+                  >
+                    {e.llmExplanation}
+                  </Typography>
+                )}
+                <Typography
+                  variant="caption"
+                  sx={{
+                    color: '#6b7280',
+                    display: 'block',
+                    mt: 0.5,
+                    fontSize: '9px',
+                  }}
+                >
+                  {e.llmProvider ?? 'anthropic'} · {e.llmModel ?? 'claude'} ·
+                  legacy ai{' '}
+                  {e.aiRating != null ? Number(e.aiRating).toFixed(1) : '—'}
                 </Typography>
               </Box>
             </Box>

--- a/app/components/Leaderboard/LeaderboardTab.tsx
+++ b/app/components/Leaderboard/LeaderboardTab.tsx
@@ -1,0 +1,180 @@
+'use client';
+
+import { useState } from 'react';
+import useSWR from 'swr';
+import {
+  Box,
+  Typography,
+  ToggleButton,
+  ToggleButtonGroup,
+  CircularProgress,
+} from '@mui/material';
+
+type Grouping = 'overall' | 'webcam' | 'country';
+type Win = 'now' | 'today' | 'all-time';
+
+interface Entry {
+  id: number;
+  aiRating: number | string;
+  firebaseUrl: string | null;
+  capturedAt: string;
+  webcamId: number;
+  webcamTitle: string | null;
+  country: string;
+}
+
+const fetcher = (url: string) =>
+  fetch(url).then((r) => (r.ok ? r.json() : { entries: [] }));
+
+const GROUPS: { v: Grouping; label: string }[] = [
+  { v: 'overall', label: 'Overall' },
+  { v: 'webcam', label: 'Per webcam' },
+  { v: 'country', label: 'Per country' },
+];
+const WINS: { v: Win; label: string }[] = [
+  { v: 'now', label: 'Now' },
+  { v: 'today', label: 'Today' },
+  { v: 'all-time', label: 'All-time' },
+];
+
+const toggleSx = {
+  '& .MuiToggleButton-root': {
+    color: '#d1d5db',
+    borderColor: '#374151',
+    textTransform: 'none',
+    py: 0.4,
+    '&.Mui-selected': {
+      color: '#60a5fa',
+      backgroundColor: 'rgba(96,165,250,0.12)',
+    },
+  },
+};
+
+export function LeaderboardTab() {
+  const [grouping, setGrouping] = useState<Grouping>('overall');
+  const [win, setWin] = useState<Win>('all-time');
+
+  const { data, isLoading } = useSWR(
+    `/api/leaderboards?grouping=${grouping}&window=${win}`,
+    fetcher,
+    { revalidateOnFocus: false },
+  );
+  const entries: Entry[] = data?.entries ?? [];
+
+  return (
+    <Box>
+      <Typography
+        variant="caption"
+        sx={{ color: '#9ca3af', display: 'block', mb: 1.5 }}
+      >
+        Best sunrises &amp; sunsets, ranked by AI score. Shows AI-scored frames
+        only — sparse until snapshot capture has run a while.
+      </Typography>
+
+      <Box sx={{ display: 'flex', gap: 2, flexWrap: 'wrap', mb: 2 }}>
+        <ToggleButtonGroup
+          size="small"
+          exclusive
+          value={grouping}
+          onChange={(_, v) => v && setGrouping(v)}
+          sx={toggleSx}
+        >
+          {GROUPS.map((g) => (
+            <ToggleButton key={g.v} value={g.v}>
+              {g.label}
+            </ToggleButton>
+          ))}
+        </ToggleButtonGroup>
+        <ToggleButtonGroup
+          size="small"
+          exclusive
+          value={win}
+          onChange={(_, v) => v && setWin(v)}
+          sx={toggleSx}
+        >
+          {WINS.map((w) => (
+            <ToggleButton key={w.v} value={w.v}>
+              {w.label}
+            </ToggleButton>
+          ))}
+        </ToggleButtonGroup>
+      </Box>
+
+      {isLoading ? (
+        <CircularProgress size={20} sx={{ color: 'white' }} />
+      ) : entries.length === 0 ? (
+        <Typography sx={{ color: '#9ca3af' }}>
+          No sunsets scored yet for this window — try All-time.
+        </Typography>
+      ) : (
+        <Box
+          sx={{
+            display: 'grid',
+            gridTemplateColumns: 'repeat(auto-fill, minmax(180px, 1fr))',
+            gap: 2,
+          }}
+        >
+          {entries.map((e, i) => (
+            <Box
+              key={e.id}
+              sx={{
+                backgroundColor: '#111827',
+                borderRadius: 2,
+                overflow: 'hidden',
+              }}
+            >
+              {e.firebaseUrl ? (
+                <Box
+                  component="img"
+                  src={e.firebaseUrl}
+                  alt={e.webcamTitle ?? 'snapshot'}
+                  sx={{
+                    width: '100%',
+                    height: 120,
+                    objectFit: 'cover',
+                    display: 'block',
+                  }}
+                />
+              ) : (
+                <Box
+                  sx={{
+                    height: 120,
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    color: '#6b7280',
+                  }}
+                >
+                  no image
+                </Box>
+              )}
+              <Box sx={{ p: 1 }}>
+                <Typography
+                  variant="body2"
+                  sx={{ color: 'white', fontWeight: 600 }}
+                >
+                  #{i + 1} · ★ {Number(e.aiRating).toFixed(1)}
+                </Typography>
+                <Typography
+                  variant="caption"
+                  sx={{
+                    color: '#9ca3af',
+                    display: 'block',
+                    whiteSpace: 'nowrap',
+                    overflow: 'hidden',
+                    textOverflow: 'ellipsis',
+                  }}
+                >
+                  {e.webcamTitle ?? `Webcam ${e.webcamId}`}
+                </Typography>
+                <Typography variant="caption" sx={{ color: '#6b7280' }}>
+                  {e.country}
+                </Typography>
+              </Box>
+            </Box>
+          ))}
+        </Box>
+      )}
+    </Box>
+  );
+}

--- a/app/components/Leaderboard/LeaderboardTab.tsx
+++ b/app/components/Leaderboard/LeaderboardTab.tsx
@@ -10,6 +10,8 @@ import {
   ToggleButtonGroup,
   CircularProgress,
 } from '@mui/material';
+import RatingCard from '@/app/components/Webcam/RatingCard';
+import type { WindyWebcam } from '@/app/lib/types';
 
 const PAGE = 60;
 const MAX = 500;
@@ -60,12 +62,39 @@ const toggleSx = {
   },
 };
 
+const noop = async () => {};
+
+/**
+ * Map a leaderboard snapshot onto the WindyWebcam shape RatingCard renders,
+ * feeding Claude's analysis into the AI-display fields so the popup's verdict
+ * block shows Claude's call: llm_quality -> a 1-5 rating, llm_is_sunset -> the
+ * "Sunset/Sunrise detected" verdict. A distinct binary "model version" makes
+ * AiRatingDisplay treat it as a real binary signal (not the legacy proxy).
+ */
+function entryToWebcam(e: Entry): WindyWebcam {
+  const quality = Number(e.llmQuality);
+  const model = e.llmModel ?? 'claude';
+  return {
+    webcamId: e.webcamId,
+    title: e.webcamTitle ?? `Webcam ${e.webcamId}`,
+    viewCount: 0,
+    status: 'active',
+    images: { current: { preview: e.firebaseUrl ?? '' } },
+    location: { country: e.country, longitude: 0, latitude: 0 },
+    categories: [],
+    phase: e.llmIsSunrise ? 'sunrise' : 'sunset',
+    aiRatingRegression: Number((1 + quality * 4).toFixed(2)),
+    aiModelVersionRegression: model,
+    aiRatingBinary: e.llmIsSunset ? 5 : 0,
+    aiModelVersionBinary: `${model}·is_sunset`,
+  } as unknown as WindyWebcam;
+}
+
 export function LeaderboardTab() {
   const [grouping, setGrouping] = useState<Grouping>('overall');
   const [win, setWin] = useState<Win>('all-time');
   const [count, setCount] = useState(PAGE);
 
-  // Reset paging when the view changes.
   useEffect(() => {
     setCount(PAGE);
   }, [grouping, win]);
@@ -86,8 +115,6 @@ export function LeaderboardTab() {
       >
         Best sunrises &amp; sunsets, ranked by Claude&apos;s quality analysis
         (claude-sonnet-4-5) — only frames Claude judged a real sunrise/sunset.
-        The small &ldquo;legacy ai&rdquo; value is the old model score, shown so
-        you can see where it disagrees.
       </Typography>
 
       <Box sx={{ display: 'flex', gap: 2, flexWrap: 'wrap', mb: 2 }}>
@@ -127,129 +154,56 @@ export function LeaderboardTab() {
         </Typography>
       ) : (
         <>
-        <Box
-          sx={{
-            display: 'grid',
-            gridTemplateColumns: 'repeat(auto-fill, minmax(180px, 1fr))',
-            gap: 2,
-          }}
-        >
-          {entries.map((e, i) => (
-            <Box
-              key={e.id}
-              sx={{
-                backgroundColor: '#111827',
-                borderRadius: 2,
-                overflow: 'hidden',
-              }}
-            >
-              {e.firebaseUrl ? (
-                <Box
-                  component="img"
-                  src={e.firebaseUrl}
-                  alt={e.webcamTitle ?? 'snapshot'}
-                  sx={{
-                    width: '100%',
-                    height: 120,
-                    objectFit: 'cover',
-                    display: 'block',
-                  }}
-                />
-              ) : (
+          <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 2 }}>
+            {entries.map((e, i) => (
+              <Box key={e.id} sx={{ position: 'relative', width: 256 }}>
                 <Box
                   sx={{
-                    height: 120,
-                    display: 'flex',
-                    alignItems: 'center',
-                    justifyContent: 'center',
-                    color: '#6b7280',
+                    position: 'absolute',
+                    top: 18,
+                    left: 18,
+                    zIndex: 2,
+                    backgroundColor: 'rgba(0,0,0,0.72)',
+                    color: 'white',
+                    px: 1,
+                    py: 0.25,
+                    borderRadius: 1,
+                    fontSize: 12,
+                    fontWeight: 700,
+                    fontFamily: 'monospace',
                   }}
                 >
-                  no image
+                  #{i + 1} · {(Number(e.llmQuality) * 100).toFixed(0)}%
                 </Box>
-              )}
-              <Box sx={{ p: 1 }}>
-                <Box
-                  sx={{
-                    display: 'flex',
-                    alignItems: 'center',
-                    justifyContent: 'space-between',
-                  }}
-                >
-                  <Typography
-                    variant="caption"
-                    sx={{
-                      color: '#fb923c',
-                      fontWeight: 700,
-                      letterSpacing: '0.08em',
-                    }}
-                  >
-                    #{i + 1} · {e.llmIsSunrise ? 'SUNRISE' : 'SUNSET'} ✓
-                  </Typography>
-                  <Typography
-                    variant="caption"
-                    sx={{ color: '#fbbf24', fontFamily: 'monospace' }}
-                  >
-                    {(Number(e.llmQuality) * 100).toFixed(0)}%
-                  </Typography>
-                </Box>
-                <Typography
-                  variant="caption"
-                  sx={{
-                    color: '#9ca3af',
-                    display: 'block',
-                    whiteSpace: 'nowrap',
-                    overflow: 'hidden',
-                    textOverflow: 'ellipsis',
-                    mt: 0.5,
-                  }}
-                >
-                  {e.webcamTitle ?? `Webcam ${e.webcamId}`} · {e.country}
-                </Typography>
+                <RatingCard webcam={entryToWebcam(e)} readOnly onRate={noop} />
                 {e.llmExplanation && (
                   <Typography
                     variant="caption"
                     sx={{
-                      color: '#cbd5e1',
+                      color: '#9ca3af',
+                      display: 'block',
                       mt: 0.5,
+                      width: 256,
                       fontSize: '10px',
-                      lineHeight: 1.3,
-                      display: '-webkit-box',
-                      WebkitLineClamp: 3,
-                      WebkitBoxOrient: 'vertical',
-                      overflow: 'hidden',
+                      lineHeight: 1.35,
                     }}
                   >
                     {e.llmExplanation}
                   </Typography>
                 )}
-                <Typography
-                  variant="caption"
-                  sx={{
-                    color: '#6b7280',
-                    display: 'block',
-                    mt: 0.5,
-                    fontSize: '9px',
-                  }}
-                >
-                  {e.llmProvider ?? 'anthropic'} · {e.llmModel ?? 'claude'} ·
-                  legacy ai{' '}
-                  {e.aiRating != null ? Number(e.aiRating).toFixed(1) : '—'}
-                </Typography>
               </Box>
-            </Box>
-          ))}
-        </Box>
-        {maybeMore && (
-          <Box sx={{ display: 'flex', justifyContent: 'center', mt: 2 }}>
-            <Button
-              onClick={() => setCount((c) => Math.min(c + PAGE, MAX))}
-              sx={{ color: '#60a5fa', textTransform: 'none' }}
-            >
-              Load more
-            </Button>
+            ))}
           </Box>
-        )}
+          {maybeMore && (
+            <Box sx={{ display: 'flex', justifyContent: 'center', mt: 2 }}>
+              <Button
+                onClick={() => setCount((c) => Math.min(c + PAGE, MAX))}
+                sx={{ color: '#60a5fa', textTransform: 'none' }}
+              >
+                Load more
+              </Button>
+            </Box>
+          )}
         </>
       )}
     </Box>

--- a/app/components/Leaderboard/LeaderboardTab.tsx
+++ b/app/components/Leaderboard/LeaderboardTab.tsx
@@ -1,14 +1,18 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import useSWR from 'swr';
 import {
   Box,
+  Button,
   Typography,
   ToggleButton,
   ToggleButtonGroup,
   CircularProgress,
 } from '@mui/material';
+
+const PAGE = 60;
+const MAX = 500;
 
 type Grouping = 'overall' | 'webcam' | 'country';
 type Win = 'now' | 'today' | 'all-time';
@@ -53,13 +57,20 @@ const toggleSx = {
 export function LeaderboardTab() {
   const [grouping, setGrouping] = useState<Grouping>('overall');
   const [win, setWin] = useState<Win>('all-time');
+  const [count, setCount] = useState(PAGE);
+
+  // Reset paging when the view changes.
+  useEffect(() => {
+    setCount(PAGE);
+  }, [grouping, win]);
 
   const { data, isLoading } = useSWR(
-    `/api/leaderboards?grouping=${grouping}&window=${win}`,
+    `/api/leaderboards?grouping=${grouping}&window=${win}&limit=${count}`,
     fetcher,
-    { revalidateOnFocus: false },
+    { revalidateOnFocus: false, keepPreviousData: true },
   );
   const entries: Entry[] = data?.entries ?? [];
+  const maybeMore = entries.length >= count && count < MAX;
 
   return (
     <Box>
@@ -107,6 +118,7 @@ export function LeaderboardTab() {
           No sunsets scored yet for this window — try All-time.
         </Typography>
       ) : (
+        <>
         <Box
           sx={{
             display: 'grid',
@@ -174,6 +186,17 @@ export function LeaderboardTab() {
             </Box>
           ))}
         </Box>
+        {maybeMore && (
+          <Box sx={{ display: 'flex', justifyContent: 'center', mt: 2 }}>
+            <Button
+              onClick={() => setCount((c) => Math.min(c + PAGE, MAX))}
+              sx={{ color: '#60a5fa', textTransform: 'none' }}
+            >
+              Load more
+            </Button>
+          </Box>
+        )}
+        </>
       )}
     </Box>
   );

--- a/app/lib/masterConfig.ts
+++ b/app/lib/masterConfig.ts
@@ -90,7 +90,7 @@ export const AI_SNAPSHOT_RECENT_WINDOW_MINUTES = 30;
 //                               (cheap: only the good ones; feeds "best sunsets").
 //   SAVE_ALL_RATED_SNAPSHOTS  — persist EVERY scored frame (expensive: every tick,
 //                               every active webcam — the "bring in everything" switch).
-export const SAVE_HIGH_RATED_SNAPSHOTS = false;
+export const SAVE_HIGH_RATED_SNAPSHOTS = true;
 export const SAVE_ALL_RATED_SNAPSHOTS = false;
 
 // ---------------------------------------------------------------------------

--- a/app/lib/masterConfig.ts
+++ b/app/lib/masterConfig.ts
@@ -78,6 +78,22 @@ export const AI_SNAPSHOT_MIN_RATING_THRESHOLD = 4.0;
 export const AI_SNAPSHOT_RECENT_WINDOW_MINUTES = 30;
 
 // ---------------------------------------------------------------------------
+// Windy snapshot capture beyond the disagreement queue
+// ---------------------------------------------------------------------------
+// The cron normally only persists a webcam_snapshots row for Windy frames when
+// the two model heads disagree (Hard Examples queue). These toggles widen that
+// so the best-of archive + the Best Sunsets leaderboard get real data. Both
+// default OFF — each adds a Firebase upload + Neon insert per matching frame
+// (cost), so opt in deliberately (cf. the reduce-db-cost work).
+//
+//   SAVE_HIGH_RATED_SNAPSHOTS — persist frames scoring >= AI_SNAPSHOT_MIN_RATING_THRESHOLD
+//                               (cheap: only the good ones; feeds "best sunsets").
+//   SAVE_ALL_RATED_SNAPSHOTS  — persist EVERY scored frame (expensive: every tick,
+//                               every active webcam — the "bring in everything" switch).
+export const SAVE_HIGH_RATED_SNAPSHOTS = false;
+export const SAVE_ALL_RATED_SNAPSHOTS = false;
+
+// ---------------------------------------------------------------------------
 // Hard-example mining — model-disagreement thresholds
 // ---------------------------------------------------------------------------
 // When the binary classifier and regression head point in opposite directions,


### PR DESCRIPTION
Builds the public **Best Sunsets** leaderboard, widens snapshot capture so the archive grows, and keeps the best-of frames. Branched off the merged auth + db-cost work.

## Leaderboard
- **Ranks by the anthropic LLM analysis** (`claude-sonnet-4-5`: `llm_quality`, filtered to `llm_is_sunset = true`) — **not** the legacy `ai_rating`, which turned out to have no model provenance (0 of 28.5k had a regression score/version) and surfaced non-sunsets.
- Public `/api/leaderboards` route: grouping (overall / per-webcam / per-country, NULL→Unknown), window (now / today / all-time), pagination, structural column allow-list, CDN cache. No auth.
- Drawer tab **🌅 Best Sunsets** (public) reuses the map-popup `RatingCard` fed with Claude's analysis — verdict + quality + explanation + the legacy `ai_rating` for comparison. Load-more paging.

## Snapshot capture + retention
- `masterConfig` toggles `SAVE_HIGH_RATED_SNAPSHOTS` (**on** — persist live frames scoring ≥4.0) and `SAVE_ALL_RATED_SNAPSHOTS` (off — the expensive "everything" switch). Cron persists the union (disagreement OR high-rated OR all-rated); persisted rows carry `ai_rating`.
- Cleanup keeps high-`ai_rating` frames (4th retention class) so the best-of archive survives.

## Also
- Enables the binary head locally (`AI_BINARY_SCORING_ENABLED`) — **needs setting in Vercel** for hard-example disagreement detection in prod (see the follow-up brainstorm).

## Not included (deliberately)
- Hard Examples seeding — held; the v5 training signal is a deliberate ML decision (separate brainstorm). `ai_rating` is junk so "Claude-vs-model" isn't a real signal; the actual model never scored the archive.

Tests: leaderboard (7), capture toggles (3), retention (1); full suite green apart from 2 pre-existing map/terminator failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)