### PR TITLE
docs: 2026-06-09 deployment checkpoint + resume prompt + 2 learnings

### DIFF
--- a/docs/hardware/2026-06-09-deployment-checkpoint-and-resume-prompt.md
+++ b/docs/hardware/2026-06-09-deployment-checkpoint-and-resume-prompt.md
@@ -1,0 +1,51 @@
+# Deployment Checkpoint + Resume Prompt — 2026-06-09
+
+Where the streamlined-deployment work stands, and a ready-to-paste prompt for next time.
+
+---
+
+## Resume prompt (paste this next session)
+
+> Pick up the sunset-cam deployment work — read `docs/hardware/2026-06-09-deployment-checkpoint-and-resume-prompt.md`. The whole firmware stack (v0.4 sun-tap aiming + `/setup/confirm` + config launcher + the device supervisor + the confirm→cloud placement report) is built on `feat/deploy-aiming-supervisor` and pending the **cam1 bench run** (sun-free, see `docs/hardware/2026-06-08-supervisor-bench-run-runbook.md`).
+> - If I've run the bench run and it's green: merge the firmware stack in order (firmware #5 v0.4 → deploy-aiming-firmware → deploy-aiming-supervisor), then build the **cloud log-shipping** slice.
+> - If not yet: walk me through the bench run, then debug the journal output.
+> Also pending physical checks: v0.4 real-sun aim accuracy, the read-only unplug-test (PR #6), and scanning/printing the QR label (PR #59).
+
+## What's built (all PRs)
+
+**Firmware (`sunset-cam-firmware`):**
+- `main` has: gyro wake fix (#4 merged), install.sh I2C (#3 merged).
+- **#5** `feat/v0.4-sun-tap-aiming` — OPEN, gated on real-sun validation.
+- `feat/deploy-aiming-firmware` (confirm + config launcher) and `feat/deploy-aiming-supervisor` (supervisor + heartbeat + service-control + confirm→cloud report; `main` merged in for the gyro dep) — pushed, **gated** behind #5.
+- **#6** `feat/read-only-root` — OPEN, INDEPENDENT (overlay-toggle helper + provisioning docs). Mergeable now; real validation = a cam1 unplug-test.
+
+**Cloud (`the-sunset-webcam-map`):**
+- Merged: deployment protocol (#52), install guide (#55), gitignore (#56), learnings (#48), specs/plans (#53), three-judge/labeling + binary classifier (#49, #54 — other session).
+- **#57** supervisor bench runbook + learnings; **#58** QR-label spec + plans — OPEN docs.
+- **#59** `feat/qr-label-generator` — OPEN, INDEPENDENT (label module + CLI; output visually verified). Pending Jesse's physical scan/print before merge.
+- **#60** `feat/qr-label-admin-page` — OPEN, stacked on #59 (the first admin page; owner-gated label UI). Retarget to main once #59 merges.
+
+## The bottleneck: physical validations (the build is ahead of the validation)
+
+A lot of code is built + stacked, almost all gated on hardware steps not yet run:
+1. **cam1 bench run** (sun-free) — validates the WHOLE firmware stack; the unblock. Runbook: `2026-06-08-supervisor-bench-run-runbook.md`.
+2. **v0.4 real-sun aim** — tap the actual sun on cam1; gates merging #5 (and thus the stack).
+3. **Read-only unplug-test** — `overlay.sh on` + pull power ~10× (PR #6).
+4. **QR label scan/print** — scan the generated label → confirm `/setup/{code}`; print on the Nelko at 14×75mm (PR #59).
+
+Per the new `build-ahead-of-validation` learning: the highest-leverage next move is one of these validations, not more stacked code.
+
+## Remaining build work
+
+- **Cloud log-shipping** (last hardening slice) — firmware heartbeat log-blob + a cloud endpoint. **Deferred on purpose**: it stacks on the gated supervisor, so build it after the bench run validates the stack.
+- Follow-on (own specs): the state-aware control surface (onboard/recalibrate/turn-off + `reaim`/`shutdown` directives), E's WiFi captive portal, v0.3 auto-calibration.
+
+## Merge order (once validations pass)
+
+1. Independent, mergeable now: read-only-root (#6), QR-label generator (#59, after scan) → then retarget #60 to main, merge.
+2. After bench run + real-sun: firmware #5 → `feat/deploy-aiming-firmware` → `feat/deploy-aiming-supervisor` (each needs `main` merged in / rebased; watch for the stacked-branch dependency-drift bug).
+
+## Key references
+- Runbook: `docs/hardware/2026-06-08-supervisor-bench-run-runbook.md`
+- Specs: `docs/superpowers/specs/2026-06-07-pi-deployment-aiming-integration-design.md`, `2026-06-08-qr-label-and-shippable-unit-hardening-design.md`
+- Learnings (this session): `docs/solutions/best-practices/build-ahead-of-validation.md`, `docs/solutions/developer-experience/git-worktrees-for-js-and-python-repos.md`, plus the earlier `walking-skeleton-over-horizontal-buildout.md`, `validate-output-before-optimizing-pipeline.md`, `integration-issues/stacked-branch-missing-merged-dependency.md`, `mpu6050-reads-fake-zeros-when-asleep.md`, `arducam-imx708-not-detected-on-pi-zero.md`.

--- a/docs/solutions/best-practices/build-ahead-of-validation.md
+++ b/docs/solutions/best-practices/build-ahead-of-validation.md
@@ -1,0 +1,54 @@
+---
+title: Don't let the build get ahead of the validation (stop stacking on un-validated foundations)
+date: 2026-06-09
+category: docs/solutions/best-practices
+module: engineering-process
+problem_type: best_practice
+component: development_workflow
+severity: medium
+applies_when:
+  - Building a multi-layer feature where each layer stacks on the previous one
+  - A foundation layer is built + unit-tested but not yet validated end-to-end (or is gated on hardware / an external step)
+  - Tempted to keep building the next slice because the code keeps flowing and the suites stay green
+tags: [process, integration, stacked-branches, validation, walking-skeleton, gated-work]
+---
+
+# Don't let the build get ahead of the validation
+
+## Context
+
+The sunset-cam deployment work grew a tall stack of branches — v0.4 aiming → confirm/launcher → device supervisor → label/admin → read-only-root — each layer green-tested and each stacked on the one below. But **almost the entire stack was gated on physical validations that hadn't been run yet**: the cam1 bench run, the real-sun aim, the read-only unplug-test, the label scan. Every new slice was being built on a foundation that *passed unit tests* but had *never run for real*.
+
+## Guidance
+
+When work stacks, periodically ask: **"What's the lowest un-validated layer, and am I building on top of it anyway?"** If yes, the highest-leverage move usually isn't the next slice — it's **one validation pass on the foundation** that either confirms it or surfaces a problem cheaply, before more code depends on it.
+
+Unit tests prove each layer *works in isolation*; they don't prove the foundation is *right* once integrated or run on real hardware. Stacking more code on an un-validated/gated layer compounds risk: if the foundation is wrong, everything above it inherits the flaw, and you've spent the effort twice.
+
+Concretely:
+- Track which layer is the **lowest un-validated one**.
+- Before starting a slice that *depends* on it, decide: validate the foundation now, or accept that this slice is provisional until it's validated.
+- If a validation is *gated* (needs hardware, the sun, an external merge), prefer building things that are **independent** of the gate over things that **stack on** it. (Read-only root and the label generator were buildable independently; cloud log-shipping stacked on the gated supervisor — so it was correctly deferred.)
+- Name it out loud when "the build is getting ahead of the validation," and offer the validation as the alternative to the next slice.
+
+## Why This Matters
+
+On this project, flagging it changed the plan: instead of building cloud log-shipping (which stacked on the still-un-run supervisor), the work pivoted to the **cam1 bench run** — one sun-free hardware session that validates the *entire* firmware stack at once and unblocks merging all of it. Building log-shipping first would have added more un-mergeable, un-validated code on top of an un-proven base.
+
+This is the same family as [[walking-skeleton-over-horizontal-buildout]] (run a thin end-to-end path early) and [[validate-output-before-optimizing-pipeline]] (inspect the real artifact before scaling) — one level up: *validate the foundation before you keep stacking on it.*
+
+## When to Apply
+
+- Stacked feature branches / a layered subsystem where slice N depends on slice N-1.
+- Any time a foundation is "done" by tests but un-run end-to-end, and the next task builds on it.
+- Especially when a validation is gated (hardware, external, a pending merge) — that's exactly when the temptation to "just keep coding" is strongest and the risk is highest.
+
+## Examples
+
+- **The trap:** v0.4 → deploy-firmware → supervisor → (would-be) log-shipping, all green-tested, none run on cam1. Each new layer assumed the one below worked end-to-end.
+- **The correction:** stop before log-shipping; queue the cam1 bench run (sun-free, validates the whole firmware stack); build only the *independent* slices (read-only root, label generator) while the gate is unresolved.
+
+## Related
+- [[walking-skeleton-over-horizontal-buildout]] — run one end-to-end path early.
+- [[validate-output-before-optimizing-pipeline]] — inspect the real artifact, not green proxies.
+- `../integration-issues/stacked-branch-missing-merged-dependency.md` — a concrete failure mode of stacking (a dependency that didn't ride along).

--- a/docs/solutions/developer-experience/git-worktrees-for-js-and-python-repos.md
+++ b/docs/solutions/developer-experience/git-worktrees-for-js-and-python-repos.md
@@ -1,0 +1,55 @@
+---
+title: Running isolated git worktrees that can actually run the test suite (JS/TS and Python)
+date: 2026-06-09
+category: docs/solutions/developer-experience
+module: dev-workflow
+problem_type: developer_experience
+component: development_workflow
+severity: low
+applies_when:
+  - Doing parallel/stacked feature work in git worktrees to keep branches isolated
+  - A fresh worktree can't run the test suite because deps aren't present (node_modules) or a stacked dependency isn't merged yet
+tags: [git, worktrees, node_modules, vitest, pytest, monorepo, parallel-work]
+---
+
+# Running isolated git worktrees that can actually run the test suite
+
+## Context
+
+Stacked/parallel feature work across two repos (a Next.js app + a Python firmware repo) used many `git worktree`s for isolation. A fresh worktree shares the `.git` dir but **not** the working files' siblings — notably `node_modules`. So a JS/TS worktree can't run `vitest`/`tsc` until its dependencies exist, and re-installing per worktree is slow. There are a couple of small gotchas worth writing down.
+
+## Guidance
+
+**JS/TS repos — symlink `node_modules` into the worktree** so it reuses the main checkout's installed deps:
+```bash
+git worktree add ~/repo-feature -b feat/x origin/main
+ln -s ~/main-repo/node_modules ~/repo-feature/node_modules
+cd ~/repo-feature && npx vitest run <path>   # works immediately
+```
+Caveats:
+- If the branch **adds a new dependency**, run `npm install <pkg>` in the worktree — with the symlink it installs into the *shared* `node_modules`, which is fine (the package.json/lock changes stay on the branch). A *later* worktree off `main` (which lacks the dep in package.json) may need its own `npm install` to pick it up — expect a one-time install there.
+- `git worktree remove --force` removes the symlink (a dir entry), **not** the real `node_modules` it points to.
+
+**Python repos — usually nothing needed** if the package is installed editable (`pip install -e`) into a shared interpreter, since `pythonpath = ["src"]` (pytest) resolves from the worktree's own `src/`. Just run `python3 -m pytest` in the worktree.
+
+**Stacked dependencies — verify the import chain before you trust the worktree.** A branch cut off `main` before a dependency PR merged won't have it; the unit suite can stay green while a launcher/entrypoint import is broken. Before deploying/merging a stacked branch, run an explicit import-chain smoke check and `git merge-base --is-ancestor origin/main <branch>` — see `../integration-issues/stacked-branch-missing-merged-dependency.md`.
+
+**Clean up.** Worktrees accumulate. List with `git worktree list` (both repos), remove the ones whose branches are pushed with `git worktree remove --force <path>`, then `git worktree prune`. Don't remove a worktree another session is actively using (its branch shows as `+` / checked-out elsewhere).
+
+## Why This Matters
+
+Without the `node_modules` symlink, each TS worktree needs a full `npm install` (minutes) before any test runs — enough friction to discourage isolation entirely. The symlink makes worktrees cheap, which keeps parallel/stacked work clean (one branch per worktree, no cross-contamination) instead of juggling branches in one checkout.
+
+## When to Apply
+
+- Any multi-branch or stacked work where you want isolated checkouts that can run tests/lint immediately.
+- Especially in a TS repo, where the missing-`node_modules` wall hits on the first `vitest`/`tsc` invocation.
+
+## Examples
+
+- TS: `ln -s ~/GitHub/the-sunset-webcam-map/node_modules ~/GitHub/swm-qr-label/node_modules` → `npx vitest run` works at once; adding `qrcode` later needed a one-time `npm install` in a sibling worktree.
+- Python: `git worktree add ~/GitHub/scf-supervisor -b feat/x origin/feat/base` → `python3 -m pytest` runs directly (editable install + `pythonpath=["src"]`).
+
+## Related
+- `../integration-issues/stacked-branch-missing-merged-dependency.md` — the import-chain / ancestry check for stacked branches.
+- [[build-ahead-of-validation]] — when stacking branches, validate the foundation before piling on.


### PR DESCRIPTION
Saves where the deployment work stands (firmware stack built + pending the cam1 bench run; full PR landscape, merge order, and the physical-validation backlog) with a paste-ready resume prompt, and folds in two new compound learnings: **build-ahead-of-validation** (stop stacking on un-validated/gated foundations) and **git worktrees that can run tests** (node_modules symlink for JS, editable-install for Python, stacked-dep import check). Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)