### PR TITLE
fix(map): markers stacked off-globe — remove inline position from marker wrapper

### DIFF
--- a/app/components/Map/hooks/createMarkerElement.test.ts
+++ b/app/components/Map/hooks/createMarkerElement.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest';
+import { createMarkerElement } from './useSetWebcamMarkers';
+import type { WindyWebcam } from '@/app/lib/types';
+
+const base: WindyWebcam = {
+  webcamId: 1,
+  title: 'cam',
+  viewCount: 0,
+  status: 'active',
+  location: { latitude: 0, longitude: 0 },
+  categories: [],
+};
+
+describe('createMarkerElement', () => {
+  it('does NOT set an inline position on the wrapper (Mapbox owns marker positioning)', () => {
+    // Regression guard: an inline `position` on the marker element overrides
+    // Mapbox's `.mapboxgl-marker { position: absolute }`, dropping every marker
+    // out of absolute positioning into normal document flow — the "markers
+    // stacked off-globe" bug. The wrapper must leave positioning to Mapbox.
+    const el = createMarkerElement(base);
+    expect(el.style.position).toBe('');
+  });
+
+  it('renders no health badge for a normal windy webcam', () => {
+    const el = createMarkerElement(base);
+    expect(el.querySelector('.webcam-marker-badge')).toBeNull();
+  });
+
+  it('still renders the health badge for a custom camera', () => {
+    const el = createMarkerElement({ ...base, cameraHealth: 'live' });
+    expect(el.querySelector('.webcam-marker-badge')).not.toBeNull();
+  });
+});

--- a/app/components/Map/hooks/useSetWebcamMarkers.tsx
+++ b/app/components/Map/hooks/useSetWebcamMarkers.tsx
@@ -38,9 +38,14 @@ type FeedbackTone = RateResult['tone'];
 
 const SNACKBAR_ID = 'webcam-rating-snackbar';
 
-function createMarkerElement(webcam: WindyWebcam) {
+export function createMarkerElement(webcam: WindyWebcam) {
   const wrapper = document.createElement('div');
   wrapper.className = 'webcam-marker';
+  // Do NOT set `position` here. Mapbox positions the marker element via
+  // `.mapboxgl-marker { position: absolute }` + a transform; an inline position
+  // overrides that and drops every marker into normal flow (stacked off-globe).
+  // The health badge below still anchors to this wrapper because Mapbox's
+  // absolute (and its transform) make it the badge's containing block.
   wrapper.style.cssText = `
     width: 60px;
     height: 60px;
@@ -49,7 +54,6 @@ function createMarkerElement(webcam: WindyWebcam) {
     align-items: center;
     justify-content: center;
     pointer-events: auto;
-    position: relative;
   `;
 
   const inner = document.createElement('div');


### PR DESCRIPTION
## Incident
After #64 merged, **all map markers (Windy + custom) detached from the globe and rendered as a vertical stack** in normal document flow. Affects the main globe view for everyone.

## Root cause
#64 (Task 7, the health-ring change) added `position: relative` to the marker element's inline `cssText`. Mapbox positions each marker via `.mapboxgl-marker { position: absolute }` + a transform; an **inline** `position` overrides the class's `absolute`, so markers fall out of absolute positioning into normal flow → the stack. The pre-#64 wrapper set no `position` at all.

## Fix
Remove the inline `position` from the wrapper (one line). Mapbox once again owns the marker element's positioning, so markers return to the globe. The custom-camera health **badge** still anchors to the wrapper because Mapbox's `absolute` + transform make it the badge's containing block. The wrapper is now functionally identical to the known-good pre-#64 version.

## Verification
- New regression test `createMarkerElement.test.ts`: asserts the wrapper sets **no inline `position`** (would have caught this), plus badge present for custom / absent for Windy. 3/3.
- Full suite: **462 pass**.
- Visual: please confirm markers are back on the globe on the redeploy (this class of bug needs a real browser; the deferred live smoke test is what would have caught it).

## Notes
Separately, prod login fails with Auth.js "server configuration" error — that's a **missing-prod-env** issue (`AUTH_SECRET`/`AUTH_GOOGLE_ID`/`AUTH_GOOGLE_SECRET`/`OWNER_EMAILS` set in dev but not in Vercel production), not a code bug. Tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)