### PR TITLE
chore(gitignore): ignore nested .next/ and .claude/worktrees/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@
 
 # next.js
 /.next/
+**/.next/
 /out/
 
 # production
@@ -45,6 +46,9 @@ next-env.d.ts
 
 # superpowers worktrees
 .worktrees/
+
+# claude worktrees (each carries its own .next/ build output)
+.claude/worktrees/
 
 # ML artifacts — surgical exclusions only.
 # Keep configs, manifests, eval reports, plots, ONNX models, meta sidecars,


### PR DESCRIPTION
Follow-up to the #23 → #55 cleanup.

#23 accidentally committed generated `.next/types/*` artifacts from a `.claude/worktrees/.../.next/` directory. They slipped past `.gitignore` because:
- the next.js rule is root-anchored (`/.next/`) so nested `.next/` dirs aren't matched, and
- only `.worktrees/` was ignored, not `.claude/worktrees/`.

This adds `**/.next/` (nested build output anywhere) and `.claude/worktrees/`. Verified with `git check-ignore` against the exact paths that polluted #23.

🤖 Generated with [Claude Code](https://claude.com/claude-code)