### PR TITLE
docs(solutions): Arducam camera detection + Tier-0 onboarding runbook

### DIFF
--- a/docs/solutions/best-practices/validate-output-before-optimizing-pipeline.md
+++ b/docs/solutions/best-practices/validate-output-before-optimizing-pipeline.md
@@ -1,0 +1,52 @@
+---
+title: Validate the product output before optimizing the pipeline
+date: 2026-06-07
+category: docs/solutions/best-practices
+module: engineering-process
+problem_type: best_practice
+component: development_workflow
+severity: medium
+applies_when:
+  - A pipeline "works" by a proxy metric (bytes uploaded, 200 OK, IDs returned) but the actual output artifact hasn't been inspected
+  - About to invest in automating, scaling, or optimizing a flow
+  - Success is currently measured by a stand-in rather than the thing you actually care about
+tags: [process, validation, debugging, premature-optimization, proxy-metrics, hardware-bringup]
+---
+
+# Validate the product output before optimizing the pipeline
+
+## Context
+
+During the sunset-cam-1 bringup, the camera had been capturing and uploading ~300 KB frames to production — the logs showed `uploaded snapshot_id=…` and the server returned IDs, so the plumbing was provably working. The instinct was to move on to optimizing how to commission *more* units faster. But we had **never once looked at an actual frame, or read a single real gyro value.** The pull to optimize the pipeline arrived before anyone confirmed the pipeline produced a good product.
+
+## Guidance
+
+Before building automation, scaling, or optimization on top of a working pipeline, **inspect the actual output artifact** — the image, the file, the record a human cares about — not just the proxy that says data moved.
+
+"Plumbing works" (bytes transferred, `200 OK`, IDs assigned, device addressable) is **not** "the product is good" (image in focus, sensor reading real values, record correct). Proxy metrics are necessary but not sufficient; they're exactly the signals that stay green while the real output is broken.
+
+Concretely: pull one real artifact and look at it. View the frame. Read the sensor value and sanity-check its range. Open the generated file. *Then* decide whether the thing is worth optimizing.
+
+## Why This Matters
+
+On sunset-cam-1, spending ten minutes to actually validate the output before optimizing:
+- **Confirmed the image was genuinely good** (sharp, well-exposed) — so the effort to scale was justified.
+- **Caught a silent bug**: the gyro was reporting a fake `(0.0, 0.0)` because the sensor was never woken (see `../integration-issues/mpu6050-reads-fake-zeros-when-asleep.md`). Every proxy was green — `i2cdetect` showed the chip, uploads succeeded — yet the orientation data was fabricated. Had we built the AR aiming tool first, it would have shown a permanently perfect "level" and silently lied.
+
+Optimizing the commissioning of five units before confirming that one produces a good picture and a real orientation is effort poured into an unvalidated foundation.
+
+## When to Apply
+
+- Any "it's working, let's scale/automate it" moment.
+- Whenever success is currently judged by a stand-in (HTTP status, byte counts, "device detected") rather than the artifact itself.
+- Right after first end-to-end success and right before the first optimization — that gap is where this check belongs.
+
+## Examples
+
+- **Proxy green, product unchecked:** server returned `snapshot_id`s for every upload (success signal) — but no one had viewed a frame. The frame turned out fine; the point is we didn't *know* until we looked.
+- **Proxy green, product fake:** `i2cdetect` showed the MPU at `0x68` and `WHO_AM_I` returned `0x68` — yet the accelerometer fed pure zeros because it was asleep. Addressable ≠ producing data.
+
+## Related
+
+- `../integration-issues/mpu6050-reads-fake-zeros-when-asleep.md` — the silent bug this check caught.
+- [[2026-06-06-fallbacks-must-not-impersonate-real-signal]] — same family: a fake value masquerading as the real signal; this practice is how you catch it.

--- a/docs/solutions/integration-issues/arducam-imx708-not-detected-on-pi-zero.md
+++ b/docs/solutions/integration-issues/arducam-imx708-not-detected-on-pi-zero.md
@@ -1,0 +1,82 @@
+---
+title: Arducam IMX708 not detected on Raspberry Pi (camera_auto_detect fails on blank EEPROM)
+date: 2026-06-07
+category: docs/solutions/integration-issues
+module: pi-firmware-onboarding
+problem_type: integration_issue
+component: tooling
+symptoms:
+  - "`rpicam-hello --list-cameras` prints `No cameras available!`"
+  - "`dmesg` shows zero camera probe activity — no imx708/csi/unicam lines at all, despite `camera_auto_detect=1` in config.txt"
+  - "`sudo dtoverlay imx708` at runtime returns `Failed to apply overlay '1_imx708' (kernel)`"
+root_cause: config_error
+resolution_type: config_change
+severity: high
+tags: [raspberry-pi, arducam, imx708, camera, csi, pi-zero, onboarding, dtoverlay]
+---
+
+# Arducam IMX708 not detected on Raspberry Pi (camera_auto_detect fails on blank EEPROM)
+
+## Problem
+
+A new webcam unit (`sunset-cam-1`, Raspberry Pi Zero 2 W + Arducam IMX708 Autofocus / "Camera Module 3 Wide") reported `No cameras available!` from `rpicam-hello`, with `dmesg` showing no camera subsystem activity whatsoever — even though `camera_auto_detect=1` was correctly set in `/boot/firmware/config.txt`. This blocks the entire hardware bringup for any Arducam-based unit.
+
+## Symptoms
+
+- `rpicam-hello --list-cameras` → `No cameras available!`
+- `dmesg | grep -iE 'imx|csi|unicam|cfe'` → **nothing camera-related** (only incidental SCSI/iSCSI text matches). No failed probe, just total absence.
+- `grep -iE 'camera' /boot/firmware/config.txt` shows `camera_auto_detect=1` is present and correct.
+- Runtime `sudo dtoverlay imx708` → `Failed to apply overlay '1_imx708' (kernel)`.
+
+## What Didn't Work
+
+- **Swapping/reseating CSI ribbon cables** (tried a 15-to-15, hunted for orientation issues, debated 22-to-22 vs 15-to-22). **This was a red herring and cost the most time.** The correct cable for a Pi Zero 2 W is the narrow **22-to-22** (both the Zero's port and the Arducam board are 22-pin / 0.5 mm), but the cable was never the actual fault. The "total dmesg silence" symptom does not point to wiring.
+- **Running `sudo dtoverlay imx708` at runtime.** Camera/I2C overlays cannot be hot-applied; they must be set at boot. The `Failed to apply overlay (kernel)` message is **expected and not diagnostic** — it says nothing about whether the camera is wired correctly.
+
+## Solution
+
+Force the `imx708` driver explicitly at boot instead of relying on auto-detect. On the Pi:
+
+```bash
+# disable auto-detect so it doesn't fight the explicit overlay
+sudo sed -i 's/camera_auto_detect=1/camera_auto_detect=0/' /boot/firmware/config.txt
+
+# load the imx708 driver directly
+echo "dtoverlay=imx708" | sudo tee -a /boot/firmware/config.txt
+
+sudo reboot
+```
+
+After reboot, `dmesg` confirms the driver bound to the sensor:
+
+```
+imx708 10-001a: camera module ID 0x0000
+```
+
+(The `ctrl ... is not handled` and `Fixed dependency cycle(s)` lines that accompany it are harmless boot noise.) `rpicam-hello --list-cameras` then lists the sensor.
+
+## Why This Works
+
+Arducam IMX708 boards ship with a **blank / non-standard camera EEPROM** — the giveaway is `camera module ID 0x0000` in the kernel log. Raspberry Pi's `camera_auto_detect` works by reading that EEPROM over I2C to decide which sensor overlay to load. With no recognizable module ID, it loads **nothing** — which is exactly why `dmesg` is completely silent rather than showing a failed probe.
+
+Forcing `dtoverlay=imx708` binds the driver directly and skips the EEPROM-identification step. The Arducam IMX708 is register/pin-compatible with the stock Raspberry Pi `imx708` driver, so no Arducam-specific software is required — only the explicit overlay.
+
+**Key diagnostic distinction:**
+
+| `dmesg` after forcing `dtoverlay=imx708` at boot | Meaning |
+|---|---|
+| Total silence (no imx708 line) before forcing | Auto-detect loaded nothing — config issue, **not wiring** |
+| `imx708 ...: failed to read chip id` / `-EIO` / i2c timeout | Driver loaded but sensor not answering — **now** it's wiring/orientation/dead module |
+| `imx708 10-001a: camera module ID ...` (no error) | Sensor alive, driver bound ✅ |
+
+## Prevention
+
+- **Set `dtoverlay=imx708` explicitly for every Arducam-based unit** in the install/onboarding guide, rather than relying on `camera_auto_detect`. Auto-detect will never recognize these boards.
+- **Diagnostic order for "no camera":** before touching cables, force the overlay at boot and read `dmesg`. *Total silence* = config/auto-detect problem; a *`failed to read chip id`* probe error = wiring/orientation. Don't swap cables first.
+- Remember that runtime `sudo dtoverlay <camera>` failing is normal — camera overlays only apply at boot. Never read that failure as a hardware signal.
+- Cable sizing reference for this hardware: Pi Zero 2 W camera port and the Arducam IMX708 board are both **22-pin (0.5 mm)** → use the **22-to-22** cable from the Arducam kit. (Full-size Pi 3/4 ports are 15-pin → use the 15-to-22 cable.)
+
+## Related Issues
+
+- Pi install/bringup guide: `docs/hardware/2026-05-29-pi-mpu6050-install-and-bringup-guide.md` (on branch `docs/pi-mpu6050-install-guide`, PR #23) — should carry the explicit `dtoverlay=imx708` step.
+- Bringup checkpoint: `docs/hardware/2026-05-31-mpu6050-bringup-checkpoint.md`.

--- a/docs/solutions/integration-issues/mpu6050-reads-fake-zeros-when-asleep.md
+++ b/docs/solutions/integration-issues/mpu6050-reads-fake-zeros-when-asleep.md
@@ -1,0 +1,68 @@
+---
+title: MPU6050 reads a fake (0.0, 0.0) orientation — sensor never woken from SLEEP
+date: 2026-06-07
+category: docs/solutions/integration-issues
+module: pi-firmware-gyro
+problem_type: integration_issue
+component: tooling
+symptoms:
+  - "read_orientation() returns a suspiciously perfect (0.0, -0.0) on every sample, with no jitter"
+  - "accel raw block reads [0, 0, 0, 0, 0, 0]"
+  - "PWR_MGMT_1 (register 0x6B) reads 0x40 — the SLEEP bit is set"
+root_cause: incomplete_setup
+resolution_type: code_fix
+severity: high
+tags: [mpu6050, gyro, imu, i2c, raspberry-pi, sleep, sensor-init, silent-failure]
+---
+
+# MPU6050 reads a fake (0.0, 0.0) orientation — sensor never woken from SLEEP
+
+## Problem
+
+During a hardware validation pass on sunset-cam-1, the gyro returned roll/pitch of exactly `(0.0, -0.0)` on every read. The MPU6050 hardware was fine — the driver simply never woke it, so it was reporting zeros that *looked* like "perfectly level."
+
+## Symptoms
+
+- `read_orientation(bus)` returns `(0.0, -0.0)` repeatedly with **zero jitter** (a real accelerometer always has ±0.x° noise — a perfectly clean reading is the tell).
+- Raw accel block (`read_i2c_block_data(0x68, 0x3B, 6)`) is all zeros.
+- `PWR_MGMT_1` (reg `0x6B`) reads `0x40` — bit 6 (SLEEP) set.
+- `WHO_AM_I` (`0x75`) still reads `0x68`, so the chip is present and addressable — masking the problem.
+
+## What Didn't Work
+
+- Trusting `i2cdetect` / `WHO_AM_I`. They confirm the chip is *wired and addressable*, not that it's *producing data*. The chip answered `0x68` while feeding pure zeros.
+
+## Solution
+
+The MPU6050 powers up with the SLEEP bit set; it must be cleared once before reads return real data. Added to `gyro_driver.py`:
+
+```python
+PWR_MGMT_1 = 0x6B  # bit 6 (0x40) is SLEEP, set at power-on
+
+def wake(bus, addr=MPU6050_ADDR):
+    """Clear the SLEEP bit so the accelerometer produces real data."""
+    bus.write_byte_data(addr, PWR_MGMT_1, 0x00)
+
+def make_orientation_reader(bus, addr=MPU6050_ADDR):
+    """Wake the chip, then return the zero-arg reader OrientationSampler expects."""
+    wake(bus, addr)
+    return lambda: read_orientation(bus, addr)
+```
+
+`OrientationSampler` takes an injected zero-arg reader and is deliberately unaware of the bus, so the wake can't live inside it. The `make_orientation_reader` factory is the wiring point that guarantees the chip is awake before the first sample — the sampler can never be handed a sleeping sensor. (firmware PR #4, TDD.)
+
+## Why This Works
+
+Until `PWR_MGMT_1`'s SLEEP bit is cleared, the MPU6050's accel registers read `0`, and `atan2(0,0)`-based roll/pitch compute to `(0, 0)`. Writing `0x00` clears SLEEP (and selects the internal oscillator), and the accelerometer starts producing real data immediately.
+
+## Prevention
+
+- **Treat a perfectly clean, jitter-free sensor reading as suspect.** Real analog sensors are noisy; a stable exact `0.0` usually means "not actually reading."
+- **Distinguish "addressable" from "producing data."** `WHO_AM_I` / `i2cdetect` only prove the former. Validate an actual value range, not just presence.
+- **Wire init through a factory** so a consumer can't be constructed against an un-initialized device.
+- This is the sensor-layer instance of a broader pattern: a fallback/uninitialized path emitting a plausible-but-fake value that masquerades as the real signal. See [[2026-06-06-fallbacks-must-not-impersonate-real-signal]] and `../best-practices/validate-output-before-optimizing-pipeline.md`.
+
+## Related Issues
+
+- `sunset-cam-firmware` PR #4 — `wake()` + `make_orientation_reader()`.
+- `../best-practices/validate-output-before-optimizing-pipeline.md` — the validation pass that surfaced this bug.

--- a/docs/solutions/workflow-issues/onboarding-a-tier0-sunset-camera.md
+++ b/docs/solutions/workflow-issues/onboarding-a-tier0-sunset-camera.md
@@ -1,0 +1,102 @@
+---
+title: Onboarding a new Tier-0 sunset camera — the real, proven flow
+date: 2026-06-07
+category: docs/solutions/workflow-issues
+module: pi-firmware-onboarding
+problem_type: workflow_issue
+component: development_workflow
+severity: medium
+applies_when:
+  - Setting up a new custom Pi (Zero 2 W) + Arducam IMX708 webcam unit
+  - Reproducing or speeding up the per-unit deployment workflow
+tags: [onboarding, raspberry-pi, tier0, device-token, configure, sunset-cam, deployment]
+---
+
+# Onboarding a new Tier-0 sunset camera — the real, proven flow
+
+## Context
+
+Bringing up `sunset-cam-1` (Pi Zero 2 W + Arducam IMX708) took hours instead of minutes, mostly because the install/bringup guide documented a setup that **does not work**. Capturing the real, verified flow here so subsequent units are fast and repeatable. This is the procedure proven end-to-end on 2026-06-07 (camera record `camera_id 4`, frames confirmed landing in prod via server-assigned `snapshot_id`s).
+
+## Guidance
+
+The per-unit flow has three machines-worth of steps: **Mac (mint), Pi (install), Pi (configure + run).**
+
+**1. Mac — create the camera record + device token** (writes to prod DB; token prints ONCE):
+
+```bash
+cd ~/GitHub/the-sunset-webcam-map
+export DATABASE_URL="$(grep '^DATABASE_URL=' .env.production.local | cut -d= -f2- | tr -d '"')"
+./scripts/tier0-create-camera.sh \
+  --hardware-id pi-zero-2w-sunset-cam-N \
+  --lat 48.7519 --lng -122.4787 \
+  --timezone America/Los_Angeles \
+  --title "sunset-cam-N" --phase sunset
+```
+
+Save the printed `camera_id` and 64-hex `device_token`.
+
+**1b. Mac — install your SSH key on the Pi** (once per unit, after the Pi is flashed and on the network). This makes every later command passwordless and lets a script or AI assistant drive the bench checks:
+
+```bash
+ssh-copy-id pi@sunset-cam-N.local   # run on the Mac; expect "Number of key(s) added: 1"
+```
+
+**2. Pi — install firmware to `/opt/sunset-cam`** (after flashing/booting/SSH and physically connecting camera + MPU):
+
+```bash
+sudo git clone https://github.com/jessekauppila/sunset-cam-firmware.git /opt/sunset-cam
+sudo bash /opt/sunset-cam/scripts/install.sh
+```
+
+**2b. Pi — apply the Arducam camera-overlay fix** (required on every Arducam unit — auto-detect can't see them; see `../integration-issues/arducam-imx708-not-detected-on-pi-zero.md`):
+
+```bash
+sudo sed -i 's/camera_auto_detect=1/camera_auto_detect=0/' /boot/firmware/config.txt
+echo "dtoverlay=imx708" | sudo tee -a /boot/firmware/config.txt
+sudo reboot
+```
+
+**3. Pi — write config + start** (substitute `<ID>` / `<TOKEN>`):
+
+```bash
+sudo bash /opt/sunset-cam/scripts/configure.sh \
+  --camera-id <ID> --device-token <TOKEN> \
+  --phase sunset --api-base https://www.sunrisesunset.studio \
+  --window-id setup --window-from-now-min 0 --window-duration-min 30
+sudo systemctl enable --now sunset-cam
+journalctl -u sunset-cam -f   # expect: uploaded snapshot_id=… bytes=…
+sudo systemctl stop sunset-cam   # stop a BENCH unit after verifying (avoid frame spam)
+```
+
+## Why This Matters
+
+Onboarding is the bottleneck on the whole project's value — if only one person can do it, slowly, the camera network can't grow. The wrong docs cost an entire session of cable-swapping and config dead-ends. The traps that wasted the most time, each now avoided above:
+
+- **`device_token`, not `claim_code`.** The firmware config reads `device_token` (from `tier0-create-camera.sh`). The `/api/admin/claim-codes` endpoint is a *separate* cloud-wizard flow this firmware never uses. Minting a claim code is a dead end.
+- **Install to `/opt/sunset-cam`, not `~/sunset-cam-firmware`.** The systemd unit hard-codes `/opt/sunset-cam/.venv/bin/python`. A `~`-based manual install (or one without the `--system-site-packages` venv that `install.sh` builds) cannot start the service.
+- **`www.sunrisesunset.studio`, not the apex.** The apex `sunrisesunset.studio` returns a 307 that strips the `Authorization` header → uploads/admin calls fail. Always target `www.`.
+- **Never hand-write `config.json`.** `configure.sh` writes the exact required schema (`camera_id`, `device_token`, `api_base`, `phase`, `window_id`, `capture_window_start_utc`, `capture_window_end_utc`, `capture_interval_s`) and validates it. There is no `lat`/`lng`/`placement` in the firmware config.
+- **Stop bench units.** ~1 frame/sec × ~300 KB = ~0.5 GB to prod per 30-min window. Pure waste for a test, and prod cost (Neon/storage) is a known concern.
+- **Install the SSH key first (`ssh-copy-id`).** The recurring pain isn't any single step — it's typing a password for *dozens* of them. A passwordless Pi is a script/AI-drivable Pi: verification (frame capture, gyro read, log tail) can run non-interactively instead of hand-by-hand. This is the lever that turns commissioning from a manual slog into an automatable pass.
+
+## When to Apply
+
+- Any time a new custom camera unit is being set up, or the onboarding workflow is being scripted/automated further.
+- A fresh `sunset-cam-N` bench camera will show `count: 0` in the public archive API (`/api/snapshots?webcam_id=N`) even when frames are landing — that's the active/visibility gate, not a failure. Verify success by the server-returned `snapshot_id`s in the Pi logs, not by the public map.
+
+## Examples
+
+Proven values from the sunset-cam-1 bringup: `hardware-id pi-zero-2w-sunset-cam-1`, `camera_id 4`, Bellingham coords `48.7519, -122.4787`, `America/Los_Angeles`. Logs on success:
+
+```
+picamera2 Camera started
+INFO sunset_cam uploaded snapshot_id=100906 bytes=303923
+INFO sunset_cam uploaded snapshot_id=100907 bytes=303798
+```
+
+## Related
+
+- `../integration-issues/arducam-imx708-not-detected-on-pi-zero.md` — the Arducam overlay fix (step 2b).
+- Install/bringup guide: `docs/hardware/2026-05-29-pi-mpu6050-install-and-bringup-guide.md` (rewritten to this flow on branch `docs/pi-mpu6050-install-guide`, PR #23).
+- **Open opportunity:** wire `setup_alignment.py`'s `stream_mjpeg` / `render_align_page` / `render_orientation_json` into a runnable HTTP server so onboarding validates via a live preview (nothing saved) instead of uploading frames.


### PR DESCRIPTION
Two `docs/solutions/` learnings captured from the sunset-cam-1 hardware bringup:

- **integration-issues/arducam-imx708-not-detected-on-pi-zero.md** — `camera_auto_detect` can't identify the Arducam's blank EEPROM (`camera module ID 0x0000`); fix is explicit `dtoverlay=imx708`. Includes a dmesg-first triage so the next person doesn't lose time swapping cables.
- **workflow-issues/onboarding-a-tier0-sunset-camera.md** — the real, proven Tier-0 onboarding flow (`tier0-create-camera.sh` → `/opt/sunset-cam` `install.sh` → `configure.sh`), the traps that made it slow, and `ssh-copy-id` as the step that makes a unit AI/script-drivable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)