### PR TITLE
docs(plan): three-judge Phase 3 (Flickr) — corrected for existing Claude scores

### DIFF
--- a/app/HomeClient.tsx
+++ b/app/HomeClient.tsx
@@ -22,6 +22,7 @@ import { ModelAnalysisTab } from './components/ModelAnalysis/ModelAnalysisTab';
 import { AuthControl } from './components/auth/AuthControl';
 import { useIsOperator } from './components/auth/useIsOperator';
 import { LeaderboardTab } from './components/Leaderboard/LeaderboardTab';
+import { VerificationTab } from './components/Verification/VerificationTab';
 
 interface Props {
   manifestRuns: ManifestEntry[];
@@ -42,6 +43,7 @@ export function HomeClient({ manifestRuns }: Props) {
     { key: 'current', label: 'Current Sunrises/Sunsets', operatorOnly: false },
     { key: 'best', label: '🌅 Best Sunsets', operatorOnly: false },
     { key: 'hard', label: '⚠ Hard Examples', operatorOnly: true },
+    { key: 'verify', label: '🔎 Verification', operatorOnly: true },
     { key: 'archive', label: 'Snapshot Archive', operatorOnly: false },
     { key: 'curated', label: 'Curated', operatorOnly: false },
     { key: 'unrated', label: 'Unrated Queue', operatorOnly: true },
@@ -203,6 +205,13 @@ export function HomeClient({ manifestRuns }: Props) {
                     title={'⚠ Hard Examples — confirm or correct the model'}
                     hotkeysEnabled={drawerOpen}
                   />
+                </Box>
+              )}
+
+              {tabKey === 'verify' && (
+                // Verification — webcam + Flickr union, disagreements toggle
+                <Box>
+                  <VerificationTab />
                 </Box>
               )}
 

--- a/app/api/cron/update-cameras/lib/aiScoring.ts
+++ b/app/api/cron/update-cameras/lib/aiScoring.ts
@@ -39,7 +39,7 @@ import {
 import { sha256Hex } from './imageHash';
 import { preprocessJpegToImagenetTensor } from './imagePreprocess';
 
-export type WebcamSource = 'windy' | 'custom';
+export type WebcamSource = 'windy' | 'custom' | 'flickr';
 
 export interface ScoreImageInput {
   webcamId: number;

--- a/app/api/cron/update-cameras/lib/dbOperations.external.test.ts
+++ b/app/api/cron/update-cameras/lib/dbOperations.external.test.ts
@@ -1,0 +1,172 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const sqlMock = vi.fn();
+
+vi.mock('@/app/lib/db', () => ({
+  sql: (strings: TemplateStringsArray, ...values: unknown[]) =>
+    sqlMock(strings, ...values),
+}));
+
+import {
+  findExternalImagesNeedingScore,
+  countExternalImagesNeedingScore,
+  updateExternalImageModelScores,
+  markExternalImageDeadUrl,
+  findExternalImagesNeedingDisagreementRecompute,
+  updateExternalImageDisagreementsBatch,
+} from './dbOperations';
+
+beforeEach(() => sqlMock.mockReset());
+
+describe('findExternalImagesNeedingScore', () => {
+  it('selects unscored, non-dead-url flickr rows and maps the row shape', async () => {
+    sqlMock.mockResolvedValue([
+      {
+        external_image_id: 11,
+        image_url: 'https://live.staticflickr.com/x/11.jpg',
+        llm_quality: '0.910', // NUMERIC comes back as a string
+        llm_is_sunset: true,
+      },
+    ]);
+    const rows = await findExternalImagesNeedingScore(50);
+    expect(rows).toEqual([
+      {
+        externalImageId: 11,
+        imageUrl: 'https://live.staticflickr.com/x/11.jpg',
+        llmQuality: 0.91,
+        llmIsSunset: true,
+      },
+    ]);
+    const [strings, ...values] = sqlMock.mock.calls[0];
+    const q = strings.join('?');
+    expect(q).toMatch(/from\s+external_images/i);
+    expect(q).toMatch(/ai_regression_score\s+is\s+null/i);
+    expect(q).toMatch(/image_url\s+is\s+not\s+null/i);
+    expect(q).toMatch(/scoring_state\s+is\s+distinct\s+from\s+'dead-url'/i);
+    expect(q).toMatch(/source\s*=\s*'flickr'/i);
+    expect(q).toMatch(/limit/i);
+    expect(values).toContain(50);
+  });
+
+  it('coerces a null llm_quality to null, not NaN', async () => {
+    sqlMock.mockResolvedValue([
+      {
+        external_image_id: 12,
+        image_url: 'https://live.staticflickr.com/x/12.jpg',
+        llm_quality: null,
+        llm_is_sunset: null,
+      },
+    ]);
+    const [row] = await findExternalImagesNeedingScore(10);
+    expect(row.llmQuality).toBeNull();
+    expect(row.llmIsSunset).toBeNull();
+  });
+});
+
+describe('countExternalImagesNeedingScore', () => {
+  it('returns the integer count', async () => {
+    sqlMock.mockResolvedValue([{ n: 5872 }]);
+    expect(await countExternalImagesNeedingScore()).toBe(5872);
+  });
+
+  it('returns 0 when the result is empty', async () => {
+    sqlMock.mockResolvedValue([]);
+    expect(await countExternalImagesNeedingScore()).toBe(0);
+  });
+});
+
+describe('updateExternalImageModelScores', () => {
+  it('writes the judge columns + disagreement onto external_images, never ai_rating or webcams', async () => {
+    sqlMock.mockResolvedValue([]);
+    await updateExternalImageModelScores({
+      externalImageId: 7,
+      regressionScore: 0.812,
+      regressionModelVersion: 'v4_reg',
+      binaryScore: 0.91,
+      binaryIsSunset: true,
+      binaryModelVersion: 'v4_bin',
+      scoringPath: 'onnx',
+      disagreementKind: 'model_low_claude_sunset',
+    });
+    const [strings, ...values] = sqlMock.mock.calls[0];
+    const q = strings.join('?');
+    expect(q).toMatch(/update\s+external_images/i);
+    expect(q).toMatch(/ai_regression_score/);
+    expect(q).toMatch(/ai_binary_score/);
+    expect(q).toMatch(/ai_binary_is_sunset/);
+    expect(q).toMatch(/scoring_path/);
+    expect(q).toMatch(/model_disagreement_kind/);
+    expect(q).toMatch(/disagreement_computed_at\s*=\s*now\(\)/i);
+    expect(q).not.toMatch(/\bai_rating\s*=/);
+    expect(q).not.toMatch(/webcams/i);
+    expect(values).toContain(7);
+    expect(values).toContain(0.812);
+    expect(values).toContain('model_low_claude_sunset');
+  });
+});
+
+describe('markExternalImageDeadUrl', () => {
+  it("sets scoring_state='dead-url' on external_images so the finder excludes it", async () => {
+    sqlMock.mockResolvedValue([]);
+    await markExternalImageDeadUrl(99);
+    const [strings, ...values] = sqlMock.mock.calls[0];
+    const q = strings.join('?');
+    expect(q).toMatch(/update\s+external_images/i);
+    expect(q).toMatch(/scoring_state\s*=\s*'dead-url'/i);
+    expect(values).toContain(99);
+  });
+});
+
+describe('findExternalImagesNeedingDisagreementRecompute', () => {
+  it('selects rows where disagreement predates the Claude score (or is unset)', async () => {
+    sqlMock.mockResolvedValue([
+      {
+        external_image_id: 5,
+        ai_regression_score: '0.200',
+        ai_binary_is_sunset: null,
+        llm_quality: '0.850',
+        llm_is_sunset: true,
+      },
+    ]);
+    const rows = await findExternalImagesNeedingDisagreementRecompute(100);
+    expect(rows[0]).toEqual({
+      externalImageId: 5,
+      aiRegressionScore: 0.2,
+      binaryIsSunset: null,
+      llmQuality: 0.85,
+      llmIsSunset: true,
+    });
+    const [strings] = sqlMock.mock.calls[0];
+    const q = strings.join('?');
+    expect(q).toMatch(/from\s+external_images/i);
+    expect(q).toMatch(/ai_regression_score\s+is\s+not\s+null/i);
+    expect(q).toMatch(/llm_quality\s+is\s+not\s+null/i);
+    expect(q).toMatch(/disagreement_computed_at\s+is\s+null/i);
+    expect(q).toMatch(/disagreement_computed_at\s*<\s*.*llm_rated_at/i);
+  });
+});
+
+describe('updateExternalImageDisagreementsBatch', () => {
+  it('writes every row in a single unnest UPDATE on external_images', async () => {
+    sqlMock.mockResolvedValue([]);
+    await updateExternalImageDisagreementsBatch([
+      { externalImageId: 5, kind: 'model_low_claude_sunset' },
+      { externalImageId: 6, kind: null },
+    ]);
+    expect(sqlMock).toHaveBeenCalledTimes(1);
+    const [strings, ...values] = sqlMock.mock.calls[0];
+    const q = strings.join('?');
+    expect(q).toMatch(/update\s+external_images/i);
+    expect(q).toMatch(/unnest/i);
+    expect(q).toMatch(/model_disagreement_kind/);
+    expect(q).toMatch(/disagreement_computed_at\s*=\s*now\(\)/i);
+    expect(values).toContainEqual([5, 6]);
+    expect(values).toContainEqual(['model_low_claude_sunset', null]);
+  });
+
+  it('issues no query for an empty batch', async () => {
+    sqlMock.mockResolvedValue([]);
+    await updateExternalImageDisagreementsBatch([]);
+    expect(sqlMock).not.toHaveBeenCalled();
+  });
+});

--- a/app/api/cron/update-cameras/lib/dbOperations.ts
+++ b/app/api/cron/update-cameras/lib/dbOperations.ts
@@ -607,3 +607,169 @@ export async function updateSnapshotDisagreementsBatch(
   `;
 }
 
+/* -------------------------------------------------------------------------- */
+/* external_images (Flickr) — model-only backfill + recompute (plan U6)        */
+/*                                                                            */
+/* Parallel to the webcam_snapshots functions above, targeting external_images.*/
+/* Deliberately distinct (NOT generalized) because the writers must never sync */
+/* a webcams row — a Flickr image has no webcam. The Claude judge already lives */
+/* in external_images.llm_*; U6 only fills the model columns + disagreement.    */
+/* -------------------------------------------------------------------------- */
+
+export interface ExternalImageNeedingScore {
+  externalImageId: number;
+  imageUrl: string;
+  llmQuality: number | null;
+  llmIsSunset: boolean | null;
+}
+
+/**
+ * Flickr rows that still need a real v4 regression score, ordered by recency,
+ * excluding rows permanently marked `scoring_state='dead-url'`. Reads Claude's
+ * `llm_*` to compute model-vs-Claude during the backfill.
+ */
+export async function findExternalImagesNeedingScore(
+  limit: number,
+): Promise<ExternalImageNeedingScore[]> {
+  const rows = (await sql`
+    select e.id            as external_image_id,
+           e.image_url     as image_url,
+           e.llm_quality   as llm_quality,
+           e.llm_is_sunset as llm_is_sunset
+    from external_images e
+    where e.source = 'flickr'
+      and e.ai_regression_score is null
+      and e.image_url is not null
+      and e.scoring_state is distinct from 'dead-url'
+    order by e.scraped_at desc
+    limit ${limit}
+  `) as {
+    external_image_id: number;
+    image_url: string;
+    llm_quality: number | string | null;
+    llm_is_sunset: boolean | null;
+  }[];
+
+  return rows.map((r) => ({
+    externalImageId: r.external_image_id,
+    imageUrl: r.image_url,
+    llmQuality: r.llm_quality == null ? null : Number(r.llm_quality),
+    llmIsSunset: r.llm_is_sunset,
+  }));
+}
+
+/** Count of Flickr rows still needing a score — for the backfill dry-run. */
+export async function countExternalImagesNeedingScore(): Promise<number> {
+  const rows = (await sql`
+    select count(*)::int as n
+    from external_images e
+    where e.source = 'flickr'
+      and e.ai_regression_score is null
+      and e.image_url is not null
+      and e.scoring_state is distinct from 'dead-url'
+  `) as { n: number }[];
+  return rows[0]?.n ?? 0;
+}
+
+/**
+ * Persist all three judge columns + the disagreement verdict for a backfilled
+ * Flickr image. Mirrors updateSnapshotModelScores but targets external_images
+ * and never syncs a webcams row (none exists for a Flickr image).
+ */
+export async function updateExternalImageModelScores(opts: {
+  externalImageId: number;
+  regressionScore: number;
+  regressionModelVersion: string;
+  binaryScore: number | null;
+  binaryIsSunset: boolean | null;
+  binaryModelVersion: string | null;
+  scoringPath: string;
+  disagreementKind: string | null;
+}): Promise<void> {
+  await sql`
+    update external_images
+    set ai_regression_score = ${opts.regressionScore},
+        ai_model_version_regression = ${opts.regressionModelVersion},
+        ai_binary_score = ${opts.binaryScore},
+        ai_binary_is_sunset = ${opts.binaryIsSunset},
+        ai_model_version_binary = ${opts.binaryModelVersion},
+        scoring_path = ${opts.scoringPath},
+        model_disagreement_kind = ${opts.disagreementKind},
+        disagreement_computed_at = now()
+    where id = ${opts.externalImageId}
+  `;
+}
+
+/** Mark a Flickr image whose URL is permanently unreachable (404 / dead URL). */
+export async function markExternalImageDeadUrl(
+  externalImageId: number,
+): Promise<void> {
+  await sql`
+    update external_images
+    set scoring_state = 'dead-url'
+    where id = ${externalImageId}
+  `;
+}
+
+export interface ExternalImageNeedingRecompute {
+  externalImageId: number;
+  aiRegressionScore: number;
+  binaryIsSunset: boolean | null;
+  llmQuality: number | null;
+  llmIsSunset: boolean | null;
+}
+
+/**
+ * Flickr rows whose model_disagreement_kind was computed before Claude's score
+ * landed (or never computed). Pure recompute — no download/ONNX. external_images
+ * has llm_rated_at, so the predicate mirrors the webcam_snapshots recompute.
+ */
+export async function findExternalImagesNeedingDisagreementRecompute(
+  limit: number,
+): Promise<ExternalImageNeedingRecompute[]> {
+  const rows = (await sql`
+    select e.id                  as external_image_id,
+           e.ai_regression_score as ai_regression_score,
+           e.ai_binary_is_sunset as ai_binary_is_sunset,
+           e.llm_quality         as llm_quality,
+           e.llm_is_sunset       as llm_is_sunset
+    from external_images e
+    where e.ai_regression_score is not null
+      and e.llm_quality is not null
+      and (e.disagreement_computed_at is null
+           or e.disagreement_computed_at < e.llm_rated_at)
+    order by e.llm_rated_at desc nulls last
+    limit ${limit}
+  `) as {
+    external_image_id: number;
+    ai_regression_score: number | string;
+    ai_binary_is_sunset: boolean | null;
+    llm_quality: number | string | null;
+    llm_is_sunset: boolean | null;
+  }[];
+
+  return rows.map((r) => ({
+    externalImageId: r.external_image_id,
+    aiRegressionScore: Number(r.ai_regression_score),
+    binaryIsSunset: r.ai_binary_is_sunset,
+    llmQuality: r.llm_quality == null ? null : Number(r.llm_quality),
+    llmIsSunset: r.llm_is_sunset,
+  }));
+}
+
+/** Batched disagreement write for external_images (one round-trip per page). */
+export async function updateExternalImageDisagreementsBatch(
+  updates: { externalImageId: number; kind: string | null }[],
+): Promise<void> {
+  if (updates.length === 0) return;
+  const ids = updates.map((u) => u.externalImageId);
+  const kinds = updates.map((u) => u.kind);
+  await sql`
+    update external_images e
+    set model_disagreement_kind = v.kind,
+        disagreement_computed_at = now()
+    from unnest(${ids}::int[], ${kinds}::text[]) as v(id, kind)
+    where e.id = v.id
+  `;
+}
+

--- a/app/api/cron/update-cameras/lib/externalBackfill.test.ts
+++ b/app/api/cron/update-cameras/lib/externalBackfill.test.ts
@@ -24,9 +24,13 @@ vi.mock('./dbOperations', () => ({
 
 import { backfillExternalImageScores } from './externalBackfill';
 
+// Real Flickr rows are mirrored into the project's Firebase/GCS bucket.
+const GCS_URL =
+  'https://storage.googleapis.com/sunrisesunset-32a25.firebasestorage.app/external_images/flickr/1.jpg';
+
 const row = (over: Partial<Record<string, unknown>> = {}) => ({
   externalImageId: 1,
-  imageUrl: 'https://live.staticflickr.com/x/1.jpg',
+  imageUrl: GCS_URL,
   llmQuality: null,
   llmIsSunset: null,
   ...over,
@@ -60,9 +64,7 @@ describe('backfillExternalImageScores', () => {
     ]);
     const res = await backfillExternalImageScores({ limit: 50 });
 
-    expect(downloadImageMock).toHaveBeenCalledWith(
-      'https://live.staticflickr.com/x/1.jpg',
-    );
+    expect(downloadImageMock).toHaveBeenCalledWith(GCS_URL);
     // scoreImage is told the source is flickr.
     expect(scoreImageMock).toHaveBeenCalledWith(
       expect.objectContaining({ source: 'flickr' }),

--- a/app/api/cron/update-cameras/lib/externalBackfill.test.ts
+++ b/app/api/cron/update-cameras/lib/externalBackfill.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const downloadImageMock = vi.fn();
+const scoreImageMock = vi.fn();
+const findRowsMock = vi.fn();
+const writeScoresMock = vi.fn();
+const markDeadUrlMock = vi.fn();
+
+vi.mock('@/app/lib/webcamSnapshot', () => ({
+  downloadImage: (...a: unknown[]) => downloadImageMock(...a),
+}));
+
+// Keep the real computeDisagreementKind; mock only scoreImage.
+vi.mock('./aiScoring', async (importActual) => {
+  const actual = await importActual<typeof import('./aiScoring')>();
+  return { ...actual, scoreImage: (...a: unknown[]) => scoreImageMock(...a) };
+});
+
+vi.mock('./dbOperations', () => ({
+  findExternalImagesNeedingScore: (...a: unknown[]) => findRowsMock(...a),
+  updateExternalImageModelScores: (...a: unknown[]) => writeScoresMock(...a),
+  markExternalImageDeadUrl: (...a: unknown[]) => markDeadUrlMock(...a),
+}));
+
+import { backfillExternalImageScores } from './externalBackfill';
+
+const row = (over: Partial<Record<string, unknown>> = {}) => ({
+  externalImageId: 1,
+  imageUrl: 'https://live.staticflickr.com/x/1.jpg',
+  llmQuality: null,
+  llmIsSunset: null,
+  ...over,
+});
+
+const onnxResult = (over: Partial<Record<string, unknown>> = {}) => ({
+  rawScore: 0.7,
+  aiRating: 3.8,
+  modelVersion: 'v4_reg',
+  imageHash: 'h',
+  source: 'flickr',
+  pathTaken: 'onnx',
+  binaryRawScore: 0.9,
+  binaryIsSunset: true,
+  binaryModelVersion: 'v4_bin',
+  ...over,
+});
+
+beforeEach(() => {
+  downloadImageMock.mockReset().mockResolvedValue(Buffer.from('jpg'));
+  scoreImageMock.mockReset().mockResolvedValue(onnxResult());
+  findRowsMock.mockReset();
+  writeScoresMock.mockReset().mockResolvedValue(undefined);
+  markDeadUrlMock.mockReset().mockResolvedValue(undefined);
+});
+
+describe('backfillExternalImageScores', () => {
+  it('scores a flickr image and writes the model columns (source flickr, no webcam sync)', async () => {
+    findRowsMock.mockResolvedValue([
+      row({ externalImageId: 7, llmQuality: 0.9, llmIsSunset: true }),
+    ]);
+    const res = await backfillExternalImageScores({ limit: 50 });
+
+    expect(downloadImageMock).toHaveBeenCalledWith(
+      'https://live.staticflickr.com/x/1.jpg',
+    );
+    // scoreImage is told the source is flickr.
+    expect(scoreImageMock).toHaveBeenCalledWith(
+      expect.objectContaining({ source: 'flickr' }),
+    );
+    expect(writeScoresMock).toHaveBeenCalledTimes(1);
+    const writeArg = writeScoresMock.mock.calls[0][0];
+    expect(writeArg.externalImageId).toBe(7);
+    expect(writeArg.regressionScore).toBe(0.7);
+    expect(writeArg.scoringPath).toBe('onnx');
+    expect(res.scored).toBe(1);
+    expect(markDeadUrlMock).not.toHaveBeenCalled();
+  });
+
+  it('SSRF: skips a non-staticflickr host without downloading or scoring', async () => {
+    findRowsMock.mockResolvedValue([
+      row({ externalImageId: 8, imageUrl: 'https://evil.example.com/x.jpg' }),
+    ]);
+    const res = await backfillExternalImageScores({ limit: 50 });
+
+    expect(downloadImageMock).not.toHaveBeenCalled();
+    expect(scoreImageMock).not.toHaveBeenCalled();
+    expect(writeScoresMock).not.toHaveBeenCalled();
+    expect(markDeadUrlMock).not.toHaveBeenCalled();
+    expect(res.scored).toBe(0);
+    expect(res.failed).toBe(1);
+  });
+
+  it('SSRF: rejects an http (non-https) staticflickr url', async () => {
+    findRowsMock.mockResolvedValue([
+      row({ imageUrl: 'http://live.staticflickr.com/x/1.jpg' }),
+    ]);
+    const res = await backfillExternalImageScores({ limit: 50 });
+    expect(downloadImageMock).not.toHaveBeenCalled();
+    expect(res.failed).toBe(1);
+  });
+
+  it('aborts (no write) when scoreImage takes a non-ONNX path', async () => {
+    findRowsMock.mockResolvedValue([row()]);
+    scoreImageMock.mockResolvedValue(
+      onnxResult({ pathTaken: 'unscored', rawScore: null, aiRating: null }),
+    );
+    const res = await backfillExternalImageScores({ limit: 50 });
+    expect(writeScoresMock).not.toHaveBeenCalled();
+    expect(res.scored).toBe(0);
+    expect(res.abortedOnFallback).toBe(true);
+  });
+
+  it('marks a permanently-dead URL and continues', async () => {
+    findRowsMock.mockResolvedValue([row({ externalImageId: 9 })]);
+    downloadImageMock.mockRejectedValue(new Error('Failed to download image: Not Found'));
+    const res = await backfillExternalImageScores({ limit: 50 });
+    expect(markDeadUrlMock).toHaveBeenCalledWith(9);
+    expect(res.deadUrls).toBe(1);
+    expect(writeScoresMock).not.toHaveBeenCalled();
+  });
+
+  it('returns an empty result when nothing needs scoring', async () => {
+    findRowsMock.mockResolvedValue([]);
+    const res = await backfillExternalImageScores({ limit: 50 });
+    expect(res).toMatchObject({ scored: 0, failed: 0, deadUrls: 0 });
+    expect(downloadImageMock).not.toHaveBeenCalled();
+  });
+});

--- a/app/api/cron/update-cameras/lib/externalBackfill.ts
+++ b/app/api/cron/update-cameras/lib/externalBackfill.ts
@@ -20,14 +20,20 @@ export interface ExternalBackfillResult {
   scores: number[];
 }
 
-// SSRF guard: the backfill fetches an arbitrary URL stored in external_images,
-// so only allow https Flickr CDN hosts before handing it to downloadImage().
-// Matches `staticflickr.com` and any subdomain (live./farmN./…).
-function isAllowedFlickrHost(rawUrl: string): boolean {
+// SSRF guard: the backfill fetches a URL stored in external_images. In practice
+// ingestion mirrors every Flickr image into the project's own Firebase/GCS bucket
+// (storage.googleapis.com — the SAME host the webcam archive's firebase_url uses),
+// so allow that bucket; also accept raw Flickr CDN URLs for any non-mirrored rows.
+// https only.
+function isAllowedImageHost(rawUrl: string): boolean {
   try {
     const u = new URL(rawUrl);
+    if (u.protocol !== 'https:') return false;
+    const h = u.hostname.toLowerCase();
     return (
-      u.protocol === 'https:' && /(^|\.)staticflickr\.com$/i.test(u.hostname)
+      h === 'storage.googleapis.com' ||
+      h.endsWith('.firebasestorage.app') ||
+      /(^|\.)staticflickr\.com$/.test(h)
     );
   } catch {
     return false;
@@ -67,9 +73,9 @@ export async function backfillExternalImageScores(opts: {
   if (rows.length === 0) return result;
 
   for (const row of rows) {
-    if (!isAllowedFlickrHost(row.imageUrl)) {
+    if (!isAllowedImageHost(row.imageUrl)) {
       console.warn(
-        `[externalBackfill] external_image ${row.externalImageId} rejected non-Flickr/non-https URL — skipping.`,
+        `[externalBackfill] external_image ${row.externalImageId} rejected disallowed/non-https image URL — skipping.`,
       );
       result.failed += 1;
       continue;

--- a/app/api/cron/update-cameras/lib/externalBackfill.ts
+++ b/app/api/cron/update-cameras/lib/externalBackfill.ts
@@ -1,0 +1,166 @@
+import { downloadImage } from '@/app/lib/webcamSnapshot';
+import { computeDisagreementKind, scoreImage } from './aiScoring';
+import {
+  findExternalImagesNeedingScore,
+  updateExternalImageModelScores,
+  markExternalImageDeadUrl,
+} from './dbOperations';
+
+export interface ExternalBackfillResult {
+  scored: number;
+  failed: number;
+  /** Permanently-dead URLs marked so they leave the finder's working set. */
+  deadUrls: number;
+  /** Non-ONNX scoring results — should be 0. >0 means the model isn't loading. */
+  fallbacks: number;
+  /** True when a fallback was hit and the run stopped to avoid writing junk. */
+  abortedOnFallback: boolean;
+  modelVersion: string | null;
+  /** Raw [0,1] regression scores for successfully scored rows. */
+  scores: number[];
+}
+
+// SSRF guard: the backfill fetches an arbitrary URL stored in external_images,
+// so only allow https Flickr CDN hosts before handing it to downloadImage().
+// Matches `staticflickr.com` and any subdomain (live./farmN./…).
+function isAllowedFlickrHost(rawUrl: string): boolean {
+  try {
+    const u = new URL(rawUrl);
+    return (
+      u.protocol === 'https:' && /(^|\.)staticflickr\.com$/i.test(u.hostname)
+    );
+  } catch {
+    return false;
+  }
+}
+
+// Same permanent-vs-transient split as the archive backfill (see archiveBackfill).
+function isPermanentDownloadError(error: unknown): boolean {
+  const msg = error instanceof Error ? error.message : String(error);
+  return /\b40[34]\b|not found|no such|does not exist|enoent/i.test(msg);
+}
+
+/**
+ * Score Flickr images (external_images) needing a real v4 score (plan U6).
+ * Mirrors backfillArchiveSnapshotScores but:
+ *   - targets external_images (Claude judge already lives in llm_*; this fills
+ *     the model columns + model-vs-Claude disagreement),
+ *   - never syncs a webcams row (no webcam exists for a Flickr image),
+ *   - validates the image host against the Flickr CDN allowlist (SSRF) before
+ *     fetching the stored URL,
+ *   - keeps the silent-ML-fallback gate: only the real ONNX path may write.
+ */
+export async function backfillExternalImageScores(opts: {
+  limit: number;
+}): Promise<ExternalBackfillResult> {
+  const rows = await findExternalImagesNeedingScore(opts.limit);
+
+  const result: ExternalBackfillResult = {
+    scored: 0,
+    failed: 0,
+    deadUrls: 0,
+    fallbacks: 0,
+    abortedOnFallback: false,
+    modelVersion: null,
+    scores: [],
+  };
+  if (rows.length === 0) return result;
+
+  for (const row of rows) {
+    if (!isAllowedFlickrHost(row.imageUrl)) {
+      console.warn(
+        `[externalBackfill] external_image ${row.externalImageId} rejected non-Flickr/non-https URL — skipping.`,
+      );
+      result.failed += 1;
+      continue;
+    }
+
+    let bytes: Buffer;
+    try {
+      bytes = await downloadImage(row.imageUrl);
+    } catch (error) {
+      if (isPermanentDownloadError(error)) {
+        await markExternalImageDeadUrl(row.externalImageId);
+        result.deadUrls += 1;
+      } else {
+        console.warn(
+          `[externalBackfill] external_image ${row.externalImageId} download failed (transient):`,
+          error,
+        );
+        result.failed += 1;
+      }
+      continue;
+    }
+
+    let scoreResult;
+    try {
+      // webcamId is only a log/cache key; supply the external image id for the
+      // null-webcam Flickr row.
+      scoreResult = await scoreImage({
+        webcamId: row.externalImageId,
+        imageBytes: bytes,
+        source: 'flickr',
+      });
+    } catch (error) {
+      console.warn(
+        `[externalBackfill] external_image ${row.externalImageId} scoreImage threw:`,
+        error,
+      );
+      result.failed += 1;
+      continue;
+    }
+
+    // Silent-ML-fallback gate: only the real ONNX path may write (post-#45 a
+    // non-ONNX result is 'unscored' with null scores — never fabricate).
+    if (scoreResult.pathTaken !== 'onnx') {
+      result.fallbacks += 1;
+      result.abortedOnFallback = true;
+      console.error(
+        `[externalBackfill] non-ONNX scoring path "${scoreResult.pathTaken}" — aborting run to avoid writing junk. Check model paths.`,
+      );
+      break;
+    }
+
+    if (scoreResult.rawScore === null || scoreResult.aiRating === null) {
+      result.fallbacks += 1;
+      result.abortedOnFallback = true;
+      console.error(
+        `[externalBackfill] onnx path returned null scores for external_image ${row.externalImageId} — aborting run to avoid writing junk.`,
+      );
+      break;
+    }
+
+    const disagreementKind = computeDisagreementKind({
+      binaryIsSunset: scoreResult.binaryIsSunset,
+      aiRating: scoreResult.aiRating,
+      llmQuality: row.llmQuality,
+      llmIsSunset: row.llmIsSunset,
+    });
+
+    try {
+      await updateExternalImageModelScores({
+        externalImageId: row.externalImageId,
+        regressionScore: scoreResult.rawScore,
+        regressionModelVersion: scoreResult.modelVersion,
+        binaryScore: scoreResult.binaryRawScore ?? null,
+        binaryIsSunset: scoreResult.binaryIsSunset ?? null,
+        binaryModelVersion: scoreResult.binaryModelVersion ?? null,
+        scoringPath: scoreResult.pathTaken,
+        disagreementKind,
+      });
+    } catch (error) {
+      console.warn(
+        `[externalBackfill] external_image ${row.externalImageId} write failed:`,
+        error,
+      );
+      result.failed += 1;
+      continue;
+    }
+
+    result.modelVersion = scoreResult.modelVersion;
+    result.scores.push(scoreResult.rawScore);
+    result.scored += 1;
+  }
+
+  return result;
+}

--- a/app/api/cron/update-cameras/lib/recomputeExternalDisagreements.test.ts
+++ b/app/api/cron/update-cameras/lib/recomputeExternalDisagreements.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const findMock = vi.fn();
+const batchMock = vi.fn();
+
+// Keep the real computeDisagreementKind; mock only the DB layer.
+vi.mock('./dbOperations', () => ({
+  findExternalImagesNeedingDisagreementRecompute: (...a: unknown[]) =>
+    findMock(...a),
+  updateExternalImageDisagreementsBatch: (...a: unknown[]) => batchMock(...a),
+}));
+
+import { recomputeExternalDisagreements } from './recomputeExternalDisagreements';
+
+beforeEach(() => {
+  findMock.mockReset();
+  batchMock.mockReset().mockResolvedValue(undefined);
+});
+
+describe('recomputeExternalDisagreements', () => {
+  it('re-derives a model-vs-Claude miss for a Flickr row and batches it', async () => {
+    findMock.mockResolvedValue([
+      {
+        externalImageId: 1,
+        aiRegressionScore: 0.2, // → aiRating 1.8 (low); Claude confident-good sunset
+        binaryIsSunset: null,
+        llmQuality: 0.85,
+        llmIsSunset: true,
+      },
+    ]);
+    const r = await recomputeExternalDisagreements({ limit: 100 });
+    expect(r.recomputed).toBe(1);
+    expect(r.flagged).toBe(1);
+    expect(batchMock).toHaveBeenCalledWith([
+      { externalImageId: 1, kind: 'model_low_claude_sunset' },
+    ]);
+  });
+
+  it('batches all rows into a single write call', async () => {
+    findMock.mockResolvedValue([
+      { externalImageId: 1, aiRegressionScore: 0.2, binaryIsSunset: null, llmQuality: 0.85, llmIsSunset: true },
+      { externalImageId: 2, aiRegressionScore: 0.8, binaryIsSunset: null, llmQuality: 0.9, llmIsSunset: true },
+    ]);
+    const r = await recomputeExternalDisagreements({ limit: 100 });
+    expect(r.recomputed).toBe(2);
+    expect(r.flagged).toBe(1); // id 1 is a miss; id 2 agrees
+    expect(batchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('does no writes when nothing needs recompute', async () => {
+    findMock.mockResolvedValue([]);
+    const r = await recomputeExternalDisagreements({ limit: 100 });
+    expect(r).toEqual({ recomputed: 0, flagged: 0 });
+    expect(batchMock).toHaveBeenCalledWith([]);
+  });
+});

--- a/app/api/cron/update-cameras/lib/recomputeExternalDisagreements.ts
+++ b/app/api/cron/update-cameras/lib/recomputeExternalDisagreements.ts
@@ -1,0 +1,44 @@
+import { computeDisagreementKind } from './aiScoring';
+import {
+  findExternalImagesNeedingDisagreementRecompute,
+  updateExternalImageDisagreementsBatch,
+} from './dbOperations';
+
+export interface RecomputeResult {
+  recomputed: number;
+  flagged: number;
+}
+
+/**
+ * Re-derive model_disagreement_kind for Flickr rows (external_images) whose
+ * Claude score landed after the model backfill ran, or that were never computed.
+ * Pure — no image download, no ONNX; recomputes from the already-stored model +
+ * Claude scores. Mirrors recomputeDisagreements (webcam_snapshots) for the
+ * Flickr table.
+ */
+export async function recomputeExternalDisagreements(opts: {
+  limit: number;
+}): Promise<RecomputeResult> {
+  const rows = await findExternalImagesNeedingDisagreementRecompute(opts.limit);
+
+  const updates = rows.map((row) => {
+    // Stored regression score is raw [0,1]; computeDisagreementKind reasons in
+    // the 1-5 rating space (same mapping as scoreImage).
+    const aiRating = 1 + row.aiRegressionScore * 4;
+    const kind = computeDisagreementKind({
+      binaryIsSunset: row.binaryIsSunset ?? undefined,
+      aiRating,
+      llmQuality: row.llmQuality,
+      llmIsSunset: row.llmIsSunset,
+    });
+    return { externalImageId: row.externalImageId, kind };
+  });
+
+  // One batched UPDATE for the whole page instead of one round-trip per row.
+  await updateExternalImageDisagreementsBatch(updates);
+
+  return {
+    recomputed: updates.length,
+    flagged: updates.filter((u) => u.kind).length,
+  };
+}

--- a/app/api/snapshots/route.test.ts
+++ b/app/api/snapshots/route.test.ts
@@ -63,3 +63,31 @@ describe('GET /api/snapshots?mode=hard-examples', () => {
     expect(q).not.toMatch(/user_session_id/i);
   });
 });
+
+describe('central owner-auth (review #10)', () => {
+  it('gates the verification mode (private by default) before any query', async () => {
+    requireOwnerMock.mockResolvedValue(
+      NextResponse.json({ error: 'Not authenticated' }, { status: 401 }),
+    );
+    const res = await GET(req('?mode=verification'));
+    expect(res.status).toBe(401);
+    expect(sqlMock).not.toHaveBeenCalled();
+  });
+
+  it('does NOT gate public modes (archive) even if the caller is not the owner', async () => {
+    requireOwnerMock.mockResolvedValue(
+      NextResponse.json({ error: 'Not authenticated' }, { status: 401 }),
+    );
+    const res = await GET(req('?mode=archive'));
+    expect(res.status).not.toBe(401);
+    expect(sqlMock).toHaveBeenCalled();
+  });
+
+  it('does NOT gate the default (no mode) public archive read', async () => {
+    requireOwnerMock.mockResolvedValue(
+      NextResponse.json({ error: 'Forbidden' }, { status: 403 }),
+    );
+    const res = await GET(req(''));
+    expect(res.status).not.toBe(403);
+  });
+});

--- a/app/api/snapshots/route.test.ts
+++ b/app/api/snapshots/route.test.ts
@@ -91,3 +91,37 @@ describe('central owner-auth (review #10)', () => {
     expect(res.status).not.toBe(403);
   });
 });
+
+describe('GET /api/snapshots?mode=verification', () => {
+  const allText = () =>
+    sqlMock.mock.calls.map(([s]) => (s as TemplateStringsArray).join('?'));
+
+  it('reads BOTH the webcam archive and the Flickr set (external_images)', async () => {
+    await GET(req('?mode=verification'));
+    const text = allText();
+    expect(text.some((q) => /from\s+webcam_snapshots\s+s/i.test(q))).toBe(true);
+    expect(text.some((q) => /from\s+external_images\s+e/i.test(q))).toBe(true);
+  });
+
+  it('disagreements_only=true filters to flagged frames (both legs)', async () => {
+    await GET(req('?mode=verification&disagreements_only=true'));
+    const text = allText();
+    // The flagged filter fragment runs for both legs.
+    const flagged = text.filter((q) =>
+      /model_disagreement_kind\s+is\s+not\s+null/i.test(q),
+    );
+    expect(flagged.length).toBeGreaterThanOrEqual(2);
+    // And it excludes already-verdicted webcam frames.
+    expect(text.some((q) => /is_sunset_verdict\s+is\s+not\s+null/i.test(q))).toBe(
+      true,
+    );
+  });
+
+  it('browse (no toggle) does NOT filter on disagreement kind', async () => {
+    await GET(req('?mode=verification'));
+    const text = allText();
+    expect(
+      text.some((q) => /model_disagreement_kind\s+is\s+not\s+null/i.test(q)),
+    ).toBe(false);
+  });
+});

--- a/app/api/snapshots/route.ts
+++ b/app/api/snapshots/route.ts
@@ -189,6 +189,116 @@ export async function GET(request: Request) {
       });
     }
 
+    // VERIFICATION MODE (plan U7): owner-only triage view that unions the webcam
+    // archive with the Flickr set (external_images). Two queries merged in JS —
+    // the tables have different shapes, so this avoids a fragile column-matched
+    // SQL UNION; transformSnapshot defaults the webcam-only fields the Flickr
+    // rows omit. Toggle: disagreements_only=true ranks the model-vs-Claude queue;
+    // off = browse all frames (eyeball judge coverage). Owner gate enforced above.
+    if (mode === 'verification') {
+      const disagreementsOnly =
+        searchParams.get('disagreements_only') === 'true';
+      // Over-fetch so the merged result can be paged in JS.
+      const fetchN = limit + offset;
+
+      // One sort key for both tables so the merge is a single global order:
+      // disagreements → priority tier + [0,1] gap magnitude; browse → recency.
+      const webcamSortKey = disagreementsOnly
+        ? sql`(CASE s.model_disagreement_kind
+                 WHEN 'model_low_claude_sunset' THEN 100
+                 WHEN 'model_high_claude_not_sunset' THEN 100
+                 WHEN 'binary_negative_regression_high' THEN 50
+                 WHEN 'binary_positive_regression_low' THEN 50
+                 ELSE 0 END
+               + ABS(COALESCE(s.ai_regression_score, 0) - COALESCE(s.llm_quality, 0)))`
+        : sql`EXTRACT(EPOCH FROM s.captured_at)`;
+      const externalSortKey = disagreementsOnly
+        ? sql`(CASE e.model_disagreement_kind
+                 WHEN 'model_low_claude_sunset' THEN 100
+                 WHEN 'model_high_claude_not_sunset' THEN 100
+                 WHEN 'binary_negative_regression_high' THEN 50
+                 WHEN 'binary_positive_regression_low' THEN 50
+                 ELSE 0 END
+               + ABS(COALESCE(e.ai_regression_score, 0) - COALESCE(e.llm_quality, 0)))`
+        : sql`EXTRACT(EPOCH FROM e.scraped_at)`;
+
+      const webcamFilter = disagreementsOnly
+        ? sql`AND s.model_disagreement_kind IS NOT NULL
+              AND s.id NOT IN (
+                SELECT snapshot_id FROM webcam_snapshot_ratings
+                WHERE is_sunset_verdict IS NOT NULL
+              )`
+        : sql``;
+      const externalFilter = disagreementsOnly
+        ? sql`AND e.model_disagreement_kind IS NOT NULL`
+        : sql``;
+
+      const webcamRows = (await sql`
+          SELECT
+            s.id as snapshot_id, s.webcam_id, s.phase, s.rank,
+            s.initial_rating, s.calculated_rating, s.ai_rating,
+            s.firebase_url, s.firebase_path, s.captured_at, s.created_at,
+            0::int as rating_count, NULL::numeric as user_rating,
+            w.id as w_id, w.source, w.external_id, w.title, w.status,
+            w.view_count, w.lat, w.lng, w.city, w.region, w.country, w.continent,
+            w.images, w.urls, w.player, w.categories, w.last_fetched_at,
+            w.rating as webcam_rating, w.orientation,
+            w.ai_rating as webcam_ai_rating,
+            w.ai_model_version as webcam_ai_model_version,
+            w.ai_rating_binary as webcam_ai_rating_binary,
+            w.ai_model_version_binary as webcam_ai_model_version_binary,
+            w.ai_rating_regression as webcam_ai_rating_regression,
+            w.ai_model_version_regression as webcam_ai_model_version_regression,
+            s.model_disagreement_kind, s.human_sunset_majority,
+            s.llm_quality, s.llm_is_sunset, s.llm_model, NULL::text as owner,
+            ${webcamSortKey} as sort_key
+          FROM webcam_snapshots s
+          JOIN webcams w ON w.id = s.webcam_id
+          WHERE 1=1 ${webcamFilter}
+          ORDER BY sort_key DESC
+          LIMIT ${fetchN}
+        `) as (SnapshotRow & { sort_key: number | string })[];
+
+      const externalRows = (await sql`
+          SELECT
+            e.id as snapshot_id,
+            e.image_url as firebase_url, e.firebase_path,
+            e.scraped_at as captured_at, e.scraped_at as created_at,
+            0::int as rating_count,
+            e.source, e.source_id as external_id, e.title, e.owner,
+            e.model_disagreement_kind,
+            e.llm_quality, e.llm_is_sunset, e.llm_model,
+            ${externalSortKey} as sort_key
+          FROM external_images e
+          WHERE e.source = 'flickr' ${externalFilter}
+          ORDER BY sort_key DESC
+          LIMIT ${fetchN}
+        `) as (SnapshotRow & { sort_key: number | string })[];
+
+      const merged = [...webcamRows, ...externalRows]
+        .sort((a, b) => Number(b.sort_key) - Number(a.sort_key))
+        .slice(offset, offset + limit)
+        .map(transformSnapshot);
+
+      const webcamCountResult = await sql`
+          SELECT COUNT(*)::int AS total FROM webcam_snapshots s WHERE 1=1 ${webcamFilter}
+        `;
+      const externalCountResult = await sql`
+          SELECT COUNT(*)::int AS total FROM external_images e
+          WHERE e.source = 'flickr' ${externalFilter}
+        `;
+      const total =
+        ((webcamCountResult as Array<{ total: number }>)[0]?.total ?? 0) +
+        ((externalCountResult as Array<{ total: number }>)[0]?.total ?? 0);
+
+      return NextResponse.json({
+        snapshots: merged,
+        total,
+        limit,
+        offset,
+      });
+    }
+
     // CURATED MIX MODE: Fetch mix of highly rated, unrated recent, and random snapshots
     if (mode === 'curated') {
       // Fall back to archive mode if no user session

--- a/app/api/snapshots/route.ts
+++ b/app/api/snapshots/route.ts
@@ -32,12 +32,25 @@ export async function GET(request: Request) {
     const limit = parseInt(searchParams.get('limit') || '100', 10);
     const offset = parseInt(searchParams.get('offset') || '0', 10);
     const modeParam = searchParams.get('mode');
-    const mode: 'archive' | 'curated' | 'hard-examples' =
+    const mode: 'archive' | 'curated' | 'hard-examples' | 'verification' =
       modeParam === 'curated'
         ? 'curated'
         : modeParam === 'hard-examples'
         ? 'hard-examples'
+        : modeParam === 'verification'
+        ? 'verification'
         : 'archive';
+
+    // Central owner-auth (review #10): modes are PRIVATE BY DEFAULT. Only the
+    // explicitly public modes skip the owner gate; every other mode
+    // (hard-examples, verification, and any future private mode) is gated here,
+    // before any query runs — so a new private mode is secure by default rather
+    // than relying on each branch to remember to call requireOwner().
+    const PUBLIC_MODES = new Set(['archive', 'curated']);
+    if (!PUBLIC_MODES.has(mode)) {
+      const denied = await requireOwner();
+      if (denied) return denied;
+    }
     const excludeIdsParam = searchParams.get('exclude_ids');
     const excludeIds = excludeIdsParam
       ? excludeIdsParam
@@ -84,10 +97,8 @@ export async function GET(request: Request) {
     // verdicted (so submitted snapshots leave the queue). See
     // docs/superpowers/specs/2026-06-02-hard-example-mining-and-private-labeling-design.md.
     if (mode === 'hard-examples') {
-      // Operator-only read: this is the private labeling queue. UI hiding is
-      // cosmetic — this server gate is the real boundary (plan KTD8/U4).
-      const denied = await requireOwner();
-      if (denied) return denied;
+      // Operator-only read: this is the private labeling queue. The owner gate
+      // is enforced centrally above (review #10); UI hiding is cosmetic.
 
       // Membership invariant (plan U4): queue = flagged MINUS verdicted,
       // applied UNCONDITIONALLY — not gated on user_session_id. Single operator,

--- a/app/components/Verification/VerificationTab.tsx
+++ b/app/components/Verification/VerificationTab.tsx
@@ -1,0 +1,175 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import {
+  Box,
+  Typography,
+  Switch,
+  FormControlLabel,
+  CircularProgress,
+  Button,
+} from '@mui/material';
+import RatingCard from '@/app/components/Webcam/RatingCard';
+import type { Snapshot, WindyWebcam } from '@/app/lib/types';
+
+const PAGE = 60;
+const noop = async () => {};
+
+/**
+ * Map a verification snapshot onto the WindyWebcam shape RatingCard renders.
+ * The archived frame (snapshot.firebaseUrl) is the image — NOT the webcam's live
+ * image — and Claude's judge + Flickr owner already ride on the Snapshot
+ * (transformSnapshot wired them). Spreading preserves them; we only swap in the
+ * frame image.
+ */
+function frameToCard(s: Snapshot): WindyWebcam {
+  return {
+    ...s,
+    images: { current: { preview: s.snapshot.firebaseUrl } },
+  } as unknown as WindyWebcam;
+}
+
+const isFlickr = (s: Snapshot) => s.source === 'flickr';
+
+export function VerificationTab() {
+  const [disagreementsOnly, setDisagreementsOnly] = useState(false);
+  const [snapshots, setSnapshots] = useState<Snapshot[]>([]);
+  const [total, setTotal] = useState(0);
+  const [limit, setLimit] = useState(PAGE);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // Reset the page size whenever the toggle flips.
+  useEffect(() => {
+    setLimit(PAGE);
+  }, [disagreementsOnly]);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    fetch(
+      `/api/snapshots?mode=verification&disagreements_only=${disagreementsOnly}&limit=${limit}&offset=0`,
+    )
+      .then(async (res) => {
+        if (!res.ok) {
+          throw new Error(
+            res.status === 401 || res.status === 403
+              ? 'Owner sign-in required'
+              : `Failed to load (${res.status})`,
+          );
+        }
+        return res.json();
+      })
+      .then((data) => {
+        if (cancelled) return;
+        setSnapshots(data.snapshots ?? []);
+        setTotal(data.total ?? 0);
+      })
+      .catch((e) => {
+        if (!cancelled) setError(e.message);
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [disagreementsOnly, limit]);
+
+  const maybeMore = snapshots.length >= limit && snapshots.length < total;
+
+  return (
+    <Box>
+      <Typography
+        variant="caption"
+        sx={{ color: '#9ca3af', display: 'block', mb: 1 }}
+      >
+        Verification — the webcam archive and the Flickr set together, each frame
+        with all three judges. Toggle on to triage only the model-vs-Claude
+        disagreements (ranked); off to browse everything and eyeball judge
+        coverage.
+      </Typography>
+
+      <FormControlLabel
+        sx={{ color: 'white', mb: 1 }}
+        control={
+          <Switch
+            checked={disagreementsOnly}
+            onChange={(e) => setDisagreementsOnly(e.target.checked)}
+          />
+        }
+        label={`Disagreements only${
+          disagreementsOnly ? ` (${total})` : ''
+        }`}
+      />
+
+      {error ? (
+        <Typography sx={{ color: '#f87171' }}>{error}</Typography>
+      ) : loading && snapshots.length === 0 ? (
+        <CircularProgress size={20} sx={{ color: 'white' }} />
+      ) : snapshots.length === 0 ? (
+        <Typography sx={{ color: '#9ca3af' }}>
+          {disagreementsOnly
+            ? 'No disagreements yet — the model backfill may still be running, or everything has been verdicted.'
+            : 'No frames to show.'}
+        </Typography>
+      ) : (
+        <>
+          <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 2 }}>
+            {snapshots.map((s) => (
+              <Box
+                key={`${s.source ?? 'webcam'}-${s.snapshot.id}`}
+                sx={{ position: 'relative', width: 256 }}
+              >
+                {isFlickr(s) && (
+                  <Box
+                    sx={{
+                      position: 'absolute',
+                      top: 18,
+                      left: 18,
+                      zIndex: 2,
+                      backgroundColor: 'rgba(124,58,237,0.85)', // violet — Flickr
+                      color: 'white',
+                      px: 1,
+                      py: 0.25,
+                      borderRadius: 1,
+                      fontSize: 11,
+                      fontWeight: 700,
+                      maxWidth: 220,
+                      whiteSpace: 'nowrap',
+                      overflow: 'hidden',
+                      textOverflow: 'ellipsis',
+                    }}
+                    title={`Flickr · ${s.title ?? ''}${
+                      s.owner ? ` · ${s.owner}` : ''
+                    }`}
+                  >
+                    Flickr · {s.title || 'untitled'}
+                    {s.owner ? ` · ${s.owner}` : ''}
+                  </Box>
+                )}
+                <RatingCard webcam={frameToCard(s)} readOnly onRate={noop} />
+              </Box>
+            ))}
+          </Box>
+
+          {maybeMore && (
+            <Box sx={{ mt: 2, textAlign: 'center' }}>
+              <Button
+                variant="outlined"
+                onClick={() => setLimit((n) => n + PAGE)}
+                disabled={loading}
+                sx={{ color: 'white', borderColor: '#4b5563' }}
+              >
+                {loading ? 'Loading…' : 'Load more'}
+              </Button>
+            </Box>
+          )}
+        </>
+      )}
+    </Box>
+  );
+}
+
+export default VerificationTab;

--- a/app/lib/snapshotTransform.ts
+++ b/app/lib/snapshotTransform.ts
@@ -3,8 +3,10 @@ import type { Snapshot, Orientation } from './types';
 // Database row structure from JOIN query
 export interface SnapshotRow {
   snapshot_id: number;
-  webcam_id: number;
-  phase: 'sunrise' | 'sunset';
+  // Nullable for external_images (Flickr) rows in the verification UNION — those
+  // have no parent webcam, location, or phase.
+  webcam_id: number | null;
+  phase: 'sunrise' | 'sunset' | null;
   rank: number | null;
   initial_rating: number | null;
   calculated_rating: number | null;
@@ -16,14 +18,14 @@ export interface SnapshotRow {
   rating_count: number;
   user_rating: number | null;
   // Webcam fields
-  w_id: number;
+  w_id: number | null;
   source: string;
-  external_id: string;
+  external_id: string | null;
   title: string | null;
   status: string | null;
   view_count: number | null;
-  lat: number;
-  lng: number;
+  lat: number | null;
+  lng: number | null;
   city: string | null;
   region: string | null;
   country: string | null;
@@ -46,6 +48,12 @@ export interface SnapshotRow {
   // fields are optional to avoid TypeScript errors on rows that don't include them.
   model_disagreement_kind?: string | null;
   human_sunset_majority?: boolean | null;
+  // Verification mode extras: Claude's judge (shown distinctly on the card) and
+  // the Flickr owner (part of the source label for external_images rows).
+  llm_quality?: number | string | null;
+  llm_is_sunset?: boolean | null;
+  llm_model?: string | null;
+  owner?: string | null;
 }
 
 /**
@@ -54,7 +62,7 @@ export interface SnapshotRow {
 export function transformSnapshot(row: SnapshotRow): Snapshot {
   return {
     // WindyWebcam fields
-    webcamId: row.webcam_id,
+    webcamId: row.webcam_id ?? 0, // 0 = no parent webcam (Flickr/external row)
     title: row.title || 'Unknown',
     viewCount: row.view_count || 0,
     status: row.status || 'unknown',
@@ -66,8 +74,8 @@ export function transformSnapshot(row: SnapshotRow): Snapshot {
     location: {
       city: row.city || '',
       region: row.region || '',
-      longitude: row.lng,
-      latitude: row.lat,
+      longitude: row.lng ?? 0,
+      latitude: row.lat ?? 0,
       country: row.country || '',
       continent: row.continent || '',
     },
@@ -87,10 +95,10 @@ export function transformSnapshot(row: SnapshotRow): Snapshot {
         ? JSON.parse(row.urls)
         : row.urls
       : null,
-    phase: row.phase,
+    phase: row.phase ?? undefined,
     rank: row.rank ?? undefined,
     source: row.source,
-    externalId: row.external_id,
+    externalId: row.external_id ?? undefined,
     rating: row.webcam_rating ?? undefined,
     orientation: (row.orientation as Orientation) ?? undefined,
     aiRating: row.webcam_ai_rating ?? undefined,
@@ -102,11 +110,20 @@ export function transformSnapshot(row: SnapshotRow): Snapshot {
     aiModelVersionRegression:
       row.webcam_ai_model_version_regression ?? undefined,
 
+    // Claude (LLM) judge — populated in verification/leaderboard reads; absent
+    // (undefined) in archive/curated, which don't SELECT these columns.
+    llmQuality:
+      row.llm_quality == null ? undefined : Number(row.llm_quality),
+    llmIsSunset: row.llm_is_sunset ?? undefined,
+    llmModel: row.llm_model ?? undefined,
+    // Flickr (external_images) owner — part of the source label on the card.
+    owner: row.owner ?? undefined,
+
     // Snapshot metadata
     snapshot: {
       id: row.snapshot_id,
-      webcamId: row.webcam_id,
-      phase: row.phase,
+      webcamId: row.webcam_id ?? 0,
+      phase: row.phase ?? 'sunset', // Flickr rows have no phase; default for typing
       rank: row.rank,
       initialRating: row.initial_rating,
       calculatedRating: row.calculated_rating,

--- a/app/lib/types.ts
+++ b/app/lib/types.ts
@@ -101,6 +101,10 @@ export interface WindyWebcam {
   llmIsSunset?: boolean | null; // Claude's "is this a sunset?" verdict
   llmModel?: string | null; // e.g. "claude-sonnet-4-5"
 
+  // Source label for external_images (Flickr) rows in the verification view —
+  // these have no webcam title/location, so the card shows source + title + owner.
+  owner?: string | null; // e.g. Flickr photo owner
+
   // Live-asset format discriminator. Tells the popup/renderer what KIND of
   // asset is on screen. Omitted when no asset is available (no snapshot, no
   // Windy images).

--- a/database/migrations/20260607_external_images_model_columns.sql
+++ b/database/migrations/20260607_external_images_model_columns.sql
@@ -1,0 +1,53 @@
+-- Three-judge hard examples — Phase 3 (plan U5). Adds the per-image model-score
+-- columns to external_images so the Flickr set carries all three judges, mirroring
+-- what 20260604 added to webcam_snapshots. external_images already has the Claude
+-- judge (llm_quality, llm_is_sunset, llm_rated_at, …, populated for the v4 export);
+-- it has NONE of the model columns, so the full set is added here:
+--
+--   ai_regression_score / ai_model_version_regression
+--     The regression head's [0,1] score + model version (the model judge).
+--
+--   ai_binary_score / ai_binary_is_sunset / ai_model_version_binary
+--     The binary head's verdict (the third judge, R1).
+--
+--   scoring_path
+--     Provenance of the score: 'onnx' | 'cache-hit' | 'unscored' (post-#45; there
+--     is no metadata fallback — the model is the only thing that may produce a score).
+--
+--   scoring_state
+--     Sentinel distinct from scoring_path. 'dead-url' marks an image whose URL 404s
+--     permanently so the backfill finder excludes it. NULL = scoreable.
+--
+--   model_disagreement_kind / disagreement_computed_at
+--     The model-vs-Claude (and binary-vs-regression) verdict + when it was last
+--     (re)computed; the recompute finder compares disagreement_computed_at against
+--     llm_rated_at, identical to the webcam_snapshots path.
+--
+-- Forward-only, idempotent. Apply manually via:
+--   psql "$DATABASE_URL" -f database/migrations/20260607_external_images_model_columns.sql
+
+ALTER TABLE external_images
+  ADD COLUMN IF NOT EXISTS ai_regression_score        NUMERIC(4,3),
+  ADD COLUMN IF NOT EXISTS ai_model_version_regression TEXT,
+  ADD COLUMN IF NOT EXISTS ai_binary_score            NUMERIC(4,3),
+  ADD COLUMN IF NOT EXISTS ai_binary_is_sunset        BOOLEAN,
+  ADD COLUMN IF NOT EXISTS ai_model_version_binary    TEXT,
+  ADD COLUMN IF NOT EXISTS scoring_path               TEXT,
+  ADD COLUMN IF NOT EXISTS scoring_state              TEXT,
+  ADD COLUMN IF NOT EXISTS model_disagreement_kind    TEXT,
+  ADD COLUMN IF NOT EXISTS disagreement_computed_at   TIMESTAMPTZ;
+
+-- Backfill finder hot path: unscored, scoreable Flickr rows ordered by recency.
+-- Partial index keeps the one-time drain cheap (mirrors webcam_snapshots_needs_score_idx).
+CREATE INDEX IF NOT EXISTS external_images_needs_score_idx
+  ON external_images (scraped_at DESC)
+  WHERE ai_regression_score IS NULL
+    AND image_url IS NOT NULL
+    AND scoring_state IS DISTINCT FROM 'dead-url';
+
+-- Recompute finder hot path: rows that already have both a model score and a Claude
+-- score, ordered by llm_rated_at DESC (mirrors webcam_snapshots_needs_recompute_idx).
+CREATE INDEX IF NOT EXISTS external_images_needs_recompute_idx
+  ON external_images (llm_rated_at DESC)
+  WHERE ai_regression_score IS NOT NULL
+    AND llm_quality IS NOT NULL;

--- a/docs/plans/2026-06-07-001-three-judge-phase3-flickr-corrected.md
+++ b/docs/plans/2026-06-07-001-three-judge-phase3-flickr-corrected.md
@@ -35,19 +35,22 @@ one env flip.
 > `'unscored'` discipline (skip write on non-ONNX, no fabrication, no `webcams`
 > sync). And the deferred **review finding #10 (central owner-auth)** lands in U7.
 
-## Open question (gates U5)
+## Open question (gates U5) — RESOLVED 2026-06-07
 
-Is `external_images.llm_*` **still populated in production**, or has it been lost
-since the 2026-05-13 export? Treat **CSV re-import as the safe default** until
-confirmed. Decision gate (run against prod):
+Verified against prod: `external_images.llm_*` **is fully populated** — no re-import
+needed.
 
-```sql
-SELECT count(*) FROM external_images
-WHERE source = 'flickr' AND llm_quality IS NOT NULL;
+```
+flickr_total                    5872
+flickr_llm_quality_not_null     5767   ← matches the v4 export exactly
+flickr_llm_is_sunset_not_null   5767
+external_total_all_sources      5872   (all external_images are flickr)
 ```
 
-- `~5,767` → DB intact; no re-import needed.
-- materially lower / `0` → re-import `llm_*` from `ratings_20260512_204416.csv`.
+→ **U5 drops the re-import path entirely**; it's now just the mirror migration.
+Note: 105 Flickr rows (5872 − 5767) have no Claude score — those can only produce
+binary-vs-regression disagreements (Claude absent), same as Claude-absent archive
+frames. Not a blocker.
 
 ## Implementation units (corrected)
 

--- a/docs/plans/2026-06-07-001-three-judge-phase3-flickr-corrected.md
+++ b/docs/plans/2026-06-07-001-three-judge-phase3-flickr-corrected.md
@@ -1,0 +1,114 @@
+---
+title: "Three-judge hard examples — Phase 3 (Flickr), corrected"
+date: 2026-06-07
+supersedes: "Phase 3 (U5–U8) of docs/plans/2026-06-04-001-feat-three-judge-hard-examples-plan.md"
+status: plan
+---
+
+# Three-judge Phase 3 (Flickr) — corrected
+
+This revises **Phase 3 only** of the [three-judge plan](2026-06-04-001-feat-three-judge-hard-examples-plan.md).
+Phases 1–2 (U1–U4) are **merged** (PRs #43 + #44/#46) on top of the
+baseline-fallback removal (#45). U5–U8 below replace the original Phase 3.
+
+## What changed since the original plan
+
+The original Phase 3 assumed Flickr had to be ingested and scored by Claude from
+scratch, gated on an Anthropic spend approval (original U6 + the "Claude-over-Flickr
+spend" risk). **That work already exists:**
+
+- **On disk (durable):** `ml/artifacts/llm_ratings/ratings_20260512_204416.csv` —
+  5,747 Flickr images scored by `claude-sonnet-4-5` (`llm_quality`, `llm_is_sunset`,
+  `llm_confidence`, palette, …). Same judge as the webcam archive.
+- **In the DB:** `external_images.llm_*` was populated for the 2026-05-13 v4 export
+  (`export_dataset.py` pulled `external_images WHERE llm_quality IS NOT NULL` →
+  5,767 Flickr rows). **The running v4 model was trained on these exact labels.**
+- The v4 training manifests (`…/v4_regression_llm_with_flickr/dataset/…/manifest_*.csv`)
+  reference the same scores.
+
+**Consequence:** the Claude judge for Flickr is done. No re-scrape, no Anthropic
+spend, no approval gate. Phase 3 is now **pure code + one Vercel flip**:
+one migration + one TS model-only backfill (unscored-gated) + one private view +
+one env flip.
+
+> **Also folds in:** because #45 merged, the model backfill here must use the
+> `'unscored'` discipline (skip write on non-ONNX, no fabrication, no `webcams`
+> sync). And the deferred **review finding #10 (central owner-auth)** lands in U7.
+
+## Open question (gates U5)
+
+Is `external_images.llm_*` **still populated in production**, or has it been lost
+since the 2026-05-13 export? Treat **CSV re-import as the safe default** until
+confirmed. Decision gate (run against prod):
+
+```sql
+SELECT count(*) FROM external_images
+WHERE source = 'flickr' AND llm_quality IS NOT NULL;
+```
+
+- `~5,767` → DB intact; no re-import needed.
+- materially lower / `0` → re-import `llm_*` from `ratings_20260512_204416.csv`.
+
+## Implementation units (corrected)
+
+### U5 — Confirm/repair Flickr in `external_images` (was: "ingest Flickr")
+The rows + Claude scores already exist. Real work is the **mirror migration** plus
+a verification gate; **no Claude run, no scrape.**
+- **Migration** `database/migrations/<new>_external_images_model_columns.sql`:
+  add the model-score columns that #44 added to `webcam_snapshots` —
+  `ai_regression_score`, `ai_binary_score`, `ai_binary_is_sunset`,
+  `ai_model_version_regression`, `ai_model_version_binary`,
+  `model_disagreement_kind`, `scoring_state`, `disagreement_computed_at`.
+  Forward-only, idempotent (`ADD COLUMN IF NOT EXISTS`), nullable/defaultless.
+  Add the **recompute-finder partial index** equivalent (see #44's
+  `webcam_snapshots_needs_recompute_idx`) for `external_images`.
+- **Verification gate:** the SQL above. If lost, re-import `llm_*` from the CSV
+  (one-off script keyed on the Flickr id/url already in `external_images`).
+- Keep the existing URL/title/owner validation from the original U5 (host-allowlist
+  `*.staticflickr.com`, sanitize `title`/`owner`) — still relevant for U7's card label.
+
+### U6 — Score Flickr with the **model only** (was: "all three judges")
+Claude judge = reuse existing `llm_*`. Remaining = run the ONNX regression + binary
+heads over Flickr via the **TS backfill module #44 shipped** (`archiveBackfill`),
+targeting `external_images`. **Zero Anthropic spend.**
+- Add an `external_images`-targeted finder/writer to the backfill. The external
+  writer **must NOT** call `updateWebcamRegressionScoreFromLatestCustomSnapshot`
+  (no `webcams` row exists for a Flickr image) — keep archive and external writers
+  distinct.
+- **Post-#45 `'unscored'` discipline:** reuse #44's `pathTaken !== 'onnx'` abort +
+  the null-score narrow — a Flickr `'unscored'` result must never write a fabricated
+  score, and never sync a webcam.
+- **SSRF:** fetch `external_images.image_url` (the Flickr CDN URL), validate the host
+  against `*.staticflickr.com` immediately before the request.
+- Extend `scoreImage`'s source union to include `'flickr'` (or thread a neutral
+  source; `webcamId` is only a log/cache key — supply a synthetic id for
+  null-webcam rows).
+- Then the **disagreement recompute** (#44's `recomputeDisagreements`, run over
+  `external_images` too) produces model-vs-Claude for Flickr.
+
+### U7 — Verification view (unchanged) + **central auth fix (review #10)**
+One operator tab, `requireOwner` server-side AND owner-only client render;
+disagreements-only toggle (defaults OFF = browse all, eyeball judge coverage; ON =
+ranked disagreement queue with verdict actions). UNION projection across
+`webcam_snapshots` + `external_images` (NULL-pad webcam-only columns; tolerate null
+`webcam_id`/location). Flickr card label = source badge + `title`/`owner`.
+- **Fold in review finding #10:** instead of gating each owner-only mode inline,
+  classify modes as owner-only vs public **once** before the query branches in
+  `app/api/snapshots/route.ts`, so a new private mode (this verification view) is
+  secure by default rather than relying on remembering to add `requireOwner`.
+
+### U8 — Flip `AI_BINARY_SCORING_ENABLED` in Vercel (unchanged, operational)
+Enable the binary head in production; confirm live binary-vs-regression flagging.
+Note: the offline backfills (U3/U6) compute model-vs-Claude without binary; U8 is
+what lights up the *live* binary dimension.
+
+## Net effect
+Phase 3 = **one migration + one TS model-only backfill (unscored-gated) + one
+private view + one env flip.** No Anthropic approval, no re-scraping. Detailed TDD
+steps for U6 build directly on the now-merged #44 backfill module.
+
+## Deferred (carried from #44 review, not Phase-3-blocking)
+- #6 NULL-safe recompute predicate; #7 dead-url match on HTTP status not message;
+  #9 generate the priority `CASE` from `DISAGREEMENT_KIND_PRIORITY`;
+  the vestigial `AI_SCORING_MODE` guard in `scripts/backfill-archive-scores.ts`
+  (runtime ignores it post-#45).

--- a/docs/superpowers/plans/2026-06-07-hard-examples-labeling-queue.md
+++ b/docs/superpowers/plans/2026-06-07-hard-examples-labeling-queue.md
@@ -1,0 +1,833 @@
+# Hard Examples — Unified Labeling Queue Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** One fast, keyboard-driven labeling queue over webcam + Flickr disagreement frames that writes an operator gold-label set (`manual_labels`) for v5 training, with blind-then-reveal, a queue/grid view toggle, a source filter, and a provenance badge.
+
+**Architecture:** A new `manual_labels` table is the single gold-label store (replacing the use of `webcam_snapshot_ratings.is_sunset_verdict` for operator verdicts). The existing union disagreements read (`mode=verification` in `app/api/snapshots/route.ts`) becomes the queue data source — upgraded to exclude already-labeled frames, expose provenance, and accept a source filter. A new owner-gated `POST/DELETE /api/manual-labels` route persists labels. A new `HardExamplesQueue` client component reuses `SnapshotQueueCard` for the blind rating UI, adds the three controls + reveal panel, and writes labels. The old webcam-only Hard Examples tab and the read-only Verification tab are retired into this one tab.
+
+**Tech Stack:** Next.js (app router), TypeScript, `@neondatabase/serverless` (`sql` tagged template), Postgres (Neon), Vitest (mocking `sql`), MUI, `requireOwner` (Auth.js).
+
+**Spec:** `docs/superpowers/specs/2026-06-07-hard-examples-labeling-queue-design.md`
+
+**Branch:** Implement on a fresh branch off `main` after PR #47 merges (so it's a clean PR). Use the `superpowers:using-git-worktrees` skill at execution time.
+
+---
+
+## File structure
+
+- **Create** `database/migrations/20260608_manual_labels.sql` — gold-label table + verdict backfill.
+- **Create** `app/lib/provenance.ts` (+ test) — derive `flickr | archive_trained | archive_new` from source + captured_at.
+- **Create** `app/lib/manualLabels.ts` (+ test) — `upsertManualLabel`, `deleteManualLabel`, `fetchLabeledKeys`.
+- **Create** `app/api/manual-labels/route.ts` (+ test) — owner-gated POST (upsert) / DELETE (undo).
+- **Modify** `app/lib/masterConfig.ts` — add `V4_TRAINING_CUTOFF`.
+- **Modify** `app/api/snapshots/route.ts` (+ `route.test.ts`) — verification read: manual_labels exclusion (both legs), `provenance` in response, `source` filter param.
+- **Create** `app/components/HardExamples/HardExamplesQueue.tsx` — the unified queue (data + controls + SnapshotQueueCard + reveal + manual_labels write).
+- **Modify** `app/HomeClient.tsx` — point the "Hard Examples" tab at `HardExamplesQueue`; remove the `verify` tab + `VerificationTab` import.
+- **Delete** `app/components/Verification/VerificationTab.tsx` — folded into HardExamplesQueue.
+
+---
+
+## Task 1: `manual_labels` migration + verdict backfill
+
+**Files:**
+- Create: `database/migrations/20260608_manual_labels.sql`
+
+- [ ] **Step 1: Write the migration**
+
+```sql
+-- Operator gold-label set for v5 training (plan: hard-examples labeling queue).
+-- One row per (source, image_id) — the operator's adjudication of a hard /
+-- disagreement frame. Distinct from webcam_snapshot_ratings (public crowd
+-- ratings); that idea is retired. Forward-only, idempotent.
+--   psql "$DATABASE_URL" -f database/migrations/20260608_manual_labels.sql
+
+CREATE TABLE IF NOT EXISTS manual_labels (
+  id          BIGSERIAL PRIMARY KEY,
+  source      TEXT NOT NULL CHECK (source IN ('webcam', 'flickr')),
+  image_id    BIGINT NOT NULL,
+  is_sunset   BOOLEAN NOT NULL,
+  rating      INT CHECK (rating BETWEEN 1 AND 5),
+  origin      TEXT NOT NULL DEFAULT 'hard_example',
+  labeled_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+  UNIQUE (source, image_id)
+);
+
+-- Carry over existing operator verdicts from the old blind Hard Examples queue.
+INSERT INTO manual_labels (source, image_id, is_sunset, rating, origin, labeled_at)
+SELECT 'webcam', snapshot_id, is_sunset_verdict, rating, 'hard_example', created_at
+FROM webcam_snapshot_ratings
+WHERE is_sunset_verdict IS NOT NULL
+ON CONFLICT (source, image_id) DO NOTHING;
+```
+
+- [ ] **Step 2: Validate against prod in a rolled-back transaction**
+
+Run:
+```bash
+DB=$(grep -E '^DATABASE_URL=' .env.production.local | head -1 | sed -E 's/^DATABASE_URL=//; s/^"//; s/"$//')
+( echo 'BEGIN;'; cat database/migrations/20260608_manual_labels.sql; cat database/migrations/20260608_manual_labels.sql; echo 'ROLLBACK;' ) | psql "$DB" -v ON_ERROR_STOP=1
+```
+Expected: `CREATE TABLE` / `INSERT 0 N` then on the 2nd pass `NOTICE: relation "manual_labels" already exists, skipping` and `ROLLBACK`; exit 0 (idempotent, no error).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add database/migrations/20260608_manual_labels.sql
+git commit -m "feat(db): manual_labels gold-label table + verdict backfill"
+```
+
+*(Apply to prod with explicit owner approval at execution time — additive/idempotent, same pattern as prior migrations.)*
+
+---
+
+## Task 2: `V4_TRAINING_CUTOFF` + provenance helper
+
+**Files:**
+- Modify: `app/lib/masterConfig.ts`
+- Create: `app/lib/provenance.ts`
+- Test: `app/lib/provenance.test.ts`
+
+- [ ] **Step 1: Add the cutoff constant**
+
+In `app/lib/masterConfig.ts`, add near the other AI constants:
+```ts
+// v4 training data export date. Webcam frames captured after this were NOT in
+// v4 training (highest-value new labels); before is the trained-era archive.
+// Approximate: exact membership would require the v4 manifest (deferred).
+export const V4_TRAINING_CUTOFF = '2026-05-13';
+```
+
+- [ ] **Step 2: Write the failing test**
+
+`app/lib/provenance.test.ts`:
+```ts
+import { describe, it, expect } from 'vitest';
+import { deriveProvenance } from './provenance';
+
+describe('deriveProvenance', () => {
+  it('returns flickr for external rows regardless of date', () => {
+    expect(deriveProvenance('flickr', '2026-04-01T00:00:00Z')).toBe('flickr');
+    expect(deriveProvenance('flickr', null)).toBe('flickr');
+  });
+  it('returns archive_new for webcam frames captured after the v4 cutoff', () => {
+    expect(deriveProvenance('windy', '2026-06-01T00:00:00Z')).toBe('archive_new');
+  });
+  it('returns archive_trained for webcam frames captured on/before the cutoff', () => {
+    expect(deriveProvenance('windy', '2026-05-01T00:00:00Z')).toBe('archive_trained');
+  });
+  it('treats a null captured_at as trained-era (conservative)', () => {
+    expect(deriveProvenance('windy', null)).toBe('archive_trained');
+  });
+});
+```
+
+- [ ] **Step 3: Run it — verify it fails**
+
+Run: `npx vitest run app/lib/provenance.test.ts`
+Expected: FAIL — `deriveProvenance` is not exported / module missing.
+
+- [ ] **Step 4: Implement**
+
+`app/lib/provenance.ts`:
+```ts
+import { V4_TRAINING_CUTOFF } from './masterConfig';
+
+export type Provenance = 'flickr' | 'archive_trained' | 'archive_new';
+
+/**
+ * Where a queued frame came from, for the operator badge:
+ *  - flickr           → external_images
+ *  - archive_new      → webcam frame captured AFTER v4 training (untrained)
+ *  - archive_trained  → webcam frame from the v4 training era (approx; see cutoff)
+ */
+export function deriveProvenance(
+  source: string,
+  capturedAt: string | null,
+): Provenance {
+  if (source === 'flickr') return 'flickr';
+  if (capturedAt && new Date(capturedAt) > new Date(V4_TRAINING_CUTOFF)) {
+    return 'archive_new';
+  }
+  return 'archive_trained';
+}
+```
+
+- [ ] **Step 5: Run it — verify it passes**
+
+Run: `npx vitest run app/lib/provenance.test.ts`
+Expected: PASS (4 tests).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/lib/masterConfig.ts app/lib/provenance.ts app/lib/provenance.test.ts
+git commit -m "feat(labels): V4_TRAINING_CUTOFF + deriveProvenance helper"
+```
+
+---
+
+## Task 3: `manual_labels` DB helpers
+
+**Files:**
+- Create: `app/lib/manualLabels.ts`
+- Test: `app/lib/manualLabels.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+`app/lib/manualLabels.test.ts`:
+```ts
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const sqlMock = vi.fn();
+vi.mock('@/app/lib/db', () => ({
+  sql: (strings: TemplateStringsArray, ...values: unknown[]) =>
+    sqlMock(strings, ...values),
+}));
+
+import { upsertManualLabel, deleteManualLabel } from './manualLabels';
+
+beforeEach(() => sqlMock.mockReset().mockResolvedValue([]));
+
+describe('upsertManualLabel', () => {
+  it('upserts on (source, image_id) and stamps labeled_at', async () => {
+    await upsertManualLabel({ source: 'flickr', imageId: 7, isSunset: true, rating: 4 });
+    const [strings, ...values] = sqlMock.mock.calls[0];
+    const q = strings.join('?');
+    expect(q).toMatch(/insert\s+into\s+manual_labels/i);
+    expect(q).toMatch(/on\s+conflict\s*\(source,\s*image_id\)\s+do\s+update/i);
+    expect(q).toMatch(/labeled_at\s*=\s*now\(\)/i);
+    expect(values).toContain('flickr');
+    expect(values).toContain(7);
+    expect(values).toContain(true);
+    expect(values).toContain(4);
+  });
+  it('passes null rating when omitted', async () => {
+    await upsertManualLabel({ source: 'webcam', imageId: 9, isSunset: false });
+    const [, ...values] = sqlMock.mock.calls[0];
+    expect(values).toContain(null);
+  });
+});
+
+describe('deleteManualLabel', () => {
+  it('deletes the (source, image_id) row', async () => {
+    await deleteManualLabel('webcam', 9);
+    const [strings, ...values] = sqlMock.mock.calls[0];
+    const q = strings.join('?');
+    expect(q).toMatch(/delete\s+from\s+manual_labels/i);
+    expect(values).toContain('webcam');
+    expect(values).toContain(9);
+  });
+});
+
+```
+
+*(Queue exclusion is done in SQL in the read — Task 5 — via `NOT IN (SELECT image_id FROM manual_labels WHERE source = …)`, so no JS key-set helper is needed here.)*
+
+- [ ] **Step 2: Run it — verify it fails**
+
+Run: `npx vitest run app/lib/manualLabels.test.ts`
+Expected: FAIL — functions not exported.
+
+- [ ] **Step 3: Implement**
+
+`app/lib/manualLabels.ts`:
+```ts
+import { sql } from '@/app/lib/db';
+
+export type LabelSource = 'webcam' | 'flickr';
+
+export async function upsertManualLabel(opts: {
+  source: LabelSource;
+  imageId: number;
+  isSunset: boolean;
+  rating?: number | null;
+}): Promise<void> {
+  await sql`
+    INSERT INTO manual_labels (source, image_id, is_sunset, rating)
+    VALUES (${opts.source}, ${opts.imageId}, ${opts.isSunset}, ${opts.rating ?? null})
+    ON CONFLICT (source, image_id) DO UPDATE
+      SET is_sunset = EXCLUDED.is_sunset,
+          rating = EXCLUDED.rating,
+          labeled_at = now()
+  `;
+}
+
+export async function deleteManualLabel(
+  source: LabelSource,
+  imageId: number,
+): Promise<void> {
+  await sql`
+    DELETE FROM manual_labels WHERE source = ${source} AND image_id = ${imageId}
+  `;
+}
+
+```
+
+- [ ] **Step 4: Run it — verify it passes**
+
+Run: `npx vitest run app/lib/manualLabels.test.ts`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/lib/manualLabels.ts app/lib/manualLabels.test.ts
+git commit -m "feat(labels): manual_labels DB helpers (upsert/delete/fetchKeys)"
+```
+
+---
+
+## Task 4: `POST/DELETE /api/manual-labels` route
+
+**Files:**
+- Create: `app/api/manual-labels/route.ts`
+- Test: `app/api/manual-labels/route.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+`app/api/manual-labels/route.test.ts`:
+```ts
+// @vitest-environment node
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NextResponse } from 'next/server';
+
+const requireOwnerMock = vi.fn();
+const upsertMock = vi.fn();
+const deleteMock = vi.fn();
+
+vi.mock('@/app/lib/owner', () => ({
+  requireOwner: (...a: unknown[]) => requireOwnerMock(...a),
+}));
+vi.mock('@/app/lib/manualLabels', () => ({
+  upsertManualLabel: (...a: unknown[]) => upsertMock(...a),
+  deleteManualLabel: (...a: unknown[]) => deleteMock(...a),
+}));
+
+import { POST, DELETE } from './route';
+
+const post = (body: unknown) =>
+  new Request('http://test/api/manual-labels', {
+    method: 'POST',
+    body: JSON.stringify(body),
+  });
+
+beforeEach(() => {
+  requireOwnerMock.mockReset().mockResolvedValue(null); // owner
+  upsertMock.mockReset().mockResolvedValue(undefined);
+  deleteMock.mockReset().mockResolvedValue(undefined);
+});
+
+describe('POST /api/manual-labels', () => {
+  it('gates on owner before writing', async () => {
+    requireOwnerMock.mockResolvedValue(
+      NextResponse.json({ error: 'no' }, { status: 401 }),
+    );
+    const res = await POST(post({ source: 'flickr', imageId: 1, isSunset: true }));
+    expect(res.status).toBe(401);
+    expect(upsertMock).not.toHaveBeenCalled();
+  });
+
+  it('upserts a valid label', async () => {
+    const res = await POST(
+      post({ source: 'flickr', imageId: 7, isSunset: true, rating: 4 }),
+    );
+    expect(res.status).toBe(200);
+    expect(upsertMock).toHaveBeenCalledWith({
+      source: 'flickr',
+      imageId: 7,
+      isSunset: true,
+      rating: 4,
+    });
+  });
+
+  it('rejects a bad source', async () => {
+    const res = await POST(post({ source: 'nope', imageId: 1, isSunset: true }));
+    expect(res.status).toBe(400);
+    expect(upsertMock).not.toHaveBeenCalled();
+  });
+
+  it('rejects an out-of-range rating', async () => {
+    const res = await POST(
+      post({ source: 'webcam', imageId: 1, isSunset: true, rating: 9 }),
+    );
+    expect(res.status).toBe(400);
+  });
+});
+
+describe('DELETE /api/manual-labels', () => {
+  it('removes a label (owner-gated)', async () => {
+    const req = new Request('http://test/api/manual-labels', {
+      method: 'DELETE',
+      body: JSON.stringify({ source: 'webcam', imageId: 9 }),
+    });
+    const res = await DELETE(req);
+    expect(res.status).toBe(200);
+    expect(deleteMock).toHaveBeenCalledWith('webcam', 9);
+  });
+});
+```
+
+- [ ] **Step 2: Run it — verify it fails**
+
+Run: `npx vitest run app/api/manual-labels/route.test.ts`
+Expected: FAIL — `./route` missing.
+
+- [ ] **Step 3: Implement**
+
+`app/api/manual-labels/route.ts`:
+```ts
+import { NextResponse } from 'next/server';
+import { requireOwner } from '@/app/lib/owner';
+import {
+  upsertManualLabel,
+  deleteManualLabel,
+  type LabelSource,
+} from '@/app/lib/manualLabels';
+
+export const dynamic = 'force-dynamic';
+
+const SOURCES: LabelSource[] = ['webcam', 'flickr'];
+
+export async function POST(request: Request) {
+  const denied = await requireOwner();
+  if (denied) return denied;
+
+  try {
+    const { source, imageId, isSunset, rating } = await request.json();
+    if (!SOURCES.includes(source)) {
+      return NextResponse.json({ error: 'bad source' }, { status: 400 });
+    }
+    if (typeof imageId !== 'number' || !Number.isInteger(imageId)) {
+      return NextResponse.json({ error: 'bad imageId' }, { status: 400 });
+    }
+    if (typeof isSunset !== 'boolean') {
+      return NextResponse.json({ error: 'isSunset required' }, { status: 400 });
+    }
+    if (
+      rating != null &&
+      (typeof rating !== 'number' || rating < 1 || rating > 5)
+    ) {
+      return NextResponse.json({ error: 'bad rating' }, { status: 400 });
+    }
+    await upsertManualLabel({ source, imageId, isSunset, rating: rating ?? null });
+    return NextResponse.json({ ok: true });
+  } catch (error) {
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : 'error' },
+      { status: 500 },
+    );
+  }
+}
+
+export async function DELETE(request: Request) {
+  const denied = await requireOwner();
+  if (denied) return denied;
+
+  try {
+    const { source, imageId } = await request.json();
+    if (!SOURCES.includes(source) || typeof imageId !== 'number') {
+      return NextResponse.json({ error: 'bad request' }, { status: 400 });
+    }
+    await deleteManualLabel(source, imageId);
+    return NextResponse.json({ ok: true });
+  } catch (error) {
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : 'error' },
+      { status: 500 },
+    );
+  }
+}
+```
+
+- [ ] **Step 4: Run it — verify it passes**
+
+Run: `npx vitest run app/api/manual-labels/route.test.ts`
+Expected: PASS (6 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/api/manual-labels/route.ts app/api/manual-labels/route.test.ts
+git commit -m "feat(api): owner-gated POST/DELETE /api/manual-labels"
+```
+
+---
+
+## Task 5: Upgrade the verification read (exclusion + provenance + source filter)
+
+**Files:**
+- Modify: `app/api/snapshots/route.ts` (the `mode === 'verification'` branch)
+- Modify: `app/api/snapshots/route.test.ts`
+
+- [ ] **Step 1: Write the failing tests** (append to the verification describe block in `route.test.ts`)
+
+```ts
+  it('excludes frames already in manual_labels (per leg)', async () => {
+    await GET(req('?mode=verification&disagreements_only=true'));
+    const text = allText();
+    expect(
+      text.some((q) => /not in\s*\(\s*select image_id from manual_labels where source\s*=\s*'webcam'/i.test(q)),
+    ).toBe(true);
+    expect(
+      text.some((q) => /not in\s*\(\s*select image_id from manual_labels where source\s*=\s*'flickr'/i.test(q)),
+    ).toBe(true);
+  });
+
+  it('source=flickr filter queries only the external leg', async () => {
+    await GET(req('?mode=verification&source=flickr'));
+    const text = allText();
+    expect(text.some((q) => /from\s+external_images\s+e/i.test(q))).toBe(true);
+    expect(text.some((q) => /from\s+webcam_snapshots\s+s\b/i.test(q))).toBe(false);
+  });
+
+  it('attaches a provenance field to each returned snapshot', async () => {
+    sqlMock.mockResolvedValue([
+      { snapshot_id: 1, source: 'flickr', firebase_url: 'x', captured_at: '2026-04-01', snapshot: {} },
+    ]);
+    const res = await GET(req('?mode=verification'));
+    const body = await res.json();
+    expect(body.snapshots[0]).toHaveProperty('provenance');
+  });
+```
+
+- [ ] **Step 2: Run them — verify they fail**
+
+Run: `npx vitest run app/api/snapshots/route.test.ts`
+Expected: FAIL — exclusion still references `webcam_snapshot_ratings`; no `source` filter; no `provenance` field.
+
+- [ ] **Step 3: Implement** in the `mode === 'verification'` branch of `app/api/snapshots/route.ts`
+
+3a. Parse the source filter near the top of the branch:
+```ts
+const sourceFilter = searchParams.get('source'); // 'webcam' | 'flickr' | null
+```
+
+3b. Replace the webcam-leg verdict exclusion (was `webcam_snapshot_ratings ... is_sunset_verdict`) and add the external-leg exclusion:
+```ts
+const webcamFilter = disagreementsOnly
+  ? sql`AND s.model_disagreement_kind IS NOT NULL
+        AND s.id NOT IN (SELECT image_id FROM manual_labels WHERE source = 'webcam')`
+  : sql`AND s.id NOT IN (SELECT image_id FROM manual_labels WHERE source = 'webcam')`;
+const externalFilter = disagreementsOnly
+  ? sql`AND e.model_disagreement_kind IS NOT NULL
+        AND e.id NOT IN (SELECT image_id FROM manual_labels WHERE source = 'flickr')`
+  : sql`AND e.id NOT IN (SELECT image_id FROM manual_labels WHERE source = 'flickr')`;
+```
+
+3c. Gate each leg on the source filter (only run/merge the requested leg):
+```ts
+const webcamRows = sourceFilter === 'flickr' ? [] : (await sql`... existing webcam query ...`) as ...;
+const externalRows = sourceFilter === 'webcam' ? [] : (await sql`... existing external query ...`) as ...;
+```
+Apply the same guard to the two COUNT queries (skip the suppressed leg's count, treat as 0).
+
+3d. Attach provenance after transform. Add the import at the top of `route.ts`:
+```ts
+import { deriveProvenance } from '@/app/lib/provenance';
+```
+Then build the merged list with provenance:
+```ts
+const merged = [...webcamRows, ...externalRows]
+  .sort((a, b) => Number(b.sort_key) - Number(a.sort_key))
+  .slice(offset, offset + limit)
+  .map((row) => {
+    const snap = transformSnapshot(row);
+    return {
+      ...snap,
+      provenance: deriveProvenance(row.source, row.captured_at ?? null),
+    };
+  });
+```
+
+- [ ] **Step 4: Run the suite — verify pass**
+
+Run: `npx vitest run app/api/snapshots/route.test.ts`
+Expected: PASS (existing + 3 new).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/api/snapshots/route.ts app/api/snapshots/route.test.ts
+git commit -m "feat(api): verification read — manual_labels exclusion, provenance, source filter"
+```
+
+---
+
+## Task 6: `HardExamplesQueue` component
+
+**Files:**
+- Create: `app/components/HardExamples/HardExamplesQueue.tsx`
+
+This component is the unified queue. It reuses `SnapshotQueueCard` (blind rating UI), `RatingCard` (reveal panel), and writes via `/api/manual-labels`. There are no component tests in this repo; verify via tsc + lint + the manual run in Task 8. Keep logic (provenance badge label, label→leave) trivial and obvious.
+
+- [ ] **Step 1: Implement the component**
+
+```tsx
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import {
+  Box, Typography, Switch, FormControlLabel, CircularProgress, Button,
+  ToggleButtonGroup, ToggleButton,
+} from '@mui/material';
+import { SnapshotQueueCard } from '@/app/components/SnapshotQueueCard';
+import RatingCard from '@/app/components/Webcam/RatingCard';
+import type { Snapshot, WindyWebcam } from '@/app/lib/types';
+import type { Provenance } from '@/app/lib/provenance';
+
+type QueuedSnapshot = Snapshot & { provenance: Provenance };
+
+const PROVENANCE_LABEL: Record<Provenance, string> = {
+  flickr: 'Flickr',
+  archive_trained: 'Archive · trained',
+  archive_new: 'Archive · new',
+};
+
+const labelSource = (s: Snapshot): 'webcam' | 'flickr' =>
+  s.source === 'flickr' ? 'flickr' : 'webcam';
+
+const frameToCard = (s: Snapshot): WindyWebcam =>
+  ({ ...s, images: { current: { preview: s.snapshot.firebaseUrl } } } as unknown as WindyWebcam);
+
+export function HardExamplesQueue({ hotkeysEnabled = true }: { hotkeysEnabled?: boolean }) {
+  const [blind, setBlind] = useState(true);          // blind-then-reveal default
+  const [view, setView] = useState<'queue' | 'grid'>('queue');
+  const [source, setSource] = useState<'all' | 'webcam' | 'flickr'>('all');
+
+  const [snapshots, setSnapshots] = useState<QueuedSnapshot[]>([]);
+  const [total, setTotal] = useState(0);
+  const [idx, setIdx] = useState(0);
+  const [revealed, setRevealed] = useState(false);   // post-submit reveal in blind mode
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // Fetch (disagreements only — this IS the labeling queue).
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true); setError(null);
+    const srcParam = source === 'all' ? '' : `&source=${source}`;
+    fetch(`/api/snapshots?mode=verification&disagreements_only=true&limit=200&offset=0${srcParam}`)
+      .then(async (r) => {
+        if (!r.ok) throw new Error(r.status === 401 || r.status === 403 ? 'Owner sign-in required' : `Failed (${r.status})`);
+        return r.json();
+      })
+      .then((d) => { if (!cancelled) { setSnapshots(d.snapshots ?? []); setTotal(d.total ?? 0); setIdx(0); setRevealed(false); } })
+      .catch((e) => { if (!cancelled) setError(e.message); })
+      .finally(() => { if (!cancelled) setLoading(false); });
+    return () => { cancelled = true; };
+  }, [source]);
+
+  const current = snapshots[idx];
+
+  const advance = useCallback(() => { setRevealed(false); setIdx((i) => i + 1); }, []);
+
+  const submitLabel = useCallback(async (rating: number, isSunset: boolean) => {
+    if (!current) return;
+    await fetch('/api/manual-labels', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        source: labelSource(current),
+        imageId: current.snapshot.id,
+        isSunset,
+        rating: isSunset ? rating : null,
+      }),
+    });
+    if (blind && !revealed) { setRevealed(true); return; } // reveal first, then advance on next key
+    advance();
+  }, [current, blind, revealed, advance]);
+
+  // SnapshotQueueCard contract: onRate(rating, { isSunsetVerdict }).
+  const onRate = useCallback(async (rating: number, opts?: { isSunsetVerdict?: boolean }) => {
+    await submitLabel(rating, opts?.isSunsetVerdict ?? rating > 0);
+  }, [submitLabel]);
+
+  const onSkip = useCallback(() => advance(), [advance]);
+  const onUndo = useCallback(async () => {
+    const prev = snapshots[idx - 1];
+    if (!prev) return;
+    await fetch('/api/manual-labels', {
+      method: 'DELETE', headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ source: labelSource(prev), imageId: prev.snapshot.id }),
+    });
+    setRevealed(false); setIdx((i) => Math.max(0, i - 1));
+  }, [snapshots, idx]);
+
+  // Hotkeys (mirror SnapshotConsole): 1-5 rate, space skip, z undo. In blind mode
+  // after a reveal, the next key advances.
+  useEffect(() => {
+    if (!hotkeysEnabled || view !== 'queue') return;
+    const handler = (e: KeyboardEvent) => {
+      if (e.repeat) return;
+      if (blind && revealed) { e.preventDefault(); advance(); return; }
+      if (/^[1-5]$/.test(e.key)) { e.preventDefault(); void onRate(Number(e.key), { isSunsetVerdict: true }); }
+      else if (e.key === '0' || e.key.toLowerCase() === 'n') { e.preventDefault(); void onRate(0, { isSunsetVerdict: false }); }
+      else if (e.key === ' ') { e.preventDefault(); onSkip(); }
+      else if (e.key.toLowerCase() === 'z') { e.preventDefault(); void onUndo(); }
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, [hotkeysEnabled, view, blind, revealed, onRate, onSkip, onUndo, advance]);
+
+  const Badge = ({ s }: { s: QueuedSnapshot }) => (
+    <Box sx={{ position: 'absolute', top: 18, left: 18, zIndex: 2, px: 1, py: 0.25,
+      borderRadius: 1, fontSize: 11, fontWeight: 700, color: 'white',
+      backgroundColor: s.provenance === 'flickr' ? 'rgba(124,58,237,0.85)' : 'rgba(0,0,0,0.72)' }}>
+      {PROVENANCE_LABEL[s.provenance]}
+    </Box>
+  );
+
+  return (
+    <Box>
+      <Box sx={{ display: 'flex', gap: 2, flexWrap: 'wrap', mb: 1, alignItems: 'center' }}>
+        <FormControlLabel sx={{ color: 'white' }}
+          control={<Switch checked={blind} onChange={(e) => setBlind(e.target.checked)} />}
+          label="Blind (reveal after rating)" />
+        <ToggleButtonGroup size="small" exclusive value={view} onChange={(_, v) => v && setView(v)}>
+          <ToggleButton value="queue">Queue</ToggleButton>
+          <ToggleButton value="grid">Grid</ToggleButton>
+        </ToggleButtonGroup>
+        <ToggleButtonGroup size="small" exclusive value={source} onChange={(_, v) => v && setSource(v)}>
+          <ToggleButton value="all">All</ToggleButton>
+          <ToggleButton value="webcam">Archive</ToggleButton>
+          <ToggleButton value="flickr">Flickr</ToggleButton>
+        </ToggleButtonGroup>
+        <Typography variant="caption" sx={{ color: '#9ca3af' }}>{total} flagged</Typography>
+      </Box>
+
+      {error ? <Typography sx={{ color: '#f87171' }}>{error}</Typography>
+       : loading ? <CircularProgress size={20} sx={{ color: 'white' }} />
+       : view === 'grid' ? (
+        <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 2 }}>
+          {snapshots.map((s) => (
+            <Box key={`${labelSource(s)}-${s.snapshot.id}`} sx={{ position: 'relative', width: 256 }}>
+              <Badge s={s} />
+              <RatingCard webcam={frameToCard(s)} readOnly onRate={async () => {}} />
+            </Box>
+          ))}
+        </Box>
+       ) : !current ? (
+        <Typography sx={{ color: '#9ca3af' }}>No more flagged frames — all caught up.</Typography>
+       ) : (
+        <Box sx={{ position: 'relative', maxWidth: 420 }}>
+          <Badge s={current} />
+          {blind && !revealed ? (
+            <SnapshotQueueCard snapshot={current} onRate={onRate} onSkip={onSkip} onUndo={onUndo} />
+          ) : (
+            // Reveal (blind→after submit) OR inspect mode (blind off): show the judges.
+            <>
+              <RatingCard webcam={frameToCard(current)} readOnly onRate={async () => {}} />
+              {blind && revealed && (
+                <Button sx={{ mt: 1, color: 'white' }} onClick={advance}>Next (any key)</Button>
+              )}
+              {!blind && (
+                <SnapshotQueueCard snapshot={current} onRate={onRate} onSkip={onSkip} onUndo={onUndo} />
+              )}
+            </>
+          )}
+        </Box>
+       )}
+    </Box>
+  );
+}
+
+export default HardExamplesQueue;
+```
+
+- [ ] **Step 2: Typecheck**
+
+Run: `npx tsc --noEmit 2>&1 | grep HardExamplesQueue || echo clean`
+Expected: `clean`. Fix any type errors (e.g. confirm `SnapshotQueueCard` is a named export; adjust import if it is default).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add app/components/HardExamples/HardExamplesQueue.tsx
+git commit -m "feat(ui): HardExamplesQueue — unified labeling queue (blind reveal, controls, manual_labels)"
+```
+
+---
+
+## Task 7: Wire the tab; retire Verification
+
+**Files:**
+- Modify: `app/HomeClient.tsx`
+- Delete: `app/components/Verification/VerificationTab.tsx`
+
+- [ ] **Step 1: Swap the imports**
+
+In `app/HomeClient.tsx`, replace:
+```ts
+import { VerificationTab } from './components/Verification/VerificationTab';
+```
+with:
+```ts
+import { HardExamplesQueue } from './components/HardExamples/HardExamplesQueue';
+```
+
+- [ ] **Step 2: Remove the `verify` tab entry**
+
+In `ALL_TABS`, delete the line:
+```ts
+    { key: 'verify', label: '🔎 Verification', operatorOnly: true },
+```
+
+- [ ] **Step 3: Point the Hard Examples tab at the new queue + remove the verify block**
+
+Replace the `{tabKey === 'hard' && (...)}` block body with:
+```tsx
+              {tabKey === 'hard' && (
+                <Box>
+                  <HardExamplesQueue hotkeysEnabled={drawerOpen} />
+                </Box>
+              )}
+```
+And delete the entire `{tabKey === 'verify' && ( ... )}` block.
+
+- [ ] **Step 4: Delete the retired component**
+
+```bash
+git rm app/components/Verification/VerificationTab.tsx
+```
+
+- [ ] **Step 5: Typecheck + lint**
+
+Run:
+```bash
+npx tsc --noEmit 2>&1 | grep -E "HomeClient|HardExamplesQueue|VerificationTab" || echo clean
+npx next lint --file app/HomeClient.tsx --file app/components/HardExamples/HardExamplesQueue.tsx
+```
+Expected: `clean`; no ESLint errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/HomeClient.tsx
+git commit -m "feat(ui): Hard Examples tab uses unified queue; retire Verification tab"
+```
+
+---
+
+## Task 8: Final verification
+
+- [ ] **Step 1: Full suite + tsc**
+
+Run: `npx vitest run` → all green. `npx tsc --noEmit 2>&1 | grep -c "error TS"` → not higher than the pre-feature baseline.
+
+- [ ] **Step 2: Manual run** (per the `run` skill)
+
+Apply the migration to a dev DB (or prod with approval), `npm run dev`, sign in as owner, open the drawer → **Hard Examples**:
+- A flagged frame shows blind with a provenance badge; press `1–5` (sunset+quality) or `N`/`0` (not sunset) → judges reveal → next key advances → frame is gone on reload (excluded via `manual_labels`).
+- Toggle **Blind off** → judges show immediately (inspect); **Grid** → many at once; **source filter** narrows.
+Confirm a row landed: `psql "$DATABASE_URL" -c "SELECT * FROM manual_labels ORDER BY labeled_at DESC LIMIT 3;"`
+
+- [ ] **Step 3: Commit any fixes, push, open PR.**
+
+---
+
+## Notes for the implementer
+- `sql` is the `@neondatabase/serverless` tagged template from `@/app/lib/db`; tests mock it (see `app/api/snapshots/route.test.ts` for the pattern).
+- `requireOwner()` returns a `NextResponse` to return early, or `null` for the owner.
+- Confirm whether `SnapshotQueueCard` is a named or default export and match the import (Task 6 Step 2).
+- The migration is forward-only/manual; apply to prod only with explicit owner approval (additive + idempotent).

--- a/docs/superpowers/specs/2026-06-07-hard-examples-labeling-queue-design.md
+++ b/docs/superpowers/specs/2026-06-07-hard-examples-labeling-queue-design.md
@@ -1,0 +1,148 @@
+---
+title: "Hard Examples — unified labeling queue (manual gold labels for v5)"
+date: 2026-06-07
+status: spec
+supersedes_ui: "the read-only Verification tab (PR #47) folds into this"
+---
+
+# Hard Examples — unified labeling queue
+
+## Problem & goal
+
+The three-judge backfill flagged **~7,286 disagreement frames** (webcam archive +
+Flickr) where the v4 model and Claude — or the two model heads — split on
+"is this a sunset?". These are the hard / ambiguous cases: the highest-value data
+to hand-label for **v5 training** (this is *hard-example mining* / *active
+learning* — labeling the samples the model is most uncertain about).
+
+Today there is no way to capture those labels at the needed speed/coverage:
+- The **Hard Examples** queue captures verdicts but only for **webcam** frames,
+  **blind**, and writes `is_sunset_verdict` into `webcam_snapshot_ratings`
+  (the public crowd-ratings table, FK'd to `webcam_snapshots` — Flickr can't go
+  there).
+- The **Verification** tab (PR #47) shows webcam + Flickr with the judges, but is
+  **read-only**.
+
+**Goal:** one fast, keyboard-driven labeling queue over both sources that produces
+a clean **operator gold-label set** for v5, while letting the operator confirm the
+frames really are hard.
+
+## Non-goals
+- Crowd / multi-user ratings (that idea is retired; the only labels are the
+  operator's).
+- Exact training-set membership (the v4 manifest cross-reference) — v1 uses a
+  capture-date approximation for the provenance badge (see Provenance).
+- Re-scoring or model changes — the scores already exist from the backfill.
+
+## Design overview
+
+One operator tab, **"Hard Examples"** (kept — the name is the correct ML framing).
+It unifies and replaces today's Hard Examples queue *and* the read-only
+Verification tab. Data source: the union disagreements read over
+`webcam_snapshots` + `external_images` (the `mode=verification` read built in
+PR #47), upgraded with provenance and a new exclusion.
+
+### Controls (UI state, not persisted)
+1. **Blind toggle** — default ON = *blind-then-reveal*: scores hidden while you
+   rate; on submit, the three judges + provenance reveal so you confirm the frame
+   was genuinely hard. OFF = scores always visible (inspect mode: look and skip to
+   verify hardness without rating). The blind-first default keeps labels unbiased
+   (these become v5 training data; rating while seeing the model's guess risks
+   self-reinforcing bias).
+2. **View toggle** — default = rapid single-card queue (keyboard labeling); flip to
+   a grid to eyeball many frames at once.
+3. **Source filter** — All / Flickr / Archive·trained / Archive·new.
+
+### Provenance badge (derived, not stored)
+Each frame shows where it came from:
+- **Flickr** — `external_images` rows.
+- **Archive · trained** — webcam frames captured **≤** the v4 training cutoff.
+- **Archive · new** — webcam frames captured **after** the cutoff (not yet trained
+  on — the highest-value labels).
+
+Cutoff = a `masterConfig` constant `V4_TRAINING_CUTOFF` (≈ `2026-05-13`, the v4
+export date). Derived at read time from `source` + `captured_at`; not stored.
+**Caveat (document in code):** exact for "new" (definitely post-training),
+approximate for "trained" (not every pre-cutoff frame was in the training sample).
+Pinpoint membership would require the v4 manifest — deferred.
+
+### Rapid keyboard entry
+Reuse the existing `SnapshotQueueCard` hotkey flow **exactly as implemented today**
+(no new interaction model) — `1–5` stars, the Yes/No is-sunset keys, `space` = skip,
+`z` = undo — extended only so submitting also writes a `manual_labels` row. The
+implementation reads `SnapshotQueueCard` and matches its current key mapping rather
+than inventing one. Type-and-advance; labeled frame leaves the queue.
+
+### Capture
+`is_sunset` (required) + `rating` 1–5 (optional). No free-text note.
+
+## Data model
+
+New table — the operator gold-label set, decoupled from crowd ratings:
+
+```sql
+CREATE TABLE IF NOT EXISTS manual_labels (
+  id          BIGSERIAL PRIMARY KEY,
+  source      TEXT NOT NULL CHECK (source IN ('webcam', 'flickr')),
+  image_id    BIGINT NOT NULL,        -- webcam_snapshots.id or external_images.id
+  is_sunset   BOOLEAN NOT NULL,
+  rating      INT CHECK (rating BETWEEN 1 AND 5),  -- nullable
+  origin      TEXT NOT NULL DEFAULT 'hard_example',
+  labeled_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+  UNIQUE (source, image_id)           -- one label per frame; re-label upserts
+);
+```
+
+- `source` + `image_id` is the polymorphic key into the two image tables.
+- `origin` tags the provenance of the *label activity* (hard-example mining now;
+  future label campaigns can use other values).
+- Upsert on `(source, image_id)` so re-labeling overwrites.
+
+**Migration also backfills** existing operator verdicts so prior work carries over:
+```sql
+INSERT INTO manual_labels (source, image_id, is_sunset, rating, origin, labeled_at)
+SELECT 'webcam', snapshot_id, is_sunset_verdict, rating, 'hard_example', created_at
+FROM webcam_snapshot_ratings
+WHERE is_sunset_verdict IS NOT NULL
+ON CONFLICT (source, image_id) DO NOTHING;
+```
+
+## Components & data flow
+
+1. **Read** — the disagreements union read (existing `mode=verification` in
+   `app/api/snapshots/route.ts`) is the queue source, with two changes:
+   - add the provenance badge fields (derive trained/new from `captured_at` vs
+     `V4_TRAINING_CUTOFF`; Flickr is its own value);
+   - **exclusion**: queue = flagged frames **minus** rows already in
+     `manual_labels` (was: minus `webcam_snapshot_ratings.is_sunset_verdict`).
+     This is the membership invariant — a labeled frame stays out, and a later
+     disagreement recompute must not resurrect it.
+   - optional `source` filter param.
+2. **Write** — new owner-gated route `POST /api/manual-labels`
+   `{ source, imageId, isSunset, rating? }` → upsert into `manual_labels`.
+   `DELETE` (undo) removes the row.
+3. **UI** — the **Hard Examples** tab becomes the unified queue: `SnapshotQueueCard`
+   (informed reveal after submit) + the three controls + provenance badge. The
+   read-only **Verification** tab is removed (its union read is reused here).
+
+## Testing
+- **Migration:** validate idempotency + the backfill in a rolled-back txn (per the
+  established pattern); verify `UNIQUE` upsert.
+- **`POST /api/manual-labels`:** owner-gated (401/403); upserts; rejects bad
+  `source`/`rating`; DELETE removes. (Mock `sql`, mirror `route.test.ts`.)
+- **Read:** queue excludes `manual_labels`-present frames; source filter narrows;
+  provenance derivation (trained vs new vs flickr) is correct around the cutoff.
+- **UI:** unit-test the provenance/derivation + the label→leave reducer; the card
+  hotkey flow is reused (already covered).
+
+## Scope boundaries
+- One operator; no auth roles beyond `requireOwner`.
+- Provenance is display-only and date-approximate; no manifest cross-reference.
+- No change to the scoring/backfill pipeline; labels are consumed by v5 training
+  out-of-band (export reads `manual_labels`).
+
+## Open follow-ups (not in this spec)
+- Exact training-membership via the v4 manifest (upgrade the provenance badge).
+- v5 training export that joins `manual_labels` as gold labels.
+- Binary-disagreement threshold tuning (`SUNSET_DISAGREEMENT_HIGH/LOW`) if the
+  ~18.5% archive flag rate proves noisy in practice.

--- a/package.json
+++ b/package.json
@@ -11,7 +11,9 @@
     "test": "vitest",
     "test:ui": "vitest --ui",
     "backfill:archive": "npx --yes tsx scripts/backfill-archive-scores.ts",
-    "backfill:archive:dry": "npx --yes tsx scripts/backfill-archive-scores.ts --dry-run"
+    "backfill:archive:dry": "npx --yes tsx scripts/backfill-archive-scores.ts --dry-run",
+    "backfill:flickr": "npx --yes tsx scripts/backfill-flickr-scores.ts",
+    "backfill:flickr:dry": "npx --yes tsx scripts/backfill-flickr-scores.ts --dry-run"
   },
   "dependencies": {
     "@deck.gl/core": "^9.1.14",

--- a/scripts/backfill-flickr-scores.ts
+++ b/scripts/backfill-flickr-scores.ts
@@ -1,0 +1,84 @@
+/**
+ * One-time standalone backfill of v4 model scores over the Flickr set
+ * (external_images, plan U6). Runs the SAME engine the recompute/cron would use
+ * (backfillExternalImageScores) but unbounded and with full ONNX.
+ *
+ * The Claude judge already exists in external_images.llm_* (the v4 training
+ * labels); this fills only the model columns + the model-vs-Claude disagreement.
+ * No Anthropic spend.
+ *
+ * Prerequisites (operational — set before running):
+ *   AI_ONNX_REGRESSION_MODEL_PATH=...         (real v4 regression artifact)
+ *   AI_ONNX_BINARY_MODEL_PATH=... + AI_BINARY_SCORING_ENABLED=true  (optional; persists the binary judge too)
+ *   DATABASE_URL=...                          (point at a SCOPED backfill credential with
+ *                                              INSERT/UPDATE on external_images only — not
+ *                                              the app's full-privilege role)
+ *   BACKFILL_PAGE_SIZE=100                    (optional; rows per batch)
+ *
+ * Run (no global install needed):
+ *   npx tsx scripts/backfill-flickr-scores.ts --dry-run   # just count
+ *   npx tsx scripts/backfill-flickr-scores.ts             # drain
+ *
+ * Safety: aborts immediately (exit 2) if scoreImage leaves the real ONNX path
+ * ('unscored') — never writes fabricated scores (post-#45 there is no metadata
+ * fallback, so the ONNX-or-nothing gate is the only protection; there is no
+ * AI_SCORING_MODE to set).
+ */
+import { countExternalImagesNeedingScore } from '@/app/api/cron/update-cameras/lib/dbOperations';
+import { backfillExternalImageScores } from '@/app/api/cron/update-cameras/lib/externalBackfill';
+
+const PAGE = Number(process.env.BACKFILL_PAGE_SIZE ?? '100');
+
+async function main(): Promise<number> {
+  const dryRun = process.argv.includes('--dry-run');
+
+  const total = await countExternalImagesNeedingScore();
+  console.log(`[flickr-backfill] ${total} Flickr images need a real model score`);
+  if (dryRun) {
+    console.log('[flickr-backfill] --dry-run: counted only, no writes. Exiting.');
+    return 0;
+  }
+  if (total === 0) return 0;
+
+  let scored = 0;
+  let dead = 0;
+  let failed = 0;
+
+  for (;;) {
+    const r = await backfillExternalImageScores({ limit: PAGE });
+
+    if (r.abortedOnFallback) {
+      console.error(
+        `[flickr-backfill] ABORTED: scoreImage left the ONNX path (fallbacks=${r.fallbacks}). ` +
+          'Model not loading — check the ONNX model paths. No junk written.',
+      );
+      return 2;
+    }
+
+    scored += r.scored;
+    dead += r.deadUrls;
+    failed += r.failed;
+    const did = r.scored + r.deadUrls + r.failed;
+    console.log(
+      `[flickr-backfill] +${r.scored} scored, +${r.deadUrls} dead-url, +${r.failed} failed — ${scored}/${total} done`,
+    );
+
+    if (did === 0) break; // finder returned nothing — drained
+    if (r.scored === 0 && r.deadUrls === 0 && r.failed > 0) {
+      // A whole page of only transient failures (e.g. rejected hosts or network
+      // blips): stop rather than spin. Rows stay scoreable; re-run to retry.
+      console.warn('[flickr-backfill] page was all transient failures — stopping. Re-run to retry.');
+      break;
+    }
+  }
+
+  console.log(`[flickr-backfill] done. scored=${scored} dead-url=${dead} failed=${failed}`);
+  return 0;
+}
+
+main()
+  .then((code) => process.exit(code))
+  .catch((err) => {
+    console.error('[flickr-backfill] fatal:', err);
+    process.exit(1);
+  });


### PR DESCRIPTION
Planning PR for **Phase 3** of three-judge hard examples. Phases 1–2 (U1–U4) are merged (#43 + #46) on top of #45.

## Why this rewrite
The original Phase 3 assumed Flickr needed Claude scoring from scratch (gated on Anthropic spend). **Those scores already exist** — `ml/artifacts/llm_ratings/ratings_20260512_204416.csv` (~5,747 images) and `external_images.llm_*` populated for the v4 export (the running model was trained on them). So the spend gate is dead.

## Phase 3 becomes
One migration + one TS model-only backfill (unscored-gated) + one private view + one env flip:
- **U5** — mirror migration on `external_images` (the model-score columns #44 added to `webcam_snapshots`) + a verification gate; **no Claude run, no scrape**.
- **U6** — score Flickr with the **model only**, reusing existing `llm_*`; run ONNX over `external_images` via #44's backfill module with #45's `'unscored'` discipline; then disagreement recompute. **Zero Anthropic spend.**
- **U7** — verification view; also lands the deferred review finding **#10 (central owner-auth)**.
- **U8** — flip `AI_BINARY_SCORING_ENABLED` in Vercel.

## Open question (gates U5)
Is `external_images.llm_*` still populated in prod (~5,767), or do we re-import from the CSV? The plan treats **CSV re-import as the safe default** behind a `SELECT count(*)` gate.

Draft — this is the plan for review; U6's detailed TDD builds on the now-merged #44 backfill module.

🤖 Generated with [Claude Code](https://claude.com/claude-code)