### PR TITLE
feat(label): admin label page (slice 1b — owner-gated UI over the generator)

### DIFF
--- a/app/admin/label/page.tsx
+++ b/app/admin/label/page.tsx
@@ -1,0 +1,153 @@
+'use client';
+
+import { useState } from 'react';
+import { useIsOperator } from '@/app/components/auth/useIsOperator';
+
+const TAPE_OPTIONS = [
+  { value: '14x75', label: '14 × 75 mm' },
+  { value: '14x50', label: '14 × 50 mm' },
+  { value: '14x40', label: '14 × 40 mm' },
+] as const;
+
+export default function AdminLabelPage() {
+  const { isOperator, loading } = useIsOperator();
+
+  const [claimCode, setClaimCode] = useState('');
+  const [name, setName] = useState('');
+  const [tape, setTape] = useState<string>('14x75');
+  const [pngUrl, setPngUrl] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [generating, setGenerating] = useState(false);
+
+  async function handleGenerate(e: React.FormEvent) {
+    e.preventDefault();
+    setError(null);
+    setGenerating(true);
+
+    try {
+      const params = new URLSearchParams({ claim_code: claimCode, name, tape });
+      const res = await fetch(`/api/admin/label?${params}`);
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}));
+        setError((body as { error?: string }).error ?? `Request failed: ${res.status}`);
+        return;
+      }
+      const blob = await res.blob();
+      const newUrl = URL.createObjectURL(blob);
+      setPngUrl((prev) => {
+        if (prev) URL.revokeObjectURL(prev);
+        return newUrl;
+      });
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Unknown error');
+    } finally {
+      setGenerating(false);
+    }
+  }
+
+  if (loading) {
+    return (
+      <main className="min-h-screen flex items-center justify-center bg-gray-900 text-gray-300">
+        <p className="text-sm">Loading…</p>
+      </main>
+    );
+  }
+
+  if (!isOperator) {
+    return (
+      <main className="min-h-screen flex items-center justify-center bg-gray-900 text-gray-300">
+        <p className="text-sm">Sign in as the owner to generate labels.</p>
+      </main>
+    );
+  }
+
+  return (
+    <main className="min-h-screen bg-gray-900 text-gray-100 flex flex-col items-center py-16 px-4">
+      <div className="w-full max-w-md">
+        <h1 className="text-xl font-semibold mb-8 tracking-tight">
+          Label Generator
+        </h1>
+
+        <form onSubmit={handleGenerate} className="flex flex-col gap-5">
+          {/* Claim Code */}
+          <div className="flex flex-col gap-1.5">
+            <label htmlFor="claim-code" className="text-sm text-gray-400">
+              Claim Code
+            </label>
+            <input
+              id="claim-code"
+              type="text"
+              value={claimCode}
+              onChange={(e) => setClaimCode(e.target.value)}
+              placeholder="e.g. ABC-123"
+              className="rounded-md bg-gray-800 border border-gray-700 px-3 py-2 text-sm text-gray-100 placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500"
+            />
+          </div>
+
+          {/* Camera Name */}
+          <div className="flex flex-col gap-1.5">
+            <label htmlFor="cam-name" className="text-sm text-gray-400">
+              Camera Name
+            </label>
+            <input
+              id="cam-name"
+              type="text"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="Sunset Camera"
+              className="rounded-md bg-gray-800 border border-gray-700 px-3 py-2 text-sm text-gray-100 placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500"
+            />
+          </div>
+
+          {/* Tape Size */}
+          <div className="flex flex-col gap-1.5">
+            <label htmlFor="tape-size" className="text-sm text-gray-400">
+              Tape Size
+            </label>
+            <select
+              id="tape-size"
+              value={tape}
+              onChange={(e) => setTape(e.target.value)}
+              className="rounded-md bg-gray-800 border border-gray-700 px-3 py-2 text-sm text-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-500"
+            >
+              {TAPE_OPTIONS.map((opt) => (
+                <option key={opt.value} value={opt.value}>
+                  {opt.label}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          {error && (
+            <p className="text-sm text-red-400">{error}</p>
+          )}
+
+          <button
+            type="submit"
+            disabled={!claimCode.trim() || generating}
+            className="mt-1 rounded-md bg-blue-600 hover:bg-blue-500 disabled:opacity-40 disabled:cursor-not-allowed px-4 py-2 text-sm font-medium transition-colors"
+          >
+            {generating ? 'Generating…' : 'Generate'}
+          </button>
+        </form>
+
+        {pngUrl && (
+          <div className="mt-10 flex flex-col items-center gap-4">
+            <img
+              src={pngUrl}
+              alt="label preview"
+              className="max-w-full rounded border border-gray-700"
+            />
+            <a
+              href={pngUrl}
+              download={`label-${claimCode}.png`}
+              className="rounded-md bg-gray-700 hover:bg-gray-600 px-4 py-2 text-sm font-medium transition-colors"
+            >
+              Download PNG
+            </a>
+          </div>
+        )}
+      </div>
+    </main>
+  );
+}

--- a/app/api/admin/label/route.test.ts
+++ b/app/api/admin/label/route.test.ts
@@ -1,0 +1,36 @@
+// @vitest-environment node
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NextResponse } from 'next/server';
+const requireOwnerMock = vi.fn();
+vi.mock('@/app/lib/owner', () => ({ requireOwner: (...a: unknown[]) => requireOwnerMock(...a) }));
+import sharp from 'sharp';
+import { GET } from './route';
+beforeEach(() => requireOwnerMock.mockReset());
+
+function req(qs: string) {
+  return new Request(`http://test/api/admin/label?${qs}`);
+}
+
+describe('GET /api/admin/label', () => {
+  it('returns the denial when not owner', async () => {
+    requireOwnerMock.mockResolvedValueOnce(NextResponse.json({ error: 'Forbidden' }, { status: 403 }));
+    const res = await GET(req('claim_code=SUNSET-7K3M-9XQ2&name=Backyard%20West&tape=14x75'));
+    expect(res.status).toBe(403);
+  });
+  it('returns a PNG of the tape size for the owner', async () => {
+    requireOwnerMock.mockResolvedValueOnce(null);
+    const res = await GET(req('claim_code=SUNSET-7K3M-9XQ2&name=Backyard%20West&tape=14x75'));
+    expect(res.status).toBe(200);
+    expect(res.headers.get('content-type')).toBe('image/png');
+    const buf = Buffer.from(await res.arrayBuffer());
+    const meta = await sharp(buf).metadata();
+    expect(meta.format).toBe('png');
+    expect(meta.width).toBe(886);
+    expect(meta.height).toBe(165);
+  });
+  it('400 when claim_code missing', async () => {
+    requireOwnerMock.mockResolvedValueOnce(null);
+    const res = await GET(req('name=X&tape=14x75'));
+    expect(res.status).toBe(400);
+  });
+});

--- a/app/api/admin/label/route.ts
+++ b/app/api/admin/label/route.ts
@@ -1,0 +1,28 @@
+import { NextResponse } from 'next/server';
+import { requireOwner } from '@/app/lib/owner';
+import { generateLabelPng } from '@/app/lib/labelGenerator';
+
+export const dynamic = 'force-dynamic';
+export const runtime = 'nodejs';
+
+export async function GET(request: Request) {
+  const denied = await requireOwner();
+  if (denied) return denied;
+
+  const { searchParams } = new URL(request.url);
+  const claimCode = searchParams.get('claim_code');
+  const name = searchParams.get('name') ?? 'Sunset Camera';
+  const tape = searchParams.get('tape') ?? '14x75';
+  if (!claimCode) {
+    return NextResponse.json({ error: 'claim_code is required' }, { status: 400 });
+  }
+  const [widthMm, lengthMm] = tape.split('x').map(Number);
+  const png = await generateLabelPng({ claimCode, name, tape: { widthMm, lengthMm } });
+  return new Response(new Uint8Array(png), {
+    status: 200,
+    headers: {
+      'Content-Type': 'image/png',
+      'Content-Disposition': `inline; filename="label-${claimCode}.png"`,
+    },
+  });
+}


### PR DESCRIPTION
Slice 1b of the QR-label spec — the live-preview UI over the slice-1 generator (PR #59).

- `app/api/admin/label/route.ts` — owner-gated (`requireOwner`) GET → returns the label PNG (reuses `generateLabelPng`)
- `app/admin/label/page.tsx` — the first admin page; `useIsOperator`-gated form (claim code + name + tape) → previews + downloads the PNG

TDD on the route (PNG size + 403/400 paths); the page is Tailwind UI verified by lint + manual browser check. **Stacked on #59** — retarget this PR to `main` once #59 merges. Establishes the page-level owner-gating pattern for future admin pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)