### PR TITLE
docs: v0.4 sun-tap aiming + deployment-integration specs, plans, checkpoint

### DIFF
--- a/docs/hardware/2026-06-07-cam1-validated-aiming-design-checkpoint.md
+++ b/docs/hardware/2026-06-07-cam1-validated-aiming-design-checkpoint.md
@@ -1,0 +1,86 @@
+# sunset-cam-1 Validated + AR Aiming Design — Checkpoint
+
+Date: 2026-06-07
+Supersedes the `2026-05-31-mpu6050-bringup-checkpoint.md` (hardware bringup is now complete).
+
+---
+
+## TL;DR — resume here
+
+**sunset-cam-1 is fully working and validated.** Camera produces good frames, MPU works (gyro bug fixed), onboarding flow is discovered + documented, 3 PRs are open. The aiming-experience design decision is **locked**. Next session starts with a **brainstorm of the v0.4 layered AR aiming**, then prototype it on cam1, then wire cam2 to test whether onboarding is now fast.
+
+To resume: open Claude Code in `~/GitHub/the-sunset-webcam-map` and say *"let's start the v0.4 aiming brainstorm — read `docs/hardware/2026-06-07-cam1-validated-aiming-design-checkpoint.md`."*
+
+---
+
+## What's done (validated 2026-06-07)
+
+- **sunset-cam-1 works end-to-end.** Camera → capture (picamera2) → upload → prod DB confirmed (server-assigned `snapshot_id`s, e.g. 100906+). `camera_id 4`, hardware-id `pi-zero-2w-sunset-cam-1`, Bellingham bench coords.
+- **Image quality validated** — pulled a real frame: sharp focus (AF works), good exposure on a hard mixed-light scene, natural color. The product is good, not just the plumbing.
+- **Camera detection bug fixed + documented** — Arducam's blank EEPROM defeats `camera_auto_detect`; fix is explicit `dtoverlay=imx708` + `camera_auto_detect=0`. (cloud PR #23, cloud PR #48 solution doc.)
+- **Gyro bug found + fixed** — MPU6050 powers up asleep (`PWR_MGMT_1=0x40`); `read_orientation` never woke it, so it read fake `(0.0,0.0)`. Added `wake()` + `make_orientation_reader()` (firmware **PR #4**, TDD, hardware-verified).
+- **Real onboarding flow discovered + documented** — the guide had been wrong. Real flow captured in the rewritten guide (PR #23) + runbook (PR #48).
+- **SSH key installed on cam1** — Claude can drive it directly (passwordless). `ssh-copy-id` is now a documented commissioning step.
+
+### Open PRs to merge
+- firmware **#4** — gyro wake fix
+- cloud **#23** — install guide rewritten to the real flow (+ dtoverlay + ssh-copy-id)
+- cloud **#48** — two `docs/solutions/` learnings (Arducam detection, onboarding runbook)
+
+---
+
+## Design decision — LOCKED: layered AR aiming
+
+Reverses v0.3's call. **v0.3** (`docs/superpowers/specs/2026-05-17-pi-alignment-v0.3-sun-self-calibration-design.md`) dropped sun-tap in favor of hands-off auto sun-calibration (`solvePnP` over many sunsets — precise ±2° but **eventual**, 1–7 days). That killed the instant "aim it in 5 min" moment.
+
+**Decision:** sun-tap comes BACK as the **instant fast path**, auto-calibration stays as the **precise self-healing fallback + drift detection**. Complementary, not either/or:
+
+| | Sun-tap (instant) | Auto sun-calibration (eventual) |
+|---|---|---|
+| Heading from | One tap on the visible sun → anchors heading; gyro tracks from there | `solvePnP` over many sun observations |
+| Speed / precision | Instant / rough (102° FOV is forgiving) | Days / tight (±2°) |
+| Needs | Sun visible & in frame now | Just runs during sunset windows |
+| Covers | The live aim moment | Cloudy/night, drift, no-tap units |
+
+### Key technical truths (don't re-derive these)
+- **The MPU6050 gives roll+pitch (tilt), NOT heading/yaw.** No magnetometer in BOM. World-locked AR overlay therefore needs a heading reference — and the **sun** (computed az/alt from date + lat/lng) IS that reference.
+- **The FOV math works:** at Bellingham ~48.75°N the annual sunset arc swings ~±37° around due west (~74° total) and fits inside the camera's **102° HFOV** → "aim ≈ 270° west + level" frames every sunset of the year. The job is hitting that aim.
+- **Location (lat/lng) lives in the cloud camera record** (set by `tier0-create-camera.sh`), NOT in the Pi config.json. The setup-server's solstice/sun overlay needs lat/lng passed in (flag or fetched).
+
+### Already built vs. not
+- **Built:** `solstice_math.py` (sunset azimuths, az→pixel, sunsets-in-FOV), the 2D marker/level overlay renderer in `setup_alignment.py` (`render_align_page`, `render_orientation_json`, `stream_mjpeg`) — **renderers only, NO HTTP server**. Firmware `wake()`/`make_orientation_reader()` (PR #4).
+- **NOT built:** heading derivation, sun-tap + sun-detect pipeline, the **setup-server HTTP wiring**, focus check, the whole field/commissioning mode split.
+
+---
+
+## Forward plan (the next session's work)
+
+1. **Brainstorm → v0.4 spec: layered AR aiming.** Amend v0.3 to un-drop sun-tap. Cover: the sun-tap interaction (tap the live preview → POST pixel + timestamp → compute heading), gyro tracking from the anchor, the solstice/sun overlay, and how the two layers (sun-tap + auto-cal) hand off.
+2. **Prototype the AR aiming on cam1.** This needs the **setup-server** built (wire `stream_mjpeg`/`render_align_page`/`render_orientation_json` into a runnable `ThreadingHTTPServer` — see the earlier setup-server design sketch). Auto-run it in a "setup mode" rather than a manual console command.
+3. **Wire camera + gyro for cam2 → time the onboarding.** The real test of whether the documented flow + tooling actually made it fast. Target: minutes, not the hours cam1 took.
+4. **Build the two-sided workflow (this is a first-class requirement, not an afterthought):**
+   - **(a) Local validation / commissioning self-test** — bench check that camera + gyro work (a script that captures a frame, asserts non-blank, wakes + reads the gyro, reports pass/fail). Run by Jesse at the bench.
+   - **(b) Easy recommission / relocation** — a unit moved to a NEW location must re-run field setup without a full reflash: update the camera's lat/lng (cloud record), re-aim (sun-tap), confirm. **Open question to resolve in the brainstorm:** where does location live and how is it updated on relocation? (Today it's in the cloud camera record + would need to reach the setup-server's overlay.) Relocation = repeatable field-setup, distinct from one-time commissioning.
+
+### The commissioning ↔ field-setup split (frames all of the above)
+- **Commissioning (Jesse, bench, one-time per hardware):** flash → install → overlay → self-test camera+gyro → bind identity. Output: a known-good Pi that knows who it is.
+- **Field setup (end user OR Jesse relocating, repeatable per location):** power on at location → join WiFi → aim (sun-tap AR) → confirm first frame → done. No SSH, no commands.
+- Jesse currently does both fused together — splitting them is the structural fix for "painfully slow."
+
+---
+
+## Key references
+| Doc / artifact | What |
+|---|---|
+| `docs/superpowers/specs/2026-05-17-pi-alignment-v0.3-sun-self-calibration-design.md` | v0.3 — the design to amend into v0.4 |
+| `docs/hardware/2026-05-29-pi-mpu6050-install-and-bringup-guide.md` (PR #23 branch) | rewritten onboarding guide (real flow) |
+| `docs/solutions/workflow-issues/onboarding-a-tier0-sunset-camera.md` (PR #48) | the proven Tier-0 onboarding runbook |
+| `docs/solutions/integration-issues/arducam-imx708-not-detected-on-pi-zero.md` (PR #48) | the camera-detection fix |
+| `sunset-cam-firmware` PR #4 | `wake()` + `make_orientation_reader()` |
+| `~/GitHub/sunset-cam-firmware/src/sunset_cam/setup_alignment.py` | the renderers the setup-server must wire up |
+
+## Facts worth not re-learning
+- Prod domain is **`www.sunrisesunset.studio`** (apex 307-redirects and strips auth).
+- Onboarding: `tier0-create-camera.sh` (Mac, DATABASE_URL) → `camera_id` + `device_token` → `/opt/sunset-cam` `install.sh` → `configure.sh`. Config schema has NO lat/lng. Stop bench units after verifying (frame-spam cost).
+- Pi Zero 2 W + Arducam IMX708 both use the **22-pin (0.5mm)** connector → 22-to-22 cable. The cable was never the problem on cam1; the camera issue was the `dtoverlay`.
+- Passwordless SSH (`ssh-copy-id`) per unit is what makes commissioning AI/script-drivable.

--- a/docs/hardware/2026-06-07-cam1-validated-aiming-design-checkpoint.md
+++ b/docs/hardware/2026-06-07-cam1-validated-aiming-design-checkpoint.md
@@ -84,3 +84,13 @@ Reverses v0.3's call. **v0.3** (`docs/superpowers/specs/2026-05-17-pi-alignment-
 - Onboarding: `tier0-create-camera.sh` (Mac, DATABASE_URL) → `camera_id` + `device_token` → `/opt/sunset-cam` `install.sh` → `configure.sh`. Config schema has NO lat/lng. Stop bench units after verifying (frame-spam cost).
 - Pi Zero 2 W + Arducam IMX708 both use the **22-pin (0.5mm)** connector → 22-to-22 cable. The cable was never the problem on cam1; the camera issue was the `dtoverlay`.
 - Passwordless SSH (`ssh-copy-id`) per unit is what makes commissioning AI/script-drivable.
+
+---
+
+## Progress update — 2026-06-07 (later that day)
+
+**v0.4 sun-tap aiming sub-project 1 is BUILT.** Spec + plan written (`docs/superpowers/specs/2026-06-07-pi-alignment-v0.4-sun-tap-aiming-design.md`, `docs/superpowers/plans/2026-06-07-pi-alignment-v0.4-sun-tap-aiming.md`). Implemented on firmware branch `feat/v0.4-sun-tap-aiming` (pushed, 7 commits, 62 tests green): `compute_sun_azimuth`/`solstice_sunset_azimuths`/`fov_fit`, `heading.py` (pixel→angle, heading_from_tap, `HeadingState` confidence model), `setup_server.py` (`ThreadingHTTPServer` + `AimingService`), phase-parameterized confidence-gated overlay, and `scripts/run-setup-server.py`.
+
+**Pending: Task 7 hardware validation on cam1** — needs the sun visible. Commands in `docs/superpowers/plans/2026-06-07-pi-alignment-v0.4-sun-tap-aiming.md` Task 7 (ssh + checkout the branch, stop capture, run `run-setup-server.py`, aim from a phone, then open the firmware PR).
+
+**NOW IN PROGRESS: the "setting it all up" spec** — the deferred commissioning↔field-setup workflow (sub-project 2). This is the no-typed-commands deployment experience: commissioning self-test (bench) + the device setup-mode↔capture-mode state machine (auto-runs the v0.4 aiming tool) + WiFi/AP-mode onboarding + relocation/recommission. Being decomposed and spec'd next; doesn't need the sun.

--- a/docs/superpowers/plans/2026-06-07-pi-alignment-v0.4-sun-tap-aiming.md
+++ b/docs/superpowers/plans/2026-06-07-pi-alignment-v0.4-sun-tap-aiming.md
@@ -1,0 +1,755 @@
+# Pi-Alignment v0.4 Sun-Tap Aiming — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let an operator aim a Pi sunset/sunrise camera in minutes by tapping the visible sun in a phone browser — anchoring the camera's compass heading from one observation, then showing where the year's sunsets fall and whether they fit the frame.
+
+**Architecture:** All code lives in the `sunset-cam-firmware` repo. Pure-math modules (sun azimuth, pixel↔angle, heading state, FOV-fit) are built and tested with zero hardware, then wired into a stdlib `ThreadingHTTPServer` that serves the existing renderers plus a new `/setup/tap` endpoint. The MPU-6050 supplies roll/pitch (already woken via `make_orientation_reader`); the sun supplies heading. No magnetometer, no OpenCV, no cloud/DB changes (deferred).
+
+**Tech Stack:** Python 3.11 (Pi OS Bookworm), stdlib only (`http.server`, `math`, `datetime`), `picamera2` (hardware), `smbus2` (hardware), `pytest`. Repo uses `from __future__ import annotations` and TDD with fake-injection (`FakeBus`, fake `frame_source`).
+
+**Working location:** `~/GitHub/sunset-cam-firmware` on a feature branch `feat/v0.4-sun-tap-aiming` off `origin/main`. Confirm the branch before each commit (PRs merge in parallel here).
+
+---
+
+## Scope
+
+Sub-project 1 only: the sun-tap aiming fast-path + setup-server. Deferred (NOT in this plan): v0.3 auto-calibration pipeline, the commissioning/field state machine + AP-mode hotspot, relocation, motorized pan, any cloud `app/`/`database/` change.
+
+## File Structure
+
+| File | Responsibility | New/Modify |
+|---|---|---|
+| `src/sunset_cam/solstice_math.py` | add `compute_sun_azimuth(lat,lng,t_utc)` (sun's azimuth at an arbitrary time) + `solstice_sunset_azimuths(lat,year)` + `fov_fit(lat,lng,center_az,fov,year)` | Modify |
+| `src/sunset_cam/heading.py` | `pixel_offset_to_angle()`, `heading_from_tap()`, the `HeadingState` model (uncalibrated/tapped/suspect) | Create |
+| `src/sunset_cam/setup_alignment.py` | phase-parameterize `render_align_page`; confidence-gate the arcs; add FOV-fit bars; touch tap handler | Modify |
+| `src/sunset_cam/setup_server.py` | `ThreadingHTTPServer` wiring the routes incl. `POST /setup/tap`, `GET /setup/state.json`; camera lock; injectable deps | Create |
+| `tests/test_solstice_math.py` | tests for the new functions | Modify |
+| `tests/test_heading.py` | tests for heading math + state | Create |
+| `tests/test_setup_server.py` | route dispatch / tap / 503 tests | Create |
+| `tests/test_setup_alignment.py` | overlay phase + confidence-gating tests | Modify |
+
+---
+
+### Task 1: `compute_sun_azimuth` — the sun's azimuth at an arbitrary time
+
+The fast path lets the operator tap the sun whenever it's visible, not only at the instant of sunset, so we need the general solar azimuth (existing `sunset_azimuth_for_day` is sunset-only). Reuses the existing declination/Julian-day helpers; adds equation-of-time + hour-angle.
+
+**Files:**
+- Modify: `src/sunset_cam/solstice_math.py` (add after `sunset_azimuth_for_day`)
+- Test: `tests/test_solstice_math.py`
+
+- [ ] **Step 1: Write the failing test** (cross-check against the NOAA Solar Calculator for Bellingham)
+
+```python
+# tests/test_solstice_math.py  (add)
+from datetime import datetime, timezone
+from sunset_cam.solstice_math import compute_sun_azimuth
+
+def test_compute_sun_azimuth_matches_noaa_bellingham_afternoon():
+    # Bellingham 2026-06-21 ~01:00 UTC (early evening local, sun in the NW).
+    # NOAA Solar Calculator azimuth for (48.7519, -122.4787) at this instant
+    # is ~300° (WNW). Tolerance ±2° (our model is ~±1°, plus rounding).
+    t = datetime(2026, 6, 21, 1, 0, 0, tzinfo=timezone.utc)
+    az = compute_sun_azimuth(48.7519, -122.4787, t)
+    assert 296.0 <= az <= 304.0
+
+def test_compute_sun_azimuth_due_south_near_solar_noon():
+    # At solar noon the sun is due south in the N. hemisphere → ~180°.
+    # Bellingham lng -122.4787 → solar noon ≈ 20:10 UTC. Use 20:10Z.
+    t = datetime(2026, 3, 20, 20, 10, 0, tzinfo=timezone.utc)
+    az = compute_sun_azimuth(48.7519, -122.4787, t)
+    assert 174.0 <= az <= 186.0
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python3 -m pytest tests/test_solstice_math.py::test_compute_sun_azimuth_matches_noaa_bellingham_afternoon -v`
+Expected: FAIL — `ImportError: cannot import name 'compute_sun_azimuth'`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+# src/sunset_cam/solstice_math.py  (add; needs: from datetime import datetime)
+def compute_sun_azimuth(lat_deg: float, lng_deg: float, t_utc) -> float:
+    """Azimuth (degrees from North, clockwise) of the sun at time t_utc (a
+    timezone-aware UTC datetime) seen from (lat, lng). NOAA approximation,
+    good to ~±1°. Reuses the declination model used elsewhere in this module."""
+    jd = _julian_day(t_utc.year, t_utc.month, t_utc.day)
+    n = jd - 2451545.0
+    g = math.radians((357.528 + 0.9856003 * n) % 360.0)
+    lam = math.radians(
+        (280.460 + 0.9856474 * n + 1.915 * math.sin(g) + 0.020 * math.sin(2 * g)) % 360.0
+    )
+    eps = math.radians(23.439 - 0.0000004 * n)
+    decl = math.asin(math.sin(eps) * math.sin(lam))
+
+    # Equation of time (minutes): mean solar longitude minus apparent right ascension.
+    ra_deg = math.degrees(math.atan2(math.cos(eps) * math.sin(lam), math.cos(lam))) % 360.0
+    l_mean = (280.460 + 0.9856474 * n) % 360.0
+    eot_min = 4.0 * (((l_mean - ra_deg + 180.0) % 360.0) - 180.0)
+
+    minutes_utc = t_utc.hour * 60.0 + t_utc.minute + t_utc.second / 60.0
+    true_solar_min = (minutes_utc + eot_min + 4.0 * lng_deg) % 1440.0
+    hour_angle = math.radians(true_solar_min / 4.0 - 180.0)
+
+    phi = math.radians(lat_deg)
+    gamma = math.atan2(
+        math.sin(hour_angle),
+        math.cos(hour_angle) * math.sin(phi) - math.tan(decl) * math.cos(phi),
+    )
+    return (math.degrees(gamma) + 180.0) % 360.0
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `python3 -m pytest tests/test_solstice_math.py -v`
+Expected: PASS (both new tests + the existing ones). If an azimuth is off by ~180°, the `+ 180.0` convention or `hour_angle` sign is wrong — fix to satisfy the due-south test first (it's the unambiguous anchor).
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd ~/GitHub/sunset-cam-firmware && git branch --show-current   # expect feat/v0.4-sun-tap-aiming
+git add src/sunset_cam/solstice_math.py tests/test_solstice_math.py
+git commit -m "feat(solstice): compute_sun_azimuth for arbitrary time (sun-tap heading input)"
+```
+
+---
+
+### Task 2: `solstice_sunset_azimuths` + `fov_fit` — does the year fit, and where's the best aim
+
+**Files:**
+- Modify: `src/sunset_cam/solstice_math.py`
+- Test: `tests/test_solstice_math.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_solstice_math.py  (add)
+from sunset_cam.solstice_math import solstice_sunset_azimuths, fov_fit
+
+def test_solstice_sunset_azimuths_bellingham_span_about_74_deg():
+    summer, winter = solstice_sunset_azimuths(48.7519, 2026)
+    # Summer sets to the NW (larger compass bearing), winter to the SW.
+    assert summer > winter
+    assert 70.0 <= (summer - winter) <= 78.0   # ~74° annual swing at 48.75°N
+
+def test_fov_fit_true_when_arc_inside_fov():
+    # 120° FOV centered due west easily contains Bellingham's ~74° arc.
+    res = fov_fit(48.7519, -122.4787, center_az=270.0, fov_deg=120.0, year=2026)
+    assert res["fits"] is True
+    assert res["captured"] == 365
+
+def test_fov_fit_false_and_suggests_best_aim_when_arc_too_wide():
+    # A deliberately narrow 40° FOV cannot contain the 74° arc.
+    res = fov_fit(48.7519, -122.4787, center_az=270.0, fov_deg=40.0, year=2026)
+    assert res["fits"] is False
+    assert res["captured"] < 365
+    # best_center_az maximizes captured sunsets; captured_at_best >= captured.
+    assert res["captured_at_best"] >= res["captured"]
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python3 -m pytest tests/test_solstice_math.py::test_solstice_sunset_azimuths_bellingham_span_about_74_deg -v`
+Expected: FAIL — `ImportError`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+# src/sunset_cam/solstice_math.py  (add)
+def solstice_sunset_azimuths(lat_deg: float, year: int) -> tuple[float, float]:
+    """(summer_solstice_sunset_az, winter_solstice_sunset_az) compass bearings.
+    Summer ≈ northernmost sunset (NW in N. hemisphere), winter ≈ southernmost (SW)."""
+    summer = sunset_azimuth_for_day(lat_deg, year, 6, 21)
+    winter = sunset_azimuth_for_day(lat_deg, year, 12, 21)
+    return summer, winter
+
+
+def fov_fit(
+    lat_deg: float, lng_deg: float, center_az: float, fov_deg: float, year: int
+) -> dict:
+    """Whether the full-year sunset arc fits the FOV at this aim, how many
+    sunsets the current aim captures, and the best fixed aim if it doesn't fit."""
+    summer, winter = solstice_sunset_azimuths(lat_deg, year)
+    half = fov_deg / 2.0
+
+    def inside(az: float, center: float) -> bool:
+        d = ((az - center + 540.0) % 360.0) - 180.0
+        return -half <= d <= half
+
+    fits = inside(summer, center_az) and inside(winter, center_az)
+    captured = count_sunsets_in_fov(lat_deg, lng_deg, center_az, fov_deg, year)
+
+    # Search candidate centers (1° steps across the arc) for the max-capture aim.
+    best_center, best_captured = center_az, captured
+    lo, hi = sorted((summer, winter))
+    c = lo
+    while c <= hi:
+        cap = count_sunsets_in_fov(lat_deg, lng_deg, c, fov_deg, year)
+        if cap > best_captured:
+            best_center, best_captured = c, cap
+        c += 1.0
+    return {
+        "fits": fits,
+        "summer_az": summer,
+        "winter_az": winter,
+        "captured": captured,
+        "best_center_az": best_center,
+        "captured_at_best": best_captured,
+    }
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `python3 -m pytest tests/test_solstice_math.py -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/sunset_cam/solstice_math.py tests/test_solstice_math.py
+git commit -m "feat(solstice): solstice_sunset_azimuths + fov_fit with best-aim search"
+```
+
+---
+
+### Task 3: `heading.py` — pixel→angle and heading-from-tap
+
+**Files:**
+- Create: `src/sunset_cam/heading.py`
+- Test: `tests/test_heading.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_heading.py
+from sunset_cam.heading import pixel_offset_to_angle, heading_from_tap
+
+def test_pixel_center_is_zero_offset():
+    assert pixel_offset_to_angle(px_x=800, width=1600, hfov_deg=120.0) == 0.0
+
+def test_pixel_right_edge_is_plus_half_fov():
+    assert abs(pixel_offset_to_angle(1600, 1600, 120.0) - 60.0) < 1e-9
+
+def test_pixel_left_edge_is_minus_half_fov():
+    assert abs(pixel_offset_to_angle(0, 1600, 120.0) - (-60.0)) < 1e-9
+
+def test_heading_from_tap_subtracts_offset_from_sun_azimuth():
+    # Sun's true azimuth 300°; tapped a bit right of center (sun appears at +20°).
+    # The camera must be pointed at 300 - 20 = 280°.
+    h = heading_from_tap(sun_azimuth_deg=300.0, tap_px_x=1066.67, width=1600, hfov_deg=120.0)
+    assert abs(h - 280.0) < 0.1
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python3 -m pytest tests/test_heading.py -v`
+Expected: FAIL — `ModuleNotFoundError: No module named 'sunset_cam.heading'`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+# src/sunset_cam/heading.py
+"""Sun-tap heading math: convert a tapped sun pixel + the sun's true azimuth
+into the camera's compass heading. No magnetometer; pinhole approximation
+adequate for aiming (lens-distortion correction is a v0.3-grade refinement)."""
+from __future__ import annotations
+
+
+def pixel_offset_to_angle(px_x: float, width: int, hfov_deg: float) -> float:
+    """Horizontal angle (deg) of a pixel from frame center. Center=0,
+    right edge=+hfov/2, left edge=-hfov/2 (azimuth increases to the right
+    for a normal forward-facing, non-mirrored camera)."""
+    return ((px_x - width / 2.0) / width) * hfov_deg
+
+
+def heading_from_tap(
+    sun_azimuth_deg: float, tap_px_x: float, width: int, hfov_deg: float
+) -> float:
+    """Camera heading (compass deg) = sun's true azimuth minus where the sun
+    appears in the frame. The object's apparent angle = its_azimuth - heading,
+    so heading = azimuth - apparent_angle."""
+    offset = pixel_offset_to_angle(tap_px_x, width, hfov_deg)
+    return (sun_azimuth_deg - offset) % 360.0
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `python3 -m pytest tests/test_heading.py -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/sunset_cam/heading.py tests/test_heading.py
+git commit -m "feat(heading): pixel_offset_to_angle + heading_from_tap (sun-tap math)"
+```
+
+---
+
+### Task 4: `HeadingState` — the uncalibrated/tapped/suspect confidence model
+
+The silent-fake-signal guard: never expose a heading we don't actually have.
+
+**Files:**
+- Modify: `src/sunset_cam/heading.py`
+- Test: `tests/test_heading.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_heading.py  (add)
+from sunset_cam.heading import HeadingState
+
+def test_starts_uncalibrated():
+    s = HeadingState(hfov_deg=120.0, width=1600)
+    assert s.status() == "uncalibrated"
+    assert s.heading_deg() is None
+
+def test_becomes_tapped_after_apply_tap():
+    s = HeadingState(hfov_deg=120.0, width=1600)
+    s.apply_tap(sun_azimuth_deg=300.0, tap_px_x=800.0, roll_deg=0.2, pitch_deg=1.0)
+    assert s.status() == "tapped"
+    assert abs(s.heading_deg() - 300.0) < 0.1  # center tap → heading == sun az
+
+def test_rejects_tap_when_not_level():
+    s = HeadingState(hfov_deg=120.0, width=1600, level_tol_deg=5.0)
+    ok = s.apply_tap(sun_azimuth_deg=300.0, tap_px_x=800.0, roll_deg=20.0, pitch_deg=0.0)
+    assert ok is False
+    assert s.status() == "uncalibrated"   # tap refused; "level the camera first"
+
+def test_becomes_suspect_when_tilt_drifts_from_tap_time():
+    s = HeadingState(hfov_deg=120.0, width=1600, drift_tol_deg=3.0)
+    s.apply_tap(sun_azimuth_deg=300.0, tap_px_x=800.0, roll_deg=0.0, pitch_deg=0.0)
+    s.update_orientation(roll_deg=10.0, pitch_deg=0.0)   # housing moved
+    assert s.status() == "suspect"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python3 -m pytest tests/test_heading.py::test_starts_uncalibrated -v`
+Expected: FAIL — `ImportError: cannot import name 'HeadingState'`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+# src/sunset_cam/heading.py  (add)
+class HeadingState:
+    """Tracks heading confidence. Three states:
+    - 'uncalibrated': no valid tap yet → overlay draws nothing speculative.
+    - 'tapped': valid heading anchored.
+    - 'suspect': housing tilt drifted from tap-time → ask for a re-tap."""
+
+    def __init__(
+        self, hfov_deg: float, width: int,
+        level_tol_deg: float = 5.0, drift_tol_deg: float = 3.0,
+    ) -> None:
+        self._hfov = hfov_deg
+        self._width = width
+        self._level_tol = level_tol_deg
+        self._drift_tol = drift_tol_deg
+        self._heading: float | None = None
+        self._tap_roll: float | None = None
+        self._tap_pitch: float | None = None
+        self._suspect = False
+
+    def apply_tap(
+        self, sun_azimuth_deg: float, tap_px_x: float, roll_deg: float, pitch_deg: float
+    ) -> bool:
+        """Anchor heading from a sun-tap. Refuses (returns False) if the camera
+        isn't level enough for the horizontal-pixel→azimuth mapping to hold."""
+        if abs(roll_deg) > self._level_tol or abs(pitch_deg) > self._level_tol:
+            return False
+        self._heading = heading_from_tap(sun_azimuth_deg, tap_px_x, self._width, self._hfov)
+        self._tap_roll, self._tap_pitch = roll_deg, pitch_deg
+        self._suspect = False
+        return True
+
+    def update_orientation(self, roll_deg: float, pitch_deg: float) -> None:
+        """Called as live roll/pitch arrive. Flags suspect if tilt drifted
+        from its value at tap-time (the housing moved)."""
+        if self._heading is None:
+            return
+        if (abs(roll_deg - self._tap_roll) > self._drift_tol
+                or abs(pitch_deg - self._tap_pitch) > self._drift_tol):
+            self._suspect = True
+
+    def status(self) -> str:
+        if self._heading is None:
+            return "uncalibrated"
+        return "suspect" if self._suspect else "tapped"
+
+    def heading_deg(self) -> float | None:
+        return self._heading
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `python3 -m pytest tests/test_heading.py -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/sunset_cam/heading.py tests/test_heading.py
+git commit -m "feat(heading): HeadingState confidence model (uncalibrated/tapped/suspect)"
+```
+
+---
+
+### Task 5: `setup_server.py` — the HTTP server (routes, camera lock, tap)
+
+**Files:**
+- Create: `src/sunset_cam/setup_server.py`
+- Test: `tests/test_setup_server.py`
+
+- [ ] **Step 1: Write the failing test** (drive the server with injected fakes — no Pi)
+
+```python
+# tests/test_setup_server.py
+import json, threading, urllib.request
+from http.client import HTTPConnection
+from sunset_cam.setup_server import make_handler, AimingService
+
+class FakeService(AimingService):
+    pass  # uses real AimingService with injected fakes (below)
+
+def _service():
+    # Injected: a frame_source returning a constant JPEG, a reader returning level.
+    return AimingService(
+        lat=48.7519, lng=-122.4787, phase="sunset", hfov_deg=120.0, width=1600,
+        frame_source=lambda: b"\xff\xd8fakejpeg\xff\xd9",
+        reader=lambda: (0.2, 1.0),
+        now_utc_fn=lambda: __import__("datetime").datetime(2026, 6, 21, 1, 0,
+                                tzinfo=__import__("datetime").timezone.utc),
+    )
+
+def test_state_json_starts_uncalibrated():
+    svc = _service()
+    body, status, ctype = svc.handle_get("/setup/state.json")
+    assert status == 200 and "application/json" in ctype
+    assert json.loads(body)["status"] == "uncalibrated"
+
+def test_tap_sets_heading_and_returns_fit():
+    svc = _service()
+    body, status, _ = svc.handle_post("/setup/tap", {"pixel_x": 800, "pixel_y": 450})
+    assert status == 200
+    data = json.loads(body)
+    assert data["status"] == "tapped"
+    assert "heading_deg" in data and "fits" in data
+
+def test_orientation_json_returns_live_roll_pitch():
+    svc = _service()
+    body, status, _ = svc.handle_get("/setup/orientation.json")
+    assert status == 200
+    assert json.loads(body)["roll_deg"] == 0.2
+
+def test_preview_returns_503_when_camera_busy():
+    def boom():
+        raise RuntimeError("camera in use")
+    svc = AimingService(lat=48.0, lng=-122.0, phase="sunset", hfov_deg=120.0, width=1600,
+                        frame_source=boom, reader=lambda: (0.0, 0.0),
+                        now_utc_fn=lambda: None)
+    status = svc.preview_status()
+    assert status == 503
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python3 -m pytest tests/test_setup_server.py -v`
+Expected: FAIL — `ModuleNotFoundError: No module named 'sunset_cam.setup_server'`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+# src/sunset_cam/setup_server.py
+"""Setup-server: a stdlib ThreadingHTTPServer that serves the aiming page,
+the live MJPEG preview, live orientation, and the sun-tap endpoint. Logic
+lives in AimingService (injectable, hardware-free) so it is unit-testable;
+the HTTP handler is a thin adapter. Camera access is serialized by a lock."""
+from __future__ import annotations
+
+import json
+import threading
+import time
+from datetime import datetime, timezone
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from typing import Callable
+
+from sunset_cam.heading import HeadingState
+from sunset_cam.solstice_math import compute_sun_azimuth, fov_fit
+from sunset_cam.setup_alignment import render_align_page, stream_mjpeg, MJPEG_BOUNDARY
+
+
+class AimingService:
+    def __init__(
+        self, *, lat: float, lng: float, phase: str, hfov_deg: float, width: int,
+        frame_source: Callable[[], bytes], reader: Callable[[], tuple[float, float]],
+        now_utc_fn: Callable[[], datetime] = lambda: datetime.now(timezone.utc),
+    ) -> None:
+        self.lat, self.lng, self.phase = lat, lng, phase
+        self.hfov_deg, self.width = hfov_deg, width
+        self.frame_source = frame_source
+        self.reader = reader
+        self.now_utc_fn = now_utc_fn
+        self.state = HeadingState(hfov_deg=hfov_deg, width=width)
+        self._cam_lock = threading.Lock()
+
+    def _orientation(self) -> tuple[float, float]:
+        try:
+            return self.reader()
+        except Exception:
+            return (0.0, 0.0)
+
+    def _fit_payload(self) -> dict:
+        roll, pitch = self._orientation()
+        self.state.update_orientation(roll, pitch)
+        payload = {"status": self.state.status(), "roll_deg": roll, "pitch_deg": pitch}
+        h = self.state.heading_deg()
+        if h is not None:
+            year = self.now_utc_fn().year
+            fit = fov_fit(self.lat, self.lng, h, self.hfov_deg, year)
+            payload.update({"heading_deg": h, **fit})
+        return payload
+
+    def handle_get(self, path: str):
+        if path in ("/", "/setup/align"):
+            html = render_align_page(self.lat, self.lng)
+            return html, 200, "text/html; charset=utf-8"
+        if path == "/setup/orientation.json":
+            roll, pitch = self._orientation()
+            return json.dumps({"roll_deg": roll, "pitch_deg": pitch}), 200, "application/json"
+        if path == "/setup/state.json":
+            return json.dumps(self._fit_payload()), 200, "application/json"
+        return json.dumps({"error": "not found"}), 404, "application/json"
+
+    def handle_post(self, path: str, body: dict):
+        if path != "/setup/tap":
+            return json.dumps({"error": "not found"}), 404, "application/json"
+        roll, pitch = self._orientation()
+        sun_az = compute_sun_azimuth(self.lat, self.lng, self.now_utc_fn())
+        ok = self.state.apply_tap(sun_az, float(body["pixel_x"]), roll, pitch)
+        if not ok:
+            return (json.dumps({"status": "uncalibrated",
+                                "error": "level the camera first"}), 422, "application/json")
+        return json.dumps(self._fit_payload()), 200, "application/json"
+
+    def preview_status(self) -> int:
+        """200 if a frame can be grabbed, 503 if the camera is unavailable/busy."""
+        with self._cam_lock:
+            try:
+                self.frame_source()
+                return 200
+            except Exception:
+                return 503
+
+    def mjpeg_frames(self, fps: int = 4):
+        def locked_source() -> bytes:
+            with self._cam_lock:
+                return self.frame_source()
+        for chunk in stream_mjpeg(locked_source, fps):
+            yield chunk
+            time.sleep(1.0 / fps)
+
+
+def make_handler(service: AimingService):
+    class Handler(BaseHTTPRequestHandler):
+        def _send(self, body, status, ctype):
+            data = body.encode() if isinstance(body, str) else body
+            self.send_response(status)
+            self.send_header("Content-Type", ctype)
+            self.send_header("Content-Length", str(len(data)))
+            self.end_headers()
+            self.wfile.write(data)
+
+        def do_GET(self):
+            if self.path == "/setup/preview.mjpg":
+                if service.preview_status() == 503:
+                    return self._send(json.dumps({"error": "camera busy"}), 503,
+                                      "application/json")
+                self.send_response(200)
+                self.send_header("Content-Type",
+                                 f"multipart/x-mixed-replace; boundary={MJPEG_BOUNDARY}")
+                self.end_headers()
+                try:
+                    for chunk in service.mjpeg_frames():
+                        self.wfile.write(chunk)
+                except (BrokenPipeError, ConnectionResetError):
+                    return
+                return
+            body, status, ctype = service.handle_get(self.path)
+            self._send(body, status, ctype)
+
+        def do_POST(self):
+            length = int(self.headers.get("Content-Length", 0))
+            raw = self.rfile.read(length) if length else b"{}"
+            try:
+                payload = json.loads(raw or b"{}")
+            except json.JSONDecodeError:
+                return self._send(json.dumps({"error": "bad json"}), 400, "application/json")
+            body, status, ctype = service.handle_post(self.path, payload)
+            self._send(body, status, ctype)
+
+        def log_message(self, *args):  # quiet
+            pass
+
+    return Handler
+
+
+def serve(service: AimingService, port: int = 8080) -> None:
+    httpd = ThreadingHTTPServer(("0.0.0.0", port), make_handler(service))
+    httpd.serve_forever()
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `python3 -m pytest tests/test_setup_server.py -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/sunset_cam/setup_server.py tests/test_setup_server.py
+git commit -m "feat(setup-server): ThreadingHTTPServer + AimingService (preview/orientation/tap/state)"
+```
+
+---
+
+### Task 6: Overlay — phase parameter, confidence-gated arcs, FOV-fit bars, touch tap
+
+**Files:**
+- Modify: `src/sunset_cam/setup_alignment.py` (`render_align_page` signature + body)
+- Test: `tests/test_setup_alignment.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_setup_alignment.py  (add)
+from sunset_cam.setup_alignment import render_align_page
+
+def test_align_page_accepts_phase_and_defaults_sunset():
+    html = render_align_page(48.7519, -122.4787, phase="sunrise")
+    assert 'data-phase="sunrise"' in html
+
+def test_align_page_posts_tap_to_setup_tap_endpoint():
+    html = render_align_page(48.7519, -122.4787)
+    # The preview must register a click/touch handler that POSTs to /setup/tap.
+    assert "/setup/tap" in html
+    assert "addEventListener" in html and ("click" in html or "pointerdown" in html)
+
+def test_align_page_polls_state_json():
+    html = render_align_page(48.7519, -122.4787)
+    assert "/setup/state.json" in html  # overlay reads heading state (gates the arcs)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python3 -m pytest tests/test_setup_alignment.py -v`
+Expected: FAIL — `render_align_page()` has no `phase` kwarg / strings absent.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Change `render_align_page` to accept `phase: str = "sunset"`, add `data-phase` to `<body>`, and add a script block that (a) polls `/setup/state.json` and only draws the solstice arcs + FOV bars when `status !== "uncalibrated"`, and (b) registers a `pointerdown`/`click` handler on the `.preview-wrap img` that converts the event to image-relative pixel-x and POSTs `{pixel_x, pixel_y}` to `/setup/tap`. Keep the existing roll/pitch HUD. Minimal version:
+
+```python
+# src/sunset_cam/setup_alignment.py  — change signature
+def render_align_page(lat: float, lng: float, year: int | None = None,
+                      phase: str = "sunset") -> str:
+    if year is None:
+        year = date.today().year
+    # ... existing facing/marker computation stays for now ...
+    # In <body ...>, add:  data-phase="{phase}"
+    # Append before </body> the tap + state-poll script:
+    tap_script = """
+    <script>
+      const img = document.querySelector('.preview-wrap img');
+      img.addEventListener('pointerdown', async (e) => {
+        const r = img.getBoundingClientRect();
+        const px = Math.round((e.clientX - r.left) / r.width * img.naturalWidth || 1600);
+        const py = Math.round((e.clientY - r.top) / r.height * img.naturalHeight || 900);
+        const resp = await fetch('/setup/tap', {method:'POST',
+          headers:{'Content-Type':'application/json'},
+          body: JSON.stringify({pixel_x: px, pixel_y: py})});
+        window._lastTap = await resp.json();
+      });
+      async function pollState() {
+        try {
+          const s = await (await fetch('/setup/state.json',{cache:'no-store'})).json();
+          document.body.dataset.headingStatus = s.status;     // CSS hides arcs when uncalibrated
+          const el = document.getElementById('heading-badge');
+          if (el) el.textContent = s.status === 'tapped'
+            ? ('aimed ' + Math.round(s.heading_deg) + '\\u00b0' + (s.fits ? ' \\u2713' : ' \\u2014 clipped'))
+            : (s.status === 'suspect' ? 're-tap' : 'tap the sun');
+        } catch (e) {}
+      }
+      setInterval(pollState, 400); pollState();
+    </script>
+    """
+    # Add `<span id="heading-badge" class="level-badge">tap the sun</span>` to the HUD,
+    # and a CSS rule: body:not([data-heading-status="tapped"]) .facing-group { display:none }
+    # so solstice geometry is hidden until a valid tap (confidence gate).
+    return f"""...existing HTML with the above inserts and data-phase="{phase}"..."""
+```
+
+Implement the full string by editing the existing `render_align_page` return template: add `data-phase="{phase}"` and `data-heading-status="uncalibrated"` to `<body>`, add the `#heading-badge` span in `.top-hud`, the confidence-gate CSS rule, and the `tap_script` before `</body>`.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `python3 -m pytest tests/test_setup_alignment.py -v`
+Expected: PASS (new + existing).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/sunset_cam/setup_alignment.py tests/test_setup_alignment.py
+git commit -m "feat(overlay): phase param, sun-tap handler, state-polling + confidence-gated arcs"
+```
+
+---
+
+### Task 7: Hardware-gated validation on cam1 (manual)
+
+Not a code task — the end-to-end check on real hardware. Requires the deferred auto-mode-switch is NOT needed: just stop capture and run the server.
+
+- [ ] **Step 1: Deploy the branch to cam1**
+
+```bash
+ssh pi@sunset-cam-1.local 'cd /opt/sunset-cam && sudo git fetch origin && sudo git checkout feat/v0.4-sun-tap-aiming && sudo systemctl stop sunset-cam'
+```
+
+- [ ] **Step 2: Run the setup-server** (wire the real frame source + woken gyro reader)
+
+Create a tiny launcher on the Pi (`/opt/sunset-cam/scripts/run-setup-server.py`) that builds an `AimingService` with `frame_source=capture.capture_jpeg`, `reader=make_orientation_reader(smbus2.SMBus(1))`, `lat/lng` from a flag, then `serve(service, 8080)`. Run it: `sudo /opt/sunset-cam/.venv/bin/python /opt/sunset-cam/scripts/run-setup-server.py --lat 48.7519 --lng -122.4787 --phase sunset`.
+
+- [ ] **Step 3: Aim from a phone**
+
+On a phone on the same WiFi, open `http://sunset-cam-1.local:8080`. Verify: live preview loads; roll/pitch HUD updates; no solstice arcs before tapping; tap the visible sun → badge shows `aimed NNN°` and the solstice arcs + FOV bars appear; bump the camera → badge flips to `re-tap`.
+
+- [ ] **Step 4: Record the result**
+
+Note the computed heading vs. reality (does "aimed 268°W" match a compass/known landmark within a few degrees?). Capture a screenshot for the PR. If heading is off by a consistent amount, check the `pixel_offset_to_angle` sign and the camera's actual HFOV.
+
+- [ ] **Step 5: Open the PR**
+
+```bash
+cd ~/GitHub/sunset-cam-firmware
+gh pr create --base main --head feat/v0.4-sun-tap-aiming \
+  --title "feat: v0.4 sun-tap instant aiming" \
+  --body "Implements docs/superpowers/specs/2026-06-07-pi-alignment-v0.4-sun-tap-aiming-design.md sub-project 1. Hardware-validated on cam1."
+```
+
+---
+
+## Self-Review
+
+- **Spec coverage:** §5.5 sun-tap math → Tasks 1,3; §5.4 confidence model → Task 4; §5.6 FOV-fit/compromise → Task 2; §5.7 setup-server → Task 5; §5.3/§5.2 overlay + phase → Task 6; §6 testing → tests in every task; §10 slice order → Tasks 1-7 in order. The high-latitude *seasonal nudge guidance* (§5.6 #2) is surfaced via `fov_fit`'s `best_center_az`/`captured_at_best` (Task 2) but the notification delivery is part of the deferred notification channel — noted, not built here.
+- **Placeholders:** Task 6's Step 3 describes edits to an existing large HTML template rather than restating the whole ~120-line string; the inserts (data attributes, badge span, CSS rule, tap_script) are given as exact code. Acceptable — it's modifying an existing template, and the tests pin the required substrings.
+- **Type consistency:** `AimingService(frame_source, reader, now_utc_fn)`, `HeadingState(hfov_deg, width, level_tol_deg, drift_tol_deg)`, `fov_fit(...) -> dict` keys (`fits`, `captured`, `best_center_az`, `captured_at_best`, `summer_az`, `winter_az`) used consistently across Tasks 2/4/5. `compute_sun_azimuth(lat, lng, t_utc)` signature consistent in Tasks 1/5.
+
+---
+
+## Open items carried from the spec (§9)
+1. Lens FOV choice (Jesse investigating Arducam) — `hfov_deg` is a parameter throughout; nothing here hard-codes a lens.
+2. Where lat/lng live on relocation — Task 7 passes them as flags; the durable source is the deferred field sub-project's concern.
+3. Clock-accuracy tolerance — Task 1's azimuth tolerance (±2°) absorbs a few minutes of skew; confirm on hardware (Task 7).

--- a/docs/superpowers/plans/2026-06-07-pi-deployment-aiming-integration-cloud.md
+++ b/docs/superpowers/plans/2026-06-07-pi-deployment-aiming-integration-cloud.md
@@ -1,0 +1,338 @@
+# Deployment-Aiming Integration (Cloud-Protocol Slice) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Teach the cloud the location-down / aim-up split: a three-state placement lifecycle (`awaiting_location` → `awaiting_aim` → `ready`), deliver lat/lng to the device once known so it can draw the sun overlay, and accept the device's confirmed aim via a new placement endpoint.
+
+**Architecture:** Pure logic in the existing Next.js API — no DB migration (the `cameras` table already has `lat`/`lng`/`azimuth_deg`/`tilt_deg`). Extend the derived `derivePlacementStatus`, branch the heartbeat response on the three states (returning lat/lng in `awaiting_aim`), add `POST /api/cameras/:id/placement`, and surface `awaiting_aim` in the wizard's `setup-status` poll.
+
+**Tech Stack:** Next.js App Router (`app/api/...route.ts`), `@/app/lib/db` tagged-template `sql`, `vitest` (`// @vitest-environment node`, mocked `sql`/`cameraAuth`/`cameraRegistration`).
+
+---
+
+## Scope & gating
+
+This is the **now-unblocked cloud-protocol slice** of `docs/superpowers/specs/2026-06-07-pi-deployment-aiming-integration-design.md` (spec slices touching `app/`+`database/`). **Unblocked because labeling-queue PR #49 merged to main** (`f78c1e4c0`), so there's no longer a shared-surface conflict.
+
+**Still gated, NOT in this plan:** the device-side **supervisor** (starts/stops `sunset-cam-aiming` vs `sunset-cam` by status) and the **`sunset-cam-aiming.service` systemd unit** + the **`reaim`/`reprovision`** relocation directives — these depend on sub-project E's device state machine existing. Separate follow-on plan.
+
+**Compatibility note:** changing `derivePlacementStatus`'s return values from `'pending'|'ready'` to the three-state set changes the device-protocol response. The existing capture firmware (sunset-cam-0/1) uses the window-based capture path, not the placement flow, so this is safe; the new firmware (this feature) expects the three states. Confirm no other caller hard-codes `'pending'`.
+
+## Working location
+
+`the-sunset-webcam-map` on branch **`feat/deploy-aiming-cloud`** off **`origin/main`** (which now includes PR #49). Use a git worktree. Confirm the branch before each commit.
+Run tests: `npx vitest run <path>` (or the repo's configured test script). Confirm the repo's lint/build passes before the final commit: `npm run lint`.
+
+## File Structure
+
+| File | Responsibility | New/Modify |
+|---|---|---|
+| `app/lib/cameraRegistration.ts` | `PlacementStatus` type + `derivePlacementStatus` → three states | Modify |
+| `app/api/cameras/[id]/heartbeat/route.ts` | branch on three states; return lat/lng in `awaiting_aim` | Modify |
+| `app/api/cameras/[id]/placement/route.ts` | **new** `POST` — device reports confirmed aim | Create |
+| `app/api/cameras/setup-status/[claim_code]/route.ts` | surface `awaiting_aim` | Modify |
+| `app/lib/cameraRegistration.test.ts` | three-state tests (create if absent) | Create/Modify |
+| `app/api/cameras/[id]/heartbeat/route.test.ts` | awaiting_aim returns lat/lng | Modify |
+| `app/api/cameras/[id]/placement/route.test.ts` | new-route tests | Create |
+| `app/api/cameras/setup-status/[claim_code]/route.test.ts` | awaiting_aim status | Modify |
+
+---
+
+### Task 1: Three-state `derivePlacementStatus`
+
+**Files:** Modify `app/lib/cameraRegistration.ts`; test `app/lib/cameraRegistration.test.ts`.
+
+- [ ] **Step 1: Write the failing tests** (create `app/lib/cameraRegistration.test.ts` if it doesn't exist; if it does, append)
+
+```typescript
+// @vitest-environment node
+import { describe, it, expect } from 'vitest';
+import { derivePlacementStatus } from './cameraRegistration';
+
+describe('derivePlacementStatus (three states)', () => {
+  it('awaiting_location when lat or lng missing', () => {
+    expect(derivePlacementStatus({ lat: null, lng: null, azimuth_deg: null, tilt_deg: null }))
+      .toBe('awaiting_location');
+    expect(derivePlacementStatus({ lat: 48.7, lng: null, azimuth_deg: null, tilt_deg: null }))
+      .toBe('awaiting_location');
+  });
+  it('awaiting_aim when located but not aimed', () => {
+    expect(derivePlacementStatus({ lat: 48.7, lng: -122.4, azimuth_deg: null, tilt_deg: null }))
+      .toBe('awaiting_aim');
+  });
+  it('ready when located and aimed', () => {
+    expect(derivePlacementStatus({ lat: 48.7, lng: -122.4, azimuth_deg: 270, tilt_deg: 2 }))
+      .toBe('ready');
+  });
+});
+```
+
+- [ ] **Step 2: Run, verify fail**
+
+Run: `npx vitest run app/lib/cameraRegistration.test.ts`
+Expected: FAIL — current function returns `'pending'`, not `'awaiting_location'`/`'awaiting_aim'`.
+
+- [ ] **Step 3: Implement** — in `app/lib/cameraRegistration.ts` replace the type + function:
+
+```typescript
+export type PlacementStatus = 'awaiting_location' | 'awaiting_aim' | 'ready';
+
+export function derivePlacementStatus(row: PlacementShape): PlacementStatus {
+  if (row.lat == null || row.lng == null) return 'awaiting_location';
+  if (row.azimuth_deg == null || row.tilt_deg == null) return 'awaiting_aim';
+  return 'ready';
+}
+```
+
+- [ ] **Step 4: Run, verify pass**
+
+Run: `npx vitest run app/lib/cameraRegistration.test.ts` → PASS. Then `npm run lint` to catch any caller that pattern-matched the old `'pending'` literal (TypeScript will flag exhaustive checks). Heartbeat + setup-status are updated in Tasks 2/4; if `register/route.ts` references `derivePlacementStatus`, it passes the value straight through to its response (no literal comparison) — verify with `grep -n "pending" app/api/cameras/register/route.ts` returns nothing; if it does, update that branch to the new states in this task.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git branch --show-current   # MUST be feat/deploy-aiming-cloud
+git add app/lib/cameraRegistration.ts app/lib/cameraRegistration.test.ts
+git commit -m "feat(cameras): three-state placement status (awaiting_location/awaiting_aim/ready)"
+```
+
+---
+
+### Task 2: Heartbeat returns lat/lng in `awaiting_aim`
+
+The device needs lat/lng to draw the sun overlay before it can aim. Current heartbeat returns `{placement_status:'pending'}` (no coords) when not ready. Split that into the two pending states.
+
+**Files:** Modify `app/api/cameras/[id]/heartbeat/route.ts`; test `app/api/cameras/[id]/heartbeat/route.test.ts`.
+
+- [ ] **Step 1: Write the failing test** (append; mirror the existing file's mock setup — `derivePlacementStatusMock`, `sqlMock`, `verifyDeviceTokenMock`, `makeRequest`, `makeContext`)
+
+```typescript
+it('returns lat/lng with awaiting_aim so the device can aim', async () => {
+  verifyDeviceTokenMock.mockResolvedValueOnce({ id: 42 });
+  sqlMock.mockResolvedValueOnce([
+    { lat: 48.7519, lng: -122.4787, elevation_m: null, timezone: 'America/Los_Angeles',
+      azimuth_deg: null, tilt_deg: null, horizon_altitude_deg: null, horizon_profile: null },
+  ]);
+  derivePlacementStatusMock.mockReturnValueOnce('awaiting_aim');
+  const res = await POST(
+    makeRequest({ id: '42', bearer: 'good', body: { request_placement: true } }),
+    makeContext('42')
+  );
+  expect(res.status).toBe(200);
+  const json = await res.json();
+  expect(json.placement_status).toBe('awaiting_aim');
+  expect(json.lat).toBe(48.7519);
+  expect(json.lng).toBe(-122.4787);
+});
+```
+
+- [ ] **Step 2: Run, verify fail**
+
+Run: `npx vitest run "app/api/cameras/[id]/heartbeat/route.test.ts"`
+Expected: FAIL — current code returns `{placement_status:'pending'}` with no lat/lng.
+
+- [ ] **Step 3: Implement** — in the placement-branch of `heartbeat/route.ts`, replace the `status === 'pending'` block with three-state handling:
+
+```typescript
+  const status = derivePlacementStatus(row);
+  if (status === 'awaiting_location') {
+    return NextResponse.json({ acknowledged_at: acknowledgedAt, placement_status: 'awaiting_location' });
+  }
+  if (status === 'awaiting_aim') {
+    return NextResponse.json({
+      acknowledged_at: acknowledgedAt,
+      placement_status: 'awaiting_aim',
+      lat: row.lat,
+      lng: row.lng,
+    });
+  }
+  return NextResponse.json({
+    acknowledged_at: acknowledgedAt,
+    placement_status: 'ready',
+    placement: {
+      lat: row.lat,
+      lng: row.lng,
+      // ...keep the existing `placement` fields (elevation_m, timezone, azimuth_deg, tilt_deg, horizon_*)
+    },
+  });
+```
+(Keep the existing `placement` object's full field list in the `ready` branch — only the pending branches change.)
+
+- [ ] **Step 4: Run, verify pass**
+
+Run: `npx vitest run "app/api/cameras/[id]/heartbeat/route.test.ts"` → PASS (new + existing). Update any existing test that asserted `placement_status: 'pending'` to the correct new state.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add "app/api/cameras/[id]/heartbeat/route.ts" "app/api/cameras/[id]/heartbeat/route.test.ts"
+git commit -m "feat(heartbeat): deliver lat/lng in awaiting_aim so the device can aim"
+```
+
+---
+
+### Task 3: `POST /api/cameras/:id/placement` — accept the confirmed aim
+
+**Files:** Create `app/api/cameras/[id]/placement/route.ts` + `app/api/cameras/[id]/placement/route.test.ts`.
+
+- [ ] **Step 1: Write the failing tests** (mirror the heartbeat test's mock harness for `verifyDeviceToken` + `sql`)
+
+```typescript
+// @vitest-environment node
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+const verifyDeviceTokenMock = vi.fn();
+const sqlMock = vi.fn();
+vi.mock('@/app/lib/cameraAuth', () => ({ verifyDeviceToken: (...a: unknown[]) => verifyDeviceTokenMock(...a) }));
+vi.mock('@/app/lib/db', () => ({ sql: (s: TemplateStringsArray, ...v: unknown[]) => sqlMock(s, ...v) }));
+import { POST } from './route';
+beforeEach(() => { verifyDeviceTokenMock.mockReset(); sqlMock.mockReset(); });
+
+function req(opts: { id?: string; bearer?: string; body?: unknown }) {
+  const headers: HeadersInit = { 'content-type': 'application/json' };
+  if (opts.bearer) headers['authorization'] = `Bearer ${opts.bearer}`;
+  return new Request(`http://test/api/cameras/${opts.id ?? '42'}/placement`, {
+    method: 'POST', headers, body: JSON.stringify(opts.body ?? {}),
+  });
+}
+const ctx = (id: string) => ({ params: Promise.resolve({ id }) });
+
+describe('POST /api/cameras/[id]/placement', () => {
+  it('401 when unauthenticated', async () => {
+    verifyDeviceTokenMock.mockResolvedValueOnce(null);
+    const res = await POST(req({ bearer: 'bad', body: { azimuth_deg: 270, tilt_deg: 2 } }), ctx('42'));
+    expect(res.status).toBe(401);
+  });
+  it('saves the aim and reports ready', async () => {
+    verifyDeviceTokenMock.mockResolvedValueOnce({ id: 42 });
+    sqlMock.mockResolvedValueOnce([{ lat: 48.7, lng: -122.4, azimuth_deg: 270, tilt_deg: 2 }]);
+    const res = await POST(req({ bearer: 'good', body: { azimuth_deg: 270, tilt_deg: 2, confirmed_at: '2026-06-07T00:00:00Z' } }), ctx('42'));
+    expect(res.status).toBe(200);
+    expect((await res.json()).placement_status).toBe('ready');
+  });
+  it('400 on non-numeric aim', async () => {
+    verifyDeviceTokenMock.mockResolvedValueOnce({ id: 42 });
+    const res = await POST(req({ bearer: 'good', body: { azimuth_deg: 'x' } }), ctx('42'));
+    expect(res.status).toBe(400);
+  });
+});
+```
+
+- [ ] **Step 2: Run, verify fail**
+
+Run: `npx vitest run "app/api/cameras/[id]/placement/route.test.ts"`
+Expected: FAIL — route file doesn't exist.
+
+- [ ] **Step 3: Implement** `app/api/cameras/[id]/placement/route.ts`. Use `verifyDeviceToken` **exactly as `heartbeat/route.ts` calls it** (same argument order + the same 401-on-null handling — open `heartbeat/route.ts` and copy that call shape):
+
+```typescript
+import { NextResponse } from 'next/server';
+import { sql } from '@/app/lib/db';
+import { verifyDeviceToken } from '@/app/lib/cameraAuth';
+import { derivePlacementStatus } from '@/app/lib/cameraRegistration';
+
+export const dynamic = 'force-dynamic';
+type RouteContext = { params: Promise<{ id: string }> };
+
+export async function POST(request: Request, context: RouteContext) {
+  const { id } = await context.params;
+  const cameraId = Number(id);
+  if (!Number.isInteger(cameraId)) {
+    return NextResponse.json({ error: 'invalid camera id' }, { status: 400 });
+  }
+  const auth = await verifyDeviceToken(request, cameraId); // MATCH heartbeat's exact call
+  if (!auth) {
+    return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
+  }
+  let body: { azimuth_deg?: unknown; tilt_deg?: unknown };
+  try { body = await request.json(); } catch {
+    return NextResponse.json({ error: 'invalid json body' }, { status: 400 });
+  }
+  const azimuth = Number(body.azimuth_deg);
+  const tilt = Number(body.tilt_deg);
+  if (!Number.isFinite(azimuth) || !Number.isFinite(tilt)) {
+    return NextResponse.json({ error: 'azimuth_deg and tilt_deg must be numbers' }, { status: 400 });
+  }
+  const rows = (await sql`
+    UPDATE cameras SET azimuth_deg = ${azimuth}, tilt_deg = ${tilt}
+    WHERE id = ${cameraId}
+    RETURNING lat, lng, azimuth_deg, tilt_deg
+  `) as { lat: number | null; lng: number | null; azimuth_deg: number | null; tilt_deg: number | null }[];
+  if (!rows[0]) {
+    return NextResponse.json({ error: 'camera not found' }, { status: 404 });
+  }
+  return NextResponse.json({ placement_status: derivePlacementStatus(rows[0]) });
+}
+```
+
+- [ ] **Step 4: Run, verify pass**
+
+Run: `npx vitest run "app/api/cameras/[id]/placement/route.test.ts"` → PASS. If `verifyDeviceToken`'s real signature differs from `(request, cameraId)`, adjust the call to match `heartbeat/route.ts` and re-run.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add "app/api/cameras/[id]/placement/route.ts" "app/api/cameras/[id]/placement/route.test.ts"
+git commit -m "feat(cameras): POST /api/cameras/:id/placement accepts the device's confirmed aim"
+```
+
+---
+
+### Task 4: `setup-status` surfaces `awaiting_aim`
+
+The cloud wizard polls this to know when to show the aiming step.
+
+**Files:** Modify `app/api/cameras/setup-status/[claim_code]/route.ts`; test `app/api/cameras/setup-status/[claim_code]/route.test.ts`.
+
+- [ ] **Step 1: Write the failing test** (append; mirror existing mock harness)
+
+```typescript
+it('reports awaiting_aim when located but not yet aimed', async () => {
+  getClaimCodeMock.mockResolvedValueOnce({ expires_at: new Date(Date.now() + 1e6) });
+  sqlMock.mockResolvedValueOnce([
+    { id: 1, hardware_id: 'pi-real', device_token_hash: 'real',
+      lat: 48.7, lng: -122.4, azimuth_deg: null, tilt_deg: null },
+  ]);
+  derivePlacementStatusMock.mockReturnValueOnce('awaiting_aim');
+  const res = await GET(new Request('http://test/'), { params: Promise.resolve({ claim_code: 'SUNSET-A-B' }) });
+  expect((await res.json()).status).toBe('awaiting_aim');
+});
+```
+(Match the existing test file's mocks — it mocks `getClaimCode`, `sql`, and `derivePlacementStatus`/`sentinelForClaimCode`. Use the same mock names already in that file.)
+
+- [ ] **Step 2: Run, verify fail**
+
+Run: `npx vitest run "app/api/cameras/setup-status/[claim_code]/route.test.ts"`
+Expected: FAIL — current mapping only emits `'ready'` or `'registered'`.
+
+- [ ] **Step 3: Implement** — replace the final return in `setup-status/[claim_code]/route.ts`:
+
+```typescript
+  const placement = derivePlacementStatus(row);
+  const status =
+    placement === 'ready' ? 'ready'
+    : placement === 'awaiting_aim' ? 'awaiting_aim'
+    : 'registered'; // awaiting_location: device is up but has no coords yet
+  return NextResponse.json({ status });
+```
+
+- [ ] **Step 4: Run, verify pass**
+
+Run: `npx vitest run "app/api/cameras/setup-status/[claim_code]/route.test.ts"` → PASS (new + existing). Then run the full cloud test suite + `npm run lint` to confirm no other caller broke on the type change.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add "app/api/cameras/setup-status/[claim_code]/route.ts" "app/api/cameras/setup-status/[claim_code]/route.test.ts"
+git commit -m "feat(setup-status): surface awaiting_aim for the cloud wizard"
+```
+
+---
+
+## Self-Review
+
+- **Spec coverage:** three-state `placement_status` → Task 1; lat/lng in register/heartbeat → Task 2 (heartbeat is where ongoing delivery happens; register passes the derived status through automatically — verified in Task 1 Step 4); `POST /api/cameras/:id/placement` → Task 3; `setup-status` `awaiting_aim` → Task 4. No migration — columns exist. The `reaim`/`reprovision` directives + `local_ip` are explicitly gated (device-supervisor plan).
+- **Placeholders:** Tasks 2 & 3 reference "keep the existing `placement` fields" / "match heartbeat's `verifyDeviceToken` call" — these point at concrete, named existing code to copy exactly (not vague "handle X"); the new logic is given in full. Acceptable for edits to existing routes.
+- **Type consistency:** `PlacementStatus` = `'awaiting_location'|'awaiting_aim'|'ready'` used consistently in Tasks 1/2/4; `derivePlacementStatus(row)` returns it; the placement route (Task 3) returns it via the same function.
+
+## Follow-on (gated on sub-project E)
+The device-side supervisor (start/stop `sunset-cam-aiming` vs `sunset-cam` by the `placement_status` it reads from heartbeat), the `sunset-cam-aiming.service` unit, heartbeat `local_ip`, and the `reaim`/`reprovision` relocation directives. The firmware already writes its confirmed placement to `/etc/sunset-cam/placement.json` (the `placement_sink`) and reports it via `POST /api/cameras/:id/placement` (this plan) — the supervisor is what ties the mode transitions together.

--- a/docs/superpowers/plans/2026-06-07-pi-deployment-aiming-integration-firmware.md
+++ b/docs/superpowers/plans/2026-06-07-pi-deployment-aiming-integration-firmware.md
@@ -1,0 +1,372 @@
+# Deployment-Aiming Integration (Firmware Slices) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add the two firmware pieces that make the built v0.4 aiming tool deployable — a `POST /setup/confirm` that commits the sun-tap aim as the device's placement, and a config-driven launcher so the aiming server can run from device config (not just CLI flags).
+
+**Architecture:** Both extend the already-built v0.4 `setup_server.py` / `setup_alignment.py` in the `sunset-cam-firmware` repo. `AimingService` gains a `confirm` path that validates the heading is in the `tapped` state, builds a placement dict, and hands it to an injectable sink (so it's filesystem-free in tests). A pure `resolve_aiming_params` function merges CLI flags over device-config over defaults. All TDD, all hardware-free.
+
+**Tech Stack:** Python 3.11 (Pi) / 3.9 (Mac dev), stdlib only, `pytest`. `from __future__ import annotations` throughout.
+
+---
+
+## Scope
+
+This is **only** the firmware-now subset of `docs/superpowers/specs/2026-06-07-pi-deployment-aiming-integration-design.md` (spec slices 1–2). These live in `sunset-cam-firmware` and are isolated from the parallel labeling-queue work (different repo).
+
+### ⛔ NOT in this plan — separate follow-on plan, gated
+Spec slices 3+ (the cloud + device-supervisor side) are a **separate plan**, blocked on TWO things: (a) the labeling-queue **PR #47 merging** (it shares the `app/` + `database/` surface these slices touch), and (b) **sub-project E's device state machine** existing (the supervisor extends it). Do NOT start these here:
+- `placement_status` three-state (`awaiting_location`/`awaiting_aim`/`ready`), `lat`/`lng` in register/heartbeat, `POST /api/cameras/:id/placement`, `setup-status` `awaiting_aim` (cloud, `app/` + `database/`)
+- the device supervisor that starts/stops `sunset-cam-aiming` vs `sunset-cam` by status
+- `sunset-cam-aiming.service` systemd unit (`Conflicts=sunset-cam.service`)
+- heartbeat `local_ip` + the `reaim`/`reprovision` relocation directives
+
+## Working location
+
+`sunset-cam-firmware` on branch **`feat/deploy-aiming-firmware`** cut **off `feat/v0.4-sun-tap-aiming`** (these extend the unmerged v0.4 `setup_server`/`setup_alignment`). Use a git worktree. Confirm the branch before each commit.
+
+Setup (controller runs once before Task 1):
+```bash
+cd ~/GitHub/sunset-cam-firmware && git fetch origin -q
+git worktree add ~/GitHub/scf-deploy-aiming -b feat/deploy-aiming-firmware origin/feat/v0.4-sun-tap-aiming
+```
+Run tests with `python3 -m pytest`. Python 3.9 on the Mac → ignore `tests/test_config.py` and `tests/test_upload.py` in full-suite runs (`--ignore=tests/test_config.py --ignore=tests/test_upload.py`).
+
+## File Structure
+
+| File | Responsibility | New/Modify |
+|---|---|---|
+| `src/sunset_cam/setup_server.py` | `AimingService`: add `placement_sink` ctor param + `confirm()` + `POST /setup/confirm` route | Modify |
+| `src/sunset_cam/aiming_config.py` | `resolve_aiming_params(cli, config, defaults)` pure merge function | Create |
+| `scripts/run-setup-server.py` | read device config + merge via `resolve_aiming_params` when flags absent | Modify |
+| `tests/test_setup_server.py` | confirm tests | Modify |
+| `tests/test_aiming_config.py` | param-merge tests | Create |
+| `tests/test_setup_alignment.py` | confirm-button test | Modify |
+
+---
+
+### Task 1: `POST /setup/confirm` — commit the aim as placement
+
+**Files:**
+- Modify: `src/sunset_cam/setup_server.py` (`AimingService.__init__` + `handle_post`)
+- Test: `tests/test_setup_server.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# tests/test_setup_server.py  (add)
+def test_confirm_in_tapped_state_returns_placement():
+    sink = []
+    svc = AimingService(
+        lat=48.7519, lng=-122.4787, phase="sunset", hfov_deg=120.0, width=1600,
+        frame_source=lambda: b"\xff\xd8\xff\xd9", reader=lambda: (0.2, 1.0),
+        now_utc_fn=lambda: datetime(2026, 6, 21, 3, 30, tzinfo=timezone.utc),
+        placement_sink=sink.append,
+    )
+    svc.handle_post("/setup/tap", {"pixel_x": 800, "pixel_y": 450})  # -> tapped
+    body, status, _ = svc.handle_post("/setup/confirm", {})
+    assert status == 200
+    data = json.loads(body)
+    assert data["status"] == "confirmed"
+    assert data["placement"]["azimuth_deg"] == svc.state.heading_deg()
+    assert data["placement"]["tilt_deg"] == 1.0          # = the pitch reading
+    assert data["placement"]["roll_deg"] == 0.2
+    assert "confirmed_at" in data["placement"]
+    assert sink == [data["placement"]]                    # persisted via the sink
+
+def test_confirm_without_tap_returns_409():
+    svc = AimingService(
+        lat=48.0, lng=-122.0, phase="sunset", hfov_deg=120.0, width=1600,
+        frame_source=lambda: b"\xff\xd8\xff\xd9", reader=lambda: (0.0, 0.0),
+        now_utc_fn=lambda: datetime(2026, 6, 21, 3, 30, tzinfo=timezone.utc),
+        placement_sink=lambda p: None,
+    )
+    body, status, _ = svc.handle_post("/setup/confirm", {})
+    assert status == 409                                  # uncalibrated -> cannot confirm
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `python3 -m pytest tests/test_setup_server.py -v`
+Expected: FAIL — `AimingService.__init__` has no `placement_sink` kwarg / `/setup/confirm` returns 404.
+
+- [ ] **Step 3: Implement**
+
+In `src/sunset_cam/setup_server.py`, add a module-level default sink + extend the class:
+
+```python
+import json, os   # json already imported; add os
+# ... existing imports ...
+
+DEFAULT_PLACEMENT_PATH = "/etc/sunset-cam/placement.json"
+
+
+def _default_placement_sink(placement: dict) -> None:
+    os.makedirs(os.path.dirname(DEFAULT_PLACEMENT_PATH), exist_ok=True)
+    with open(DEFAULT_PLACEMENT_PATH, "w") as f:
+        json.dump(placement, f)
+```
+
+Add `placement_sink` to `__init__` (after `now_utc_fn`):
+```python
+        now_utc_fn: Callable[[], datetime] = lambda: datetime.now(timezone.utc),
+        placement_sink: Callable[[dict], None] = _default_placement_sink,
+    ) -> None:
+        ...
+        self.now_utc_fn = now_utc_fn
+        self.placement_sink = placement_sink
+```
+
+In `handle_post`, add the confirm branch BEFORE the final `return 404` (keep the existing `/setup/tap` branch):
+```python
+    def handle_post(self, path: str, body: dict):
+        if path == "/setup/tap":
+            # ... existing tap logic unchanged ...
+        if path == "/setup/confirm":
+            roll, pitch = self._orientation()
+            self.state.update_orientation(roll, pitch)   # flips to suspect if moved
+            if self.state.status() != "tapped":
+                return (json.dumps({"status": self.state.status(),
+                                    "error": "aim not set — tap the sun first"}),
+                        409, "application/json")
+            placement = {
+                "azimuth_deg": self.state.heading_deg(),
+                "tilt_deg": pitch,
+                "roll_deg": roll,
+                "confirmed_at": self.now_utc_fn().isoformat(),
+            }
+            self.placement_sink(placement)
+            return (json.dumps({"status": "confirmed", "placement": placement}),
+                    200, "application/json")
+        return json.dumps({"error": "not found"}), 404, "application/json"
+```
+(Note `tilt_deg` is stored as the raw gyro pitch; its sign/zero convention is pinned during hardware validation — spec §9 Q1. Keep it raw here.)
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `python3 -m pytest tests/test_setup_server.py -v` then the runnable full suite (`--ignore=tests/test_config.py --ignore=tests/test_upload.py`). Expected: all pass, no regressions.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git branch --show-current   # MUST be feat/deploy-aiming-firmware
+git add src/sunset_cam/setup_server.py tests/test_setup_server.py
+git commit -m "feat(setup-server): POST /setup/confirm commits the aim as placement"
+```
+
+---
+
+### Task 2: "Confirm aim" button in the overlay
+
+**Files:**
+- Modify: `src/sunset_cam/setup_alignment.py` (the `_AIM_SCRIPT` constant from the v0.4 work)
+- Test: `tests/test_setup_alignment.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_setup_alignment.py  (add)
+def test_align_page_has_confirm_button_posting_to_confirm():
+    html = render_align_page(48.7519, -122.4787)
+    assert "/setup/confirm" in html
+    assert "confirm-aim" in html   # the button's id
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python3 -m pytest tests/test_setup_alignment.py::test_align_page_has_confirm_button_posting_to_confirm -v`
+Expected: FAIL — substrings absent.
+
+- [ ] **Step 3: Implement**
+
+In `src/sunset_cam/setup_alignment.py`, edit the `_AIM_SCRIPT` constant: add a confirm button element and wire it. The button is shown only while heading status is `tapped` (the same confidence gate). Replace the `<script>` open with a button + the gating in `pollHeadingState`, and add a click handler:
+
+```python
+_AIM_SCRIPT = """
+<button id="confirm-aim" hidden>Confirm aim</button>
+<script>
+  const _img = document.querySelector('.preview-wrap img');
+  if (_img) _img.addEventListener('pointerdown', async (e) => {
+    const r = _img.getBoundingClientRect();
+    const px = Math.round((e.clientX - r.left) / r.width * (_img.naturalWidth || 1600));
+    const py = Math.round((e.clientY - r.top) / r.height * (_img.naturalHeight || 900));
+    const resp = await fetch('/setup/tap', {method: 'POST',
+      headers: {'Content-Type': 'application/json'},
+      body: JSON.stringify({pixel_x: px, pixel_y: py})});
+    window._lastTap = await resp.json();
+  });
+  const _confirm = document.getElementById('confirm-aim');
+  if (_confirm) _confirm.addEventListener('click', async () => {
+    const resp = await fetch('/setup/confirm', {method: 'POST',
+      headers: {'Content-Type': 'application/json'}, body: '{}'});
+    const j = await resp.json();
+    if (j.status === 'confirmed') _confirm.textContent = 'Aim confirmed \\u2713';
+  });
+  async function pollHeadingState() {
+    try {
+      const s = await (await fetch('/setup/state.json', {cache: 'no-store'})).json();
+      document.body.dataset.headingStatus = s.status;
+      if (_confirm) _confirm.hidden = (s.status !== 'tapped');
+      const b = document.getElementById('heading-badge');
+      if (b) b.textContent = (s.status === 'tapped')
+        ? ('aimed ' + Math.round(s.heading_deg) + '\\u00b0' + (s.fits ? ' \\u2713' : ' \\u2014 clipped'))
+        : (s.status === 'suspect' ? 're-tap' : 'tap the sun');
+    } catch (e) {}
+  }
+  setInterval(pollHeadingState, 400); pollHeadingState();
+</script>
+"""
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `python3 -m pytest tests/test_setup_alignment.py -v` then the runnable full suite. Expected: all pass (existing 21 + 1 new), no regressions.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git branch --show-current
+git add src/sunset_cam/setup_alignment.py tests/test_setup_alignment.py
+git commit -m "feat(overlay): Confirm-aim button (shown only in tapped state)"
+```
+
+---
+
+### Task 3: Config-driven launcher params
+
+**Files:**
+- Create: `src/sunset_cam/aiming_config.py`
+- Test: `tests/test_aiming_config.py`
+- Modify: `scripts/run-setup-server.py` (use the resolver)
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# tests/test_aiming_config.py
+import pytest
+from sunset_cam.aiming_config import resolve_aiming_params
+
+def test_cli_overrides_config_and_defaults():
+    out = resolve_aiming_params(
+        cli={"lat": 1.0, "lng": 2.0, "phase": None, "hfov": None, "width": None},
+        config={"lat": 9.0, "lng": 9.0, "phase": "sunrise", "hfov": 90.0, "width": 1280},
+    )
+    assert out == {"lat": 1.0, "lng": 2.0, "phase": "sunrise", "hfov": 90.0, "width": 1280}
+
+def test_config_used_when_cli_absent():
+    out = resolve_aiming_params(
+        cli={"lat": None, "lng": None, "phase": None, "hfov": None, "width": None},
+        config={"lat": 48.7519, "lng": -122.4787},
+    )
+    assert out["lat"] == 48.7519 and out["lng"] == -122.4787
+    assert out["phase"] == "sunset" and out["hfov"] == 102.0 and out["width"] == 1920
+
+def test_missing_lat_lng_raises():
+    with pytest.raises(ValueError):
+        resolve_aiming_params(cli={"lat": None, "lng": None}, config={})
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `python3 -m pytest tests/test_aiming_config.py -v`
+Expected: FAIL — `ModuleNotFoundError: No module named 'sunset_cam.aiming_config'`.
+
+- [ ] **Step 3: Implement**
+
+```python
+# src/sunset_cam/aiming_config.py
+"""Resolve aiming-server parameters: CLI flags override device config override
+defaults. lat/lng are required (the sun overlay needs them); the rest default."""
+from __future__ import annotations
+
+_DEFAULTS = {"phase": "sunset", "hfov": 102.0, "width": 1920}
+
+
+def resolve_aiming_params(cli: dict, config: dict) -> dict:
+    def pick(key, default=None):
+        v = cli.get(key)
+        if v is not None:
+            return v
+        v = config.get(key)
+        if v is not None:
+            return v
+        return default
+
+    lat, lng = pick("lat"), pick("lng")
+    if lat is None or lng is None:
+        raise ValueError("lat/lng must be provided via CLI flags or device config")
+    return {
+        "lat": lat, "lng": lng,
+        "phase": pick("phase", _DEFAULTS["phase"]),
+        "hfov": pick("hfov", _DEFAULTS["hfov"]),
+        "width": pick("width", _DEFAULTS["width"]),
+    }
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `python3 -m pytest tests/test_aiming_config.py -v`
+Expected: PASS.
+
+- [ ] **Step 5: Wire into the launcher**
+
+Modify `scripts/run-setup-server.py` so flags are optional and fall back to device config. Change the argparse defaults to `None` (so "absent" is detectable), load the device config JSON if present, and resolve:
+
+```python
+# scripts/run-setup-server.py  (replace the arg-parsing + service-build section)
+import json
+from pathlib import Path
+from sunset_cam.aiming_config import resolve_aiming_params
+
+CONFIG_PATH = "/opt/sunset-cam/config/config.json"
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description="v0.4 sun-tap aiming setup-server")
+    ap.add_argument("--lat", type=float, default=None)
+    ap.add_argument("--lng", type=float, default=None)
+    ap.add_argument("--phase", default=None, choices=["sunset", "sunrise", None])
+    ap.add_argument("--hfov", type=float, default=None)
+    ap.add_argument("--width", type=int, default=None)
+    ap.add_argument("--port", type=int, default=8080)
+    ap.add_argument("--config", default=CONFIG_PATH)
+    args = ap.parse_args()
+
+    config = {}
+    p = Path(args.config)
+    if p.exists():
+        config = json.loads(p.read_text())
+    params = resolve_aiming_params(
+        cli={"lat": args.lat, "lng": args.lng, "phase": args.phase,
+             "hfov": args.hfov, "width": args.width},
+        config=config,
+    )
+
+    reader = make_orientation_reader(smbus2.SMBus(1))
+    service = AimingService(
+        lat=params["lat"], lng=params["lng"], phase=params["phase"],
+        hfov_deg=params["hfov"], width=params["width"],
+        frame_source=capture_jpeg, reader=reader,
+    )
+    print(f"setup-server on :{args.port} — open http://<pi>:{args.port}/ from a phone")
+    serve(service, args.port)
+```
+(Keep the existing imports at the top of the file; `--phase` choices include `None` so an absent flag passes argparse.)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git branch --show-current
+git add src/sunset_cam/aiming_config.py tests/test_aiming_config.py scripts/run-setup-server.py
+git commit -m "feat(setup-server): config-driven aiming params (CLI > config > defaults)"
+```
+
+---
+
+## Self-Review
+
+- **Spec coverage:** spec slice 1 (`POST /setup/confirm` + Confirm button) → Tasks 1+2; spec slice 2 (config-driven launcher) → Task 3. Spec slices 3+ (cloud, supervisor, systemd, relocation) are explicitly out of scope here (the ⛔ block) and gated. The confidence gate (spec §5.3 "confirm requires tapped, not suspect/uncalibrated") → Task 1's 409 path + Task 2's button-hidden gating. `tilt_deg` sign (spec §9 Q1) → stored raw, noted.
+- **Placeholders:** none. Task 1's tap branch is shown as "existing logic unchanged" because it is genuinely unchanged from the v0.4 commit — the new code is the confirm branch, given in full.
+- **Type consistency:** `AimingService(..., placement_sink=...)` ctor change is reflected in Task 1's tests (the existing `test_setup_server.py` tests built `AimingService` without `placement_sink`, which still works because it defaults). `resolve_aiming_params(cli, config)` signature and its returned keys (`lat/lng/phase/hfov/width`) are consistent between Task 3's tests, the function, and the launcher wiring.
+
+## Follow-on (do NOT do here)
+After PR #47 merges and E's state machine lands, write the **cloud + supervisor plan** for spec slices 3–8. The placement this firmware writes (`/etc/sunset-cam/placement.json` via the sink) is the artifact the supervisor reads to report up and transition AIMING → ACTIVE.

--- a/docs/superpowers/specs/2026-06-07-pi-alignment-v0.4-sun-tap-aiming-design.md
+++ b/docs/superpowers/specs/2026-06-07-pi-alignment-v0.4-sun-tap-aiming-design.md
@@ -1,0 +1,209 @@
+# Pi-Side Alignment Tool v0.4 — Sun-Tap Instant Aiming
+
+Status: Draft v0.4 — 2026-06-07. Amends v0.3 (`2026-05-17-pi-alignment-v0.3-sun-self-calibration-design.md`).
+Owner: Jesse Kauppila
+Sub-project C, fourth iteration.
+
+---
+
+## 1. Problem
+
+v0.3 made the camera figure out its own compass heading by watching the sun across many sunset windows (`solvePnP` over N≥5 observations). It's precise (±2°) but **eventual** — calibration completes over **1–7 days of clear sunsets**, and in the meantime the operator gets no live aiming feedback at all. v0.3 explicitly **dropped** the v0.1 "sun-tap" mechanic in favor of this hands-off auto-detection.
+
+That trade killed the thing that makes commissioning fast: an **instant "aim it in 5 minutes" moment.** For the person physically pointing the camera (Jesse commissioning units, or a recipient at install time), "mount it roughly west and wait a week to find out if it's right" is the wrong loop.
+
+v0.4 **re-introduces sun-tap as the instant fast path** and keeps v0.3's auto-calibration as the **precise, self-healing fallback** — they are complementary layers, not either/or.
+
+## 2. Core idea (plain language)
+
+The camera can *calculate* exactly where the sun is in the sky right now — pure astronomy from date, time, and GPS location. What it **cannot** know on its own is which compass direction it's physically pointed; the MPU-6050 gives roll + pitch (tilt vs. gravity) but **no heading/yaw**, and there is no magnetometer in the BOM.
+
+**Sun-tap connects the two:** the operator taps the visible sun in the live camera preview. The system reasons *"the sun is really at azimuth A; you just showed me it's at pixel offset Δ from frame center; therefore the camera is pointed at A − (Δ converted to degrees)."* One tap turns "I know where the sun is" into "I know where I'm pointed." From there it draws the summer/winter sunset extremes and a "does the year fit in frame" check, and the operator nudges until framed.
+
+### Prior art / validation
+
+This is a proven approach, not an improvisation:
+- **Sunpass** (Applied Optics, 2022, doi:10.1364/AO.61.001398): camera-based sun-tap heading with accelerometer tilt, **no magnetometer** — **0.5° raw accuracy, 0.06° calibrated.** We need only a few degrees for aiming.
+- **PhotoPills "visual calibration"**: align the virtual sun to the real sun, store an azimuth offset — sun-tap with a swipe instead of a tap.
+- **Compass-free is the correct call, not a compromise.** Phone magnetometers are ±25° worst-case and worse near metal (e.g., the camera enclosure); every field app bolts a manual sun/landmark correction on top. We skip the unreliable compass and go straight to the reliable correction.
+
+## 3. Goals
+
+1. **Instant heading from one sun-tap** — accurate enough to aim (±a few degrees) the moment the sun is visible, no waiting.
+2. **A live aiming overlay** that shows, on the Pi's camera feed: the horizon, today's sun path, the summer/winter solstice sunset extremes, the current sun, and a "does the whole year fit in this frame" check.
+3. **One shared visual language** across all sunrise *and* sunset cams, parameterized by phase (§5.2).
+4. **Honest confidence** — the overlay never draws a heading it doesn't actually have (§5.4). This is the design rule derived from the gyro silent-zeros bug.
+5. **Phone-first, no app** — served as a mobile web page reachable over the LAN; the operator opens a URL and taps.
+6. **High-latitude help** — when the annual sunset arc is wider than the lens FOV, guide the operator to the best compromise aim rather than just failing (§5.6).
+7. **Stays compatible with v0.3** — sun-tap produces the same heading artifact auto-calibration would; auto-calibration (when later implemented) refines and self-heals it.
+
+## 4. Non-goals (explicitly deferred)
+
+- **Implementing v0.3's full auto-calibration pipeline** (`detect_sun`, `pose_solver` over N observations, drift via residuals, lens-intrinsics bench calibration, OpenCV, skyfield-precise, the Subproject-B clock-drift hard-blocker). v0.4 ships the instant fast path first; auto-cal is the precise fallback layer, built later. (Per the "validate output before optimizing" learning: prove the instant aim feels right before investing in the heavy precise pipeline.)
+- **The commissioning↔field-setup state machine** — "Pi boots into setup mode until aimed, then flips to capture mode," WiFi onboarding, and the **AP-mode hotspot** for setup before the Pi has WiFi. Its own sub-project (spec E territory).
+- **The relocation/recommission workflow** — moving a unit to a new location and re-aiming. Rides on the same field-setup sub-project. (Open question: where location lives — §9.)
+- **Motorized auto-pan** that physically tracks the migrating sunset. A future hardware sub-project (motor, mount, control).
+
+## 5. Design
+
+### 5.1 What already exists vs. what's new
+
+**Reuse (built, tested):**
+- `solstice_math.py` — `sunset_azimuth_for_day`, `az_to_pixel`, `count_sunsets_in_fov`.
+- `setup_alignment.py` renderers — `render_align_page`, `render_orientation_json`, `stream_mjpeg` (renderers only; no server).
+- `gyro_driver.py` — `read_orientation`, plus `wake()` / `make_orientation_reader()` (PR #4) so the IMU is never read asleep.
+- `orientation_sampler.py` — background roll/pitch sampler.
+
+**New in v0.4:**
+- A heading model + sun-tap math (`heading.py`): tap pixel + computed sun azimuth + IMU roll/pitch → device heading; plus the confidence state.
+- The phase-parameterized overlay updates to `render_align_page`.
+- FOV-fit + high-latitude compromise logic (extends `count_sunsets_in_fov`).
+- `setup_server.py` — the HTTP server wiring it all together (§5.7).
+- A minimal sun-position function (`compute_sun_azimuth(lat, lng, t_utc)`) — for the fast path this can use a lightweight algorithm (NOAA/Spencer, already partly in `solstice_math`) rather than v0.3's full skyfield ephemeris, since rough aim tolerates ~1° error.
+
+### 5.2 Shared visual language (canonical, phase-parameterized)
+
+One legend, used by every sunrise and sunset cam, and reusable in the product (map/galleries):
+
+| Element | Style | Meaning |
+|---|---|---|
+| Horizon | thick **white** solid line | true level (from the accelerometer) |
+| Today's path | **yellow** bold arc | the sun's path today |
+| Golden hour | **orange** band where the arc nears the horizon | the money window |
+| Summer solstice | **red** dashed | northern extreme of the sunset/sunrise position |
+| Winter solstice | **cyan** dashed | southern extreme |
+| Current sun | filled **yellow** dot on the arc | live sun position |
+| FOV fit | vertical edge bars — **green** = fits, **red** = clipped | does the whole year fit in frame |
+| Up reference | white **↑ UP** | housing-up direction |
+
+**Phase just mirrors it.** Sunset cam faces **west** (~270°): arcs descend to the horizon, summer extreme to the NW, winter to the SW. Sunrise cam faces **east** (~90°): arcs ascend from the horizon, summer extreme NE, winter SE. Identical legend, flipped by direction; a `phase` parameter drives the whole thing.
+
+The **horizon line is a first-class element**: it's what the operator aligns to the real visible horizon (confirms level + pitch), it's the baseline the solstice arcs cross (so sunset points sit *on* it), and it anchors the overlay. If terrain (hills/trees) rises above true level, the gap between the white line and the visible skyline shows how much horizon is lost (the sun actually vanishes at the terrain line).
+
+### 5.3 The aiming overlay
+
+Drawn on the live MJPEG preview (ASCII sketch — sunset/west example):
+
+```
+┌─ HUD ──────────────────────────────────────────────────────┐
+│ roll 0.3°  pitch 1.1°   ● LEVEL    focus ✓   heading: TAPPED │
+├────────────────────────────────────────────────────────────┤
+│   ‖FOV edge                                      FOV edge‖   │ green when both
+│   ‖              ☀ (today's sun, yellow)                ‖   │ solstices inside
+│   ‖     ╱‾‾‾‾‾‾‾‾(yellow arc, orange near horizon)‾‾╲    ‖   │
+│ ══╪═══┊═══════════════════════════════════════════┊══╪═══   │ thick white horizon
+│   ‖   ┊ winter SS (cyan dashed)        summer SS  ┊  ‖  ↑UP  │
+│   ‖   233°·Dec21                          307°·Jun21 ‖       │
+│  Before tap: "Point at the sun and tap it to set heading"    │
+│  After tap:  "Aimed 268°W · both solstices in frame ✓"       │
+└────────────────────────────────────────────────────────────┘
+```
+
+Flow: **level it** (accelerometer badge greens) → **tap the sun** → heading anchors → solstice arcs + FOV check appear → **nudge** until both dashed arcs sit inside the green FOV edges → done.
+
+### 5.4 Heading-confidence model (the silent-fake-signal guard)
+
+Heading has three honest states. The overlay must never present a better state than it's in — this is the architectural form of the gyro silent-zeros lesson (a wrong-but-confident overlay is the same failure class).
+
+| State | When | Overlay shows |
+|---|---|---|
+| **Uncalibrated** | No sun-tap yet, or sun not visible | Level badge + horizon + "tap the sun" prompt. **No solstice arcs, no FOV check** — nothing speculative. |
+| **Tapped** | Operator tapped the sun | Full overlay live. Badge `heading: TAPPED 268°W`. |
+| **Suspect** | roll/pitch has drifted from their values at tap-time (housing moved), or a second tap disagrees with the first | Overlay dims, badge `heading: re-tap`. Triggers the **move/drift notification**. |
+
+The suspect→notification path is the stability feature: if the camera is bumped or re-aimed, the system flags it and asks for a re-tap rather than silently rendering stale geometry.
+
+### 5.5 Sun-tap math
+
+```
+heading_deg = sun_azimuth_deg − pixel_offset_to_angle(tap_px_x)
+```
+
+- `sun_azimuth_deg = compute_sun_azimuth(lat, lng, now_utc)` — sun's true azimuth.
+- `pixel_offset_to_angle(px_x)`: horizontal angle of the tapped pixel from frame center, from the known HFOV: `((px_x − width/2) / width) × HFOV` (pinhole approximation — adequate for rough aim; lens-distortion-corrected intrinsics are a v0.3-grade refinement, not needed here).
+- IMU **roll/pitch** level the frame so the horizontal pixel axis maps cleanly to azimuth; a large tilt at tap-time is rejected ("level the camera first").
+- One tap suffices to aim. A **second tap** on a later sun position tightens the estimate and doubles as a sanity check — if the two headings disagree by more than a few degrees → **suspect** state.
+
+### 5.6 FOV-fit and high-latitude nudge
+
+The fit check solves: does the full-year sunset arc fit the lens FOV at this latitude? The arc half-width is `arcsin(sin 23.44° / cos[lat])`; it fits when `2 × that ≤ usable FOV`. Equivalently, a lens of horizontal FOV H covers latitudes up to `arccos(sin 23.44° / sin(H/2))` (with ~5° per-side margin recommended so extremes avoid the distorted edges):
+
+| Usable HFOV | Comfortable latitude limit |
+|---|---|
+| 90° | ~52° |
+| 100° | ~56° |
+| ~102° (Arducam Wide; "120°" is *diagonal*) | ~57° |
+
+Behavior when it **doesn't** fit (high latitude):
+1. **Compromise aim (in scope):** instead of "clipped," show the single fixed aim that captures the most sunsets/year (reuses `count_sunsets_in_fov`): *"can't fit the whole year — best aim captures 280/365, point here ←."*
+2. **Seasonal nudge guidance (designed, served by notifications):** *"nudge ~8° south for winter"* a few times a year as the sunset migrates — manual re-aim, guided, riding the same notification channel as drift.
+3. **Motorized auto-pan:** deferred (§4).
+
+### 5.7 Setup-server
+
+A stdlib `ThreadingHTTPServer` (no Flask — preserve the firmware's two-dependency footprint), one module `setup_server.py`. Threaded because the long-lived MJPEG stream must not block the overlay's `state.json` polling.
+
+| Route | Serves |
+|---|---|
+| `GET /` | the aiming page (`render_align_page`, phase-parameterized) |
+| `GET /setup/preview.mjpg` | live MJPEG (`stream_mjpeg`), rate-limited; a lock serializes camera access |
+| `GET /setup/orientation.json` | live roll/pitch (gyro via `make_orientation_reader` — woken) |
+| `POST /setup/tap` | `{pixel_x, pixel_y}` → compute + store heading → returns heading + fit result |
+| `GET /setup/state.json` | heading state (uncalibrated/tapped/suspect) + aim + fit, polled by the overlay |
+
+- **Camera arbitration:** the camera is a singleton (picamera2) — the setup-server and the capture/upload service are **mutually exclusive by mode**: setup-server owns the camera while aiming; capture owns it during sunset windows. If the camera is busy, `preview.mjpg` returns **503** with a clear message rather than hanging.
+- **Auto-run seam:** the full "boot into setup mode → flip to capture mode when aimed" state machine is the deferred field sub-project (§4). For the **cam1 prototype**, the setup-server is a runnable unit mutually exclusive with capture — enough to prototype the aiming, with auto-mode-switching as the clean follow-on seam.
+- **Testable without a Pi:** `run()` takes an injectable `frame_source` and `reader`, so route dispatch, content-types, and the tap math are unit-tested with fakes; the hardware path is just the default wiring.
+
+### 5.8 Phone-first client
+
+- Served as a mobile web page at the Pi's LAN address (e.g. `http://sunset-cam-1.local:8080`). **No app to install** — open a URL (aligns with the non-technical-recipient streamlined-deployment goal).
+- `render_align_page` is already responsive (`<meta viewport>`). Design the tap as a **touch event** (handle pointer/touch, not just mouse); the MJPEG scales to the phone viewport with the overlay aligned to it.
+- **Important:** the phone shows the **Pi's** camera feed, not the phone's camera — the operator taps the sun *as the Pi sees it*, because we calibrate the **Pi's** heading.
+- **Connectivity:** works when phone + Pi share a WiFi. Cam1 prototype: home WiFi → the Pi's address. The "before the Pi has WiFi" case (a recipient's house) needs the Pi to host an **AP-mode hotspot** — deferred field sub-project (§4).
+
+## 6. Testing
+
+TDD throughout. Unit tests need no hardware (injected `frame_source`/`reader`):
+- `pixel_offset_to_angle(px, width, hfov)` — center → 0°, right edge → +HFOV/2, left edge → −HFOV/2.
+- `compute_sun_azimuth(lat, lng, t_utc)` — cross-check a known value against NOAA Solar Calculator.
+- Sun-tap heading: synthetic tap pixel + known sun azimuth + known tilt → recovers the expected heading.
+- Confidence transitions: no tap → uncalibrated (no arcs); tap → tapped; tilt-drift or disagreeing second tap → suspect.
+- FOV-fit + latitude limits: known latitude/HFOV pairs → fits/clips as computed; compromise aim returns the max-sunset azimuth.
+- setup-server route dispatch: correct status/content-type for each route with a fake frame source; `POST /setup/tap` returns a heading; busy camera → 503.
+
+Hardware-gated (manual, on cam1): tap the real sun on the phone preview; verify the computed heading matches reality; verify solstice arcs + FOV check render; bump the camera → suspect/notification fires.
+
+## 7. Design rules carried from compound learnings
+
+- **No silent fake signal** → the heading-confidence model (§5.4): draw nothing speculative; degrade honestly to "re-tap." (From the MPU6050 fake-zeros bug.)
+- **Validate output before optimizing** → ship the lean sun-tap fast path and prove the aim feels right on cam1 *before* building v0.3's heavy precise pipeline. (Today's learning.)
+- **Don't trust "addressable" as "working"** → the tap flow surfaces the actual computed heading for the operator to visually confirm against the real sun, rather than asserting correctness silently.
+
+## 8. Relationship to v0.3
+
+v0.4 **amends** v0.3; it does not replace it. v0.3's auto-calibration becomes the **precise, self-healing fallback layer** built later: it refines the sun-tap heading over clear sunsets, and detects drift independent of the operator. The heading artifact is shared — sun-tap writes an initial heading; auto-cal (when implemented) refines the same record. v0.3's focus-verification, camera-source abstraction, and heartbeat provenance fields remain valid and unaffected.
+
+## 9. Open questions
+
+1. **Lens FOV choice** — image drama (narrower ~90–100°, sun fills the frame, less edge distortion) vs. one-SKU-everywhere coverage (wider ~102°+). The aiming tool is FOV-parameterized and warns on clip, so a narrower lens is *safe* to choose per-latitude. Jesse investigating Arducam options. (Decide deliberately; does not block this spec.)
+2. **Where does location (lat/lng) live, especially on relocation?** Today it's set in the cloud camera record at `tier0-create-camera.sh` time and is *not* in the Pi config; the setup-server overlay needs it (flag or fetched). Relocation = update location + re-aim. Resolve in the field-setup sub-project.
+3. **Clock-accuracy tolerance for sun-tap.** Sun azimuth drifts ~0.25°/minute of clock error. Rough aim tolerates a few minutes of skew, so sun-tap likely does **not** inherit v0.3's hard Subproject-B blocker — confirm the tolerance and document it.
+
+## 10. Implementation slice order (cam1 prototype)
+
+1. `compute_sun_azimuth(lat, lng, t_utc)` (lightweight) + tests vs. NOAA.
+2. `pixel_offset_to_angle` + the sun-tap heading function + tests.
+3. Heading state model (uncalibrated/tapped/suspect) + tests.
+4. FOV-fit + compromise-aim extension to `solstice_math` + tests.
+5. Overlay updates to `render_align_page`: phase parameter, confidence-gated arcs, FOV-fit bars, horizon line, touch tap handler + tests.
+6. `setup_server.py` (ThreadingHTTPServer, the five routes, camera lock, injectable deps) + route tests.
+7. Wire on cam1: run the setup-server (capture stopped), open on phone, tap the sun, verify the aim — the hardware-gated validation.
+
+## 11. Sources / precedent
+
+- Sunpass solar compass — Applied Optics 2022 (doi:10.1364/AO.61.001398): camera+accelerometer sun-tap heading, no magnetometer, 0.5°/0.06°.
+- PhotoPills visual calibration (swipe-to-align azimuth offset); arc color encoding (yellow/orange/purple twilight).
+- Sun Seeker (solstice color convention: summer red / today yellow / winter cyan; gyro-only + landmark-drag modes).
+- Sun Surveyor, Helios Pro (ARKit), Shadowmap, Cadrage — AR sun-path + FOV-framing conventions.
+- Magnetometer accuracy caveats (±25° worst-case; interference) — motivates compass-free sun-tap.

--- a/docs/superpowers/specs/2026-06-07-pi-deployment-aiming-integration-design.md
+++ b/docs/superpowers/specs/2026-06-07-pi-deployment-aiming-integration-design.md
@@ -1,0 +1,150 @@
+# Pi Deployment Integration — Auto-Running v0.4 Aiming in the Setup Flow
+
+Status: Draft v0.1 — 2026-06-07
+Owner: Jesse Kauppila
+The glue between sub-project **E** (WiFi onboarding + provisioning, `2026-05-15-wifi-onboarding-and-provisioning-design.md`) and the now-built **v0.4 sun-tap aiming** (`2026-06-07-pi-alignment-v0.4-sun-tap-aiming-design.md`, which fulfills and exceeds sub-project **C**). Amends E.
+
+---
+
+## 1. Problem
+
+E was written 2026-05-15, before v0.3/v0.4 existed. Three concrete gaps now block the end-to-end deploy:
+
+1. **No AIMING state.** E's state machine goes BOOT → SETUP → ONLINE → IDLE → ACTIVE. It assumes *placement is delivered down from the cloud* (operator pre-register or wizard). But v0.4 *produces* the aim **on the device** when the recipient taps the sun. There is no state where the v0.4 aiming tool runs, and no "auto-launch it" path — so the recipient would still need a typed command, which defeats the goal.
+2. **E §5.5's alignment integration is stale.** It wires the old v0.2 routes (`render_align_page`/`stream_mjpeg`/`render_orientation_json`) as three separate registrations and contradicts itself: it says the setup service *exits* after WiFi joins, yet that same service hosts the aiming page, which is used *after* WiFi joins. It knows nothing of the built `setup_server.py`, `/setup/tap`, `HeadingState`, or `fov_fit`.
+3. **The location↔aim chicken-and-egg.** The v0.4 overlay needs **lat/lng** to draw the sun — but aiming is what *produces* the placement. The order and data-flow were never pinned down.
+
+## 2. Goals
+
+1. The v0.4 aiming tool **launches automatically** at the right moment in the deploy — no typed command for the recipient (or the operator).
+2. Pin the **location↔aim split**: location comes *down* from the cloud wizard; the *aim* (azimuth/tilt) is produced *up* by on-device sun-tap. Placement = location + aim.
+3. The recipient can **commit the aim** from the aiming page, and the device then transitions itself to capturing.
+4. A unit can be **relocated** (re-aimed at a new spot) without re-flashing.
+5. Supersede E §5.5 with the real v0.4 `setup_server` wiring.
+
+## 3. Non-goals (covered elsewhere / deferred)
+
+- **The captive portal / AP-mode / WiFi-credential intake / SD provisioning** — E owns these unchanged.
+- **The cloud wizard's internal screens** (collecting lat/lng, delivery prefs) — sub-project F.
+- **First-image verification UX** — sub-project G.
+- **AI placement-quality checks** — sub-project D.
+- **v0.3 auto-calibration** (the precise self-healing fallback) — separate, later.
+- **New-WiFi reprovision implementation** — designed at the seam here (§5.6) but built later; same-WiFi re-aim is in scope.
+
+## 4. Relationship to existing specs
+
+- **E** (`2026-05-15-wifi-onboarding...`): this spec amends E's §5.3 state machine (adds AIMING) and replaces E's §5.5 alignment integration. Everything else in E stands.
+- **v0.4** (`2026-06-07-pi-alignment-v0.4-sun-tap...`): built and on firmware branch `feat/v0.4-sun-tap-aiming`. This spec adds **one endpoint** (`POST /setup/confirm`) and makes the launcher **config-driven** instead of CLI-flag-driven.
+- **C**: considered fulfilled by v0.4 (which exceeds the original roll-only orientation scope).
+- **F**: consumes the handoff contract defined here (deep-link to the device aiming page; collect location; poll placement status).
+
+## 5. Design
+
+### 5.1 The three-mode architecture + the AIMING state
+
+The device has three mutually-exclusive-where-they-share-the-camera modes, each a systemd unit:
+
+| Mode | Service | Camera | Network | Purpose |
+|---|---|---|---|---|
+| **SETUP** | `sunset-cam-setup` (E) | no | own AP | collect WiFi creds (captive portal) |
+| **AIMING** | `sunset-cam-aiming` (**new**) | **yes** | home WiFi | run `setup_server.py`; recipient sun-taps + confirms |
+| **ACTIVE** | `sunset-cam` | **yes** | home WiFi | capture loop |
+
+`sunset-cam-aiming.service` declares `Conflicts=sunset-cam.service` (and vice versa) so the camera is never double-claimed — the deployment-side enforcement of v0.4's camera-arbitration requirement. SETUP needs no camera, so it doesn't conflict on that resource (it already conflicts with ACTIVE in E for process-coordination reasons).
+
+Updated state machine (replaces E §5.3's tail end):
+
+```
+... ONLINE --/register--> placement_status?
+      "awaiting_location"  -> IDLE  (heartbeat; wait for lat/lng)
+      "awaiting_aim"       -> AIMING (auto-launch sunset-cam-aiming)
+      "ready"              -> ACTIVE (operator pre-set everything; legacy)
+
+IDLE --lat/lng arrives via heartbeat--> AIMING
+AIMING --recipient confirms aim (POST /setup/confirm)--> ACTIVE
+ACTIVE --cloud "reaim" command (heartbeat)--> AIMING        (relocation, same WiFi)
+ACTIVE --cloud "reprovision" command (heartbeat)--> SETUP   (relocation, new WiFi; §5.6)
+```
+
+A small supervisor (extending E's slice-4 state machine) owns these transitions: it starts/stops `sunset-cam-aiming` vs `sunset-cam` based on the placement status it learns from register/heartbeat. **No recipient command** — entering AIMING is automatic once location is known.
+
+### 5.2 The location↔aim split (resolves the chicken-and-egg)
+
+The key reframe E missed: **placement has two halves with opposite data-flow directions.**
+
+- **Location (lat/lng): flows DOWN.** Collected by the cloud wizard (phone GPS or zip), sent via `pre-register`, delivered to the device in the `register`/heartbeat response. Needed *before* aiming so the overlay can compute the sun.
+- **Aim (azimuth_deg, tilt_deg): flows UP.** Produced on-device by the recipient's sun-tap (azimuth = the anchored heading; tilt from the gyro pitch). Reported to the cloud on confirm.
+
+`placement_status` gains an explicit progression:
+`awaiting_location` (no lat/lng) → `awaiting_aim` (lat/lng known, not yet aimed) → `ready` (aimed). The device maps these to IDLE / AIMING / ACTIVE.
+
+### 5.3 Sun-tap result → placement (the one v0.4 addition)
+
+`setup_server.py` currently *shows* the aim but never *commits* it. Add:
+
+- **`POST /setup/confirm`** on the `AimingService`: requires the current state is `tapped` (not uncalibrated/suspect — the confidence gate applies here too). It finalizes `{azimuth_deg: heading_deg, tilt_deg: <from pitch>, roll_deg, confirmed_at}`, writes it to the device config, reports it to the cloud (§6), and signals the supervisor to transition AIMING → ACTIVE. Returns `{status: "confirmed", placement: {...}}` or `409` if not in `tapped` state.
+- A **"Confirm aim"** button on the aiming page, enabled only while the heading badge shows `tapped` (hidden in uncalibrated/suspect — same silent-fake-signal guard).
+
+### 5.4 The aiming launcher — config-driven
+
+In deployment, lat/lng comes from the device config (delivered by the cloud), not a CLI flag. So `sunset-cam-aiming.service`'s `ExecStart` runs a config-reading entrypoint (evolve `run-setup-server.py` to read `lat`/`lng`/`phase`/`hfov`/`width` from the device config when flags are absent). The CLI flags remain for bench use (cam1 prototype); config is the default in the field.
+
+### 5.5 Reaching the aiming page
+
+After WiFi join the recipient's phone is back on home WiFi; the cloud wizard must deep-link them to the device's *local* aiming page. The device reports its **local IP** (and relies on the mDNS name `sunset-cam-XXXX.local`) in its heartbeat; the cloud wizard links the phone to `http://<local-ip-or-mdns>:8080/`. (mDNS is the friendlier primary; local-IP is the fallback when mDNS is flaky on the recipient's network.)
+
+### 5.6 Relocation
+
+- **Same WiFi, new spot (in scope):** the cloud sends a `reaim` directive (+ new lat/lng) in a heartbeat response; the supervisor transitions ACTIVE → AIMING with the new location; recipient re-aims and confirms → ACTIVE. It is literally re-entering AIMING — no new machinery beyond the directive.
+- **New WiFi (seam, build later):** a `reprovision` directive transitions ACTIVE → SETUP (wipes creds, re-enters the captive portal), then the normal flow resumes through AIMING. Designed here; implementation deferred.
+
+### 5.7 Supersede E §5.5
+
+E §5.5's "must register three routes from `sunset_cam.setup_alignment`" is replaced by: **the setup web app for placement is the v0.4 `setup_server.AimingService`**, mounted by `sunset-cam-aiming.service`, which already serves `/`, `/setup/preview.mjpg`, `/setup/orientation.json`, `/setup/state.json`, `POST /setup/tap`, and (new) `POST /setup/confirm`. E's captive-portal Flask app (the WiFi form) is unaffected — it's a different service in a different state.
+
+## 6. Protocol amendments (extends E §5.4 and `device-protocol.md`)
+
+- **`register`/heartbeat response carries `lat`/`lng`** when known, alongside `placement_status` ∈ {`awaiting_location`, `awaiting_aim`, `ready`}.
+- **New device→cloud call: `POST /api/cameras/:id/placement`** — body `{azimuth_deg, tilt_deg, roll_deg, confirmed_at}`. Sets the camera's placement and flips its status to `ready`. (Alternatively fold into heartbeat; a dedicated call is clearer for the confirm moment.)
+- **Heartbeat response may carry a directive:** `{reaim: {lat, lng}}` or `{reprovision: true}` for relocation.
+- **Heartbeat request carries `local_ip`** so the wizard can deep-link the phone to the aiming page.
+- `setup-status/:claim_code` (E's wizard-poll endpoint) gains the `awaiting_aim` state.
+
+## 7. Testing
+
+Device-side, mockable on a laptop (the v0.4 modules already inject fakes):
+- Supervisor transitions: feed synthetic statuses (`awaiting_location`→IDLE, `awaiting_aim`→starts aiming service, confirm→stops aiming/starts capture, `reaim`→back to aiming). Assert which service it would start/stop (mock systemctl).
+- `POST /setup/confirm`: in `tapped` state → returns confirmed placement with `azimuth_deg == heading_deg`; in uncalibrated/suspect → `409`.
+- Config-driven launcher: with lat/lng in config and no flags → builds the AimingService with config values.
+
+Cloud-side:
+- `register`/heartbeat returns `lat`/`lng` + correct `placement_status` across the three states.
+- `POST /api/cameras/:id/placement` sets placement and flips status to `ready`.
+- `setup-status` reports `awaiting_aim` when location is set but aim isn't.
+
+Integration (on cam1 / a bench unit): drive the full IDLE→AIMING→confirm→ACTIVE locally with a mock cloud, then the relocation `reaim` round-trip.
+
+## 8. Risks
+
+- **Recipient closes the wizard mid-aim.** The device sits in AIMING (serving the page) indefinitely; heartbeat keeps reporting `awaiting_aim`. The wizard can be reopened via the sticker QR. No data loss.
+- **mDNS unreachable on the recipient's network** (AP isolation, some routers). Mitigation: fall back to the reported local IP; the wizard shows both.
+- **Camera contention if the supervisor mis-sequences.** The `Conflicts=` systemd directives are the hard backstop — even a supervisor bug can't double-claim the camera.
+- **A bad aim confirmed.** v0.4's drift/suspect handling + the cloud's first-image (sub-project G) catch a wrong aim; and `reaim` makes re-doing it cheap.
+
+## 9. Open questions
+
+1. **Tilt from pitch — sign/convention.** `tilt_deg` from gyro pitch needs the same care as the heading sign; pin with a test during implementation.
+2. **Does confirm require level?** Probably yes — only allow confirm when roll/pitch are within the level tolerance (reuse `HeadingState`'s `level_tol`). Decide during impl.
+3. **Where the device persists placement** — the existing config.json vs a separate `placement.json`. Lean toward a separate file so capture config and placement evolve independently.
+4. Carried from v0.4: lens FOV choice (affects `hfov` in config); clock tolerance for sun-tap.
+
+## 10. Implementation slice order
+
+1. v0.4 firmware: `POST /setup/confirm` + the "Confirm aim" button (TDD). Smallest, unblocks the rest.
+2. v0.4 firmware: config-driven launcher (lat/lng from config when flags absent).
+3. Cloud: `placement_status` three-state + `lat`/`lng` in register/heartbeat + `POST /api/cameras/:id/placement` + `setup-status` `awaiting_aim` (TDD).
+4. Firmware: the supervisor/state-machine AIMING branch (start/stop `sunset-cam-aiming` vs `sunset-cam` by status; mock systemctl in tests). Extends E's slice-4 state machine.
+5. Systemd: `sunset-cam-aiming.service` with `Conflicts=sunset-cam.service`, config-driven ExecStart.
+6. Heartbeat `local_ip` + the `reaim` directive (same-WiFi relocation).
+7. Integration smoke on a bench unit (mock cloud): IDLE→AIMING→confirm→ACTIVE, then `reaim`.
+8. Update E §5.3/§5.5 inline and `device-protocol.md` with the amendments. Hand the deep-link + status contract to sub-project F.


### PR DESCRIPTION
Design docs from the Pi aiming + deployment work (docs only — no code):

- `specs/2026-06-07-pi-alignment-v0.4-sun-tap-aiming-design.md` — the sun-tap instant-aiming design
- `specs/2026-06-07-pi-deployment-aiming-integration-design.md` — the v0.4↔E/F deployment glue (AIMING state, location-down/aim-up split, confirm, relocation)
- `plans/2026-06-07-pi-alignment-v0.4-sun-tap-aiming.md` — v0.4 implementation plan (shipped on `feat/v0.4-sun-tap-aiming`)
- `plans/2026-06-07-pi-deployment-aiming-integration-firmware.md` — firmware slices (shipped on `feat/deploy-aiming-firmware`)
- `plans/2026-06-07-pi-deployment-aiming-integration-cloud.md` — cloud slices (shipped on `feat/deploy-aiming-cloud`, PR #52)
- `hardware/2026-06-07-cam1-validated-aiming-design-checkpoint.md` — resume checkpoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)