### PR TITLE
docs(hardware): session notes — hardware decision, resume checkpoint, next steps

### DIFF
--- a/docs/hardware/2026-06-15-camera-hardware-decision.md
+++ b/docs/hardware/2026-06-15-camera-hardware-decision.md
@@ -1,0 +1,71 @@
+# Camera Hardware Decision — Module 3 Wide + Central Scoring
+
+**Date:** 2026-06-15
+**Status:** Decided (revisit trigger noted below)
+**Context:** Choosing the camera/compute for the Pi-based fleet node. See the System Design Brief (score-then-escalate architecture) this record accompanies.
+
+## Decision
+
+**Use the Raspberry Pi Camera Module 3 Wide on every Pi node, run sunset-quality
+scoring centrally (Path A), and use cheap on-Pi heuristics as the bandwidth/cost
+lever — not the Sony IMX500 AI Camera.**
+
+## The fork that was considered
+
+| | A. Module 3 Wide + central scoring (CHOSEN) | B. IMX500 AI Camera + on-sensor inference |
+|---|---|---|
+| FOV | Wide (~102° horizontal) — all 365 Bellingham sunsets, headroom north | Not offered wide — loses solstice sunsets |
+| HDR | Yes (the key sunset feature) | No |
+| Model | Existing PyTorch unchanged, server-side | PyTorch → Sony MCT quantize → `.rpk`; sensor geared to detection, not aesthetic regression |
+| Bandwidth | Thumbnails to server (~10–20 KB each) | Rank/metadata only |
+| Cost | Baseline | ~2× |
+
+## Why A wins
+
+1. **FOV is disqualifying for B.** The Wide lens is what delivers full-year
+   coverage in Bellingham (≈48.75°N) and headroom for nodes farther north. The
+   AI Camera has no wide variant, so it gives up the exact solstice frames the
+   fleet exists to catch.
+2. **No HDR on B.** HDR (bright sky over dark foreground) is the core sunset
+   capability — losing it degrades both the streamed imagery and the scored
+   imagery.
+3. **The fleet is heterogeneous.** API-based cameras can't do on-sensor
+   inference regardless, so the central scoring path must exist anyway. Adding
+   edge inference on some nodes is a *second* scoring system to maintain (plus
+   IMX500 model-conversion friction), not a simplification. One central path
+   covers Pi nodes and API cameras alike.
+4. **The bandwidth win is a non-problem at this scale.** A 320×240 JPEG
+   thumbnail is ~10–20 KB; a 20-node fleet at 2 fps is < 1 MB/s aggregate. Edge
+   inference only earns its keep on metered/cellular links or much larger scale.
+
+## The valuable part of the edge-ranking idea is kept — without the IMX500
+
+The appeal of B was "decide locally, only move the best image(s), switch the feed
+to the current highest rank." That pipeline is achievable on Module 3 + Pi 3A+
+with cheap heuristics on the `lores` numpy frames already being pulled (the
+512 MB Pi can't run the full PyTorch model, but it can do these trivially):
+
+- **Sunset-window + activity gate** — sky-region brightness/saturation,
+  frame-to-frame change. Decides *when* a node is worth listening to.
+- **Coarse local pre-rank** — a cheap "is something happening here" scalar, sent
+  as a few bytes.
+- **Upload-on-candidate** — push a thumbnail only when the local gate says it's
+  plausibly interesting; pull full-res only from the promoted winner.
+
+Net pipeline: **local coarse gate → upload candidate thumbnails → central
+fine-grained aesthetic rank → promote highest current rank.** Keeps HDR, keeps
+wide FOV, keeps the model unchanged, keeps one coherent scoring architecture.
+The bandwidth/cost reduction comes from the local gate, not from different
+silicon.
+
+## Revisit triggers
+
+Reopen this decision only if:
+
+- **Central scoring cost becomes the real bottleneck.** Next step is a tiny int8
+  classifier (tflite/onnxruntime) *on the Module 3 Pi* — risky on 512 MB, adds
+  conversion work, but still no camera change. Reach for it only after the
+  cheap-heuristic gate proves insufficient.
+- **On-sensor inference becomes a hard requirement** (e.g. truly offline nodes
+  with no server reachable). Only then does the IMX500's FOV/HDR sacrifice and
+  conversion friction become worth paying.

--- a/docs/hardware/2026-06-15-resume-checkpoint.md
+++ b/docs/hardware/2026-06-15-resume-checkpoint.md
@@ -1,0 +1,100 @@
+# Resume Checkpoint — 2026-06-15
+
+Escape hatch from a long session. Three live threads; read the anchor doc for each
+before acting. The build is **ahead of validation** — prefer the next *validation*
+over more stacked code.
+
+Two repos: cloud = `~/GitHub/the-sunset-webcam-map`, firmware = `~/GitHub/sunset-cam-firmware`.
+
+---
+
+## Resume prompt (paste this next session)
+
+> Resume the sunset-cam work — escape hatch from a long prior session. There are
+> three live threads; read the anchor doc for each before acting (build is ahead of
+> validation, so prefer the next *validation* over more stacked code).
+>
+> Two repos: cloud = ~/GitHub/the-sunset-webcam-map, firmware = ~/GitHub/sunset-cam-firmware.
+>
+> 1. CLOUD PROGRAM — branch `feat/cloud-https-setup` (ahead of origin).
+>    Carries (a) the deployment-model refactor: provision → pre-register → register →
+>    heartbeat/setup-status/decommission now act on a `deployments` table, with 4
+>    un-applied migrations dated 2026-06-13 (deployment_model + backfill, lifecycle,
+>    bracket_provenance); and (b) HTTPS phone-compass calibration.
+>    The standalone-wizard plan
+>    `docs/superpowers/plans/2026-06-13-cloud-https-phone-compass-calibration.md` is
+>    SUPERSEDED — kept only `app/lib/solar.ts`, `app/lib/declination.ts`, and
+>    `GET /api/setup/[code]/declination`. REAL NEXT STEP: fold the sun-arc overlay into
+>    the existing wizard at `app/setup/[claim_code]/` (ArPlacementPlaceholder, spec
+>    `2026-05-16-cloud-wizard-frontend-design.md` §4) — do NOT build a second wizard.
+>    See memory `cloud-https-setup-mvp-in-progress`. Decide: apply the deployment
+>    migrations + open a PR, or keep iterating on the branch first.
+>
+> 2. COMMISSION THIS ONE PI — cam1 (`camera_id 4`, `pi-zero-2w-sunset-cam-1`; already
+>    paired webcam_id 28759753, reads Stale, window expired 2026-06-07).
+>    The firmware stack (v0.4 sun-tap aiming PR #5 + the device supervisor) is BUILT and
+>    STACKED, gated on physical validations. Anchor:
+>    `docs/hardware/2026-06-09-deployment-checkpoint-and-resume-prompt.md` (PR landscape
+>    + merge order + validation backlog). The unblock is the sun-free cam1 BENCH RUN
+>    (`docs/hardware/2026-06-08-supervisor-bench-run-runbook.md`): deploy
+>    `feat/deploy-aiming-supervisor`, start the supervisor, tap+Confirm on a phone, watch
+>    it flip aiming→capture. Then: v0.4 real-sun aim accuracy, read-only-root unplug-test
+>    (firmware PR #6), QR-label scan/print (PR #59).
+>
+> 3. SCRIPT TO COMMISSION PIs IN FUTURE — the operator `provision-unit.sh` (Mac flash +
+>    claim-code mint + sticker) is partially covered by firmware `scripts/install.sh` +
+>    the QR-label generator (cloud PRs #59/#60). BLOCKER to fix first: the register-API
+>    pairing gap — `register` creates a `cameras` row but never the `webcams` pairing
+>    (`cameras.webcam_id`); only the tier0 seed does, so a claim-code onboard never
+>    surfaces or accepts snapshots. See memory `reference_custom_camera_pairing` (+ the
+>    commissioning-self-test-frame idea). Streamlined-deployment umbrella status is in
+>    memory `project-streamlined-deployment-status`.
+>
+> Also note: the camera *hardware* choice is now decided —
+> `docs/hardware/2026-06-15-camera-hardware-decision.md` (Module 3 Wide + central
+> scoring, not the IMX500).
+>
+> Tell me which thread to pick up; if I just say "where are we," summarize all three
+> from the anchor docs and recommend the highest-leverage next move.
+
+---
+
+## Thread detail
+
+### 1. Cloud program — `feat/cloud-https-setup`
+- **Deployment-model refactor:** the camera lifecycle (provision → pre-register →
+  register → heartbeat / setup-status / decommission / pause / resume) was retargeted
+  onto a `deployments` table; public map + my-cameras read deployments; the wizard is
+  owner-aware with re-aim/new mode + publish. **4 migrations dated 2026-06-13 are not
+  yet applied** (`deployment_model`, `deployment_model_backfill`, `cameras_lifecycle`,
+  `cameras_bracket_provenance`).
+- **HTTPS phone-compass calibration:** the standalone plan
+  `docs/superpowers/plans/2026-06-13-cloud-https-phone-compass-calibration.md` is
+  **superseded** — kept only `app/lib/solar.ts`, `app/lib/declination.ts`, and
+  `GET /api/setup/[code]/declination`. **Real next step:** fold the sun-arc overlay
+  into the *existing* wizard (`app/setup/[claim_code]/` → `ArPlacementPlaceholder`,
+  spec `2026-05-16-cloud-wizard-frontend-design.md` §4). Do **not** build a 2nd wizard.
+- **Decision pending:** apply the deployment migrations + open a PR, or keep iterating
+  on the branch first.
+
+### 2. Commission this one Pi — cam1 / `camera_id 4`
+- `pi-zero-2w-sunset-cam-1`; already paired (`webcam_id 28759753`); reads **Stale**
+  (heartbeating but not capturing since the window expired 2026-06-07).
+- Firmware stack (v0.4 sun-tap aiming PR #5 + device supervisor) is **built + stacked,
+  gated on physical validation**. Anchor:
+  `docs/hardware/2026-06-09-deployment-checkpoint-and-resume-prompt.md`.
+- **Unblock = the sun-free cam1 bench run**
+  (`docs/hardware/2026-06-08-supervisor-bench-run-runbook.md`). Then: v0.4 real-sun aim,
+  read-only-root unplug-test (firmware PR #6), QR-label scan/print (PR #59).
+
+### 3. Script to commission Pis in future
+- Operator `provision-unit.sh` (Mac flash + claim-code mint + sticker) — partially
+  covered by firmware `scripts/install.sh` + QR-label generator (cloud PRs #59/#60).
+- **Blocker:** the register-API pairing gap — `register` creates a `cameras` row but
+  never the `webcams` pairing, so a claim-code onboard never surfaces or accepts
+  snapshots (only the tier0 seed pairs today). See memory `reference_custom_camera_pairing`
+  (+ commissioning-self-test-frame idea).
+
+### Decided this session
+- Camera hardware: `docs/hardware/2026-06-15-camera-hardware-decision.md` — Module 3
+  Wide + central scoring, not the IMX500.

--- a/docs/hardware/2026-06-16-next-steps-pairing-gap-and-cloud-thread.md
+++ b/docs/hardware/2026-06-16-next-steps-pairing-gap-and-cloud-thread.md
@@ -1,0 +1,114 @@
+# Next Steps — 2026-06-16 (post camera-2 onboarding fix)
+
+Where we landed and the two highest-leverage things to do next, each with a
+paste-ready resume prompt. Supersedes the open items in
+`docs/hardware/2026-06-15-resume-checkpoint.md` for the onboarding thread.
+
+## What just shipped (done + verified)
+
+**Camera 2 now onboards unattended.** A cold boot → the supervisor auto-starts →
+registers + heartbeats to prod, with zero SSH / zero manual commands. Verified by
+two clean reboots on `hw-sunset-cam-2` (192.168.0.103).
+
+- Root cause was a missing `if __name__ == "__main__": main()` in firmware
+  `boot.py` (`ExecStart=python -m sunset_cam.boot` ran the module but never called
+  `main()`, so the dispatcher never executed — device booted and sat dark).
+- Fix: firmware **PR #10** (`feat/e-onboarding-stage1`), commit `1465680` + learning
+  doc `docs/solutions/integration-issues/systemd-oneshot-python-module-missing-main-entrypoint.md`.
+- Pi access: `ssh pi@192.168.0.103` (key-based), passwordless sudo enabled
+  (`/etc/sudoers.d/010-pi-nopasswd`) — burner board, leave as-is for now.
+
+---
+
+## Item 1 — The register-API pairing gap (next substantive build)
+
+**Symptom:** camera 2 heartbeats fine but `cameras.webcam_id` is empty, so it does
+**not** surface on the public map and **cannot accept snapshots** (snapshot POST 404s).
+An onboarded-but-invisible camera isn't really onboarded.
+
+**Root cause:** the `webcams` pairing row (the thing `cameras.webcam_id` points at) is
+created today only by the **tier-0 seed script**, not by the register/provision API
+path a claim-code onboard goes through. See memory `reference-custom-camera-pairing`.
+
+**Where to look (cloud repo `the-sunset-webcam-map`):**
+- `app/api/cameras/register/`, `app/api/cameras/provision/`, `app/api/cameras/pre-register/`
+- `app/lib/cameraRegistration.ts` (and the deployment-model variants on
+  `feat/cloud-https-setup`)
+- the tier-0 seed (`scripts/tier0-create-camera.sh` / the `.superpowers/camera4-bringup/`
+  scripts) — copy how IT creates the `webcams` row + sets `cameras.webcam_id`
+- the snapshot route `app/api/cameras/[id]/snapshot/` (confirm what it requires)
+
+**Goal:** provisioning/registration creates the `webcams` pairing (and links
+`cameras.webcam_id`) so a claim-code onboard surfaces and accepts frames — no manual
+seed. Consider the "commissioning self-test frame" idea (device pushes one frame at
+the end of onboarding to prove the whole path) from the pairing memory.
+
+**Decision to make first:** which endpoint owns pairing — `provision` (owner mints the
+unit) vs `register` (device first contact). Likely `provision`, so the unit is
+map-ready before it ships. Brainstorm before building.
+
+### Paste-ready prompt — pairing gap
+
+> Resume the sunset-cam onboarding work. Camera 2 now onboards unattended (firmware
+> PR #10 merged/landed). The next blocker is the **register-API pairing gap**: a
+> claim-code onboard creates the `cameras` row but never the `webcams` pairing, so
+> `cameras.webcam_id` stays empty and the camera never surfaces on the map or accepts
+> snapshots (snapshot POST 404s). Read memory `reference-custom-camera-pairing` and
+> `docs/hardware/2026-06-16-next-steps-pairing-gap-and-cloud-thread.md`. Look at how
+> the tier-0 seed creates the `webcams` row and replicate that in the
+> provision/register path (decide which endpoint owns pairing — probably `provision`).
+> Brainstorm the approach first (incl. the commissioning self-test frame), then
+> TDD it. Verify against camera 2 (id 2, `hw-sunset-cam-2`): after the fix, a
+> provisioned unit should get a non-null `webcam_id` and appear on the map. Prod DB
+> reads need my explicit OK (auto-mode blocks unprompted prod queries).
+
+---
+
+## Item 4 — The cloud HTTPS / deployment-model thread
+
+Branch `feat/cloud-https-setup` (60 commits ahead of `main`, pushed) carries:
+- the **deployment-model refactor** — provision → pre-register → register →
+  heartbeat / setup-status / decommission all act on a `deployments` table; public map
+  + my-cameras read deployments; owner-aware wizard with re-aim/new + publish.
+- **4 un-applied migrations** dated 2026-06-13 in `database/migrations/`:
+  `20260613_deployment_model.sql`, `_backfill.sql`, `cameras_lifecycle.sql`,
+  `cameras_bracket_provenance.sql`. **Prod does NOT have the `deployments` table yet**
+  (confirmed 2026-06-15) — this refactor is unmerged and not live.
+- the kept HTTPS phone-compass pieces: `app/lib/solar.ts`, `app/lib/declination.ts`,
+  and the route at **`app/api/setup/declination/`** (NOTE: the older checkpoint says
+  `/api/setup/[code]/declination` and references an `ArPlacementPlaceholder` step —
+  both are stale; the live wizard steps are `MeasureWindow`, `HingeToEquinox`,
+  `FacingPhase`, `MountConfirm`, `BracketSpec` under `app/setup/[claim_code]/`).
+
+**Decision to make:** apply the 4 deployment migrations and open the PR for
+`feat/cloud-https-setup` (the refactor is built; a 60-commit unmerged branch is risk,
+not progress) — vs. keep iterating first. Folding the sun-arc overlay into the
+existing wizard's heading step is a separate follow-on slice, not a blocker for the PR.
+
+**Caution:** the deployment-model refactor changes the same register/provision code
+the pairing gap (Item 1) lives in. Sequence them deliberately — either fix the pairing
+gap **on** `feat/cloud-https-setup` (so it lands with the refactor), or merge the
+refactor first then fix pairing on `main`. Don't fix pairing on `main` and refactor on
+the branch in parallel and have them diverge.
+
+### Paste-ready prompt — cloud thread
+
+> Resume the cloud thread on branch `feat/cloud-https-setup`. Read
+> `docs/hardware/2026-06-16-next-steps-pairing-gap-and-cloud-thread.md` and memory
+> `cloud-https-setup-mvp-in-progress` if present. The deployment-model refactor is
+> built (provision/register/heartbeat/etc. on a `deployments` table) with 4 un-applied
+> migrations dated 2026-06-13 in `database/migrations/`; prod does not have the
+> `deployments` table yet. Decide with me: apply the migrations + open the PR now, or
+> iterate first. If we PR: review the 60-commit diff vs main, run the full cloud test
+> suite, apply migrations to prod carefully (backfill is prod-safe per its header),
+> and confirm the public map + my-cameras still render. Note the pairing-gap fix
+> (Item 1) touches the same register/provision code — decide ordering so the two don't
+> diverge. Prod DB reads need my explicit OK.
+
+---
+
+## Pointers
+- Onboarding status + lessons: memory `project-streamlined-deployment-status`,
+  `feedback-instrument-the-silent-component`, `reference-sunset-cam-2-access`.
+- Prior escape hatch: `docs/hardware/2026-06-15-resume-checkpoint.md`.
+- Two repos: cloud `~/GitHub/the-sunset-webcam-map`, firmware `~/GitHub/sunset-cam-firmware`.


### PR DESCRIPTION
Adds this session's hardware/planning notes to `main` so they live alongside everything else. The `feat/cloud-https-setup` code already landed via #67 — this PR is **docs-only** (the diff is exactly three files).

## What's included
- `docs/hardware/2026-06-15-camera-hardware-decision.md` — Module 3 Wide + central scoring (not the IMX500); A/B fork, reasoning, revisit triggers.
- `docs/hardware/2026-06-15-resume-checkpoint.md` — escape-hatch checkpoint with a paste-ready resume prompt covering the three live threads (cloud program, cam1 commissioning, future provision script).
- `docs/hardware/2026-06-16-next-steps-pairing-gap-and-cloud-thread.md` — camera-2 unattended-onboarding fix + next-step prompts (register-API pairing gap, deployment migrations).

## Risk
None — additive Markdown only, no code or migrations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)