### PR TITLE
feat(cameras): deployment aiming — three-state placement + confirm endpoint

### DIFF
--- a/app/api/cameras/[id]/heartbeat/route.test.ts
+++ b/app/api/cameras/[id]/heartbeat/route.test.ts
@@ -98,7 +98,7 @@ describe('POST /api/cameras/[id]/heartbeat', () => {
     expect(body.placement).toMatchObject({ azimuth_deg: 270, tilt_deg: 5 });
   });
 
-  it('returns placement_status=pending without placement when not yet ready', async () => {
+  it('returns placement_status=awaiting_location without placement when no lat/lng yet', async () => {
     verifyDeviceTokenMock.mockResolvedValueOnce({ id: 42, status: 'active' });
     sqlMock.mockResolvedValueOnce([
       {
@@ -114,7 +114,7 @@ describe('POST /api/cameras/[id]/heartbeat', () => {
         delivery_preferences: null,
       },
     ]); // UPDATE ... RETURNING
-    derivePlacementStatusMock.mockReturnValueOnce('pending');
+    derivePlacementStatusMock.mockReturnValueOnce('awaiting_location');
 
     const res = await POST(
       makeRequest({
@@ -126,8 +126,27 @@ describe('POST /api/cameras/[id]/heartbeat', () => {
     );
     expect(res.status).toBe(200);
     const body = await res.json();
-    expect(body.placement_status).toBe('pending');
+    expect(body.placement_status).toBe('awaiting_location');
     expect(body.placement).toBeUndefined();
+  });
+
+  it('returns lat/lng with awaiting_aim so the device can aim', async () => {
+    verifyDeviceTokenMock.mockResolvedValueOnce({ id: 42 });
+    sqlMock.mockResolvedValueOnce([
+      { lat: 48.7519, lng: -122.4787, elevation_m: null, timezone: 'America/Los_Angeles',
+        azimuth_deg: null, tilt_deg: null, horizon_altitude_deg: null, horizon_profile: null,
+        phase_preference: 'sunset', delivery_preferences: null },
+    ]);
+    derivePlacementStatusMock.mockReturnValueOnce('awaiting_aim');
+    const res = await POST(
+      makeRequest({ id: '42', bearer: 'good', body: { request_placement: true } }),
+      makeContext('42')
+    );
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.placement_status).toBe('awaiting_aim');
+    expect(json.lat).toBe(48.7519);
+    expect(json.lng).toBe(-122.4787);
   });
 
   it('returns 404 when the camera row vanished between auth and update', async () => {

--- a/app/api/cameras/[id]/heartbeat/route.ts
+++ b/app/api/cameras/[id]/heartbeat/route.ts
@@ -65,13 +65,20 @@ export async function POST(request: Request, context: RouteContext) {
   }
 
   const status = derivePlacementStatus(row);
-  if (status === 'pending') {
+  if (status === 'awaiting_location') {
     return NextResponse.json({
       acknowledged_at: acknowledgedAt,
-      placement_status: 'pending',
+      placement_status: 'awaiting_location',
     });
   }
-
+  if (status === 'awaiting_aim') {
+    return NextResponse.json({
+      acknowledged_at: acknowledgedAt,
+      placement_status: 'awaiting_aim',
+      lat: row.lat,
+      lng: row.lng,
+    });
+  }
   return NextResponse.json({
     acknowledged_at: acknowledgedAt,
     placement_status: 'ready',

--- a/app/api/cameras/[id]/placement/route.test.ts
+++ b/app/api/cameras/[id]/placement/route.test.ts
@@ -1,0 +1,50 @@
+// @vitest-environment node
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const verifyDeviceTokenMock = vi.fn();
+const sqlMock = vi.fn();
+const derivePlacementStatusMock = vi.fn();
+
+vi.mock('@/app/lib/cameraAuth', () => ({ verifyDeviceToken: (...a: unknown[]) => verifyDeviceTokenMock(...a) }));
+vi.mock('@/app/lib/db', () => ({ sql: (s: TemplateStringsArray, ...v: unknown[]) => sqlMock(s, ...v) }));
+vi.mock('@/app/lib/cameraRegistration', () => ({ derivePlacementStatus: (...a: unknown[]) => derivePlacementStatusMock(...a) }));
+
+import { POST } from './route';
+
+beforeEach(() => {
+  verifyDeviceTokenMock.mockReset();
+  sqlMock.mockReset();
+  derivePlacementStatusMock.mockReset();
+});
+
+function req(opts: { id?: string; bearer?: string; body?: unknown }) {
+  const headers: HeadersInit = { 'content-type': 'application/json' };
+  if (opts.bearer) headers['authorization'] = `Bearer ${opts.bearer}`;
+  return new Request(`http://test/api/cameras/${opts.id ?? '42'}/placement`, {
+    method: 'POST', headers, body: JSON.stringify(opts.body ?? {}),
+  });
+}
+const ctx = (id: string) => ({ params: Promise.resolve({ id }) });
+
+describe('POST /api/cameras/[id]/placement', () => {
+  it('401 when unauthenticated', async () => {
+    verifyDeviceTokenMock.mockResolvedValueOnce(null);
+    const res = await POST(req({ bearer: 'bad', body: { azimuth_deg: 270, tilt_deg: 2 } }), ctx('42'));
+    expect(res.status).toBe(401);
+  });
+
+  it('saves the aim and reports ready', async () => {
+    verifyDeviceTokenMock.mockResolvedValueOnce({ id: 42 });
+    sqlMock.mockResolvedValueOnce([{ lat: 48.7, lng: -122.4, azimuth_deg: 270, tilt_deg: 2 }]);
+    derivePlacementStatusMock.mockReturnValueOnce('ready');
+    const res = await POST(req({ bearer: 'good', body: { azimuth_deg: 270, tilt_deg: 2, confirmed_at: '2026-06-07T00:00:00Z' } }), ctx('42'));
+    expect(res.status).toBe(200);
+    expect((await res.json()).placement_status).toBe('ready');
+  });
+
+  it('400 on non-numeric aim', async () => {
+    verifyDeviceTokenMock.mockResolvedValueOnce({ id: 42 });
+    const res = await POST(req({ bearer: 'good', body: { azimuth_deg: 'x' } }), ctx('42'));
+    expect(res.status).toBe(400);
+  });
+});

--- a/app/api/cameras/[id]/placement/route.ts
+++ b/app/api/cameras/[id]/placement/route.ts
@@ -1,0 +1,53 @@
+import { NextResponse } from 'next/server';
+import { sql } from '@/app/lib/db';
+import { verifyDeviceToken } from '@/app/lib/cameraAuth';
+import { derivePlacementStatus } from '@/app/lib/cameraRegistration';
+
+export const dynamic = 'force-dynamic';
+
+type RouteContext = { params: Promise<{ id: string }> };
+
+type PlacementRow = {
+  lat: number | null;
+  lng: number | null;
+  azimuth_deg: number | null;
+  tilt_deg: number | null;
+};
+
+export async function POST(request: Request, context: RouteContext) {
+  const { id } = await context.params;
+  const cameraId = Number.parseInt(id, 10);
+  if (!Number.isFinite(cameraId) || cameraId <= 0) {
+    return NextResponse.json({ error: 'invalid camera id' }, { status: 400 });
+  }
+
+  const camera = await verifyDeviceToken(cameraId, request.headers.get('authorization'));
+  if (!camera) {
+    return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
+  }
+
+  let body: { azimuth_deg?: unknown; tilt_deg?: unknown; roll_deg?: unknown; confirmed_at?: unknown };
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: 'invalid json body' }, { status: 400 });
+  }
+
+  const azimuth = Number(body.azimuth_deg);
+  const tilt = Number(body.tilt_deg);
+  if (!Number.isFinite(azimuth) || !Number.isFinite(tilt)) {
+    return NextResponse.json({ error: 'azimuth_deg and tilt_deg must be numbers' }, { status: 400 });
+  }
+
+  const rows = (await sql`
+    UPDATE cameras SET azimuth_deg = ${azimuth}, tilt_deg = ${tilt}
+    WHERE id = ${cameraId}
+    RETURNING lat, lng, azimuth_deg, tilt_deg
+  `) as PlacementRow[];
+
+  if (!rows[0]) {
+    return NextResponse.json({ error: 'camera not found' }, { status: 404 });
+  }
+
+  return NextResponse.json({ placement_status: derivePlacementStatus(rows[0]) });
+}

--- a/app/api/cameras/setup-status/[claim_code]/route.test.ts
+++ b/app/api/cameras/setup-status/[claim_code]/route.test.ts
@@ -167,4 +167,29 @@ describe('GET /api/cameras/setup-status/[claim_code]', () => {
     const body = await res.json();
     expect(body.status).toBe('ready');
   });
+
+  it('reports awaiting_aim when located but not yet aimed', async () => {
+    getClaimCodeMock.mockResolvedValueOnce({
+      code: 'SUNSET-AAAA-BBBB',
+      expires_at: new Date('2099-01-01'),
+      consumed_at: new Date(),
+      consumed_by_camera_id: 17,
+    });
+    sqlMock.mockResolvedValueOnce([
+      {
+        id: 17,
+        hardware_id: 'rpi-real-serial',
+        device_token_hash: 'real-hash-abc',
+        lat: 47.6,
+        lng: -122.3,
+        azimuth_deg: null,
+        tilt_deg: null,
+      },
+    ]);
+    derivePlacementStatusMock.mockReturnValueOnce('awaiting_aim');
+    const res = await GET(makeRequest('SUNSET-AAAA-BBBB'), makeContext('SUNSET-AAAA-BBBB'));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.status).toBe('awaiting_aim');
+  });
 });

--- a/app/api/cameras/setup-status/[claim_code]/route.ts
+++ b/app/api/cameras/setup-status/[claim_code]/route.ts
@@ -42,7 +42,9 @@ export async function GET(_request: Request, context: RouteContext) {
   }
 
   const placement = derivePlacementStatus(row);
-  return NextResponse.json({
-    status: placement === 'ready' ? 'ready' : 'registered',
-  });
+  const status =
+    placement === 'ready' ? 'ready'
+    : placement === 'awaiting_aim' ? 'awaiting_aim'
+    : 'registered'; // awaiting_location: device is up but has no coords yet
+  return NextResponse.json({ status });
 }

--- a/app/lib/cameraRegistration.test.ts
+++ b/app/lib/cameraRegistration.test.ts
@@ -30,7 +30,7 @@ describe('derivePlacementStatus', () => {
     ).toBe('ready');
   });
 
-  it('returns "pending" when lat is null', () => {
+  it('returns "awaiting_location" when lat is null', () => {
     expect(
       derivePlacementStatus({
         lat: null,
@@ -38,10 +38,10 @@ describe('derivePlacementStatus', () => {
         azimuth_deg: 270,
         tilt_deg: 5,
       })
-    ).toBe('pending');
+    ).toBe('awaiting_location');
   });
 
-  it('returns "pending" when azimuth_deg is null', () => {
+  it('returns "awaiting_aim" when azimuth_deg is null', () => {
     expect(
       derivePlacementStatus({
         lat: 47.6,
@@ -49,10 +49,10 @@ describe('derivePlacementStatus', () => {
         azimuth_deg: null,
         tilt_deg: 5,
       })
-    ).toBe('pending');
+    ).toBe('awaiting_aim');
   });
 
-  it('returns "pending" when tilt_deg is null', () => {
+  it('returns "awaiting_aim" when tilt_deg is null', () => {
     expect(
       derivePlacementStatus({
         lat: 47.6,
@@ -60,7 +60,7 @@ describe('derivePlacementStatus', () => {
         azimuth_deg: 270,
         tilt_deg: null,
       })
-    ).toBe('pending');
+    ).toBe('awaiting_aim');
   });
 });
 
@@ -187,5 +187,22 @@ describe('upsertCameraByClaimCode', () => {
 describe('sentinelForClaimCode', () => {
   it('returns the pending-<code> shape', () => {
     expect(sentinelForClaimCode('SUNSET-AAAA-BBBB')).toBe('pending-SUNSET-AAAA-BBBB');
+  });
+});
+
+describe('derivePlacementStatus (three states)', () => {
+  it('awaiting_location when lat or lng missing', () => {
+    expect(derivePlacementStatus({ lat: null, lng: null, azimuth_deg: null, tilt_deg: null }))
+      .toBe('awaiting_location');
+    expect(derivePlacementStatus({ lat: 48.7, lng: null, azimuth_deg: null, tilt_deg: null }))
+      .toBe('awaiting_location');
+  });
+  it('awaiting_aim when located but not aimed', () => {
+    expect(derivePlacementStatus({ lat: 48.7, lng: -122.4, azimuth_deg: null, tilt_deg: null }))
+      .toBe('awaiting_aim');
+  });
+  it('ready when located and aimed', () => {
+    expect(derivePlacementStatus({ lat: 48.7, lng: -122.4, azimuth_deg: 270, tilt_deg: 2 }))
+      .toBe('ready');
   });
 });

--- a/app/lib/cameraRegistration.ts
+++ b/app/lib/cameraRegistration.ts
@@ -5,7 +5,7 @@ import { hashDeviceToken } from '@/app/lib/cameraAuth';
 export const PHASE_VALUES = ['sunrise', 'sunset', 'both'] as const;
 export type PhasePreference = typeof PHASE_VALUES[number];
 
-export type PlacementStatus = 'pending' | 'ready';
+export type PlacementStatus = 'awaiting_location' | 'awaiting_aim' | 'ready';
 
 export type PlacementShape = {
   lat: number | null;
@@ -19,10 +19,8 @@ export function sentinelForClaimCode(claimCode: string): string {
 }
 
 export function derivePlacementStatus(row: PlacementShape): PlacementStatus {
-  if (row.lat == null) return 'pending';
-  if (row.lng == null) return 'pending';
-  if (row.azimuth_deg == null) return 'pending';
-  if (row.tilt_deg == null) return 'pending';
+  if (row.lat == null || row.lng == null) return 'awaiting_location';
+  if (row.azimuth_deg == null || row.tilt_deg == null) return 'awaiting_aim';
   return 'ready';
 }
 


### PR DESCRIPTION
Cloud-protocol slice of the Pi deployment↔v0.4-aiming integration (`docs/superpowers/specs/2026-06-07-pi-deployment-aiming-integration-design.md`). No DB migration — the `cameras` table already has the columns.

- **Three-state placement status** — `awaiting_location` → `awaiting_aim` → `ready` (`app/lib/cameraRegistration.ts`)
- **Heartbeat delivers lat/lng in `awaiting_aim`** so the device can draw the sun overlay before it aims
- **`POST /api/cameras/:id/placement`** — accepts the device's confirmed sun-tap aim (device-token auth), updates `azimuth_deg`/`tilt_deg`
- **`setup-status` surfaces `awaiting_aim`** for the cloud wizard

TDD throughout. Full cloud suite 401/401, lint clean. Device supervisor + systemd + relocation stay gated on sub-project E.

🤖 Generated with [Claude Code](https://claude.com/claude-code)