### PR TITLE
fix: remove metadata-heuristic scoring fallback (honest 'unscored')

### DIFF
--- a/app/api/cron/update-cameras/lib/aiScoring.test.ts
+++ b/app/api/cron/update-cameras/lib/aiScoring.test.ts
@@ -33,7 +33,6 @@ describe('scoreImage', () => {
     preprocessMock.mockReset().mockResolvedValue(new Float32Array(3 * 224 * 224));
     sha256Mock.mockReset().mockReturnValue('hash-abc');
     runMock.mockReset().mockResolvedValue({ output: { data: [0.64] } });
-    process.env.AI_SCORING_MODE = 'onnx';
     process.env.AI_REGRESSION_MODEL_VERSION = 'test-v4';
     __resetScoreImageCacheForTests();
   });
@@ -102,19 +101,30 @@ describe('scoreImage', () => {
     expect(result.aiRating).toBe(3);
   });
 
-  it('falls back to baseline when ONNX inference throws', async () => {
+  it('returns "unscored" with null scores when ONNX inference throws', async () => {
     runMock.mockRejectedValueOnce(new Error('boom'));
     const result = await scoreImage({
       webcamId: 1,
       imageBytes: Buffer.from('jpeg'),
       source: 'windy',
-      fallbackMeta: { viewCount: 1000, manualRating: 4 },
     });
-    expect(result.pathTaken).toBe('baseline-fallback');
-    expect(result.rawScore).toBeGreaterThanOrEqual(0);
-    expect(result.rawScore).toBeLessThanOrEqual(1);
-    expect(result.aiRating).toBeGreaterThanOrEqual(1);
-    expect(result.aiRating).toBeLessThanOrEqual(5);
+    expect(result.pathTaken).toBe('unscored');
+    expect(result.rawScore).toBeNull();
+    expect(result.aiRating).toBeNull();
+    expect(result.modelVersion).toBe('test-v4');
+    expect(result.imageHash).toBe('hash-abc');
+  });
+
+  it('returns "unscored" when ONNX setup (preprocess) throws', async () => {
+    preprocessMock.mockRejectedValueOnce(new Error('no model'));
+    const result = await scoreImage({
+      webcamId: 1,
+      imageBytes: Buffer.from('jpeg'),
+      source: 'windy',
+    });
+    expect(result.pathTaken).toBe('unscored');
+    expect(result.rawScore).toBeNull();
+    expect(result.aiRating).toBeNull();
   });
 
   it('preserves the source field on the return value', async () => {
@@ -124,23 +134,6 @@ describe('scoreImage', () => {
       source: 'custom',
     });
     expect(result.source).toBe('custom');
-  });
-
-  it('returns pathTaken=baseline when AI_SCORING_MODE is not onnx', async () => {
-    process.env.AI_SCORING_MODE = 'baseline';
-    const result = await scoreImage({
-      webcamId: 1,
-      imageBytes: Buffer.from('jpeg'),
-      source: 'windy',
-      fallbackMeta: { viewCount: 1000, manualRating: 4 },
-    });
-    expect(result.pathTaken).toBe('baseline');
-    expect(result.rawScore).toBeGreaterThanOrEqual(0);
-    expect(result.rawScore).toBeLessThanOrEqual(1);
-    expect(result.aiRating).toBeGreaterThanOrEqual(1);
-    expect(result.aiRating).toBeLessThanOrEqual(5);
-    expect(preprocessMock).not.toHaveBeenCalled();
-    expect(runMock).not.toHaveBeenCalled();
   });
 
   describe('binary classifier (opt-in via AI_BINARY_SCORING_ENABLED)', () => {
@@ -236,8 +229,9 @@ describe('scoreImage', () => {
       });
       expect(result.pathTaken).toBe('onnx');
       expect(result.aiRating).toBeCloseTo(3.56, 2);
-      expect(result.binaryPathTaken).toBe('baseline-fallback');
-      expect(result.binaryIsSunset).toBe(false);
+      expect(result.binaryPathTaken).toBeUndefined();
+      expect(result.binaryRawScore).toBeUndefined();
+      expect(result.binaryIsSunset).toBeUndefined();
     });
   });
 });

--- a/app/api/cron/update-cameras/lib/aiScoring.ts
+++ b/app/api/cron/update-cameras/lib/aiScoring.ts
@@ -16,9 +16,11 @@
  *      `memory/project_two_tier_sunset_classification.md`.
  *
  * A SHA-256 of the bytes lets callers short-circuit re-scoring identical
- * frames (Redis-backed at call site). On any regression-ONNX failure,
- * falls back to the metadata-only baseline so the cron never crashes;
- * binary failures degrade silently (binary fields left undefined).
+ * frames (Redis-backed at call site). On any ONNX failure (setup or the
+ * regression head), returns pathTaken:'unscored' with null scores — callers
+ * must NOT write a score for these. Binary failures degrade silently (binary
+ * fields left undefined). There is no metadata fallback: the model is the only
+ * thing that may produce a score.
  */
 
 import path from 'node:path';
@@ -28,7 +30,6 @@ import {
   AI_ONNX_BINARY_MODEL_PATH_DEFAULT,
   AI_REGRESSION_MODEL_VERSION_DEFAULT,
   AI_ONNX_REGRESSION_MODEL_PATH_DEFAULT,
-  AI_SCORING_MODE_DEFAULT,
   SUNSET_DISAGREEMENT_HIGH,
   SUNSET_DISAGREEMENT_LOW,
 } from '@/app/lib/masterConfig';
@@ -43,16 +44,14 @@ export interface ScoreImageInput {
   source: WebcamSource;
   /** From Redis. When equal to the new hash, returns cache-hit without scoring. */
   lastImageHash?: string;
-  /** Used only when ONNX fails. Optional. */
-  fallbackMeta?: { viewCount?: number; manualRating?: number };
 }
 
-export type ScorePath = 'onnx' | 'cache-hit' | 'baseline' | 'baseline-fallback';
+export type ScorePath = 'onnx' | 'cache-hit' | 'unscored';
 
 export interface ScoreImageResult {
-  // Regression (required — always present except cache-hit).
-  rawScore: number;   // 0..1 (normalized; matches training label scale)
-  aiRating: number;   // 1..5 (display; inverse of (rating-1)/4 used at train time)
+  // Regression (null iff pathTaken === 'unscored').
+  rawScore: number | null;   // 0..1 (normalized; matches training label scale)
+  aiRating: number | null;   // 1..5 (display; inverse of (rating-1)/4 used at train time)
   modelVersion: string;
   imageHash: string;
   source: WebcamSource;
@@ -63,7 +62,7 @@ export interface ScoreImageResult {
   binaryRawScore?: number;       // softmax probability of class 1 (sunset), 0..1
   binaryIsSunset?: boolean;      // binaryRawScore >= AI_BINARY_DECISION_THRESHOLD
   binaryModelVersion?: string;
-  binaryPathTaken?: ScorePath;   // 'onnx' | 'baseline-fallback'
+  binaryPathTaken?: 'onnx';      // 'onnx'
 }
 
 const cachedSessions = new Map<string, unknown>();
@@ -154,20 +153,6 @@ async function getSession(modelPath: string): Promise<unknown> {
 /* Output mappings                                                             */
 /* -------------------------------------------------------------------------- */
 
-function baselineRaw(input: ScoreImageInput): number {
-  const views = input.fallbackMeta?.viewCount ?? 0;
-  const manual = input.fallbackMeta?.manualRating ?? 3;
-  const normViews = clamp(Math.log10(views + 1) / 6, 0, 1);
-  const normManual = clamp(manual / 5, 0, 1);
-  return clamp(normViews * 0.65 + normManual * 0.35, 0, 1);
-}
-
-function ratingFromRaw(raw: number): number {
-  // Inverse of the (rating-1)/4 label normalization in ml/export_dataset.py:
-  // rawScore=0 -> 1 star, rawScore=1 -> 5 stars, rawScore=0.5 -> 3 stars.
-  return Number((1 + clamp(raw, 0, 1) * 4).toFixed(2));
-}
-
 function normalizeRegressionOutput(value: number): {
   rawScore: number;
   aiRating: number;
@@ -255,7 +240,7 @@ async function scoreBinary(
   rawScore: number;
   isSunset: boolean;
   modelVersion: string;
-  pathTaken: ScorePath;
+  pathTaken: 'onnx';
 } | undefined> {
   if (!binaryEnabled()) return undefined;
   const modelVersion = resolveBinaryModelVersion();
@@ -274,13 +259,23 @@ async function scoreBinary(
       `[scoreImage] binary ONNX failed for webcam ${webcamId}, leaving binary fields unset:`,
       error,
     );
-    return {
-      rawScore: 0,
-      isSunset: false,
-      modelVersion,
-      pathTaken: 'baseline-fallback',
-    };
+    return undefined;
   }
+}
+
+function unscored(
+  input: ScoreImageInput,
+  imageHash: string,
+  modelVersion: string,
+): ScoreImageResult {
+  return {
+    rawScore: null,
+    aiRating: null,
+    modelVersion,
+    imageHash,
+    source: input.source,
+    pathTaken: 'unscored',
+  };
 }
 
 /**
@@ -305,75 +300,43 @@ export async function scoreImage(
     };
   }
 
-  const mode =
-    process.env.AI_SCORING_MODE?.trim() || AI_SCORING_MODE_DEFAULT;
-
-  if (mode !== 'onnx') {
-    const raw = baselineRaw(input);
-    return {
-      rawScore: raw,
-      aiRating: ratingFromRaw(raw),
-      modelVersion,
-      imageHash,
-      source: input.source,
-      pathTaken: 'baseline',
-    };
-  }
-
-  // ONNX mode — preprocess once, run both heads against the same tensor.
+  // ONNX is the only real scorer. If it can't run, return 'unscored' (null
+  // scores) — never a fabricated number.
   let ort: unknown;
   let tensorData: Float32Array;
   try {
     ort = await getOrt();
     tensorData = await preprocessJpegToImagenetTensor(input.imageBytes);
   } catch (error) {
-    console.warn(
-      `[scoreImage] ONNX setup failed for webcam ${input.webcamId}, falling back:`,
+    console.error(
+      `[scoreImage] ONNX setup failed for webcam ${input.webcamId}, leaving unscored:`,
       error,
     );
-    const raw = baselineRaw(input);
-    return {
-      rawScore: raw,
-      aiRating: ratingFromRaw(raw),
-      modelVersion,
-      imageHash,
-      source: input.source,
-      pathTaken: 'baseline-fallback',
-    };
+    return unscored(input, imageHash, modelVersion);
   }
 
-  // Regression head — required.
-  let regression: { rawScore: number; aiRating: number; pathTaken: ScorePath };
+  let regression: { rawScore: number; aiRating: number };
   try {
     const data = await runOnnxSession(ort, resolveRegressionModelPath(), tensorData);
     const value = Number(data[0] ?? 0.5);
-    const normalized = normalizeRegressionOutput(value);
-    regression = {
-      rawScore: normalized.rawScore,
-      aiRating: normalized.aiRating,
-      pathTaken: 'onnx',
-    };
+    regression = normalizeRegressionOutput(value);
   } catch (error) {
-    console.warn(
-      `[scoreImage] regression ONNX failed for webcam ${input.webcamId}, falling back:`,
+    console.error(
+      `[scoreImage] regression ONNX failed for webcam ${input.webcamId}, leaving unscored:`,
       error,
     );
-    const raw = baselineRaw(input);
-    regression = {
-      rawScore: raw,
-      aiRating: ratingFromRaw(raw),
-      pathTaken: 'baseline-fallback',
-    };
+    return unscored(input, imageHash, modelVersion);
   }
 
-  // Binary head — optional. Don't fail the result if it errors.
   const binary = await scoreBinary(ort, input.webcamId, tensorData);
 
   return {
-    ...regression,
+    rawScore: regression.rawScore,
+    aiRating: regression.aiRating,
     modelVersion,
     imageHash,
     source: input.source,
+    pathTaken: 'onnx',
     binaryRawScore: binary?.rawScore,
     binaryIsSunset: binary?.isSunset,
     binaryModelVersion: binary?.modelVersion,

--- a/app/api/cron/update-cameras/lib/customBackfill.test.ts
+++ b/app/api/cron/update-cameras/lib/customBackfill.test.ts
@@ -71,6 +71,28 @@ describe('backfillCustomSnapshotScores', () => {
     expect(syncWebcamMock).toHaveBeenCalledWith(42);
   });
 
+  it('does NOT write a score for an unscored snapshot and does not sync the webcam', async () => {
+    findMock.mockResolvedValue([
+      { snapshotId: 11, webcamId: 42, firebaseUrl: 'https://x/1.jpg' },
+    ]);
+    downloadMock.mockResolvedValue(Buffer.from('jpg'));
+    scoreMock.mockResolvedValue({
+      rawScore: null,
+      aiRating: null,
+      modelVersion: 'v4',
+      imageHash: 'h',
+      source: 'custom',
+      pathTaken: 'unscored',
+    });
+
+    const result = await backfillCustomSnapshotScores({ limit: 10 });
+
+    expect(updateSnapMock).not.toHaveBeenCalled();
+    expect(syncWebcamMock).not.toHaveBeenCalled();
+    expect(result.scored).toBe(0);
+    expect(result.scores).toEqual([]);
+  });
+
   it('counts a download failure as `failed` and continues with other rows', async () => {
     findMock.mockResolvedValue([
       { snapshotId: 11, webcamId: 42, firebaseUrl: 'https://x/1.jpg' },

--- a/app/api/cron/update-cameras/lib/customBackfill.ts
+++ b/app/api/cron/update-cameras/lib/customBackfill.ts
@@ -42,6 +42,13 @@ export async function backfillCustomSnapshotScores(opts: {
         imageBytes: bytes,
         source: 'custom',
       });
+      if (result.rawScore === null || result.aiRating === null) {
+        // 'unscored' — ONNX produced no real score. Skip the write entirely so
+        // we don't fabricate, and don't sync the parent webcam from a non-score.
+        // The finder (WHERE ai_regression_score IS NULL) re-queues this row.
+        failed += 1;
+        continue;
+      }
       const disagreementKind = computeDisagreementKind({
         binaryIsSunset: result.binaryIsSunset,
         aiRating: result.aiRating,

--- a/app/api/cron/update-cameras/route.test.ts
+++ b/app/api/cron/update-cameras/route.test.ts
@@ -260,7 +260,7 @@ describe('GET /api/cron/update-cameras', () => {
   });
 
   it('returns a scoringPaths breakdown counted from scored.pathTaken', async () => {
-    // Three webcams: one onnx, one cache-hit, one baseline-fallback.
+    // Three webcams: one onnx, one cache-hit, one unscored.
     fetchBatchesMock.mockResolvedValueOnce([[
       { webcamId: 7, location: { latitude: 0, longitude: 0 },
         images: { current: { preview: 'https://x/a.jpg' } }, viewCount: 1, rating: 3 },
@@ -273,15 +273,29 @@ describe('GET /api/cron/update-cameras', () => {
     scoreMock
       .mockResolvedValueOnce({ rawScore: 0.6, aiRating: 3.4, modelVersion: 'v4', imageHash: 'h1', source: 'windy', pathTaken: 'onnx' })
       .mockResolvedValueOnce({ rawScore: 0, aiRating: 0, modelVersion: 'v4', imageHash: 'h2', source: 'windy', pathTaken: 'cache-hit' })
-      .mockResolvedValueOnce({ rawScore: 0.4, aiRating: 2.6, modelVersion: 'v4', imageHash: 'h3', source: 'windy', pathTaken: 'baseline-fallback' });
+      .mockResolvedValueOnce({ rawScore: null, aiRating: null, modelVersion: 'v4', imageHash: 'h3', source: 'windy', pathTaken: 'unscored' });
     const res = await GET(makeReq());
     const body = await res.json();
     expect(body.scoringPaths).toEqual({
       onnx: 1,
       'cache-hit': 1,
-      'baseline-fallback': 1,
-      baseline: 0,
+      unscored: 1,
     });
+  });
+
+  it('does NOT write AI fields for an unscored webcam (leaves columns null)', async () => {
+    scoreMock.mockReset().mockResolvedValue({
+      rawScore: null, aiRating: null, modelVersion: 'v4',
+      imageHash: 'h', source: 'windy', pathTaken: 'unscored',
+    });
+    updateAiFieldsMock.mockClear();
+
+    const res = await GET(makeReq());
+    const body = await res.json();
+
+    expect(updateAiFieldsMock).not.toHaveBeenCalled();
+    expect(body.scoringPaths.unscored).toBeGreaterThan(0);
+    expect(body.scoringPaths.onnx).toBe(0);
   });
 
   it('persists a Windy snapshot when computeDisagreementKind flags the score', async () => {

--- a/app/api/cron/update-cameras/route.ts
+++ b/app/api/cron/update-cameras/route.ts
@@ -136,12 +136,11 @@ export async function GET(req: Request) {
   let fallbacks = 0;
   // Per-tick breakdown of which scoring path each webcam took. Makes
   // 'is ONNX actually running' inspectable from the cron response —
-  // scoringPaths.onnx > 0 && scoringPaths['baseline-fallback'] === 0 is green.
-  const scoringPaths: Record<'onnx' | 'cache-hit' | 'baseline-fallback' | 'baseline', number> = {
+  // scoringPaths.onnx > 0 && scoringPaths.unscored === 0 is green.
+  const scoringPaths: Record<'onnx' | 'cache-hit' | 'unscored', number> = {
     onnx: 0,
     'cache-hit': 0,
-    'baseline-fallback': 0,
-    baseline: 0,
+    unscored: 0,
   };
 
   async function scoreOneWindy(webcam: typeof windyAll[number]): Promise<void> {
@@ -165,10 +164,6 @@ export async function GET(req: Request) {
         imageBytes: bytes,
         source: 'windy',
         lastImageHash: lastHash ?? undefined,
-        fallbackMeta: {
-          viewCount: webcam.viewCount,
-          manualRating: webcam.rating ?? undefined,
-        },
       });
 
       if (scored.pathTaken === 'cache-hit') {
@@ -176,8 +171,15 @@ export async function GET(req: Request) {
         scoringPaths['cache-hit'] += 1;
         return;
       }
-      if (scored.pathTaken === 'baseline-fallback') fallbacks += 1;
-      scoringPaths[scored.pathTaken] += 1;
+      if (scored.rawScore === null || scored.aiRating === null) {
+        // 'unscored' — ONNX produced no real score. Write nothing; leave the
+        // columns NULL so the backfill (WHERE ai_regression_score IS NULL)
+        // reclaims this row once the model is loading again. Never fabricate.
+        fallbacks += 1;
+        scoringPaths.unscored += 1;
+        return;
+      }
+      scoringPaths.onnx += 1;
       windyScores.push(scored.rawScore);
 
       // Write Neon first: if the DB write fails, Redis hash is not committed
@@ -259,8 +261,8 @@ export async function GET(req: Request) {
       );
       fallbacks += 1;
       // Same conflation as `fallbacks`: download/timeout failures count
-      // as a fallback path since no real score was produced.
-      scoringPaths['baseline-fallback'] += 1;
+      // as unscored since no real score was produced.
+      scoringPaths.unscored += 1;
     }
   }
 

--- a/app/api/snapshots/cleanup/route.test.ts
+++ b/app/api/snapshots/cleanup/route.test.ts
@@ -79,4 +79,13 @@ describe('GET /api/snapshots/cleanup', () => {
     const q = strings.join('?');
     expect(q).toMatch(/ai_rating\s+is\s+null\s+or\s+ai_rating\s*</i);
   });
+
+  it('excludes Claude-scored frames (llm_quality set) — they may be on the leaderboard', async () => {
+    cleanupEnabledMock.value = true;
+    sqlMock.mockResolvedValueOnce([]); // SELECT returns nothing
+    await GET(makeReq());
+    const [strings] = sqlMock.mock.calls[0];
+    const q = strings.join('?').toLowerCase();
+    expect(q).toMatch(/llm_quality\s+is\s+null/i);
+  });
 });

--- a/app/api/snapshots/cleanup/route.ts
+++ b/app/api/snapshots/cleanup/route.ts
@@ -21,6 +21,8 @@ export const maxDuration = 300; // 5 minutes
 //      the Hard Examples queue waiting for a verdict
 //   4. Snapshots with a high ai_rating (>= AI_SNAPSHOT_MIN_RATING_THRESHOLD)
 //      survive — they're the best-of frames the leaderboard ranks
+//   5. Snapshots with llm_quality set survive — the Best Sunsets leaderboard
+//      ranks by llm_quality; these are Claude-scored frames
 //
 // Before adding this endpoint to vercel.json's crons or POSTing to it
 // manually, re-read the retention rules above. The archive contained
@@ -60,18 +62,21 @@ async function cleanup(request: Request) {
 
     console.log('Starting snapshot cleanup...');
 
-    // Four classes of snapshots are NEVER cleaned up — we only drop a frame
-    // older than 7 days that has none of these signals:
+    // Snapshots with ANY of these signals are NEVER cleaned up — we only drop a
+    // frame older than 7 days that has none of them:
     //   1. model_disagreement_kind set (queued for Hard Examples triage).
     //   2. Any user ever rated or verdicted it (training data).
-    //   3. A high AI score (ai_rating >= AI_SNAPSHOT_MIN_RATING_THRESHOLD) —
-    //      the best-of frames the Best Sunsets leaderboard ranks. NULL ai_rating
-    //      counts as "not high" and is eligible for deletion.
+    //   3. A high AI score (ai_rating >= AI_SNAPSHOT_MIN_RATING_THRESHOLD).
+    //   4. Claude scored it (llm_quality set) — the Best Sunsets leaderboard
+    //      ranks by llm_quality, so these are the real best-of frames. This also
+    //      guards the window where the ONNX backfill has nulled ai_rating but
+    //      Claude's quality is the live ranking signal.
     const oldSnapshots = await sql`
       SELECT id, firebase_path, captured_at
       FROM webcam_snapshots
       WHERE captured_at < NOW() - INTERVAL '7 days'
         AND model_disagreement_kind IS NULL
+        AND llm_quality IS NULL
         AND (ai_rating IS NULL OR ai_rating < ${AI_SNAPSHOT_MIN_RATING_THRESHOLD})
         AND id NOT IN (
           SELECT DISTINCT snapshot_id FROM webcam_snapshot_ratings

--- a/app/lib/masterConfig.ts
+++ b/app/lib/masterConfig.ts
@@ -138,13 +138,9 @@ export const SNAPSHOT_QUEUE_PROGRESS_RATED_SCOPE =
 // This lets queue assignment stay personal while progress stays global.
 export const SNAPSHOT_QUEUE_UNRATED_SCOPE = 'session_specific';
 
-// Runtime mode selection:
-// - baseline: deterministic metadata-based score
-// - onnx: load ONNX artifact and score via onnxruntime
 // ONNX creation/export workflow lives in `ml/README.md` ("Export ONNX and verify locally").
 // Defaults here are compatibility fallbacks; production/experiment usage should
 // set AI_ONNX_*_MODEL_PATH + AI_*_MODEL_VERSION env vars to versioned artifacts.
-export const AI_SCORING_MODE_DEFAULT = 'baseline';
 export const AI_MODEL_VERSION_DEFAULT = 'baseline-v1';
 export const AI_ONNX_MODEL_PATH_DEFAULT =
   'ml/artifacts/models/model.onnx';

--- a/database/migrations/20260606_null_baseline_scores.sql
+++ b/database/migrations/20260606_null_baseline_scores.sql
@@ -1,0 +1,27 @@
+-- Null the AI-produced scores that the metadata heuristic fabricated, so the
+-- leaderboard stops ranking guesses and the ONNX backfill reclaims these rows
+-- (finder = WHERE ai_regression_score IS NULL). Forward-only, idempotent.
+--
+-- SCOPE BOUNDARY: touches ONLY ai_* / scoring_path / model_disagreement_kind.
+-- It NEVER touches human-rating columns — webcams.rating, initial_rating, or
+-- any column of webcam_snapshot_ratings — which are preserved for v5 training.
+--
+-- Apply manually via:
+--   psql "$DATABASE_URL" -f database/migrations/20260606_null_baseline_scores.sql
+
+-- 1) Snapshots: the source of truth the leaderboard ranks.
+UPDATE webcam_snapshots
+SET ai_regression_score     = NULL,
+    ai_rating               = NULL,
+    scoring_path            = NULL,
+    model_disagreement_kind = NULL
+WHERE scoring_path IN ('baseline', 'baseline-fallback');
+
+-- 2) Denormalized AI values on webcams (written by the live-cron baseline path).
+--    webcams has no per-row scoring_path, so null all denormalized AI ratings
+--    and let the next real ONNX score re-sync each webcam. webcams.rating
+--    (human) is intentionally NOT in this list.
+UPDATE webcams
+SET ai_rating            = NULL,
+    ai_rating_regression = NULL,
+    ai_rating_binary     = NULL;

--- a/docs/solutions/2026-06-06-fallbacks-must-not-impersonate-real-signal.md
+++ b/docs/solutions/2026-06-06-fallbacks-must-not-impersonate-real-signal.md
@@ -1,0 +1,41 @@
+# Fallbacks must not impersonate the real signal
+
+**Date:** 2026-06-06
+**Area:** ML scoring / data integrity
+
+## The trap
+
+`scoreImage` had a "fallback": when the ONNX model failed to load, it scored the
+image from **webcam popularity + a default manual rating** (`baselineRaw`) and
+wrote that guess into `ai_regression_score` / `ai_rating` — the SAME columns the
+real model writes. The mode selector even defaulted to it
+(`AI_SCORING_MODE_DEFAULT = 'baseline'`), so a missing env var silently
+fabricated scores. Two writers (the Windy cron and `customBackfill`) shipped the
+guess to the DB; the leaderboard ranked it as if it were real. Result: broken
+infrastructure looked perfectly healthy, and "we think it's working but it isn't"
+recurred for weeks.
+
+## The rule
+
+**A fallback that writes a plausible value into the same column as the real
+signal is worse than no fallback — it is undetectable.** A heuristic that never
+reads the input it claims to score produces silent, confidently-wrong data.
+
+Fallbacks must be either:
+1. **Absent** — write `NULL`, increment a counter, log loudly. Honest absence is
+   recoverable (a `WHERE col IS NULL` finder reclaims it); a fake number is not.
+2. **A distinct, clearly-labeled channel** — never the column reserved for the
+   real signal.
+
+And never default a mode selector to the fake path.
+
+## What we did
+
+Deleted `baselineRaw` + the `AI_SCORING_MODE` knob; `scoreImage` now returns
+`pathTaken: 'unscored'` with `null` scores on any ONNX failure; all writers skip
+the write on `'unscored'`; a migration nulled the existing junk so the real model
+reclaims it. A second-order effect: the cleanup cron deleted by `ai_rating` while
+the leaderboard ranks by `llm_quality`, so nulling `ai_rating` widened the
+deletion net — we added an `AND llm_quality IS NULL` retention guard so
+Claude-scored frames are never deleted. See
+`docs/superpowers/specs/2026-06-06-remove-metadata-heuristic-fallback-design.md`.

--- a/docs/superpowers/plans/2026-06-06-remove-baseline-fallback.md
+++ b/docs/superpowers/plans/2026-06-06-remove-baseline-fallback.md
@@ -1,0 +1,593 @@
+# Remove Metadata-Heuristic Scoring Fallback — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make ONNX the only thing that can produce a sunset score — when it can't run, return honest `NULL` instead of a fabricated view-count guess — and clean the fake scores already in the database.
+
+**Architecture:** `scoreImage` loses its `baseline`/`baseline-fallback` heuristic and the `AI_SCORING_MODE` knob; on any ONNX failure it returns `pathTaken: 'unscored'` with `null` scores. All three score-writers (`route.ts` Windy cron, `customBackfill.ts`, the read-only smoke endpoint) skip the write on `'unscored'`, leaving columns `NULL` so the existing `WHERE ai_regression_score IS NULL` finders reclaim the row once the model loads. A one-time migration nulls existing baseline junk.
+
+**Tech Stack:** TypeScript, Next.js API routes, Vitest, Postgres (Neon), onnxruntime-node.
+
+**Branch:** `fix/remove-baseline-fallback` (off `main`). Spec: `docs/superpowers/specs/2026-06-06-remove-metadata-heuristic-fallback-design.md`.
+
+**Canonical contract (used by every task — keep consistent):**
+- `ScorePath = 'onnx' | 'cache-hit' | 'unscored'`
+- `ScoreImageResult.rawScore: number | null`, `ScoreImageResult.aiRating: number | null` (both `null` iff `pathTaken === 'unscored'`)
+- `ScoreImageInput` no longer has `fallbackMeta`
+- `scoreBinary` returns `undefined` on failure (no `binaryPathTaken: 'baseline-fallback'`)
+- Consumer guard (narrows both fields to `number`): `if (scored.rawScore === null || scored.aiRating === null) { /* unscored */ }`
+
+---
+
+## Task 1: `scoreImage` returns honest `'unscored'`; delete the heuristic + mode branch
+
+**Files:**
+- Modify: `app/api/cron/update-cameras/lib/aiScoring.ts`
+- Test: `app/api/cron/update-cameras/lib/aiScoring.test.ts`
+
+- [ ] **Step 1: Rewrite the affected tests to assert the `'unscored'` contract (failing)**
+
+In `aiScoring.test.ts`, **remove** `process.env.AI_SCORING_MODE = 'onnx';` from the `beforeEach` (line 36).
+
+**Replace** the test `'falls back to baseline when ONNX inference throws'` (lines 105–118) with:
+
+```ts
+  it('returns "unscored" with null scores when ONNX inference throws', async () => {
+    runMock.mockRejectedValueOnce(new Error('boom'));
+    const result = await scoreImage({
+      webcamId: 1,
+      imageBytes: Buffer.from('jpeg'),
+      source: 'windy',
+    });
+    expect(result.pathTaken).toBe('unscored');
+    expect(result.rawScore).toBeNull();
+    expect(result.aiRating).toBeNull();
+    expect(result.modelVersion).toBe('test-v4');
+    expect(result.imageHash).toBe('hash-abc');
+  });
+
+  it('returns "unscored" when ONNX setup (preprocess) throws', async () => {
+    preprocessMock.mockRejectedValueOnce(new Error('no model'));
+    const result = await scoreImage({
+      webcamId: 1,
+      imageBytes: Buffer.from('jpeg'),
+      source: 'windy',
+    });
+    expect(result.pathTaken).toBe('unscored');
+    expect(result.rawScore).toBeNull();
+    expect(result.aiRating).toBeNull();
+  });
+```
+
+**Delete** the test `'returns pathTaken=baseline when AI_SCORING_MODE is not onnx'` (lines 129–144) entirely — the mode no longer exists.
+
+**Replace** the binary-failure test `'leaves regression intact when only the binary head throws'` (lines 226–241) body's last two assertions:
+
+```ts
+      expect(result.pathTaken).toBe('onnx');
+      expect(result.aiRating).toBeCloseTo(3.56, 2);
+      expect(result.binaryPathTaken).toBeUndefined();
+      expect(result.binaryRawScore).toBeUndefined();
+      expect(result.binaryIsSunset).toBeUndefined();
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `npx vitest run app/api/cron/update-cameras/lib/aiScoring.test.ts`
+Expected: FAIL — current code returns `'baseline-fallback'`/`'baseline'` and a numeric `rawScore`, and `fallbackMeta` is gone from the type.
+
+- [ ] **Step 3: Implement — delete the heuristic, return `'unscored'`**
+
+In `aiScoring.ts`:
+
+1. Update the top doc comment (lines 18–21) — replace the "falls back to the metadata-only baseline so the cron never crashes" sentence with:
+
+```ts
+ * A SHA-256 of the bytes lets callers short-circuit re-scoring identical
+ * frames (Redis-backed at call site). On any ONNX failure (setup or the
+ * regression head), returns pathTaken:'unscored' with null scores — callers
+ * must NOT write a score for these. Binary failures degrade silently (binary
+ * fields left undefined). There is no metadata fallback: the model is the only
+ * thing that may produce a score.
+```
+
+2. Remove `AI_SCORING_MODE_DEFAULT,` from the masterConfig import (line 31).
+
+3. Change the `fallbackMeta` field off `ScoreImageInput` — delete lines 46–47:
+
+```ts
+  /** From Redis. When equal to the new hash, returns cache-hit without scoring. */
+  lastImageHash?: string;
+}
+```
+
+4. Narrow the path types:
+
+```ts
+export type ScorePath = 'onnx' | 'cache-hit' | 'unscored';
+```
+
+5. Make the regression fields nullable in `ScoreImageResult` (lines 53–59):
+
+```ts
+  // Regression (number when pathTaken==='onnx'; null when 'unscored';
+  // 0 is an ignored placeholder on 'cache-hit').
+  rawScore: number | null;   // 0..1 (normalized; matches training label scale)
+  aiRating: number | null;   // 1..5 (display)
+  modelVersion: string;
+  imageHash: string;
+  source: WebcamSource;
+  pathTaken: ScorePath;
+```
+
+And update the `binaryPathTaken` comment (line 66) to `// 'onnx'`.
+
+6. **Delete** `baselineRaw` (lines 160–166) and `ratingFromRaw` (lines 168–172) — both are now unused.
+
+7. Add an `unscored` helper just above `scoreImage`:
+
+```ts
+function unscored(
+  input: ScoreImageInput,
+  imageHash: string,
+  modelVersion: string,
+): ScoreImageResult {
+  return {
+    rawScore: null,
+    aiRating: null,
+    modelVersion,
+    imageHash,
+    source: input.source,
+    pathTaken: 'unscored',
+  };
+}
+```
+
+8. In `scoreBinary` (lines 338–349), replace the catch's returned object with `undefined`:
+
+```ts
+  } catch (error) {
+    console.warn(
+      `[scoreImage] binary ONNX failed for webcam ${webcamId}, leaving binary fields unset:`,
+      error,
+    );
+    return undefined;
+  }
+```
+
+And update its return type `pathTaken: ScorePath;` → `pathTaken: 'onnx';` (line 324).
+
+9. Rewrite the body of `scoreImage` from the mode block onward (replace lines 374–447):
+
+```ts
+  // ONNX is the only real scorer. If it can't run, return 'unscored' (null
+  // scores) — never a fabricated number.
+  let ort: unknown;
+  let tensorData: Float32Array;
+  try {
+    ort = await getOrt();
+    tensorData = await preprocessJpegToImagenetTensor(input.imageBytes);
+  } catch (error) {
+    console.error(
+      `[scoreImage] ONNX setup failed for webcam ${input.webcamId}, leaving unscored:`,
+      error,
+    );
+    return unscored(input, imageHash, modelVersion);
+  }
+
+  // Regression head — required. Failure means unscored.
+  let regression: { rawScore: number; aiRating: number };
+  try {
+    const data = await runOnnxSession(ort, resolveRegressionModelPath(), tensorData);
+    const value = Number(data[0] ?? 0.5);
+    regression = normalizeRegressionOutput(value);
+  } catch (error) {
+    console.error(
+      `[scoreImage] regression ONNX failed for webcam ${input.webcamId}, leaving unscored:`,
+      error,
+    );
+    return unscored(input, imageHash, modelVersion);
+  }
+
+  // Binary head — optional. Don't fail the result if it errors.
+  const binary = await scoreBinary(ort, input.webcamId, tensorData);
+
+  return {
+    rawScore: regression.rawScore,
+    aiRating: regression.aiRating,
+    modelVersion,
+    imageHash,
+    source: input.source,
+    pathTaken: 'onnx',
+    binaryRawScore: binary?.rawScore,
+    binaryIsSunset: binary?.isSunset,
+    binaryModelVersion: binary?.modelVersion,
+    binaryPathTaken: binary?.pathTaken,
+  };
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `npx vitest run app/api/cron/update-cameras/lib/aiScoring.test.ts`
+Expected: PASS (all `scoreImage`, `softmaxBinaryClassOne`, `computeDisagreementKind` tests green).
+
+- [ ] **Step 5: Typecheck**
+
+Run: `npx tsc --noEmit`
+Expected: No errors in `aiScoring.ts`. (Consumer files `route.ts` / `customBackfill.ts` / `scoring-smoke` may now error on `rawScore` being `number | null` — that is expected and fixed in Tasks 3–5. If you want a clean checkpoint, you can defer this command until after Task 5.)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/api/cron/update-cameras/lib/aiScoring.ts app/api/cron/update-cameras/lib/aiScoring.test.ts
+git commit -m "feat(scoring): scoreImage returns 'unscored' on ONNX failure, delete baseline heuristic"
+```
+
+---
+
+## Task 2: Delete the `AI_SCORING_MODE_DEFAULT` footgun
+
+**Files:**
+- Modify: `app/lib/masterConfig.ts`
+
+- [ ] **Step 1: Confirm no remaining references**
+
+Run: `grep -rn "AI_SCORING_MODE" app/ --include="*.ts" --include="*.tsx"`
+Expected: only the definition line in `masterConfig.ts` (Task 1 removed the `aiScoring.ts` import + usage). If any other reference appears, stop and reconcile.
+
+- [ ] **Step 2: Remove the export**
+
+In `app/lib/masterConfig.ts`, delete the line:
+
+```ts
+export const AI_SCORING_MODE_DEFAULT = 'baseline';
+```
+
+(plus any immediately-preceding comment that only documents it).
+
+- [ ] **Step 3: Typecheck**
+
+Run: `npx tsc --noEmit`
+Expected: no new errors attributable to `masterConfig.ts`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add app/lib/masterConfig.ts
+git commit -m "refactor(scoring): remove AI_SCORING_MODE_DEFAULT — missing env var can no longer fake scores"
+```
+
+---
+
+## Task 3: Live Windy cron skips the write on `'unscored'`
+
+**Files:**
+- Modify: `app/api/cron/update-cameras/route.ts:136-145,174-181,255-264` (and the comment at 137–139)
+- Test: `app/api/cron/update-cameras/route.test.ts`
+
+- [ ] **Step 1: Update + add tests (failing)**
+
+In `route.test.ts`, find the test `'returns a scoringPaths breakdown counted from scored.pathTaken'` (line 262). Change the third mock (line 276) and the expected object (lines 279–284):
+
+```ts
+      .mockResolvedValueOnce({ rawScore: 0.6, aiRating: 3.4, modelVersion: 'v4', imageHash: 'h1', source: 'windy', pathTaken: 'onnx' })
+      .mockResolvedValueOnce({ rawScore: 0, aiRating: 0, modelVersion: 'v4', imageHash: 'h2', source: 'windy', pathTaken: 'cache-hit' })
+      .mockResolvedValueOnce({ rawScore: null, aiRating: null, modelVersion: 'v4', imageHash: 'h3', source: 'windy', pathTaken: 'unscored' });
+```
+
+```ts
+    expect(body.scoringPaths).toEqual({
+      onnx: 1,
+      'cache-hit': 1,
+      unscored: 1,
+    });
+```
+
+Add a new test directly after it (mirror the existing mock setup in this file — `scoreMock`, `updateAiFieldsMock`, three webcams from `windyApi` mock):
+
+```ts
+  it('does NOT write AI fields for an unscored webcam (leaves columns null)', async () => {
+    scoreMock.mockReset().mockResolvedValue({
+      rawScore: null, aiRating: null, modelVersion: 'v4',
+      imageHash: 'h', source: 'windy', pathTaken: 'unscored',
+    });
+    updateAiFieldsMock.mockClear();
+
+    const res = await GET(makeReq());
+    const body = await res.json();
+
+    expect(updateAiFieldsMock).not.toHaveBeenCalled();
+    expect(body.scoringPaths.unscored).toBeGreaterThan(0);
+    expect(body.scoringPaths.onnx).toBe(0);
+  });
+```
+
+> Note: use the same request/`GET` invocation helper the surrounding tests use in this file (e.g. the existing `makeReq()` / `GET(...)` pattern visible in the other `it(...)` blocks). If the helper has a different name, match it.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npx vitest run app/api/cron/update-cameras/route.test.ts`
+Expected: FAIL — current code increments `'baseline-fallback'`/`'baseline'` buckets and writes AI fields for every non-cache-hit path.
+
+- [ ] **Step 3: Implement the skip-on-unscored path**
+
+In `route.ts`:
+
+1. Update the comment + `scoringPaths` declaration (lines 137–145):
+
+```ts
+  // Per-tick breakdown of which scoring path each webcam took. Makes
+  // 'is ONNX actually running' inspectable from the cron response —
+  // scoringPaths.onnx > 0 && scoringPaths.unscored === 0 is green.
+  const scoringPaths: Record<'onnx' | 'cache-hit' | 'unscored', number> = {
+    onnx: 0,
+    'cache-hit': 0,
+    unscored: 0,
+  };
+```
+
+2. Replace the path-handling block (lines 174–181):
+
+```ts
+      if (scored.pathTaken === 'cache-hit') {
+        cacheHits += 1;
+        scoringPaths['cache-hit'] += 1;
+        return;
+      }
+      if (scored.rawScore === null || scored.aiRating === null) {
+        // 'unscored' — ONNX produced no real score. Write nothing; leave the
+        // columns NULL so the backfill (WHERE ai_regression_score IS NULL)
+        // reclaims this row once the model is loading again. Never fabricate.
+        fallbacks += 1;
+        scoringPaths.unscored += 1;
+        return;
+      }
+      scoringPaths.onnx += 1;
+      windyScores.push(scored.rawScore);
+```
+
+3. In the `catch` block (lines 260–263), change the bucket name:
+
+```ts
+      fallbacks += 1;
+      // Same conflation as `fallbacks`: download/timeout failures count as a
+      // non-scored path since no real score was produced.
+      scoringPaths.unscored += 1;
+```
+
+(Everything between — `updateWebcamAiFields`, the `binaryRating` math, `computeDisagreementKind`, the snapshot persist — now only runs for genuine `'onnx'` rows, and `scored.rawScore` / `scored.aiRating` are narrowed to `number` by the guard above.)
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npx vitest run app/api/cron/update-cameras/route.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/api/cron/update-cameras/route.ts app/api/cron/update-cameras/route.test.ts
+git commit -m "feat(cron): Windy scoring writes nothing on 'unscored', rename telemetry bucket"
+```
+
+---
+
+## Task 4: `customBackfill` skips the write on `'unscored'`
+
+**Files:**
+- Modify: `app/api/cron/update-cameras/lib/customBackfill.ts:37-67`
+- Test: `app/api/cron/update-cameras/lib/customBackfill.test.ts`
+
+- [ ] **Step 1: Add a failing test**
+
+In `customBackfill.test.ts`, add (mirroring the file's existing `scoreMock` / `updateSnapMock` / `findMock` setup):
+
+```ts
+  it('does NOT write a score for an unscored snapshot and does not sync the webcam', async () => {
+    findMock.mockResolvedValue([
+      { snapshotId: 11, webcamId: 7, firebaseUrl: 'https://x/img.jpg' },
+    ]);
+    scoreMock.mockResolvedValue({
+      rawScore: null, aiRating: null, modelVersion: 'v4',
+      imageHash: 'h', source: 'custom', pathTaken: 'unscored',
+    });
+
+    const result = await backfillCustomSnapshotScores({ limit: 10 });
+
+    expect(updateSnapMock).not.toHaveBeenCalled();
+    expect(syncWebcamMock).not.toHaveBeenCalled();
+    expect(result.scored).toBe(0);
+    expect(result.scores).toEqual([]);
+  });
+```
+
+> Use the mock variable names already defined at the top of this test file for `findCustomSnapshotsNeedingScore`, `updateSnapshotAiRegressionScore`, and `updateWebcamRegressionScoreFromLatestCustomSnapshot`. (Above they are referenced as `findMock`, `updateSnapMock`, `syncWebcamMock` — match the file's actual names.)
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run app/api/cron/update-cameras/lib/customBackfill.test.ts`
+Expected: FAIL — current code calls `updateSnapshotAiRegressionScore` with `result.rawScore` regardless of path.
+
+- [ ] **Step 3: Implement the guard**
+
+In `customBackfill.ts`, inside the `for` loop, immediately after the `scoreImage` call (after line 44) and before `computeDisagreementKind`:
+
+```ts
+      if (result.rawScore === null || result.aiRating === null) {
+        // 'unscored' — ONNX produced no real score. Skip the write entirely so
+        // we don't fabricate, and don't sync the parent webcam from a non-score.
+        // The finder (WHERE ai_regression_score IS NULL) re-queues this row.
+        failed += 1;
+        continue;
+      }
+```
+
+(The existing `scores.push(result.rawScore)` and `touchedWebcamIds.add(...)` below now only run for real scores, so the per-webcam sync loop never fires from an unscored row.)
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx vitest run app/api/cron/update-cameras/lib/customBackfill.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/api/cron/update-cameras/lib/customBackfill.ts app/api/cron/update-cameras/lib/customBackfill.test.ts
+git commit -m "feat(scoring): customBackfill writes nothing on 'unscored' (second fake-score leak)"
+```
+
+---
+
+## Task 5: Smoke endpoint tolerates `null` + full typecheck/test sweep
+
+**Files:**
+- Verify: `app/api/debug/scoring-smoke/route.ts` (no code change expected — `NextResponse.json` serializes `null` fine; `rawScore`/`aiRating` already returned)
+
+- [ ] **Step 1: Confirm the smoke endpoint compiles with nullable fields**
+
+Run: `npx tsc --noEmit`
+Expected: PASS across the whole project. The smoke route already passes `result.rawScore` / `result.aiRating` straight into `NextResponse.json`, which accepts `null`. If `tsc` flags it, the fix is only to allow `null` in any explicit response type — do not add a fallback value.
+
+- [ ] **Step 2: Full test sweep for the touched modules**
+
+Run: `npx vitest run app/api/cron/update-cameras app/api/debug`
+Expected: PASS. (Pre-existing unrelated `app/components/Map/` failures, if any, are out of scope — do not fix them here.)
+
+- [ ] **Step 3: Commit (only if a change was needed)**
+
+```bash
+git add app/api/debug/scoring-smoke/route.ts
+git commit -m "chore(scoring): smoke endpoint tolerates null rawScore from 'unscored'"
+```
+
+If no change was needed, skip this commit.
+
+---
+
+## Task 6: Cleanup migration — null the existing baseline junk
+
+**Files:**
+- Create: `database/migrations/20260606_null_baseline_scores.sql`
+
+- [ ] **Step 1: Write the migration**
+
+```sql
+-- Null the AI-produced scores that the metadata heuristic fabricated, so the
+-- leaderboard stops ranking guesses and the ONNX backfill reclaims these rows
+-- (finder = WHERE ai_regression_score IS NULL). Forward-only, idempotent.
+--
+-- SCOPE BOUNDARY: touches ONLY ai_* / scoring_path / model_disagreement_kind.
+-- It NEVER touches human-rating columns — webcams.rating, initial_rating, or
+-- any column of webcam_snapshot_ratings — which are preserved for v5 training.
+--
+-- Apply manually via:
+--   psql "$DATABASE_URL" -f database/migrations/20260606_null_baseline_scores.sql
+
+-- 1) Snapshots: the source of truth the leaderboard ranks.
+UPDATE webcam_snapshots
+SET ai_regression_score     = NULL,
+    ai_rating               = NULL,
+    scoring_path            = NULL,
+    model_disagreement_kind = NULL
+WHERE scoring_path IN ('baseline', 'baseline-fallback');
+
+-- 2) Denormalized AI values on webcams (written by the live-cron baseline path).
+--    webcams has no per-row scoring_path, so null all denormalized AI ratings
+--    and let the next real ONNX score re-sync each webcam. webcams.rating
+--    (human) is intentionally NOT in this list.
+UPDATE webcams
+SET ai_rating            = NULL,
+    ai_rating_regression = NULL,
+    ai_rating_binary     = NULL;
+```
+
+- [ ] **Step 2: Verify the migration is safe to run (dry inspection)**
+
+Run: `grep -n "rating\|scoring_path\|ai_" database/migrations/20260606_null_baseline_scores.sql`
+Confirm by eye: no reference to `webcam_snapshot_ratings`, `initial_rating`, or the bare `webcams.rating` column in any `SET` clause.
+
+- [ ] **Step 3: Commit (operator applies the SQL manually — see Operational steps)**
+
+```bash
+git add database/migrations/20260606_null_baseline_scores.sql
+git commit -m "feat(db): migration to null fabricated baseline scores (manual ratings untouched)"
+```
+
+> **Operational (owner runs after merge):** `psql "$DATABASE_URL" -f database/migrations/20260606_null_baseline_scores.sql`. Before/after sanity:
+> `SELECT count(*) FROM webcam_snapshots WHERE scoring_path IN ('baseline','baseline-fallback');` should go to 0;
+> `SELECT count(*) FROM webcam_snapshot_ratings;` must be unchanged.
+
+---
+
+## Task 7: Compound-engineering learning
+
+**Files:**
+- Create: `docs/solutions/2026-06-06-fallbacks-must-not-impersonate-real-signal.md`
+
+- [ ] **Step 1: Write the learning doc**
+
+```markdown
+# Fallbacks must not impersonate the real signal
+
+**Date:** 2026-06-06
+**Area:** ML scoring / data integrity
+
+## The trap
+
+`scoreImage` had a "fallback": when the ONNX model failed to load, it scored the
+image from **webcam popularity + a default manual rating** (`baselineRaw`) and
+wrote that guess into `ai_regression_score` / `ai_rating` — the SAME columns the
+real model writes. The mode selector even defaulted to it
+(`AI_SCORING_MODE_DEFAULT = 'baseline'`), so a missing env var silently
+fabricated scores. Two writers (the Windy cron and `customBackfill`) shipped the
+guess to the DB; the leaderboard ranked it as if it were real. Result: broken
+infrastructure looked perfectly healthy, and "we think it's working but it isn't"
+recurred for weeks.
+
+## The rule
+
+**A fallback that writes a plausible value into the same column as the real
+signal is worse than no fallback — it is undetectable.** A heuristic that never
+reads the input it claims to score produces silent, confidently-wrong data.
+
+Fallbacks must be either:
+1. **Absent** — write `NULL`, increment a counter, log loudly. Honest absence is
+   recoverable (a `WHERE col IS NULL` finder reclaims it); a fake number is not.
+2. **A distinct, clearly-labeled channel** — never the column reserved for the
+   real signal.
+
+And never default a mode selector to the fake path.
+
+## What we did
+
+Deleted `baselineRaw` + the `AI_SCORING_MODE` knob; `scoreImage` now returns
+`pathTaken: 'unscored'` with `null` scores on any ONNX failure; all writers skip
+the write on `'unscored'`; a migration nulled the existing junk so the real model
+reclaims it. See `docs/superpowers/specs/2026-06-06-remove-metadata-heuristic-fallback-design.md`.
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add docs/solutions/2026-06-06-fallbacks-must-not-impersonate-real-signal.md
+git commit -m "docs(solutions): learning — fallbacks must not impersonate the real signal"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Spec §1 (scoreImage stops manufacturing) → Task 1. ✅
+- Spec §2 (kill `'baseline'` default mode) → Task 1 (remove mode branch) + Task 2 (delete the constant). ✅
+- Spec §3a/b/c (three writers) → Task 3 (Windy), Task 4 (customBackfill), Task 5 (smoke null-tolerance). ✅
+- Spec §4 (cleanup migration) → Task 6. ✅
+- Spec §5 (tests) → TDD steps in Tasks 1, 3, 4. ✅
+- Spec "compound-engineering learning" → Task 7. ✅
+- Scope boundary (manual ratings off-limits) → enforced in Task 6 SQL + verified in its Step 2. ✅
+
+**Placeholder scan:** No "TBD"/"handle edge cases"/"add validation" steps; every code step shows complete code. The one soft spot — exact mock variable names in `route.test.ts` / `customBackfill.test.ts` — is called out explicitly with the file's visible names and an instruction to match. Acceptable: the implementer reads the test file's top-of-file mock declarations.
+
+**Type consistency:** `ScorePath`, `rawScore: number | null`, `aiRating: number | null`, the `rawScore === null || aiRating === null` guard, and `scoringPaths: Record<'onnx' | 'cache-hit' | 'unscored', number>` are used identically across Tasks 1, 3, 4. `scoreBinary` → `undefined` on failure matches the Task 1 test assertions (`binaryPathTaken` undefined). ✅
+
+**Integration note:** Phase 2 (`feat/three-judge-p2`) also edits `aiScoring.ts` (`computeDisagreementKind`) and adds `archiveBackfill.ts` (which already has the `pathTaken !== 'onnx'` gate). When Phase 2 lands, reconcile: Phase 2's `archiveBackfill` gate should adopt the `'unscored'` path name, and the `ScorePath`/nullable-`rawScore` changes here must be merged into Phase 2's copy of `aiScoring.ts`. The `/code-review ultra 44` findings may overlap here — fold them in at merge.

--- a/docs/superpowers/plans/2026-06-06-remove-baseline-fallback.md
+++ b/docs/superpowers/plans/2026-06-06-remove-baseline-fallback.md
@@ -519,7 +519,92 @@ git commit -m "feat(db): migration to null fabricated baseline scores (manual ra
 
 ---
 
-## Task 7: Compound-engineering learning
+## Task 7: Cleanup retention must protect Claude-scored frames
+
+**Why this is here (from the #44 review, finding #2):** the cleanup cron deletes
+old snapshots where `ai_rating IS NULL OR ai_rating < threshold` and does **not**
+protect `llm_quality`. The Best Sunsets leaderboard ranks by `llm_quality`
+(`app/api/leaderboards/route.ts`), so a high-`llm_quality` frame with a low/NULL
+`ai_rating` is already deletion-eligible. **Task 6 nulls `ai_rating` on every
+baseline row**, which turns more leaderboard-eligible frames into deletion
+candidates — so this fix ships *with* our change. It is latent only because
+`CLEANUP_ENABLED` defaults false; fix it before that flag is ever flipped.
+
+**Files:**
+- Modify: `app/api/snapshots/cleanup/route.ts:63-81`
+- Test: `app/api/snapshots/cleanup/route.test.ts`
+
+- [ ] **Step 1: Add a failing test**
+
+In `cleanup/route.test.ts`, add (mirroring the file's existing pattern — set
+`cleanupEnabledMock.value = true`, `sqlMock.mockResolvedValueOnce([])`, invoke
+the route the same way the surrounding `it(...)` blocks do, then read the tagged
+SQL from `sqlMock.mock.calls[0]`):
+
+```ts
+  it('excludes Claude-scored frames (llm_quality set) — they may be on the leaderboard', async () => {
+    cleanupEnabledMock.value = true;
+    sqlMock.mockResolvedValueOnce([]); // SELECT returns nothing
+    await GET(new Request('http://localhost/api/snapshots/cleanup'));
+    const [strings] = sqlMock.mock.calls[0];
+    const q = strings.join('?').toLowerCase();
+    expect(q).toMatch(/llm_quality\s+is\s+null/i);
+  });
+```
+
+> Match the exact route invocation the other tests in this file use (the same
+> `GET(...)` argument shape). If they use a shared `makeReq()`, use that.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run app/api/snapshots/cleanup/route.test.ts`
+Expected: FAIL — the current query has no `llm_quality` clause.
+
+- [ ] **Step 3: Implement the retention guard**
+
+In `cleanup/route.ts`, update the retention comment (lines 63–69) to add the
+Claude-scored class, and add `AND llm_quality IS NULL` to the SELECT:
+
+```ts
+    // Snapshots with ANY of these signals are NEVER cleaned up — we only drop a
+    // frame older than 7 days that has none of them:
+    //   1. model_disagreement_kind set (queued for Hard Examples triage).
+    //   2. Any user ever rated or verdicted it (training data).
+    //   3. A high AI score (ai_rating >= AI_SNAPSHOT_MIN_RATING_THRESHOLD).
+    //   4. Claude scored it (llm_quality set) — the Best Sunsets leaderboard
+    //      ranks by llm_quality, so these are the real best-of frames. This also
+    //      guards the window where the ONNX backfill has nulled ai_rating but
+    //      Claude's quality is the live ranking signal.
+    const oldSnapshots = await sql`
+      SELECT id, firebase_path, captured_at
+      FROM webcam_snapshots
+      WHERE captured_at < NOW() - INTERVAL '7 days'
+        AND model_disagreement_kind IS NULL
+        AND llm_quality IS NULL
+        AND (ai_rating IS NULL OR ai_rating < ${AI_SNAPSHOT_MIN_RATING_THRESHOLD})
+        AND id NOT IN (
+          SELECT DISTINCT snapshot_id FROM webcam_snapshot_ratings
+          WHERE rating IS NOT NULL OR is_sunset_verdict IS NOT NULL
+        )
+      ORDER BY captured_at ASC
+    `;
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx vitest run app/api/snapshots/cleanup/route.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/api/snapshots/cleanup/route.ts app/api/snapshots/cleanup/route.test.ts
+git commit -m "fix(cleanup): never delete Claude-scored frames (llm_quality) — guards leaderboard + null-ai_rating window"
+```
+
+---
+
+## Task 8: Compound-engineering learning
 
 **Files:**
 - Create: `docs/solutions/2026-06-06-fallbacks-must-not-impersonate-real-signal.md`
@@ -583,11 +668,30 @@ git commit -m "docs(solutions): learning — fallbacks must not impersonate the 
 - Spec §3a/b/c (three writers) → Task 3 (Windy), Task 4 (customBackfill), Task 5 (smoke null-tolerance). ✅
 - Spec §4 (cleanup migration) → Task 6. ✅
 - Spec §5 (tests) → TDD steps in Tasks 1, 3, 4. ✅
-- Spec "compound-engineering learning" → Task 7. ✅
+- #44 review finding #2 (cleanup deletes leaderboard frames; worsened by our nulling) → Task 7. ✅
+- Spec "compound-engineering learning" → Task 8. ✅
 - Scope boundary (manual ratings off-limits) → enforced in Task 6 SQL + verified in its Step 2. ✅
 
 **Placeholder scan:** No "TBD"/"handle edge cases"/"add validation" steps; every code step shows complete code. The one soft spot — exact mock variable names in `route.test.ts` / `customBackfill.test.ts` — is called out explicitly with the file's visible names and an instruction to match. Acceptable: the implementer reads the test file's top-of-file mock declarations.
 
 **Type consistency:** `ScorePath`, `rawScore: number | null`, `aiRating: number | null`, the `rawScore === null || aiRating === null` guard, and `scoringPaths: Record<'onnx' | 'cache-hit' | 'unscored', number>` are used identically across Tasks 1, 3, 4. `scoreBinary` → `undefined` on failure matches the Task 1 test assertions (`binaryPathTaken` undefined). ✅
 
-**Integration note:** Phase 2 (`feat/three-judge-p2`) also edits `aiScoring.ts` (`computeDisagreementKind`) and adds `archiveBackfill.ts` (which already has the `pathTaken !== 'onnx'` gate). When Phase 2 lands, reconcile: Phase 2's `archiveBackfill` gate should adopt the `'unscored'` path name, and the `ScorePath`/nullable-`rawScore` changes here must be merged into Phase 2's copy of `aiScoring.ts`. The `/code-review ultra 44` findings may overlap here — fold them in at merge.
+**Integration note:** Phase 2 (`feat/three-judge-p2`) also edits `aiScoring.ts` (`computeDisagreementKind`) and adds `archiveBackfill.ts` (which already has the `pathTaken !== 'onnx'` gate). When Phase 2 lands, reconcile: Phase 2's `archiveBackfill` gate should adopt the `'unscored'` path name, and the `ScorePath`/nullable-`rawScore` changes here must be merged into Phase 2's copy of `aiScoring.ts`.
+
+**Disposition of the PR #44 review findings (2026-06-06 local high-effort review):**
+
+| # | Finding | Where it's fixed |
+|---|---------|------------------|
+| 2 | Cleanup deletes high-`llm_quality` frames; our nulling widens the net | **This plan, Task 7** |
+| 9 (sub) | Rating mapping re-inlined; "centralize on `ratingFromRaw`" | This plan **deletes** `ratingFromRaw` (baseline-only on main) — Phase 2 must centralize on `normalizeRegressionOutput` instead |
+| 1 | Undo pushes hard-example into unrated queue (`SnapshotConsole`/`useSnapshotStore`) | **`feat/three-judge-p2`** — Phase 2 code, not on this branch |
+| 3 | Recompute finder has no supporting index | `feat/three-judge-p2` |
+| 4 | Recompute does ≤500 sequential single-row UPDATEs | `feat/three-judge-p2` |
+| 5 | Archive backfill scores strictly sequentially | `feat/three-judge-p2` |
+| 6 | Recompute skips rows with NULL `llm_rated_at` | `feat/three-judge-p2` |
+| 7 | `isPermanentDownloadError` regex false-positives | `feat/three-judge-p2` |
+| 9 (main) | Priority map vs SQL `CASE` duplicated; constant is dead | `feat/three-judge-p2` |
+| 10 | Owner auth gated per-mode, not centrally | `feat/three-judge-p2` / Phase 3 U7 (secure-by-default before adding a new private mode) |
+| 8 | Migrations manual/forward-only | Our Task 6 is data-only (no columns) → no deploy-order 500 risk; the runner concern is repo-wide and tracked on Phase 2 |
+
+The must-fix-before-#44-merge set (#1, and #3/#4 for cost) lives on the Phase 2 branch — out of scope for this plan but recorded here so nothing is dropped.

--- a/docs/superpowers/specs/2026-06-06-remove-metadata-heuristic-fallback-design.md
+++ b/docs/superpowers/specs/2026-06-06-remove-metadata-heuristic-fallback-design.md
@@ -93,18 +93,33 @@ on it, so the leaderboard ranks guesses as if they were real.
   var but default it to `'onnx'` and make non-onnx return `'unscored'` rather
   than baseline. Lean is full delete.)*
 
-### 3. Live cron writes nothing on `'unscored'`
+### 3. Every score-writer writes nothing on `'unscored'`
 
-In `route.ts`, mirror the backfill's discipline:
+On `main` there are **three** `scoreImage` consumers, and two of them write fake
+scores today (the third is read-only):
 
-- On `pathTaken === 'unscored'`: **skip** the score write. The snapshot row is
-  still inserted (the image exists) but with `ai_regression_score` / `ai_rating`
-  / binary columns left `NULL`. Do not call `updateWebcamAiFields` with a faked
-  score.
-- Increment the `fallbacks` / unscored counter and log loudly (keep the existing
-  `scoringPaths` telemetry; rename the `baseline-fallback` bucket to `unscored`).
-- The row re-enters the scoring queue automatically — the finder is
-  `WHERE ai_regression_score IS NULL` — so the real model reclaims it next tick.
+**(a) `route.ts` `scoreOneWindy` (live Windy cron).**
+- On `'unscored'`: **skip** the write — do not call `updateWebcamAiFields`, do
+  not push to `windyScores`, do not persist a snapshot. The image exists but
+  carries no score.
+- Increment an `unscored` counter and log. Rename the `baseline-fallback`
+  telemetry bucket to `unscored`.
+
+**(b) `customBackfill.ts` (custom-camera backfill).** This is the second leak —
+it currently writes `result.rawScore` with no gate (lines 49–58).
+- On `'unscored'`: `continue` without calling `updateSnapshotAiRegressionScore`,
+  without pushing to `scores`, and without adding the webcam to
+  `touchedWebcamIds` (so no `updateWebcamRegressionScoreFromLatestCustomSnapshot`
+  sync from a non-score). Count it as `failed` (or a new `unscored` field).
+- The finder is `WHERE ai_regression_score IS NULL`, so the row is retried.
+
+**(c) `app/api/debug/scoring-smoke/route.ts` (diagnostic, read-only).** Does not
+write — just needs to tolerate a null `rawScore` in its JSON response (a null
+`rawScore` + `pathTaken: 'unscored'` is itself the useful "model isn't loading"
+signal).
+
+In all cases the row re-enters the scoring queue automatically — the finders are
+`WHERE ai_regression_score IS NULL` — so the real model reclaims it next tick.
 
 ### 4. Cleanup migration (null the existing junk)
 

--- a/docs/superpowers/specs/2026-06-06-remove-metadata-heuristic-fallback-design.md
+++ b/docs/superpowers/specs/2026-06-06-remove-metadata-heuristic-fallback-design.md
@@ -1,0 +1,189 @@
+# Remove the metadata-heuristic scoring fallback
+
+**Date:** 2026-06-06
+**Branch:** `fix/remove-baseline-fallback` (off `main` — standalone production safety fix)
+**Status:** Design approved, pending spec review
+
+## Problem
+
+`scoreImage` (`app/api/cron/update-cameras/lib/aiScoring.ts`) has a non-ONNX
+fallback that fabricates a sunset score **without looking at the image**.
+`baselineRaw` computes a value from webcam popularity and a default manual
+rating:
+
+```ts
+function baselineRaw(input) {
+  const views  = input.fallbackMeta?.viewCount ?? 0;
+  const manual = input.fallbackMeta?.manualRating ?? 3;
+  const normViews  = clamp(Math.log10(views + 1) / 6, 0, 1);
+  const normManual = clamp(manual / 5, 0, 1);
+  return clamp(normViews * 0.65 + normManual * 0.35, 0, 1);
+}
+```
+
+That number is then dressed up as a 1–5 "AI rating" (`ratingFromRaw`) and
+written into `ai_regression_score` / `ai_rating` — **the same columns the real
+ONNX model writes.** Consumers (the leaderboard) cannot tell a real model score
+from a view-count guess.
+
+Two paths produce it:
+
+- `'baseline'` — deliberate: `AI_SCORING_MODE !== 'onnx'`.
+- `'baseline-fallback'` — accidental: ONNX was supposed to run but failed to
+  load, so it silently falls back to the heuristic.
+
+**Root cause of "we think it's working but it isn't":**
+`AI_SCORING_MODE_DEFAULT = 'baseline'` (`app/lib/masterConfig.ts:147`). Anytime
+`AI_SCORING_MODE=onnx` is not explicitly set — a missing env var, a
+misconfigured preview, a fresh environment — the cron writes fake scores and
+every dashboard looks green.
+
+**Where it leaks:** the Phase-2 `archiveBackfill` already refuses to write
+non-ONNX results (it `break`s). But the **live cron** (`route.ts`) writes
+`baseline` / `baseline-fallback` scores into `webcam_snapshots` + `webcams`
+every tick. The provenance is recorded in `scoring_path`, but no consumer filters
+on it, so the leaderboard ranks guesses as if they were real.
+
+## Goals
+
+1. The model is the only thing that can produce a score. When ONNX can't run,
+   the result is honest **absence** (`NULL`), never a fabricated number.
+2. Remove the footgun default so a missing env var can never silently fake data.
+3. Clean the fake scores already in the database so they stop being ranked and
+   get re-scored by the real model.
+4. Record the anti-pattern so it cannot be reintroduced.
+
+## Non-goals / scope boundaries
+
+- **Claude (`llm_*`) scoring is untouched.** This work never reads or writes
+  `llm_quality` / `llm_is_sunset` / any `llm_*` column. Claude scoring stays in
+  `ml/llm_rater.py`.
+- **Human manual ratings are off-limits.** The cleanup touches only
+  AI-produced columns. It must **never** modify `webcams.rating`,
+  `initial_rating`, or any column of `webcam_snapshot_ratings` (manual ratings +
+  operator verdicts). These are preserved for future v5 training. (The heuristic
+  *read* `webcams.rating` as an input but only ever read it — we delete the fake
+  output, the human labels survive.)
+- **No change to the disagreement engine, Phase 2, or Phase 3.** This composes
+  with the in-flight backfill; it does not alter `computeDisagreementKind` logic.
+
+## Design
+
+### 1. `scoreImage` stops manufacturing scores
+
+- Delete `baselineRaw`, the `fallbackMeta` field on `ScoreImageInput`, and the
+  baseline use of `ratingFromRaw`.
+- Collapse `ScorePath` from
+  `'onnx' | 'cache-hit' | 'baseline' | 'baseline-fallback'`
+  to **`'onnx' | 'cache-hit' | 'unscored'`**.
+- Whenever ONNX cannot produce a real number — `getOrt`/preprocess throws, or the
+  regression head throws — return a single honest result with
+  `pathTaken: 'unscored'` and **null** `rawScore` / `aiRating`. The binary head
+  already returns its fields unset on failure; keep them null (no `0`/`false`
+  placeholder).
+
+### 2. Remove the `AI_SCORING_MODE` branch (kill the `'baseline'` default)
+
+- `scoreImage` always attempts ONNX. "No model available" naturally becomes
+  `'unscored'`.
+- Delete `AI_SCORING_MODE` + `AI_SCORING_MODE_DEFAULT` so a missing/incorrect env
+  var can never again mean "fabricate." Local dev / tests without the model get
+  honest `'unscored'` results (or mock the ONNX session for real-score tests).
+- *(Conservative fallback if we decide to keep a local-skip knob: keep the env
+  var but default it to `'onnx'` and make non-onnx return `'unscored'` rather
+  than baseline. Lean is full delete.)*
+
+### 3. Live cron writes nothing on `'unscored'`
+
+In `route.ts`, mirror the backfill's discipline:
+
+- On `pathTaken === 'unscored'`: **skip** the score write. The snapshot row is
+  still inserted (the image exists) but with `ai_regression_score` / `ai_rating`
+  / binary columns left `NULL`. Do not call `updateWebcamAiFields` with a faked
+  score.
+- Increment the `fallbacks` / unscored counter and log loudly (keep the existing
+  `scoringPaths` telemetry; rename the `baseline-fallback` bucket to `unscored`).
+- The row re-enters the scoring queue automatically — the finder is
+  `WHERE ai_regression_score IS NULL` — so the real model reclaims it next tick.
+
+### 4. Cleanup migration (null the existing junk)
+
+New forward, idempotent migration
+`database/migrations/<date>_null_baseline_scores.sql`:
+
+```sql
+-- Null AI-produced scores that were fabricated by the metadata heuristic, so the
+-- leaderboard stops ranking guesses and the ONNX backfill reclaims these rows
+-- (finder = WHERE ai_regression_score IS NULL). Touches ONLY ai_* / scoring_path
+-- / disagreement columns. NEVER touches human-rating columns (webcams.rating,
+-- initial_rating, webcam_snapshot_ratings.*).
+UPDATE webcam_snapshots
+SET ai_regression_score     = NULL,
+    ai_rating               = NULL,
+    scoring_path            = NULL,
+    model_disagreement_kind = NULL
+WHERE scoring_path IN ('baseline', 'baseline-fallback');
+
+-- Denormalized AI values on webcams (written from the live-cron baseline path).
+-- Only the ai_* columns; webcams.rating (human) is untouched.
+UPDATE webcams
+SET ai_rating            = NULL,
+    ai_rating_regression = NULL,
+    ai_rating_binary     = NULL
+WHERE /* rows whose latest score came from a baseline path — see Open question */;
+```
+
+**Open question for the plan:** `webcams` has no per-row `scoring_path`, so the
+exact predicate for which denormalized rows to null needs to be pinned in
+planning (options: null all `ai_rating*` and let the next scored snapshot re-sync
+each webcam; or join to the latest snapshot's `scoring_path`). The
+`webcam_snapshots` cleanup is unambiguous and is the source of truth the
+leaderboard ranks.
+
+Binary columns (`ai_binary_*`) are **Phase-2-only** and absent on `main`, so
+there is no binary junk to clean on this branch.
+
+### 5. Tests (TDD — written first)
+
+Rewrite the three test files that assert baseline behavior to assert the
+`'unscored'` contract:
+
+- `aiScoring.test.ts` — ONNX failure / no-model returns `pathTaken: 'unscored'`
+  with null scores; no fabricated number.
+- `route.test.ts` — an `'unscored'` result writes no score (columns stay null),
+  bumps the unscored counter, still inserts the snapshot.
+- `archiveBackfill.test.ts` — gate still holds against the renamed path.
+
+## Compound-engineering learning
+
+Write `docs/solutions/<date>-fallbacks-must-not-impersonate-real-signal.md`:
+
+> **A fallback that writes a plausible value into the same column as the real
+> signal is worse than no fallback — it is undetectable.** A heuristic that never
+> reads the input it claims to score (here: a view-count guess written into the
+> model's score column) produces silent, confidently-wrong data and makes broken
+> infrastructure look healthy. Fallbacks must be either **absent** (write `NULL`,
+> count it, log it) or stored in a **distinct, clearly-labeled channel** — never
+> in the column reserved for the real signal. Bonus footgun: defaulting the mode
+> selector to the fake path (`AI_SCORING_MODE_DEFAULT = 'baseline'`) means a
+> missing env var silently fabricates.
+
+## Dependencies / integration
+
+- **Base:** `main`. This is a standalone production safety fix and ships
+  independently of the Phase 1/2/3 stack.
+- **Known overlap:** Phase 2 (`feat/three-judge-p2`) also edits `aiScoring.ts`
+  (`computeDisagreementKind`). A small merge resolution is expected when both
+  land. The two changes are logically disjoint (this removes the baseline path;
+  Phase 2 extends the disagreement function), so resolution is mechanical.
+
+## Verification
+
+- A forced ONNX failure yields `pathTaken: 'unscored'` and writes no score.
+- With no `AI_SCORING_MODE` set, the cron does not fabricate scores.
+- After the cleanup migration, `SELECT count(*) FROM webcam_snapshots WHERE
+  scoring_path IN ('baseline','baseline-fallback')` is 0, and those rows have
+  `ai_regression_score IS NULL`.
+- `webcams.rating`, `initial_rating`, and `webcam_snapshot_ratings` row counts
+  and values are unchanged by the migration.
+- Leaderboard ranks only real (ONNX / Claude) scores.

--- a/docs/superpowers/specs/2026-06-06-remove-metadata-heuristic-fallback-design.md
+++ b/docs/superpowers/specs/2026-06-06-remove-metadata-heuristic-fallback-design.md
@@ -191,6 +191,19 @@ Write `docs/solutions/<date>-fallbacks-must-not-impersonate-real-signal.md`:
   (`computeDisagreementKind`). A small merge resolution is expected when both
   land. The two changes are logically disjoint (this removes the baseline path;
   Phase 2 extends the disagreement function), so resolution is mechanical.
+- **Cleanup-retention coupling (from PR #44 review, finding #2):** the cleanup
+  cron deletes old frames where `ai_rating IS NULL OR ai_rating < threshold` and
+  does not protect `llm_quality` — but the leaderboard ranks by `llm_quality`.
+  Nulling `ai_rating` on baseline rows (above) turns more leaderboard-eligible
+  frames into deletion candidates, so this plan **also** adds an
+  `AND llm_quality IS NULL` retention guard (gated behind `CLEANUP_ENABLED`,
+  default false). See the plan's Task 7.
+- **`ratingFromRaw` removal:** this plan deletes `ratingFromRaw` (baseline-only
+  on `main`). The #44 review's suggestion to centralize rating math on it is
+  therefore redirected — Phase 2 should centralize on `normalizeRegressionOutput`.
+- **Other #44 findings** (#1 undo, #3–#7 recompute/backfill cost+correctness,
+  #9 priority duplication, #10 central auth) are Phase-2 code, fixed on
+  `feat/three-judge-p2` — see the plan's disposition table.
 
 ## Verification
 


### PR DESCRIPTION
## Summary

The model is now the only thing that can produce a sunset score. Previously, when ONNX failed to load, `scoreImage` fabricated a score from **webcam popularity + a default manual rating** (`baselineRaw`) and wrote it into the model's real columns (`ai_regression_score` / `ai_rating`) — undetectable fake data that the leaderboard ranked as real. The mode selector even **defaulted** to that path (`AI_SCORING_MODE_DEFAULT = 'baseline'`), so a missing env var silently faked scores.

- **`scoreImage` returns `pathTaken: 'unscored'` with `null` scores** on any ONNX failure; deletes `baselineRaw`, `ratingFromRaw`, the `AI_SCORING_MODE` branch, and the `'baseline'` default footgun. `rawScore`/`aiRating` are now `number | null`.
- **All three writers skip the write on `'unscored'`** — the Windy cron (`route.ts`), `customBackfill.ts` (a second un-gated leak), and the read-only smoke endpoint. Columns are left `NULL` so the backfill (`WHERE ai_regression_score IS NULL`) reclaims the row once the model loads.
- **Cleanup migration** nulls the fabricated baseline scores already in the DB. Scope-bounded to `ai_*`/`scoring_path`/`model_disagreement_kind` — **human manual ratings (`webcams.rating`, `initial_rating`, `webcam_snapshot_ratings`) are never touched** (preserved for v5 training).
- **Folds in PR #44 review finding #2:** cleanup retention now protects Claude-scored frames (`AND llm_quality IS NULL`), since nulling `ai_rating` widened the deletion net against leaderboard frames.
- **Learning doc** (`docs/solutions/`) capturing the anti-pattern so it can't return.

Spec + plan: `docs/superpowers/specs/2026-06-06-remove-metadata-heuristic-fallback-design.md`, `docs/superpowers/plans/2026-06-06-remove-baseline-fallback.md`.

## Operational (owner runs after merge)

```
psql "$DATABASE_URL" -f database/migrations/20260606_null_baseline_scores.sql
```
Verify: `SELECT count(*) FROM webcam_snapshots WHERE scoring_path IN ('baseline','baseline-fallback');` → 0; `SELECT count(*) FROM webcam_snapshot_ratings;` unchanged.

## Test plan

- [x] 191 tests pass across touched areas (scoreImage / Windy cron / customBackfill / cleanup); new tests assert no score is written on `'unscored'` and that cleanup protects `llm_quality`.
- [x] No type errors in any touched source file.
- [ ] Apply the migration in prod, confirm baseline rows drain to NULL and re-score via ONNX.

## Notes

Independent of the #43/#44 stack. A small **mechanical** `aiScoring.ts` merge reconciliation is expected when #44 lands — Phase 2's `archiveBackfill` gate should adopt the `'unscored'` path name and the `number | null` change. See the plan's disposition table for where the other 9 review findings are handled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)