### PR TITLE
docs(spec): QR label + shippable-unit hardening (read-only root + log-shipping)

### DIFF
--- a/docs/superpowers/plans/2026-06-09-qr-label-generator.md
+++ b/docs/superpowers/plans/2026-06-09-qr-label-generator.md
@@ -1,0 +1,252 @@
+# QR Label Generator (Slice 1) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Generate a print-ready PNG label for a camera — a scannable QR to `…/setup/{claim_code}` plus human-readable name/URL/claim-code — sized for Nelko P21 14×75mm tape, from a claim code + camera name.
+
+**Architecture:** A pure-ish generation module in the Next.js app (`app/lib/labelGenerator.ts`) using the existing `sharp` + a new `qrcode` dep, driven by a thin CLI (`scripts/generate-label.mjs`). Pure helpers (URL, mm→px) are unit-tested; the compositor is tested for output format/size. A later follow-on (slice 1b) wraps the same module in an owner-gated admin page for live preview — this plan ships the testable core first.
+
+**Tech Stack:** TypeScript, `sharp` (already a dep), `qrcode` (add), `vitest` (`// @vitest-environment node`).
+
+## Scope
+
+Slice 1 of `docs/superpowers/specs/2026-06-08-qr-label-and-shippable-unit-hardening-design.md` §4.1 — the label-generation core + CLI. **Not here:** the admin-page live preview (slice 1b, follow-on — thin wrapper over this module); read-only root (slice 2); cloud log-shipping (slice 3). Each is its own plan.
+
+## Working location
+
+`the-sunset-webcam-map` on branch `feat/qr-label-generator` off `origin/main`. Worktree, `npm install` (or symlink `node_modules`) so `sharp`/`vitest` run. Confirm the branch before each commit. Tests: `npx vitest run <path>`.
+
+## File Structure
+
+| File | Responsibility | New/Modify |
+|---|---|---|
+| `app/lib/labelGenerator.ts` | `buildSetupUrl`, `labelDimensionsPx`, `generateLabelPng` | Create |
+| `app/lib/labelGenerator.test.ts` | unit tests | Create |
+| `scripts/generate-label.mjs` | CLI entrypoint | Create |
+| `package.json` | add `qrcode` (+ `@types/qrcode` dev) | Modify |
+
+---
+
+### Task 1: `buildSetupUrl` + `labelDimensionsPx` (pure)
+
+**Files:** Create `app/lib/labelGenerator.ts` + `app/lib/labelGenerator.test.ts`.
+
+- [ ] **Step 1: Write the failing tests**
+
+```typescript
+// @vitest-environment node
+import { describe, it, expect } from 'vitest';
+import { buildSetupUrl, labelDimensionsPx } from './labelGenerator';
+
+describe('buildSetupUrl', () => {
+  it('builds the www setup URL with the claim code', () => {
+    expect(buildSetupUrl('SUNSET-7K3M-9XQ2'))
+      .toBe('https://www.sunrisesunset.studio/setup/SUNSET-7K3M-9XQ2');
+  });
+});
+
+describe('labelDimensionsPx', () => {
+  it('converts 14x75mm at 300dpi to landscape px (length x width)', () => {
+    // 75mm/25.4*300 ≈ 886 ; 14mm/25.4*300 ≈ 165
+    const d = labelDimensionsPx({ widthMm: 14, lengthMm: 75 }, 300);
+    expect(d.width).toBe(886);
+    expect(d.height).toBe(165);
+  });
+});
+```
+
+- [ ] **Step 2: Run, verify fail** — `npx vitest run app/lib/labelGenerator.test.ts` → import error.
+
+- [ ] **Step 3: Implement** (start `app/lib/labelGenerator.ts`):
+
+```typescript
+import sharp from 'sharp';
+import QRCode from 'qrcode';
+
+const SETUP_BASE = 'https://www.sunrisesunset.studio/setup';
+
+export function buildSetupUrl(claimCode: string): string {
+  return `${SETUP_BASE}/${claimCode}`;
+}
+
+export type TapeMm = { widthMm: number; lengthMm: number };
+export type Dimensions = { width: number; height: number };
+
+export function labelDimensionsPx(tape: TapeMm, dpi: number): Dimensions {
+  const mmToPx = (mm: number) => Math.round((mm / 25.4) * dpi);
+  // The tape's printable height is its width (14mm); the label length is the image width.
+  return { width: mmToPx(tape.lengthMm), height: mmToPx(tape.widthMm) };
+}
+```
+
+- [ ] **Step 4: Run, verify pass.**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git branch --show-current   # MUST be feat/qr-label-generator
+git add app/lib/labelGenerator.ts app/lib/labelGenerator.test.ts
+git commit -m "feat(label): buildSetupUrl + labelDimensionsPx (pure helpers)"
+```
+
+---
+
+### Task 2: add `qrcode` dependency
+
+**Files:** Modify `package.json`.
+
+- [ ] **Step 1:** `npm install qrcode && npm install -D @types/qrcode`
+- [ ] **Step 2:** Verify it resolves: `node -e "require('qrcode'); console.log('qrcode ok')"` → `qrcode ok`.
+- [ ] **Step 3: Commit**
+
+```bash
+git add package.json package-lock.json
+git commit -m "build: add qrcode dependency for label generation"
+```
+
+---
+
+### Task 3: `generateLabelPng` — composite QR + text via sharp
+
+**Files:** Modify `app/lib/labelGenerator.ts`; modify `app/lib/labelGenerator.test.ts`.
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+// @vitest-environment node  (add to the existing test file)
+import sharp from 'sharp';
+import { generateLabelPng } from './labelGenerator';
+
+describe('generateLabelPng', () => {
+  it('produces a PNG of the tape dimensions', async () => {
+    const png = await generateLabelPng({
+      claimCode: 'SUNSET-7K3M-9XQ2',
+      name: 'Backyard West',
+      tape: { widthMm: 14, lengthMm: 75 },
+      dpi: 300,
+    });
+    const meta = await sharp(png).metadata();
+    expect(meta.format).toBe('png');
+    expect(meta.width).toBe(886);
+    expect(meta.height).toBe(165);
+  });
+});
+```
+
+- [ ] **Step 2: Run, verify fail** — `generateLabelPng` undefined.
+
+- [ ] **Step 3: Implement** (append to `app/lib/labelGenerator.ts`):
+
+```typescript
+export type LabelInput = {
+  claimCode: string;
+  name: string;
+  tape: TapeMm;
+  dpi?: number;
+};
+
+function escapeXml(s: string): string {
+  return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+}
+
+export async function generateLabelPng(input: LabelInput): Promise<Buffer> {
+  const dpi = input.dpi ?? 300;
+  const { width, height } = labelDimensionsPx(input.tape, dpi);
+
+  // QR fills the label height (minus a small margin); placed on the left.
+  const margin = Math.round(height * 0.08);
+  const qrSize = height - margin * 2;
+  const qrPng = await QRCode.toBuffer(buildSetupUrl(input.claimCode), {
+    type: 'png',
+    width: qrSize,
+    margin: 0,
+    errorCorrectionLevel: 'M',
+  });
+
+  // Text column to the right of the QR: name (bold), URL, claim code.
+  const textX = qrSize + margin * 2;
+  const textW = width - textX - margin;
+  const fontPx = (px: number) => Math.max(8, Math.round(px));
+  const nameSize = fontPx(height * 0.26);
+  const lineSize = fontPx(height * 0.2);
+  const svg = `<svg width="${textW}" height="${height}" xmlns="http://www.w3.org/2000/svg">
+    <text x="0" y="${fontPx(height * 0.3)}" font-family="sans-serif" font-weight="bold" font-size="${nameSize}">${escapeXml(input.name)}</text>
+    <text x="0" y="${fontPx(height * 0.58)}" font-family="sans-serif" font-size="${lineSize}">sunrisesunset.studio/setup</text>
+    <text x="0" y="${fontPx(height * 0.85)}" font-family="monospace" font-size="${lineSize}">${escapeXml(input.claimCode)}</text>
+  </svg>`;
+  const textPng = await sharp(Buffer.from(svg)).png().toBuffer();
+
+  return sharp({
+    create: { width, height, channels: 3, background: { r: 255, g: 255, b: 255 } },
+  })
+    .composite([
+      { input: qrPng, top: margin, left: margin },
+      { input: textPng, top: 0, left: textX },
+    ])
+    .png()
+    .toBuffer();
+}
+```
+(If sharp's SVG text rendering needs fonts not present in CI/the Pi-free build env, the test only asserts PNG format + dimensions, which holds regardless of glyph rendering; the visual text is verified in Task 4's manual print.)
+
+- [ ] **Step 4: Run, verify pass.** Then `npx vitest run` (full suite) — no regressions.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/lib/labelGenerator.ts app/lib/labelGenerator.test.ts
+git commit -m "feat(label): generateLabelPng composites QR + name/URL/claim-code via sharp"
+```
+
+---
+
+### Task 4: CLI entrypoint
+
+**Files:** Create `scripts/generate-label.mjs`.
+
+- [ ] **Step 1: Implement** (no unit test — a thin arg-parser over the tested module; verified by printing a real label):
+
+```javascript
+#!/usr/bin/env node
+// Generate a Nelko-P21 label PNG. Example:
+//   node scripts/generate-label.mjs --claim SUNSET-7K3M-9XQ2 --name "Backyard West" --tape 14x75 --out label.png
+import { writeFile } from 'node:fs/promises';
+import { generateLabelPng } from '../app/lib/labelGenerator.ts';
+
+function arg(name, def) {
+  const i = process.argv.indexOf(`--${name}`);
+  return i >= 0 ? process.argv[i + 1] : def;
+}
+
+const claimCode = arg('claim');
+const name = arg('name', 'Sunset Camera');
+const [widthMm, lengthMm] = arg('tape', '14x75').split('x').map(Number);
+const out = arg('out', 'label.png');
+if (!claimCode) { console.error('--claim is required'); process.exit(2); }
+
+const png = await generateLabelPng({ claimCode, name, tape: { widthMm, lengthMm } });
+await writeFile(out, png);
+console.log(`wrote ${out} (${name} / ${claimCode})`);
+```
+NOTE: importing a `.ts` from `.mjs` needs a loader. If the repo can't run TS directly via node, the implementer should either (a) run it through the repo's existing TS runner (e.g. `tsx scripts/generate-label.mjs` if `tsx` is available — check `package.json`), or (b) make the script `.ts` and run via the repo's TS exec. Confirm which by checking how other `scripts/*.ts` are run (e.g. `scripts/backfill-flickr-scores.ts` exists — match its invocation).
+
+- [ ] **Step 2: Manual verify** — run the CLI with a real claim code, open the PNG, confirm: QR scans to the setup URL, the name/URL/claim-code are legible, dimensions match the tape. Print one on the Nelko to confirm physical legibility at 14×75mm.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add scripts/generate-label.mjs
+git commit -m "feat(label): generate-label CLI over the label module"
+```
+
+---
+
+## Self-Review
+
+- **Spec coverage:** §4.1 label content (QR → setup URL, name/URL/claim-code, no secrets) → Tasks 1+3; 14×75mm sizing → Task 1 `labelDimensionsPx`; parameterized tape → `TapeMm` input; generator → Tasks 3+4. The admin-page live preview (§4.1's recommended UI) is deliberately deferred to slice 1b — this plan ships the tested core it will wrap.
+- **Placeholder scan:** none — complete code in every step. (Task 4 names two acceptable invocation options for the `.ts`-from-script question, both pointing at the existing `scripts/*.ts` convention to match — a verify-and-match instruction, not a placeholder.)
+- **Type consistency:** `TapeMm`/`Dimensions` and `buildSetupUrl`/`labelDimensionsPx`/`generateLabelPng` signatures are consistent across Tasks 1/3/4 and the CLI.
+
+## Follow-on
+- **Slice 1b:** owner-gated admin page (`/admin/label`) that calls `generateLabelPng` for a live preview + Export PNG. The first admin page in the app, so it establishes the page-level owner-gating pattern (build on `app/lib/owner.ts` / `useIsOperator`).
+- **Slice 2/3:** read-only root, cloud log-shipping (separate plans).

--- a/docs/superpowers/specs/2026-06-08-qr-label-and-shippable-unit-hardening-design.md
+++ b/docs/superpowers/specs/2026-06-08-qr-label-and-shippable-unit-hardening-design.md
@@ -73,11 +73,18 @@ So a read-only unit (volatile logs) is still debuggable.
 - **Read-only root:** a provisioning checklist + an **unplug test** — cut power mid-operation ~10×, confirm clean boot each time and that the device re-fetches lat/lng + mode from the cloud.
 - **Log-shipping:** device — the heartbeat payload includes the log blob (test with a fake journal source); cloud — the handler stores and returns the latest blob.
 
-## 6. Open questions
+## 6. Decisions (resolved) + scale tripwires
 
-1. **Confirm the P21 tape length** — design targets 14×75mm; if the on-hand stock is 14×40mm, the layout falls back to QR-only (text on a second label or omitted). (Default 14×75mm.)
-2. **Log storage shape** — `cameras.last_log` column (simplest) vs a `camera_logs` table with rotation (richer history). Lean toward the column first.
-3. **Config persistence** — bake identity at commission + cloud-refetch mutable state (chosen), vs a small writable partition for `/opt/sunset-cam/config`. Lean toward bake + refetch (no extra partition).
+The fleet trajectory is ~a dozen → several hundred → a couple thousand cameras. Each decision picks the simplest thing that's right *now* and records the **tripwire** — the concrete signal that says "revisit this."
+
+1. **Label size: 14×75mm.** The only fixed stock length (options are 14×40 / 14×50 / 14×75mm) with room for a reliably-scannable QR (~12–13mm, constrained by the 14mm tape *width*) **plus** all three human-readable lines (name, URL, claim code). The generator stays parameterized by tape dimensions, so 50/40mm remain available (they degrade to fewer text lines / QR-only). No tripwire — stable.
+
+2. **Log storage: `cameras.last_log` column** (the latest log snapshot per camera). Bounded forever — N cameras = N rows, each overwritten — so it's cheap from a dozen through the low hundreds, and it fully serves the immediate goal ("is this read-only field unit OK?").
+   - **Why not a table now:** raw per-heartbeat logs in Postgres don't scale. At ~2,000 cameras heartbeating every 30s, a row-per-heartbeat table is ≈ **5.7M rows/day** — unbounded growth, indexing pain, and real Neon cost (a known sensitivity). Logs are high-volume / append-only / low-value-per-row, which relational DBs handle badly and expensively.
+   - **Tripwire → move history off the column when** you genuinely need *historical* logs (not just latest) around the **hundreds-of-cameras** mark, OR `last_log` write volume starts showing in Neon cost. Target then: an **external log store** (object storage / a logging service) or a **retention-bounded, error-only `camera_logs` table** (e.g. keep 24–72h, ERROR/WARN only) — never an unbounded table. The column coexists with whichever ("latest" vs "history"), so it's additive, not a migration of the column itself.
+
+3. **Config persistence: bake identity at commission + cloud-refetch mutable state.** Simplest, fully read-only (max corruption safety), and the cloud already owns mutable config (lat/lng, capture window, settings delivered via heartbeat into the RAM overlay). Identity (`device_token`/`camera_id`/`api_base`) is written once at commission while the FS is writable, then locked.
+   - **Tripwire → add a tiny writable config partition when** you need to change a **deployed** unit's persistent identity/config **without re-imaging or an overlay-toggle maintenance window** — concretely, **fleet-wide `device_token` rotation** (a leaked token, or routine rotation hygiene at the thousands mark) or **re-binding** units remotely. Until then, the rare identity change is handled by the overlay-toggle window. Adding the partition later is additive (partition the SD + point `/opt/sunset-cam/config` at it), not a rewrite.
 
 ## 7. Implementation slice order
 

--- a/docs/superpowers/specs/2026-06-08-qr-label-and-shippable-unit-hardening-design.md
+++ b/docs/superpowers/specs/2026-06-08-qr-label-and-shippable-unit-hardening-design.md
@@ -1,0 +1,94 @@
+# QR Label + Shippable-Unit Hardening (Read-Only Root + Log-Shipping)
+
+Status: Draft v0.1 — 2026-06-08
+Owner: Jesse Kauppila
+Part of the streamlined-deployment umbrella (`2026-05-15-streamlined-deployment-overview.md`). Refines E's sticker (`2026-05-15-wifi-onboarding-and-provisioning-design.md` §5.1–5.2).
+
+---
+
+## 1. Problem
+
+A pre-built camera shipped to a non-technical recipient needs three things it doesn't have:
+
+1. **A physical entry point** to onboarding (and later, management) that works even for someone who isn't digitally savvy or lacks a camera-phone.
+2. **To survive being unplugged** without SD-card corruption — recipients *will* pull the power, and there's no graceful-shutdown ritual a non-technical person will perform.
+3. **To stay debuggable** once it's a read-only field unit whose logs are volatile.
+
+## 2. Goals
+
+1. **A Nelko-P21 label per unit:** one QR to the setup/management site, plus human-readable URL + claim code + a friendly camera name — and **no secrets on the label**.
+2. **Unplug-safe:** the unit can lose power at any instant with zero corruption risk — no button, no shutdown step.
+3. **Debuggable while read-only:** recent device logs reach the cloud.
+
+## 3. Non-goals (deferred / elsewhere)
+
+- **The state-aware control surface** (the site menu: onboard / recalibrate / turn-off) and the **`reaim`/`shutdown` directives** — depends on sub-project F + the device supervisor; its own follow-on spec. This spec only points the QR at the setup URL; the site decides what to show.
+- **E's full `provision-unit.sh` + WiFi captive portal** — not built yet; the label generator starts standalone and folds into provisioning later.
+- **On-device "best sunset" ML** — that scoring is cloud-side (Vercel), unaffected by read-only root.
+- **A/B-partition OTA** — the overlay-toggle maintenance window suffices at this fleet size.
+- **A physical safe-shutdown button** — superseded by read-only root (the safe-unplug answer).
+
+## 4. Design
+
+### 4.1 The label
+
+**Tape:** Nelko P21. Default stock is **14×40mm**, but that's too cramped for a scannable QR plus three text lines — so the design targets **14×75mm (0.55"×2.95")**. The generator is **parameterized by tape dimensions** (width_mm, length_mm, print DPI) so 14×50mm or 14×40mm-QR-only remain options.
+
+**Layout (14×75mm, landscape):**
+- **Left:** the QR, ~12–13mm square (the tape's 14mm height minus margins) — large enough to scan reliably.
+- **Right column** (the human-readable fallback): **camera name** (bold, e.g. "Backyard West"), the **URL** (`sunrisesunset.studio/setup`), and the **claim code** (`SUNSET-7K3M-9XQ2`) in a clear monospace.
+
+**The QR encodes** `https://www.sunrisesunset.studio/setup/{claim_code}` — E's existing format. **No `device_token`, no password** — the claim_code is the only credential, and it's a safe-to-show one-time binding key (§ Security below).
+
+**The generator — an owner-gated admin label page** (recommended over a standalone script — it fits the Next.js stack, gives a live print preview, and reuses the existing admin claim-code mint):
+- Route: `/admin/label` (owner-gated via the existing `requireOwner`), querying `?claim_code=…&name=…&tape=14x75`.
+- Renders the label at the tape's pixel size (mm → px at the chosen DPI) — QR via the `qrcode` npm library, composited with the text — and offers **Export PNG** (and/or print).
+- The operator exports the PNG → loads it into the Nelko phone app → prints on P21 tape.
+- Ties to the existing `/api/admin/claim-codes` mint and `tier0-create-camera.sh` (which already produce the claim_code + camera identity).
+
+**Security (why no secret on the label):** the camera authenticates to the cloud with a `device_token` the user never sees; the `claim_code` is a one-time binding key consumed at onboarding. A photographed label can at worst let someone claim an *un-onboarded* camera (the real owner notices). Putting the `device_token` on a physically-visible label would let anyone impersonate the camera — explicitly avoided.
+
+### 4.2 Read-only root (overlay filesystem) — "unplug anytime"
+
+The SD is mounted **read-only** with all writes going to a **RAM overlay** discarded on reboot, so power loss can never interrupt an SD write → zero corruption risk.
+
+- **SD-image template:** enable the overlay filesystem (Raspberry Pi OS `raspi-config nonint enable_overlayfs`, or the boot-config equivalent) as the **last** image-build step.
+- **Provisioning-order rule:** flash → boot → **commission** (write `device_token`/`camera_id`/`api_base` via `configure.sh` while the FS is still writable) → **enable overlay** → ship. Identity is baked in read-only and survives power loss permanently.
+- **Runtime mutable state comes from the cloud:** the supervisor's `write_location` write lands in the RAM overlay (works during the session, re-fetched from the heartbeat after a reboot — self-healing). Captured images upload immediately; nothing important lives only on the SD at runtime.
+- **Remote updates:** a deliberate maintenance window — toggle overlay **off** + reboot (writable) → `apt upgrade` / `git pull` the firmware / drop in files → toggle overlay **on** + reboot. Done over SSH now; a future cloud "maintenance mode" directive can orchestrate it.
+
+**Known costs (accepted):** no persistent on-disk logs (mitigated by §4.3), updates require the toggle ceremony, future features must not assume disk persistence, and the Pi Zero's lack of an RTC means NTP-on-boot remains a dependency (unchanged by this).
+
+### 4.3 Cloud log-shipping (thin)
+
+So a read-only unit (volatile logs) is still debuggable.
+
+- **Device side:** the supervisor's heartbeat loop attaches the **last N journal lines** (e.g. `journalctl -n 50 --no-pager` output, or a captured recent-log buffer) and a short status summary to its heartbeat request.
+- **Cloud side:** the heartbeat handler stores the latest log blob per camera (a `cameras.last_log` text column, or a small `camera_logs` table with light rotation), readable by the owner/operator.
+- Deliberately minimal — enough to see what a field unit is doing without SSH.
+
+## 5. Testing
+
+- **Label generator:** given `claim_code` + name + tape dims → the rendered output is the correct pixel size, the QR decodes to `…/setup/{claim_code}`, and the name/URL/code text is present. (Unit-test the URL construction + the mm→px sizing; verify the visual layout by eye.)
+- **Read-only root:** a provisioning checklist + an **unplug test** — cut power mid-operation ~10×, confirm clean boot each time and that the device re-fetches lat/lng + mode from the cloud.
+- **Log-shipping:** device — the heartbeat payload includes the log blob (test with a fake journal source); cloud — the handler stores and returns the latest blob.
+
+## 6. Open questions
+
+1. **Confirm the P21 tape length** — design targets 14×75mm; if the on-hand stock is 14×40mm, the layout falls back to QR-only (text on a second label or omitted). (Default 14×75mm.)
+2. **Log storage shape** — `cameras.last_log` column (simplest) vs a `camera_logs` table with rotation (richer history). Lean toward the column first.
+3. **Config persistence** — bake identity at commission + cloud-refetch mutable state (chosen), vs a small writable partition for `/opt/sunset-cam/config`. Lean toward bake + refetch (no extra partition).
+
+## 7. Implementation slice order
+
+1. **Admin label page** (`/admin/label`, owner-gated) + the `qrcode` dep — the centerpiece, usable the moment it lands (mint a code → render → print).
+2. **Read-only root** — document + script the SD-image overlay step and the provisioning-order rule (operator procedure + an overlay-toggle helper for the update window).
+3. **Cloud log-shipping** — firmware heartbeat log blob + the cloud store/view.
+
+Each slice is independent and shippable on its own.
+
+## 8. Relationship to existing work
+
+- Refines E §5.1 (the sticker) and §5.2 (provisioning) — the label generator is the concrete production of E's sticker, starting standalone.
+- The QR target (`/setup/{claim_code}`) is E's existing route; the state-aware behavior behind it is F + the control-surface follow-on.
+- Read-only root pairs with the cloud-source-of-truth design already chosen (heartbeat delivers lat/lng; the supervisor re-derives mode on boot).


### PR DESCRIPTION
Design for the Nelko-P21 QR label (one QR, no secrets, human-readable fallback, owner-gated admin generator), read-only root (overlay fs → unplug-safe, no button), and thin cloud log-shipping. Refines sub-project E's sticker. Control surface + directives deferred. Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)