### PR TITLE
docs(solutions): deploy + verification learnings from the binary-head ship

### DIFF
--- a/docs/solutions/best-practices/verify-the-feature-isnt-already-built.md
+++ b/docs/solutions/best-practices/verify-the-feature-isnt-already-built.md
@@ -1,0 +1,47 @@
+---
+title: Trace the data path before planning a "new" feature — it may be 90% built already
+date: 2026-06-09
+category: docs/solutions/best-practices
+module: engineering-process
+problem_type: best_practice
+component: development_workflow
+severity: medium
+applies_when:
+  - About to write a plan or spec for a feature in an area that already has related infrastructure (models, endpoints, UI components, cron jobs)
+  - The request sounds like a build ("implement X") but X might reduce to enabling something that already exists
+  - You're tempted to scope a multi-task plan before reading the end-to-end data path
+tags: [process, scoping, planning, yagni, ops-vs-code, verify-first]
+---
+
+# Trace the data path before planning a "new" feature — it may be 90% built already
+
+## Principle
+
+Before scoping a build, **trace the full data path end-to-end in the actual code** and find the one piece that's genuinely missing. Features that touch mature areas are often already wired; the real work is frequently an operational flip, not new code. Planning the build before reading the path means planning work that's already done.
+
+## The case that taught this
+
+The ask was to "implement the two-tier popup binary sunset classifier verdict" — show a real *Sunset detected* verdict in the public popup from the binary model instead of thresholding the regression score. It sounded like a feature. Tracing the path showed it was almost entirely built:
+
+- the popup's `AiRatingDisplay` **already** preferred the binary "is-sunset" signal when present, only falling back to the regression-threshold proxy when it was absent;
+- the live cron **already** wrote `webcams.ai_rating_binary` and `binaryIsSunset` (gated by an env flag);
+- `next.config.ts` **already** bundled the binary model into the function.
+
+The only real gap was **operational**: the binary head wasn't enabled in the live Vercel env, plus a bundle-size guard so the deploy would fit. The whole thing reduced to one env flip + one config pin — not a feature build. (cloud #50, #54.)
+
+## How to apply
+
+- **Grep/Read the consumer first.** Does the UI/endpoint that "needs" the feature already accept the input? (Here: the component already had an `isSunset` prop and used it.)
+- **Walk backward to the producer.** Is the data already being written/computed somewhere, perhaps behind a flag? (Here: the cron already wrote it.)
+- **Name the single missing link.** Usually it's one of: a disabled flag, an unset env var, an unbundled asset, an unapplied migration — not a new subsystem.
+- **Distinguish "build" from "enable."** If the answer is "enable," the plan is a checklist (flip flag → redeploy → verify), and most of your planning budget evaporates — correctly.
+
+## Why it compounds
+
+Every plan you *don't* write for already-built work is saved effort, and the verification you do instead (confirm the flip worked) is cheaper and higher-signal than re-implementing. The failure mode is the opposite: writing a confident multi-task plan, then discovering mid-execution that tasks 1–4 were already done.
+
+## Related
+
+- [[vercel-bundles-all-model-versions-near-size-limit]] — the one piece of real code work the "build" actually needed (the bundle pin).
+- [[verifying-prod-behind-vercel-deployment-protection]] — how the "enable" was verified instead of re-built.
+- `../best-practices/reuse-existing-llm-labels-before-rescoring.md` — the data-layer sibling of this principle (reuse what's computed before recomputing).

--- a/docs/solutions/developer-experience/nested-build-artifacts-escape-root-anchored-gitignore.md
+++ b/docs/solutions/developer-experience/nested-build-artifacts-escape-root-anchored-gitignore.md
@@ -1,0 +1,71 @@
+---
+title: Nested build artifacts slip past a root-anchored .gitignore — and how to clean a polluted PR
+date: 2026-06-09
+category: docs/solutions/developer-experience
+module: repo-hygiene
+problem_type: developer_experience
+component: tooling
+severity: medium
+applies_when:
+  - A `.gitignore` rule is root-anchored (`/.next/`) but the same build output also appears in nested dirs (`.claude/worktrees/<wt>/.next/`, a submodule, a sub-package)
+  - A PR turns out to carry generated artifacts or unrelated files from a stray commit
+  - You want to land a clean PR without an interactive rebase (which isn't always available to agents)
+tags: [gitignore, worktrees, nextjs, pr-hygiene, clean-reroll, build-artifacts, stale-main]
+---
+
+# Nested build artifacts slip past a root-anchored .gitignore — and how to clean a polluted PR
+
+## Problem
+
+A docs PR (cloud #23) was found, at merge time, to contain three files that didn't belong: two generated `.claude/worktrees/feat-custom-cam-visibility/.next/types/*.ts` artifacts and an unrelated scratch HTML preview — all introduced by one stray commit ("New UI for details/tooltip popup") mixed into the branch. Merging it would have dumped generated build output onto `main`.
+
+## Symptoms
+
+- A PR's **file list** contains generated/build files (`.next/`, `dist/`, `*.tsbuildinfo`) or files unrelated to the PR's stated purpose.
+- `git check-ignore` on those paths returns nothing, even though you "have a `.next/` rule."
+
+## Root Cause
+
+Two gitignore gaps:
+
+1. **Root-anchoring.** `/.next/` (leading slash) matches `.next/` only at the repo root. A `.next/` produced inside a nested working dir — e.g. `.claude/worktrees/<wt>/.next/` — is *not* matched.
+2. **Wrong worktree path.** Only `.worktrees/` was ignored, not `.claude/worktrees/` (where the harness places agent worktrees, each with its own `.next/` build output).
+
+## Solution
+
+### Harden the ignore (cloud #56)
+
+```gitignore
+# next.js
+/.next/
+**/.next/          # nested build output anywhere (worktrees, sub-packages)
+
+# claude worktrees (each carries its own .next/ build output)
+.claude/worktrees/
+```
+
+Verify with the actual offending paths before trusting it:
+
+```bash
+git check-ignore .claude/worktrees/x/.next/types/routes.d.ts   # should print the path (ignored)
+```
+
+### Re-roll the polluted PR clean (cloud #23 → #55)
+
+Interactive rebase to drop the stray middle commit isn't always available (and rewriting a shared branch is risky). Simpler: **rebuild the branch with only the wanted file(s)**, off fresh `main`:
+
+```bash
+git checkout -b docs/<feature>-clean origin/main
+git checkout origin/<polluted-branch> -- path/to/the/one/file/you/want.md
+git add path/to/the/one/file/you/want.md && git commit
+git push -u origin docs/<feature>-clean
+# open the new PR; close the polluted one pointing at it
+```
+
+This grabs the final state of just the file(s) you want and leaves every artifact and unrelated change behind — no history surgery.
+
+## Prevention
+
+- **Review a PR's file *list*, not just its title/diff summary, before merging.** The junk here was invisible unless you looked at which paths changed.
+- **Anchor build-output ignores with `**/`** when the tool can run in nested dirs (worktrees, monorepo packages).
+- **Watch for stale local refs when collaborators merge in parallel.** Separately this session, `next.config.ts` appeared "reverted" on a freshly-created branch — the cause was a local `origin/main` that was 2 commits behind a teammate's merge. `git fetch` before trusting a working-tree diff or basing a branch; see `memory/feedback_implementer_verify_branch`.

--- a/docs/solutions/integration-issues/vercel-bundles-all-model-versions-near-size-limit.md
+++ b/docs/solutions/integration-issues/vercel-bundles-all-model-versions-near-size-limit.md
@@ -1,0 +1,76 @@
+---
+title: Vercel function bundle balloons toward the 250 MB limit — ONNX tracing globbed every model version
+date: 2026-06-09
+category: docs/solutions/integration-issues
+module: ml-scoring-deploy
+problem_type: integration_issue
+component: build_config
+symptoms:
+  - "Vercel build fails (or hovers dangerously close to) `Function bundle exceeded 250 MB`"
+  - "`outputFileTracingIncludes` uses `regression_resnet18/**/*` + `binary_resnet18/**/*`, which bundles BOTH the v2 and v4 artifacts (4 × ~43 MB = 172 MB) even though only the v4 pair is ever loaded"
+  - "Enabling a SECOND ONNX head (the binary classifier) is what finally tips the deploy over"
+root_cause: over_broad_glob
+resolution_type: config_change
+severity: high
+tags: [vercel, nextjs, onnx, bundle-size, outputFileTracingIncludes, model-deploy, ml, guard-test]
+---
+
+# Vercel function bundle balloons toward the 250 MB limit — ONNX tracing globbed every model version
+
+## Problem
+
+The cron + smoke serverless functions need the ONNX model files bundled in. `next.config.ts` did this with a wildcard over the whole model-type folder:
+
+```ts
+outputFileTracingIncludes: {
+  '/api/cron/update-cameras': [
+    './ml/artifacts/models/regression_resnet18/**/*',
+    './ml/artifacts/models/binary_resnet18/**/*',
+  ],
+  // ...same for /api/debug/scoring-smoke
+}
+```
+
+Each ResNet-18 ONNX is ~43 MB, and **both a v2 and a v4 version of each head are committed** (kept for rollback-via-re-export). The `**/*` glob swept all four (~172 MB) into every function bundle. With onnxruntime-node (~36 MB) + sharp (~16 MB) + the Next framework (~40 MB) that lands ~264 MB — already over Vercel's 250 MB estimate (it shipped only because Vercel's real accounting is more permissive). Turning on the binary head as a live scorer would have pushed it past the actual limit.
+
+## Symptoms
+
+- The bundle hovers ~264 MB; any new model or dependency risks `Function bundle exceeded 250 MB`.
+- Only the v4 regression (`20260513_113243_v4_regression_llm_with_flickr`) and v4 binary (`20260601_063518_v4_binary_llm_with_flickr`) are actually loaded — the v2 pair is dead weight in the bundle.
+
+## What Didn't Work
+
+- `vercel.json` `functions.includeFiles` silently does **not** match `ml/artifacts/models/**` (logs show `File doesn't exist at /var/task/...`). Next's own `outputFileTracingIncludes` is the mechanism that works — but it inherited the same over-broad glob.
+
+## Solution
+
+Pin the tracing includes to the **specific deployed version directories**, not the model-type parent:
+
+```ts
+outputFileTracingIncludes: {
+  '/api/cron/update-cameras': [
+    './ml/artifacts/models/regression_resnet18/20260513_113243_v4_regression_llm_with_flickr/**/*',
+    './ml/artifacts/models/binary_resnet18/20260601_063518_v4_binary_llm_with_flickr/**/*',
+  ],
+  // ...same for /api/debug/scoring-smoke
+}
+```
+
+This drops the two unused v2 models from the bundle (−86 MB → ~178 MB) while keeping them committed in git for rollback. Then **lock it in with a guard test** (`next.config.test.ts`) that fails the build if anyone re-broadens the globs or bundles a v2 model again:
+
+- every include pattern must resolve to a `v4` version dir (never `v2`, never a whole-type glob),
+- each pinned dir must exist on disk with a `model.onnx`,
+- total bundled model weight stays under a budget (120 MB) — well below the 172 MB you'd get if a v2 model crept back in.
+
+(cloud PR #54.)
+
+## Why This Works
+
+`outputFileTracingIncludes` is a literal glob over the filesystem at build time. `regression_resnet18/**/*` matches *every* version subdir; naming the exact version dir matches only that one. The guard test converts an invisible size regression (which only surfaces as a failed deploy) into a fast, local unit-test failure.
+
+## Prevention
+
+- **Pin bundled model artifacts to the exact deployed version**, never glob the family. New version → bump the path here AND the matching `AI_ONNX_*_MODEL_PATH` env var in Vercel together (they must agree).
+- **Add a build-size guard test** whenever a bundle nears a hard platform limit — the limit is otherwise only discoverable by a failed remote deploy.
+- Verify the deploy actually shipped the model via the smoke endpoint's latency signature — see [[verifying-prod-behind-vercel-deployment-protection]].
+- Related: `memory/feedback_vercel_nextjs_ml_bundling` (the broader Vercel/Next ML bundling gotchas).

--- a/docs/solutions/workflow-issues/verifying-prod-behind-vercel-deployment-protection.md
+++ b/docs/solutions/workflow-issues/verifying-prod-behind-vercel-deployment-protection.md
@@ -1,0 +1,65 @@
+---
+title: Smoke-testing a prod endpoint that sits behind Vercel Deployment Protection
+date: 2026-06-09
+category: docs/solutions/workflow-issues
+module: ml-scoring-deploy
+problem_type: workflow_issue
+component: tooling
+symptoms:
+  - "curl to the per-deployment `*-<hash>-<scope>.vercel.app` URL returns Vercel's `Authentication Required` SSO HTML page (HTTP 401) instead of your app's response"
+  - "The app's own `CRON_SECRET` / device auth never even runs — the SSO wall is in front of it"
+  - "Guessing stable aliases (`<project>.vercel.app`) just 404s"
+root_cause: deployment_protection
+resolution_type: process
+severity: medium
+tags: [vercel, deployment-protection, sso, smoke-test, cron-secret, prod-verification, onnx]
+---
+
+# Smoke-testing a prod endpoint that sits behind Vercel Deployment Protection
+
+## Problem
+
+To confirm a deploy actually loaded the ONNX models (vs. a baseline fallback), you hit `/api/debug/scoring-smoke` with the `CRON_SECRET`. Pointed at the **per-deployment URL** (`https://the-sunset-webcam-<hash>-<scope>.vercel.app/...`), curl came back HTTP 401 with Vercel's `Authentication Required` SSO HTML — not the app's auth, not the JSON.
+
+## Symptoms
+
+- The 401 body is a full HTML page mentioning "Vercel Authentication" / SSO redirect, with a `vercel.com/sso-api?url=...` link.
+- Your app-level secret (`?secret=` / `Bearer`) is irrelevant — the request never reaches your handler.
+- The per-deployment `*.vercel.app` URL is the one GitHub deployment statuses expose, so it's the easy one to grab — and it's exactly the one that's SSO-walled.
+
+## What Didn't Work
+
+- **The per-deployment URL.** Vercel Deployment Protection ("Vercel Authentication") gates deployment-specific URLs even for production builds.
+- **Guessing the stable alias** (`the-sunset-webcam-map.vercel.app`, etc.) — all 404.
+- **Putting the secret in the query string.** Worse than useless here: the SSO redirect page echoes the full request URL back (URL-encoded) in its HTML, so the `CRON_SECRET` leaks into the response body / your terminal scrollback / any transcript. Rotate it if that happens.
+
+## Solution
+
+Hit the **stable public production domain** — the custom domain users actually visit — which is *not* deployment-protected:
+
+```bash
+S=$(grep -E '^CRON_SECRET=' .env.production.local | head -1 | cut -d= -f2- | tr -d '"')
+curl -sS -G "https://www.sunrisesunset.studio/api/debug/scoring-smoke" \
+  --data-urlencode "secret=$S" | python3 -m json.tool
+```
+
+Deployment Protection's "Standard" setting protects preview + per-deployment URLs but leaves the assigned production domain public. If even that is walled, the documented bypasses are `vercel curl`, a Protection-Bypass-for-Automation token (`x-vercel-protection-bypass` header), or Trusted Sources OIDC.
+
+### Reading the result — the latency signature
+
+The smoke JSON tells you the model genuinely loaded:
+
+| Signal | Real ONNX | Baseline / fallback |
+|---|---|---|
+| `pathTaken` / `binaryPathTaken` | `onnx` | absent / `unscored` |
+| `latencyMs` (cold start) | ~1300–1900 ms (loading two 43 MB sessions) | — |
+| `latencyMs` (warm) | ~100–500 ms | ~10–20 ms |
+| `binaryModelVersion` | matches the pinned artifact | — |
+
+A first call ~1.4 s that drops to ~140 ms on the second call is the fingerprint of a real, now-cached ONNX session. A flat ~15 ms means the baseline path — the model never loaded.
+
+## Prevention
+
+- **Verify prod against the stable public domain, not the per-deployment URL.** Keep that domain in the runbook (here: `www.sunrisesunset.studio`; the apex 307-redirects and strips auth — use `www.`).
+- **Never put a secret in a query string against a protected host** — the SSO redirect reflects the URL. Prefer the `Authorization: Bearer` header, or accept the leak and rotate.
+- Pairs with [[vercel-bundles-all-model-versions-near-size-limit]] — the smoke latency is how you confirm the bundle actually shipped the model after pinning.


### PR DESCRIPTION
Folds this session's engineering learnings into the compound-engineering corpus (`docs/solutions/`, the set `ce-learnings-researcher` reads). Four new files, matching the existing frontmatter schema.

| File | Category | Learning |
|---|---|---|
| `vercel-bundles-all-model-versions-near-size-limit.md` | integration-issues | `outputFileTracingIncludes` globbing `model_type/**` bundles *every* version (172 MB) toward Vercel's 250 MB limit. Pin to the deployed v4 dirs (−86 MB) + a `next.config.test.ts` guard. (#54) |
| `verifying-prod-behind-vercel-deployment-protection.md` | workflow-issues | Per-deployment `*.vercel.app` URLs are SSO-walled; smoke-test against the stable public domain. Read the cold→warm latency signature to tell real ONNX from baseline. Don't put the secret in the URL (the SSO redirect reflects it). |
| `nested-build-artifacts-escape-root-anchored-gitignore.md` | developer-experience | `/.next/` doesn't match `.claude/worktrees/**/.next/`; harden with `**/.next/` + `.claude/worktrees/`. Re-roll a polluted PR as a clean single-file branch instead of rebasing. (#23 → #55, #56) |
| `verify-the-feature-isnt-already-built.md` | best-practices | Trace the data path before planning a build — the two-tier binary verdict was 90% wired; the real work was an env flip. (#50) |

Already captured by the parallel session (not duplicated here): the MPU6050 gyro-wake and build-ahead-of-validation learnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)