### PR TITLE
docs: supervisor bench runbook + stacked-branch & walking-skeleton learnings

### DIFF
--- a/docs/hardware/2026-06-08-supervisor-bench-run-runbook.md
+++ b/docs/hardware/2026-06-08-supervisor-bench-run-runbook.md
@@ -1,0 +1,70 @@
+# Device Supervisor — Current State + Bench-Run Runbook
+
+Date: 2026-06-08
+Resume anchor for the device-supervisor / deployment-integration work.
+
+---
+
+## Where we are
+
+The **device supervisor** (AIMING↔ACTIVE auto-run) is **built and deployable**, on firmware branch `feat/deploy-aiming-supervisor` (pushed). It bundles the entire device side of the deployment integration: v0.4 sun-tap aiming + `POST /setup/confirm` + the config-driven launcher + the supervisor + the gyro fix (firmware `main` merged in for `make_orientation_reader`). **83 tests green, full import chain resolves.**
+
+Pieces on the branch:
+- `heartbeat.py` — `post_heartbeat` / `parse_placement` (read `placement_status` + lat/lng from the cloud)
+- `service_control.py` — `SystemctlController.set_mode("aiming"|"capture"|"idle")` (idempotent systemctl)
+- `device_config.py` — `write_location` (merge cloud lat/lng into config.json)
+- `placement_report.py` — `post_placement` (report the confirmed aim to the cloud's `/placement`)
+- `supervisor.py` — `decide_mode` + `run_once` + `main` (the always-on brain)
+- `systemd/sunset-cam-aiming.service` (`Conflicts=sunset-cam.service`) + `systemd/sunset-cam-supervisor.service`
+
+The end-to-end chain is wired: supervisor heartbeats → `awaiting_aim` → writes lat/lng + starts aiming → phone tap + **Confirm** → `/setup/confirm` → `post_placement` to the cloud → cloud flips to `ready` → supervisor stops aiming, starts capture.
+
+## What's next: the BENCH END-TO-END RUN (the walking-skeleton validation)
+
+No real sun needed — only the sun-tap *accuracy* needs a real sunset; the *plumbing* doesn't. This is the integration test that proves the green-tested pieces actually fit.
+
+### A — Deploy to cam1
+```bash
+ssh pi@sunset-cam-1.local
+cd /opt/sunset-cam && sudo git fetch origin && sudo git checkout feat/deploy-aiming-supervisor && sudo git pull
+sudo cp systemd/sunset-cam-aiming.service systemd/sunset-cam-supervisor.service /etc/systemd/system/
+sudo systemctl daemon-reload
+sudo systemctl stop sunset-cam      # let the supervisor own it
+```
+
+### B — Start the supervisor and watch
+```bash
+sudo systemctl start sunset-cam-supervisor
+journalctl -u sunset-cam-supervisor -f
+```
+Expect: `supervisor up; camera_id=4` → then `mode=aiming` (camera 4 has lat/lng but no aim yet → `awaiting_aim`).
+
+### C — Aim from the phone
+- `http://sunset-cam-1.local:8080` (same WiFi) → live preview + overlay.
+- Tap anywhere (the sun if up; anything works for the plumbing test).
+- The **"Confirm aim"** button appears → tap it.
+
+### D — Watch the flip
+Within ~30s: `mode=capture` in the supervisor log — it saw the cloud flip to `ready`, stopped aiming, started capture. Confirm `sudo systemctl status sunset-cam` is active.
+
+**Success = the whole loop ran with no typed commands after `start`.**
+
+### Likely snags (integration — surprises live here)
+- **camera 4 not `awaiting_aim`**: if already `ready` → straight to capture (clear the aim to re-test); if `awaiting_location` → idles.
+- **`User=root` units** (aiming + supervisor) vs the existing capture unit's `User=pi` — watch journals for camera/venv permission issues as root.
+- **placement POST 401** — if camera 4's `device_token` in `config.json` doesn't match.
+
+## Branch stack + merge gating
+
+```
+firmware main (has gyro #4, install #3)
+  └─ feat/v0.4-sun-tap-aiming  (PR #5 — OPEN, gated on real-sun hardware validation)
+       └─ feat/deploy-aiming-firmware  (confirm + config launcher)
+            └─ feat/deploy-aiming-supervisor  (this — supervisor + cloud report; main merged in for gyro)
+```
+Nothing in this stack merges until **#5's real-sun hardware validation** (tap the actual sun on cam1, confirm the heading is right). The bench run validates the *plumbing*; the real sunset validates *accuracy*. Cloud side (#52) is already merged + deployed.
+
+## Related
+- Spec: `docs/superpowers/specs/2026-06-07-pi-deployment-aiming-integration-design.md`
+- Plans: `docs/superpowers/plans/2026-06-08-pi-deployment-supervisor.md`, `...-firmware.md`, `...-cloud.md`
+- Learnings: `docs/solutions/integration-issues/stacked-branch-missing-merged-dependency.md`, `docs/solutions/best-practices/walking-skeleton-over-horizontal-buildout.md`

--- a/docs/solutions/best-practices/walking-skeleton-over-horizontal-buildout.md
+++ b/docs/solutions/best-practices/walking-skeleton-over-horizontal-buildout.md
@@ -1,0 +1,51 @@
+---
+title: Build a thin end-to-end walking skeleton before fleshing out components
+date: 2026-06-08
+category: docs/solutions/best-practices
+module: engineering-process
+problem_type: best_practice
+component: development_workflow
+severity: medium
+applies_when:
+  - Building a feature that spans multiple layers/services (device + cloud, UI + API + DB)
+  - Each component is being completed and unit-tested before any end-to-end run
+  - Tempted to keep adding components because the unit suites are all green
+tags: [process, integration, walking-skeleton, thin-vertical-slice, tdd, testing]
+---
+
+# Build a thin end-to-end walking skeleton before fleshing out components
+
+## Context
+
+The sunset-cam deployment integration was built *horizontally* — each component finished and unit-tested in isolation (v0.4 aiming tool, cloud placement protocol, `/setup/confirm`, the config launcher, the device supervisor), every suite green. But the pieces had **never run together**. Reasoning about the full end-to-end path (before even deploying) surfaced a **missing wire**: `/setup/confirm` wrote the aim to a local file but **never reported it to the cloud**, so the cloud would never flip to `ready` and the supervisor would never leave aiming mode. Every unit test was green; the *seam* was unwired.
+
+## Guidance
+
+Get **one crude end-to-end path working through all the layers as early as possible** — a "walking skeleton" — before completing any single component. The integration seams (the wires *between* components) are where the real surprises live, not inside the well-specified components.
+
+Unit tests prove each piece *works*; they do **not** prove the pieces *fit*, or that the design is right. A wall of green unit tests can coexist with a system that doesn't function end-to-end.
+
+Concretely: as soon as you have rough versions of each layer, run the whole path — even with stubs, fakes, or (here) a fake sun. Find the missing/wrong wires while they're cheap. Then flesh out.
+
+## Why This Matters
+
+Horizontal build-out front-loads a tall stack of un-integrated code; the integration risk is deferred to the very end, where it's most expensive and most surprising. On this project:
+- Building the supervisor + wizard on top of an aiming flow we'd never run end-to-end meant we were piling on an *unvalidated foundation*.
+- The missing confirm→cloud wire would have made the bench run silently stall (camera never flips to capture) — invisible to every unit test, obvious the moment you trace the seam.
+
+This is the same lesson as [[validate-output-before-optimizing-pipeline]], one level up: there, validate the *artifact* before optimizing; here, validate the *integration* before building more on top.
+
+## When to Apply
+
+- Any multi-layer/multi-service feature, especially device↔cloud.
+- The moment you notice you're "completing the next component" without having run the previous ones together.
+- Before investing in components that *sit on top of* an un-run foundation.
+
+## Examples
+
+- **Green pieces, unwired seam:** `/setup/confirm` (tested: writes placement to an injected sink) + cloud `POST /placement` (tested: accepts a placement) + supervisor (tested: flips on `ready`) — all green, but nothing connected confirm to the cloud. Caught by tracing the end-to-end path, not by any unit test.
+- **The cheap fix:** run a bench end-to-end with a *fake* sun — only sun-tap *accuracy* needs a real sunset; the *plumbing* (tap → heading → confirm → cloud → mode flip) runs anytime, and exercises every seam.
+
+## Related
+- [[validate-output-before-optimizing-pipeline]] — validate the real artifact, not just proxy/green signals.
+- `../integration-issues/stacked-branch-missing-merged-dependency.md` — another seam-level bug a walking-skeleton run catches.

--- a/docs/solutions/integration-issues/stacked-branch-missing-merged-dependency.md
+++ b/docs/solutions/integration-issues/stacked-branch-missing-merged-dependency.md
@@ -1,0 +1,62 @@
+---
+title: Stacked feature branch missing a dependency that merged to main after it was cut
+date: 2026-06-08
+category: docs/solutions/integration-issues
+module: dev-workflow
+problem_type: integration_issue
+component: development_workflow
+symptoms:
+  - "A function/symbol exists on main but ImportErrors at runtime/deploy from a feature branch"
+  - "Unit tests pass because the import is in an un-exercised entrypoint (a launcher/script), not a tested module"
+  - "`git merge-base --is-ancestor origin/main <branch>` reports the branch is NOT a descendant of main"
+root_cause: incomplete_setup
+resolution_type: workflow_improvement
+severity: high
+tags: [git, branches, stacked-prs, dependencies, deploy, importerror, raspberry-pi]
+---
+
+# Stacked feature branch missing a dependency that merged to main after it was cut
+
+## Problem
+
+A feature branch cut off `main` (or off another feature branch) **before** a dependency PR merged does not contain that dependency. Everything looks fine — the code references the symbol, unit tests are green — but it `ImportError`s the moment the real entrypoint runs (deploy, or a script the tests never import). This bit the sunset-cam firmware **twice in one session**: both `feat/v0.4-sun-tap-aiming` and `feat/deploy-aiming-supervisor` referenced `make_orientation_reader` (from the gyro fix, PR #4) in `scripts/run-setup-server.py`, but were cut before #4 merged to `main` — so the launcher would have died on import on the Pi.
+
+## Symptoms
+
+- The symbol exists on `main` (`git show origin/main:path | grep 'def thing'` → found) but not on the branch (count 0).
+- `git merge-base --is-ancestor origin/main <branch>` → **not** an ancestor (main isn't merged in).
+- Unit tests pass — because the broken import lives in a **launcher/script** (`run-setup-server.py`) that the test suite never imports. A green suite hid it.
+
+## What Didn't Work
+
+- **Trusting green unit tests.** They prove the tested modules import and behave; they say nothing about an entrypoint script the suite doesn't load. The gap was invisible until someone reasoned about the deploy (or until deploy itself).
+
+## Solution
+
+Before deploying or merging a stacked branch, do two checks:
+
+1. **Resolve the real import chain**, including the entrypoints tests skip:
+   ```bash
+   python3 -c "import sys; sys.path.insert(0,'src'); \
+     from sunset_cam.gyro_driver import make_orientation_reader; \
+     from sunset_cam.setup_server import AimingService; \
+     from sunset_cam import supervisor; print('chain OK')"
+   ```
+2. **Confirm the dependency is actually present** / main is merged in:
+   ```bash
+   git merge-base --is-ancestor origin/main <branch> && echo MERGED || echo "main not in branch"
+   ```
+   If a dependency landed on main after the branch was cut, **merge it in**: `git merge origin/main --no-edit` (clean when the branch didn't touch the dependency's files).
+
+## Why This Works
+
+Stacked branches snapshot their base at cut time; later merges to that base don't propagate. The import only fails at the seam the test suite doesn't cover (the entrypoint). Explicitly exercising the entrypoint's import chain + verifying ancestry surfaces the drift before it reaches hardware.
+
+## Prevention
+
+- **Cut a branch off its actual dependency**, not off `main`, when a needed PR is still open. (Or rebase/merge the dependency in as soon as it lands.)
+- **Add an import-chain smoke check** to the pre-deploy step — `python3 -c "import <entrypoint chain>"` — so launcher-only imports are exercised even when no unit test loads them.
+- A **walking-skeleton run** (deploy + run the real entrypoint early) catches this class of bug structurally — see [[walking-skeleton-over-horizontal-buildout]].
+
+## Related Issues
+- `../integration-issues/mpu6050-reads-fake-zeros-when-asleep.md` — the gyro `wake()`/`make_orientation_reader` fix (PR #4) that was the missing dependency here.


### PR DESCRIPTION
Saves where the device-supervisor work stands + the cam1 bench-run runbook, and folds in two compound learnings: stacked-branch dependency drift (the gyro-import bug that bit twice) and walking-skeleton-over-horizontal-buildout (the missing confirm→cloud wire). Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)