### PR TITLE
build(vercel): pin ONNX tracing to v4 dirs so the binary head fits under 250MB

### DIFF
--- a/next.config.test.ts
+++ b/next.config.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import nextConfig from './next.config';
+
+/**
+ * Guard the Vercel function bundle size. onnxruntime-node + sharp + the
+ * Next framework already put us near Vercel's 250 MB function limit (see
+ * docs/ml-deploy-runbook.md "Trap 4" and memory/feedback_vercel_nextjs_ml_bundling).
+ *
+ * Each ResNet-18 ONNX is ~43 MB. We keep BOTH v2 and v4 versions committed in
+ * git for rollback-via-re-export, but the live serverless functions only ever
+ * load the v4 pair. So `outputFileTracingIncludes` must pin to the specific v4
+ * version dirs — a recursive glob over `regression_resnet18`/`binary_resnet18`
+ * sweeps the v2 files in too (+86 MB) and pushes the bundle over the limit when
+ * the binary head is enabled.
+ *
+ * This test fails the build if anyone re-broadens the globs or bundles v2.
+ */
+
+const MODEL_ROUTES = ['/api/cron/update-cameras', '/api/debug/scoring-smoke'];
+// v4 regression (43M) + v4 binary (43M) = 86M. The threshold sits above that
+// but well below the 172M you'd get if a v2 model crept back in.
+const MAX_BUNDLED_MODEL_BYTES = 120 * 1024 * 1024;
+
+function patternDir(pattern: string): string {
+  // Patterns look like './ml/artifacts/models/<type>/<version>/**/*'.
+  return pattern.replace(/\/\*\*\/\*$/, '').replace(/^\.\//, '');
+}
+
+describe('next.config outputFileTracingIncludes (bundle-size guard)', () => {
+  const includes = nextConfig.outputFileTracingIncludes ?? {};
+
+  it('configures model tracing for both ONNX routes', () => {
+    for (const route of MODEL_ROUTES) {
+      expect(includes[route], `missing tracing includes for ${route}`).toBeDefined();
+    }
+  });
+
+  it('pins each include to a real v4 version dir (never v2, never a whole-type glob)', () => {
+    for (const route of MODEL_ROUTES) {
+      for (const pattern of includes[route] ?? []) {
+        const dir = patternDir(pattern);
+        // Must point at a specific version dir, not the model-type parent.
+        expect(/v4/.test(dir), `pattern is not pinned to a v4 dir: ${pattern}`).toBe(true);
+        expect(/v2/.test(dir), `pattern bundles a v2 model: ${pattern}`).toBe(false);
+        // The pinned dir + its model.onnx must actually exist on disk.
+        expect(fs.existsSync(dir), `pinned dir does not exist: ${dir}`).toBe(true);
+        expect(
+          fs.existsSync(path.join(dir, 'model.onnx')),
+          `no model.onnx under pinned dir: ${dir}`,
+        ).toBe(true);
+      }
+    }
+  });
+
+  it('keeps total bundled model weight under the size budget', () => {
+    const seen = new Set<string>();
+    let total = 0;
+    for (const route of MODEL_ROUTES) {
+      for (const pattern of includes[route] ?? []) {
+        const file = path.join(patternDir(pattern), 'model.onnx');
+        if (seen.has(file)) continue;
+        seen.add(file);
+        total += fs.statSync(file).size;
+      }
+    }
+    expect(total).toBeLessThan(MAX_BUNDLED_MODEL_BYTES);
+  });
+});

--- a/next.config.ts
+++ b/next.config.ts
@@ -35,14 +35,23 @@ const nextConfig: NextConfig = {
   // /var/task/ml/artifacts/models/...). Switch to Next's own tracing
   // includes which DO work consistently. Route keys must NOT have the
   // `.ts` suffix and must include the leading `app/` prefix.
+  //
+  // PIN to the specific v4 version dirs — do NOT glob the whole model-type
+  // folder. Both v2 and v4 ONNX stay committed in git for rollback (via
+  // re-export), but the live functions only load the v4 pair. A recursive
+  // glob would sweep the v2 files into the bundle too (+86 MB) and blow the
+  // 250 MB Vercel function limit once the binary head is enabled. See
+  // docs/ml-deploy-runbook.md "Trap 4" and next.config.test.ts (the guard).
+  // When you deploy a new model version, bump these paths AND the matching
+  // AI_ONNX_*_MODEL_PATH env vars in Vercel together.
   outputFileTracingIncludes: {
     '/api/cron/update-cameras': [
-      './ml/artifacts/models/regression_resnet18/**/*',
-      './ml/artifacts/models/binary_resnet18/**/*',
+      './ml/artifacts/models/regression_resnet18/20260513_113243_v4_regression_llm_with_flickr/**/*',
+      './ml/artifacts/models/binary_resnet18/20260601_063518_v4_binary_llm_with_flickr/**/*',
     ],
     '/api/debug/scoring-smoke': [
-      './ml/artifacts/models/regression_resnet18/**/*',
-      './ml/artifacts/models/binary_resnet18/**/*',
+      './ml/artifacts/models/regression_resnet18/20260513_113243_v4_regression_llm_with_flickr/**/*',
+      './ml/artifacts/models/binary_resnet18/20260601_063518_v4_binary_llm_with_flickr/**/*',
     ],
   },
 };


### PR DESCRIPTION
## Why
The cron + smoke functions globbed `regression_resnet18/**` and `binary_resnet18/**`, sweeping **both** the v2 and v4 ONNX (4 × ~43MB = 172MB) into each bundle. With onnxruntime-node + sharp + the Next framework that lands ~264MB — right against Vercel's 250MB function limit. Enabling the binary head live would tip it over and fail the deploy.

## What
- **Pin `next.config.ts`** `outputFileTracingIncludes` to the deployed **v4** version dirs only (regression `20260513_113243`, binary `20260601_063518`). Drops the two unused v2 models from the bundle (−86MB → ~178MB) while keeping them committed for rollback-via-re-export.
- **Add `next.config.test.ts`** — a guard that fails the build if the globs get re-broadened or a v2 model is bundled again (asserts each include pins to a real v4 dir, no v2, total model weight < 120MB).

## Test
- TDD: red (current `**` glob isn't pinned to v4 / resolves to a missing path) → green after pinning.
- Full suite: **396/396 passing**.

## Unblocks
[#50](https://github.com/jessekauppila/the-sunset-webcam-map/issues/50) — once merged + redeployed, flip in Vercel Production env:
- `AI_BINARY_SCORING_ENABLED=true`
- `AI_ONNX_BINARY_MODEL_PATH=ml/artifacts/models/binary_resnet18/20260601_063518_v4_binary_llm_with_flickr/model.onnx`
- `AI_BINARY_MODEL_VERSION=20260601_063518_v4_binary_llm_with_flickr`

Then verify via `/api/debug/scoring-smoke` (real ONNX binary = `latencyMs` ~100–500ms, not ~10–20ms baseline).

## Note
When deploying a new model version, bump the pinned paths here **and** the matching `AI_ONNX_*_MODEL_PATH` env vars in Vercel together. The guard test enforces that the pinned dirs exist on disk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)