### PR TITLE
feat(ml): hard-example triage — Claude adjudicates the flag backlog

### DIFF
--- a/app/api/cron/update-cameras/lib/aiScoring.test.ts
+++ b/app/api/cron/update-cameras/lib/aiScoring.test.ts
@@ -350,10 +350,11 @@ describe('computeDisagreementKind — model-vs-Claude (Claude trusted)', () => {
     ).toBe('binary_negative_regression_high');
   });
 
-  it('prefers the model-vs-Claude kind when both families apply', () => {
-    // binary says no + aiRating 4.0 would be binary_negative_regression_high,
-    // but Claude also says not-a-sunset at a high model rating → false positive
-    // (model-vs-Claude) must win on priority.
+  it('settles rather than flags when binary agrees with Claude that it is not a sunset', () => {
+    // binary says no + Claude says no: two of three judges agree, so the
+    // regression head's high rating does not promote to
+    // model_high_claude_not_sunset.
+    // v2 (2026-07-29): Claude present ⇒ adjudicated, binary flags cleared
     expect(
       computeDisagreementKind({
         binaryIsSunset: false,
@@ -361,7 +362,7 @@ describe('computeDisagreementKind — model-vs-Claude (Claude trusted)', () => {
         llmIsSunset: false,
         llmQuality: 0.1,
       }),
-    ).toBe('model_high_claude_not_sunset');
+    ).toBeNull();
   });
 
   it('ranks model-vs-Claude kinds above binary-vs-regression kinds', () => {
@@ -371,5 +372,87 @@ describe('computeDisagreementKind — model-vs-Claude (Claude trusted)', () => {
     expect(
       DISAGREEMENT_KIND_PRIORITY.model_high_claude_not_sunset,
     ).toBeGreaterThan(DISAGREEMENT_KIND_PRIORITY.binary_positive_regression_low);
+  });
+});
+
+describe('v2: Claude adjudicates once present (2026-07-29 triage spec)', () => {
+  it('clears a binary-vs-regression flag when Claude has rated and no model-vs-Claude contest applies', () => {
+    // Dark frame: binary says no, regression 3.2 (>= 3.0 would have
+    // flagged it), Claude confirms not-a-sunset. Settled.
+    expect(
+      computeDisagreementKind({
+        binaryIsSunset: false,
+        aiRating: 3.2,
+        llmQuality: 0.05,
+        llmIsSunset: false,
+      }),
+    ).toBeNull();
+  });
+
+  it('two judges agreeing not-sunset settles even a high regression score', () => {
+    // Binary head AND Claude both say not-a-sunset: 2 of 3 judges agree,
+    // so no promotion to model_high_claude_not_sunset despite rating >= 3.5.
+    expect(
+      computeDisagreementKind({
+        binaryIsSunset: false,
+        aiRating: 4.2,
+        llmQuality: 0.05,
+        llmIsSunset: false,
+      }),
+    ).toBeNull();
+  });
+
+  it('still flags model_high_claude_not_sunset when the binary head sides with the regression head', () => {
+    expect(
+      computeDisagreementKind({
+        binaryIsSunset: true,
+        aiRating: 4.0,
+        llmQuality: 0.1,
+        llmIsSunset: false,
+      }),
+    ).toBe('model_high_claude_not_sunset');
+  });
+
+  it('keeps model_high_claude_not_sunset when the binary verdict is absent (June archive rows)', () => {
+    expect(
+      computeDisagreementKind({
+        aiRating: 4.0,
+        llmQuality: 0.1,
+        llmIsSunset: false,
+      }),
+    ).toBe('model_high_claude_not_sunset');
+  });
+
+  it('model_low_claude_sunset is unchanged', () => {
+    expect(
+      computeDisagreementKind({
+        binaryIsSunset: false,
+        aiRating: 1.5,
+        llmQuality: 0.8,
+        llmIsSunset: true,
+      }),
+    ).toBe('model_low_claude_sunset');
+  });
+
+  it('Claude-present with a mediocre verdict settles a binary_positive_regression_low flag', () => {
+    // Would be binary_positive_regression_low (yes + 1.8 <= 2.0) without
+    // Claude; Claude's mediocre-sunset verdict settles it.
+    expect(
+      computeDisagreementKind({
+        binaryIsSunset: true,
+        aiRating: 1.8,
+        llmQuality: 0.3,
+        llmIsSunset: true,
+      }),
+    ).toBeNull();
+  });
+
+  it('Claude-absent binary-vs-regression flags are unchanged (live cron path)', () => {
+    expect(
+      computeDisagreementKind({ binaryIsSunset: false, aiRating: 3.21 }),
+    ).toBe('binary_negative_regression_high');
+    expect(
+      computeDisagreementKind({ binaryIsSunset: true, aiRating: 1.9 }),
+    ).toBe('binary_positive_regression_low');
   });
 });

--- a/app/api/cron/update-cameras/lib/aiScoring.ts
+++ b/app/api/cron/update-cameras/lib/aiScoring.ts
@@ -205,25 +205,23 @@ export const DISAGREEMENT_KIND_PRIORITY: Record<DisagreementKind, number> = {
  * the Hard Examples queue. Pure function — no DB writes; the caller persists
  * the return value on the snapshot row.
  *
- * Returns the HIGHEST-priority applicable kind, or null. Model-vs-Claude is
- * evaluated first and does NOT require the binary head — the archive backfill
- * (U3) runs this offline before the binary head is enabled in prod (U8), so an
- * undefined `binaryIsSunset` must not short-circuit the model-vs-Claude check.
+ * v2 behavior: when Claude has rated the frame, Claude adjudicates — this
+ * returns a genuine model-vs-Claude disagreement kind if one applies, else
+ * null (settled; binary-vs-regression flags are provisional pending Claude's
+ * verdict, not final answers). When Claude has NOT rated the frame, this
+ * falls back to a provisional binary-vs-regression flag that nominates the
+ * frame for Claude review, else null. Model-vs-Claude is evaluated first and
+ * does NOT require the binary head — the archive backfill (U3) runs this
+ * offline before the binary head is enabled in prod (U8), so an undefined
+ * `binaryIsSunset` must not short-circuit the model-vs-Claude check.
  *
  * Claude's quality is the NORMALIZED [0,1] llm_quality, not the raw 1-5 rating
  * (see masterConfig). The CLAUDE_HIGH gate sits above the borderline-quality
  * band, which is the deadband that keeps borderline frames out of the queue.
  *
- * v2 (2026-07-29): once Claude has rated a frame, Claude adjudicates. Binary-
- * vs-regression flags are only PROVISIONAL — they exist to nominate frames for
- * Claude review before Claude has weighed in (the live cron path). Once
- * `llmIsSunset`/`llmQuality` are present, only a genuine model-vs-Claude
- * contest can surface the frame; everything else is considered settled and
- * returns null. The one exception is a two-judges-agree guard: if the binary
- * head agrees with Claude that a frame is NOT a sunset, the regression head's
- * high rating is outvoted 2-to-1 and does not promote to
- * `model_high_claude_not_sunset`. If Claude data is absent, behavior is
- * unchanged from v1 (binary-vs-regression rules only).
+ * v2 (2026-07-29) two-judges-agree guard: if the binary head agrees with
+ * Claude that a frame is NOT a sunset, the regression head's high rating is
+ * outvoted 2-to-1 and does not promote to `model_high_claude_not_sunset`.
  *
  * Behavior note: if Claude data is present but `aiRating` is undefined (no
  * regression score), this still returns null — every rule below requires
@@ -235,19 +233,19 @@ export function computeDisagreementKind(input: {
   llmQuality?: number | null;
   llmIsSunset?: boolean | null;
 }): DisagreementKind | null {
-  const { aiRating } = input;
+  const { aiRating, llmQuality } = input;
   const hasClaude =
     typeof input.llmIsSunset === 'boolean' &&
-    typeof input.llmQuality === 'number';
+    typeof llmQuality === 'number';
 
   // 1) Claude present → Claude adjudicates. Only genuine model-vs-Claude
   //    contests survive; everything else is settled (null). Binary-vs-
   //    regression flags are provisional pending this adjudication.
-  if (hasClaude && typeof aiRating === 'number') {
+  if (hasClaude && typeof aiRating === 'number' && typeof llmQuality === 'number') {
     // miss: Claude confident it's a good sunset, model rated it low.
     if (
       input.llmIsSunset &&
-      (input.llmQuality as number) >= MODEL_VS_CLAUDE_CLAUDE_HIGH &&
+      llmQuality >= MODEL_VS_CLAUDE_CLAUDE_HIGH &&
       aiRating <= MODEL_VS_CLAUDE_MODEL_LOW
     ) {
       return 'model_low_claude_sunset';

--- a/app/api/cron/update-cameras/lib/aiScoring.ts
+++ b/app/api/cron/update-cameras/lib/aiScoring.ts
@@ -213,6 +213,21 @@ export const DISAGREEMENT_KIND_PRIORITY: Record<DisagreementKind, number> = {
  * Claude's quality is the NORMALIZED [0,1] llm_quality, not the raw 1-5 rating
  * (see masterConfig). The CLAUDE_HIGH gate sits above the borderline-quality
  * band, which is the deadband that keeps borderline frames out of the queue.
+ *
+ * v2 (2026-07-29): once Claude has rated a frame, Claude adjudicates. Binary-
+ * vs-regression flags are only PROVISIONAL — they exist to nominate frames for
+ * Claude review before Claude has weighed in (the live cron path). Once
+ * `llmIsSunset`/`llmQuality` are present, only a genuine model-vs-Claude
+ * contest can surface the frame; everything else is considered settled and
+ * returns null. The one exception is a two-judges-agree guard: if the binary
+ * head agrees with Claude that a frame is NOT a sunset, the regression head's
+ * high rating is outvoted 2-to-1 and does not promote to
+ * `model_high_claude_not_sunset`. If Claude data is absent, behavior is
+ * unchanged from v1 (binary-vs-regression rules only).
+ *
+ * Behavior note: if Claude data is present but `aiRating` is undefined (no
+ * regression score), this still returns null — every rule below requires
+ * `aiRating`, same as before.
  */
 export function computeDisagreementKind(input: {
   binaryIsSunset?: boolean;
@@ -221,29 +236,38 @@ export function computeDisagreementKind(input: {
   llmIsSunset?: boolean | null;
 }): DisagreementKind | null {
   const { aiRating } = input;
-
-  // 1) Model-vs-Claude (Claude trusted). Needs the regression rating + Claude's
-  //    verdict; independent of the binary head.
-  if (
-    typeof aiRating === 'number' &&
+  const hasClaude =
     typeof input.llmIsSunset === 'boolean' &&
-    typeof input.llmQuality === 'number'
-  ) {
+    typeof input.llmQuality === 'number';
+
+  // 1) Claude present → Claude adjudicates. Only genuine model-vs-Claude
+  //    contests survive; everything else is settled (null). Binary-vs-
+  //    regression flags are provisional pending this adjudication.
+  if (hasClaude && typeof aiRating === 'number') {
     // miss: Claude confident it's a good sunset, model rated it low.
     if (
       input.llmIsSunset &&
-      input.llmQuality >= MODEL_VS_CLAUDE_CLAUDE_HIGH &&
+      (input.llmQuality as number) >= MODEL_VS_CLAUDE_CLAUDE_HIGH &&
       aiRating <= MODEL_VS_CLAUDE_MODEL_LOW
     ) {
       return 'model_low_claude_sunset';
     }
-    // false positive: model rated it high, Claude says it isn't a sunset.
-    if (!input.llmIsSunset && aiRating >= MODEL_VS_CLAUDE_MODEL_HIGH) {
+    // false positive: model rated it high, Claude says it isn't a sunset —
+    // UNLESS the binary head also says not-a-sunset, in which case two of
+    // three judges agree and the case is settled (the regression head's
+    // overrating is captured by the Claude label itself).
+    if (
+      !input.llmIsSunset &&
+      aiRating >= MODEL_VS_CLAUDE_MODEL_HIGH &&
+      input.binaryIsSunset !== false
+    ) {
       return 'model_high_claude_not_sunset';
     }
+    return null;
   }
 
-  // 2) Binary-vs-regression (the model's internal split). Needs both heads.
+  // 2) Claude absent → the model's internal split provisionally flags the
+  //    frame for adjudication (live cron path; unchanged).
   if (typeof input.binaryIsSunset === 'boolean' && typeof aiRating === 'number') {
     if (!input.binaryIsSunset && aiRating >= SUNSET_DISAGREEMENT_HIGH) {
       return 'binary_negative_regression_high';

--- a/docs/superpowers/plans/2026-07-29-hard-example-triage.md
+++ b/docs/superpowers/plans/2026-07-29-hard-example-triage.md
@@ -1,0 +1,1014 @@
+# Hard-Example Triage Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Claude (claude-sonnet-5) rates every unrated flagged webcam snapshot via the Batch API, and `computeDisagreementKind` treats Claude as the adjudicator so the Hard Examples queue collapses to genuine model-vs-Claude contests.
+
+**Architecture:** Three components per the spec (`docs/superpowers/specs/2026-07-29-hard-example-triage-design.md`): (1) extensions to the existing `ml/llm_rater.py` (selection, sonnet-5, Batch API, run manifest), (2) a semantic change to the pure TS function `computeDisagreementKind` in `app/api/cron/update-cameras/lib/aiScoring.ts`, (3) an operator runbook (dry-run → smoke slice → full run → recompute-reset SQL) documented in `ml/OPERATING_GUIDE.md`. No schema changes.
+
+**Tech Stack:** Python 3 + psycopg2 + `anthropic` SDK (Message Batches) + pytest; TypeScript + vitest.
+
+## Global Constraints
+
+- Branch: `feat/hard-example-triage` in the main checkout (`/Users/jessekauppila/GitHub/the-sunset-webcam-map`). NO worktrees in this repo.
+- No DB schema changes anywhere in this plan.
+- Judge provenance: every DB rating write must go through the existing `DbWriter.write_rating`, which stamps `llm_model`, `llm_provider`, `llm_rated_at`, and `prompt_version` — never write `llm_*` columns any other way.
+- Never fabricate a rating: a frame that fails (download error, batch error, unparseable JSON) is logged and left unrated. The `--flagged-unrated` predicate is the retry mechanism.
+- Python tests: `python3 -m pytest ml/test_llm_rater_triage.py -v` (new file; existing ml tests are `ml/test_*.py`). TS tests: `npx vitest run app/api/cron/update-cameras/lib/aiScoring.test.ts`.
+- The plan only builds the tooling. The operator (Jesse) runs the actual spend steps (dry-run / smoke / full run / reset SQL) from the runbook — no task in this plan calls the Anthropic API against production data.
+- Model pricing constants: `claude-sonnet-5` = $3.00 input / $15.00 output per MTok (sticker; intro $2/$10 through 2026-08-31 — comment only). Thresholds referenced in TS: `SUNSET_DISAGREEMENT_HIGH=3.0`, `SUNSET_DISAGREEMENT_LOW=2.0`, `MODEL_VS_CLAUDE_MODEL_HIGH=3.5`, `MODEL_VS_CLAUDE_MODEL_LOW=2.0`, `MODEL_VS_CLAUDE_CLAUDE_HIGH=0.6` (all already in `app/lib/masterConfig.ts` — do not change them).
+
+---
+
+### Task 1: `--flagged-unrated` selection in `llm_rater.py`
+
+**Files:**
+- Modify: `ml/llm_rater.py` (arg parser ~line 90-184; add functions near `fetch_webcam_rows` ~line 486; wire into `main()`)
+- Test: `ml/test_llm_rater_triage.py` (create)
+
+**Interfaces:**
+- Produces: `build_flagged_unrated_query(limit: int) -> str` (pure), `fetch_flagged_unrated_rows(conn, limit: int) -> list[dict]` (rows shaped exactly like `fetch_webcam_rows` output: keys `record_id, source_table, webcam_id, image_url, human_calculated_rating, human_rating_count`), argparse flag `args.flagged_unrated`.
+- Consumes: nothing from other tasks.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `ml/test_llm_rater_triage.py`:
+
+```python
+"""Tests for the hard-example triage extensions to llm_rater.py."""
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+from llm_rater import build_flagged_unrated_query
+
+
+def test_flagged_unrated_selects_only_flagged_unrated_webcam_rows():
+    q = build_flagged_unrated_query(limit=0)
+    assert "model_disagreement_kind IS NOT NULL" in q
+    assert "llm_quality IS NULL" in q
+    assert "firebase_url IS NOT NULL" in q
+    assert "webcam_snapshots" in q
+
+
+def test_flagged_unrated_orders_per_camera_round_robin():
+    q = build_flagged_unrated_query(limit=500)
+    assert (
+        "ROW_NUMBER() OVER (PARTITION BY s.webcam_id "
+        "ORDER BY s.captured_at DESC)" in q
+    )
+    # Round-robin: rank across cameras is the primary sort key, so a
+    # --limit slice spreads across cameras instead of draining one.
+    assert "ORDER BY cam_rank, webcam_id" in q
+    assert q.rstrip().endswith("LIMIT 500")
+
+
+def test_flagged_unrated_omits_limit_clause_when_zero():
+    q = build_flagged_unrated_query(limit=0)
+    assert "LIMIT" not in q
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `python3 -m pytest ml/test_llm_rater_triage.py -v`
+Expected: FAIL with `ImportError: cannot import name 'build_flagged_unrated_query'`
+
+- [ ] **Step 3: Implement the query builder + fetcher**
+
+In `ml/llm_rater.py`, directly below `fetch_webcam_rows` (~line 514), add:
+
+```python
+def build_flagged_unrated_query(limit: int) -> str:
+    """Selection SQL for the hard-example triage pass (2026-07-29 spec).
+
+    Every webcam snapshot the live cron flagged (model_disagreement_kind
+    set) that Claude has not yet rated. Per-camera round-robin ordering so
+    a --limit slice spreads coverage across cameras.
+    """
+    limit_clause = f"LIMIT {limit}" if limit > 0 else ""
+    return f"""
+    SELECT record_id, source_table, webcam_id, image_url,
+           human_calculated_rating, human_rating_count
+    FROM (
+      SELECT
+        s.id AS record_id,
+        'webcam' AS source_table,
+        s.webcam_id,
+        s.firebase_url AS image_url,
+        s.calculated_rating AS human_calculated_rating,
+        0 AS human_rating_count,
+        ROW_NUMBER() OVER (PARTITION BY s.webcam_id ORDER BY s.captured_at DESC) AS cam_rank
+      FROM webcam_snapshots s
+      WHERE s.firebase_url IS NOT NULL
+        AND s.model_disagreement_kind IS NOT NULL
+        AND s.llm_quality IS NULL
+    ) ranked
+    ORDER BY cam_rank, webcam_id
+    {limit_clause}
+    """
+
+
+def fetch_flagged_unrated_rows(
+    conn: psycopg2.extensions.connection,
+    limit: int,
+) -> list[dict[str, Any]]:
+    """Fetch flagged-but-Claude-unrated webcam snapshots (triage pass)."""
+    with conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as cur:
+        cur.execute(build_flagged_unrated_query(limit))
+        return [dict(r) for r in cur.fetchall()]
+```
+
+Note: `human_rating_count` is hardcoded 0 (the LEFT JOIN in `fetch_webcam_rows` exists only for the dry-run HTML report's agreement column; the triage pass doesn't need it and skipping the join keeps the window query cheap).
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `python3 -m pytest ml/test_llm_rater_triage.py -v`
+Expected: 3 PASS
+
+- [ ] **Step 5: Add the CLI flag and wire into `main()`**
+
+In `parse_args()` (after the `--skip-rated` argument, ~line 147):
+
+```python
+    parser.add_argument(
+        "--flagged-unrated", action="store_true",
+        help="Triage mode: select only webcam snapshots with "
+             "model_disagreement_kind set and no llm_quality yet "
+             "(per-camera round-robin order). Implies --source webcam.",
+    )
+```
+
+In `main()`, find the row-fetch dispatch (search for `fetch_webcam_rows(` inside `main()`); it looks like `rows = []` followed by `if args.source in (...)` branches. Add the triage branch FIRST, before the source branches, so it takes precedence:
+
+```python
+    if args.flagged_unrated:
+        if args.source != "webcam":
+            print("--flagged-unrated implies --source webcam; ignoring --source", file=sys.stderr)
+        rows = fetch_flagged_unrated_rows(conn, args.limit)
+    elif ...  # existing source branches unchanged, now guarded by elif
+```
+
+(Adjust the existing `if` chain to `elif` as needed — the existing `webcam` / `external` / `all` behavior must be unchanged when `--flagged-unrated` is absent.)
+
+- [ ] **Step 6: Sanity-check the script still parses and the full ml test files still pass**
+
+Run: `python3 -c "import sys; sys.path.insert(0, 'ml'); import llm_rater"` and `python3 -m pytest ml/ -v`
+Expected: import OK; all ml tests PASS
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add ml/llm_rater.py ml/test_llm_rater_triage.py
+git commit -m "feat(ml): --flagged-unrated triage selection with per-camera round-robin"
+```
+
+---
+
+### Task 2: claude-sonnet-5 support (pricing + no sampling params)
+
+**Files:**
+- Modify: `ml/llm_rater.py` (`MODEL_PRICING_USD_PER_MTOK` ~line 203; `rate_with_anthropic` ~line 383)
+- Test: `ml/test_llm_rater_triage.py` (append)
+
+**Interfaces:**
+- Produces: `rate_with_anthropic` no longer sends `temperature` (any model); pricing entry key `"claude-sonnet-5"`.
+- Consumes: nothing from other tasks.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `ml/test_llm_rater_triage.py`:
+
+```python
+def test_anthropic_request_sends_no_temperature(monkeypatch):
+    """claude-sonnet-5 rejects non-default sampling params with a 400."""
+    captured = {}
+
+    class FakeMessages:
+        def create(self, **kwargs):
+            captured.update(kwargs)
+
+            class Block:
+                text = '{"quality": 0.5, "is_sunset": true}'
+
+            class Resp:
+                content = [Block()]
+
+            return Resp()
+
+    class FakeClient:
+        def __init__(self, **kwargs):
+            self.messages = FakeMessages()
+
+    import anthropic
+    monkeypatch.setattr(anthropic, "Anthropic", FakeClient)
+
+    from llm_rater import rate_with_anthropic
+    result = rate_with_anthropic(b"fakejpegbytes", "claude-sonnet-5", "key")
+
+    assert "temperature" not in captured
+    assert captured["model"] == "claude-sonnet-5"
+    assert result["quality"] == 0.5
+
+
+def test_sonnet_5_has_a_pricing_entry():
+    from llm_rater import MODEL_PRICING_USD_PER_MTOK
+    entry = MODEL_PRICING_USD_PER_MTOK["claude-sonnet-5"]
+    assert entry == {"input": 3.00, "output": 15.00}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `python3 -m pytest ml/test_llm_rater_triage.py -v -k "temperature or pricing"`
+Expected: `test_anthropic_request_sends_no_temperature` FAILS (`temperature` IS in captured); `test_sonnet_5_has_a_pricing_entry` FAILS (KeyError)
+
+- [ ] **Step 3: Implement**
+
+In `MODEL_PRICING_USD_PER_MTOK` (~line 205), add above `"claude-sonnet-4-5"`:
+
+```python
+    # Sticker price; intro $2/$10 through 2026-08-31, Batch API halves either.
+    "claude-sonnet-5":     {"input": 3.00, "output": 15.00},
+```
+
+(Prefix matching is longest-match-wins, and `"claude-sonnet-5"` vs `"claude-sonnet-4-5"` don't prefix-collide, so placement is for readability only.)
+
+In `rate_with_anthropic` (~line 397), delete the `temperature=0.1,` line from `client.messages.create(...)`. Gemini/OpenAI providers keep their temperature settings — this change is Anthropic-path only.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `python3 -m pytest ml/test_llm_rater_triage.py -v`
+Expected: all PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add ml/llm_rater.py ml/test_llm_rater_triage.py
+git commit -m "feat(ml): claude-sonnet-5 support — pricing entry, drop temperature from anthropic path"
+```
+
+---
+
+### Task 3: Run manifest (campaign provenance)
+
+**Files:**
+- Modify: `ml/llm_rater.py` (new function near the CSV/artifacts handling; wire at end of `main()`)
+- Test: `ml/test_llm_rater_triage.py` (append)
+
+**Interfaces:**
+- Produces: `write_run_manifest(out_dir: str | Path, *, model: str, provider: str, selection: dict, attempted: int, succeeded: int, failed: int, tokens_in: int, tokens_out: int, est_cost_usd: float, started_at: str, finished_at: str) -> Path` — writes `run_<YYYYmmdd_HHMMSS>_manifest.json` and returns its path. JSON includes `prompt_sha256` (sha256 of `RATING_PROMPT`) and `prompt_version: "v2_extended"`.
+- Consumes: `RATING_PROMPT` (existing module constant, line 60).
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `ml/test_llm_rater_triage.py`:
+
+```python
+import hashlib
+import json
+
+
+def test_run_manifest_contents(tmp_path):
+    from llm_rater import write_run_manifest, RATING_PROMPT
+
+    path = write_run_manifest(
+        tmp_path,
+        model="claude-sonnet-5",
+        provider="anthropic",
+        selection={"mode": "flagged_unrated", "limit": 500},
+        attempted=500,
+        succeeded=497,
+        failed=3,
+        tokens_in=1_000_000,
+        tokens_out=75_000,
+        est_cost_usd=4.13,
+        started_at="2026-07-29T20:00:00Z",
+        finished_at="2026-07-29T21:30:00Z",
+    )
+
+    assert path.name.startswith("run_") and path.name.endswith("_manifest.json")
+    data = json.loads(path.read_text())
+    assert data["model"] == "claude-sonnet-5"
+    assert data["provider"] == "anthropic"
+    assert data["prompt_version"] == "v2_extended"
+    assert data["prompt_sha256"] == hashlib.sha256(
+        RATING_PROMPT.encode("utf-8")
+    ).hexdigest()
+    assert data["selection"] == {"mode": "flagged_unrated", "limit": 500}
+    assert data["counts"] == {"attempted": 500, "succeeded": 497, "failed": 3}
+    assert data["tokens"] == {"input": 1_000_000, "output": 75_000}
+    assert data["est_cost_usd"] == 4.13
+    assert data["started_at"] == "2026-07-29T20:00:00Z"
+    assert data["finished_at"] == "2026-07-29T21:30:00Z"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python3 -m pytest ml/test_llm_rater_triage.py::test_run_manifest_contents -v`
+Expected: FAIL with ImportError on `write_run_manifest`
+
+- [ ] **Step 3: Implement**
+
+In `ml/llm_rater.py` (near the other artifact-path helpers; `import hashlib` at top with the other stdlib imports):
+
+```python
+def write_run_manifest(
+    out_dir: "str | Path",
+    *,
+    model: str,
+    provider: str,
+    selection: dict,
+    attempted: int,
+    succeeded: int,
+    failed: int,
+    tokens_in: int,
+    tokens_out: int,
+    est_cost_usd: float,
+    started_at: str,
+    finished_at: str,
+) -> Path:
+    """Write a per-campaign provenance manifest (2026-07-29 triage spec).
+
+    Documents exactly how a rating run was produced so training exports
+    can slice by judge/campaign later. The prompt has no version constant;
+    its sha256 IS the version.
+    """
+    out_dir = Path(out_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    stamp = datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
+    path = out_dir / f"run_{stamp}_manifest.json"
+    path.write_text(json.dumps({
+        "model": model,
+        "provider": provider,
+        "prompt_version": "v2_extended",
+        "prompt_sha256": hashlib.sha256(RATING_PROMPT.encode("utf-8")).hexdigest(),
+        "selection": selection,
+        "counts": {"attempted": attempted, "succeeded": succeeded, "failed": failed},
+        "tokens": {"input": tokens_in, "output": tokens_out},
+        "est_cost_usd": est_cost_usd,
+        "started_at": started_at,
+        "finished_at": finished_at,
+    }, indent=2))
+    return path
+```
+
+(If `from pathlib import Path` isn't already imported at module top, add it.)
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `python3 -m pytest ml/test_llm_rater_triage.py::test_run_manifest_contents -v`
+Expected: PASS
+
+- [ ] **Step 5: Wire into `main()`**
+
+At the end of `main()` where the run summary is printed (search for the final summary/`print` block after the rating loop), add — for every run that is NOT `--dry-run` and NOT `--estimate-only`:
+
+```python
+    manifest_path = write_run_manifest(
+        Path("ml/artifacts/llm_ratings"),
+        model=model,
+        provider=args.provider,
+        selection={
+            "mode": "flagged_unrated" if args.flagged_unrated else args.source,
+            "limit": args.limit,
+            "skip_rated": args.skip_rated,
+            "use_batch_api": getattr(args, "use_batch_api", False),
+        },
+        attempted=attempted_count,
+        succeeded=success_count,
+        failed=failure_count,
+        tokens_in=total_tokens_in,
+        tokens_out=total_tokens_out,
+        est_cost_usd=round(est_cost, 2),
+        started_at=run_started_at_iso,
+        finished_at=datetime.now(timezone.utc).isoformat(),
+    )
+    print(f"Run manifest: {manifest_path}")
+```
+
+Map the count/token variables onto whatever `main()`'s loop already tracks (it accumulates success/failure counts and token totals for the cost summary — reuse those names; capture `run_started_at_iso = datetime.now(timezone.utc).isoformat()` at loop start). If a token total isn't tracked on some path, pass 0 — never invent numbers.
+
+- [ ] **Step 6: Run all triage tests + import check**
+
+Run: `python3 -m pytest ml/test_llm_rater_triage.py -v && python3 -c "import sys; sys.path.insert(0, 'ml'); import llm_rater"`
+Expected: all PASS, import OK
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add ml/llm_rater.py ml/test_llm_rater_triage.py
+git commit -m "feat(ml): per-campaign run manifest with prompt hash provenance"
+```
+
+---
+
+### Task 4: Batch API mode (`--use-batch-api`)
+
+**Files:**
+- Modify: `ml/llm_rater.py` (extract `normalize_rating` from `rate_image` ~line 438-483; new batch functions; arg + `main()` wiring)
+- Modify: `ml/requirements.txt` (ensure `anthropic>=0.40`)
+- Test: `ml/test_llm_rater_triage.py` (append)
+
+**Interfaces:**
+- Produces:
+  - `normalize_rating(result: dict) -> dict` — applies the exact defaulting/clamping currently inline in `rate_image` (setdefaults for `is_sunset/is_sunrise/quality/confidence/has_clouds/color_palette/obstruction/time_of_day/sky_coverage/rating_explanation`, clamps quality+confidence to [0,1], normalizes `time_of_day` and `sky_coverage` enums).
+  - `build_batch_requests(rows, model, download_timeout, download_fn=download_image_bytes) -> tuple[list[list[dict]], list[dict]]` — returns (chunks, failures). Each request dict: `{"custom_id": "<source_table>:<record_id>", "params": {...}}`. Chunk caps: `MAX_BATCH_REQUESTS = 1000`, `MAX_BATCH_BYTES = 200_000_000` (sum of base64 lengths).
+  - `parse_custom_id(custom_id: str) -> tuple[str, int]` — `"webcam:123"` → `("webcam", 123)`.
+  - argparse flag `args.use_batch_api`.
+- Consumes: `fetch_flagged_unrated_rows` rows shape (Task 1), `DbWriter.write_rating` (existing), `rate_with_anthropic`'s message shape (existing), `write_run_manifest` (Task 3).
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `ml/test_llm_rater_triage.py`:
+
+```python
+def test_normalize_rating_defaults_and_clamps():
+    from llm_rater import normalize_rating
+
+    out = normalize_rating({"quality": 1.7, "confidence": -0.2,
+                            "time_of_day": "BOGUS", "sky_coverage": "nope"})
+    assert out["quality"] == 1.0
+    assert out["confidence"] == 0.0
+    assert out["is_sunset"] is False
+    assert out["is_sunrise"] is False
+    assert out["time_of_day"] == "unclear"
+    assert out["sky_coverage"] == "partial"
+    assert out["rating_explanation"] == ""
+
+
+def test_parse_custom_id_round_trip():
+    from llm_rater import parse_custom_id
+
+    assert parse_custom_id("webcam:123") == ("webcam", 123)
+    assert parse_custom_id("external:45") == ("external", 45)
+
+
+def _fake_rows(n):
+    return [
+        {"record_id": i, "source_table": "webcam", "webcam_id": i % 7,
+         "image_url": f"https://x/{i}.jpg",
+         "human_calculated_rating": None, "human_rating_count": 0}
+        for i in range(n)
+    ]
+
+
+def test_build_batch_requests_chunks_by_request_count():
+    from llm_rater import build_batch_requests
+
+    def fake_download(url, timeout=30.0):
+        return b"tinyjpeg", "image/jpeg"
+
+    chunks, failures = build_batch_requests(
+        _fake_rows(2500), "claude-sonnet-5", 30.0, download_fn=fake_download,
+    )
+    assert failures == []
+    assert [len(c) for c in chunks] == [1000, 1000, 500]
+    first = chunks[0][0]
+    assert first["custom_id"] == "webcam:0"
+    assert first["params"]["model"] == "claude-sonnet-5"
+    assert first["params"]["max_tokens"] == 600
+    assert "temperature" not in first["params"]
+
+
+def test_build_batch_requests_records_download_failures():
+    from llm_rater import build_batch_requests
+
+    def flaky_download(url, timeout=30.0):
+        if url.endswith("1.jpg"):
+            raise RuntimeError("404 dead url")
+        return b"tinyjpeg", "image/jpeg"
+
+    chunks, failures = build_batch_requests(
+        _fake_rows(3), "claude-sonnet-5", 30.0, download_fn=flaky_download,
+    )
+    assert len(failures) == 1
+    assert failures[0]["custom_id"] == "webcam:1"
+    assert sum(len(c) for c in chunks) == 2
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `python3 -m pytest ml/test_llm_rater_triage.py -v -k "normalize or custom_id or batch_requests"`
+Expected: 4 FAIL with ImportError
+
+- [ ] **Step 3: Extract `normalize_rating` (refactor, behavior-preserving)**
+
+In `ml/llm_rater.py`, move the defaulting/clamping block currently inside `rate_image`'s try (lines ~452-472) into a module-level function, and call it from `rate_image`:
+
+```python
+def normalize_rating(result: dict) -> dict:
+    """Apply defaults + clamps to a raw LLM rating dict (shared by the
+    sequential path and the Batch API path)."""
+    result.setdefault("is_sunset", False)
+    result.setdefault("is_sunrise", False)
+    result.setdefault("quality", 0.0)
+    result.setdefault("confidence", 0.5)
+    result.setdefault("has_clouds", False)
+    result.setdefault("color_palette", "")
+    result.setdefault("obstruction", None)
+    result.setdefault("time_of_day", "unclear")
+    result.setdefault("sky_coverage", "partial")
+    result.setdefault("rating_explanation", "")
+    result["quality"] = max(0.0, min(1.0, float(result["quality"])))
+    result["confidence"] = max(0.0, min(1.0, float(result["confidence"])))
+    time_of_day = str(result["time_of_day"]).strip().lower()
+    if time_of_day not in {"golden_hour", "blue_hour", "twilight",
+                           "day", "night", "unclear"}:
+        time_of_day = "unclear"
+    result["time_of_day"] = time_of_day
+    sky_coverage = str(result["sky_coverage"]).strip().lower()
+    if sky_coverage not in {"none", "partial", "mostly", "full"}:
+        sky_coverage = "partial"
+    result["sky_coverage"] = sky_coverage
+    return result
+```
+
+Inside `rate_image`, replace the moved block with `result = normalize_rating(result)` followed by `return result`.
+
+- [ ] **Step 4: Implement `parse_custom_id` and `build_batch_requests`**
+
+```python
+MAX_BATCH_REQUESTS = 1000
+MAX_BATCH_BYTES = 200_000_000  # ~200 MB of base64 payload per batch (API cap 256 MB)
+
+
+def parse_custom_id(custom_id: str) -> tuple[str, int]:
+    source_table, _, record_id = custom_id.partition(":")
+    return source_table, int(record_id)
+
+
+def build_batch_requests(
+    rows: list[dict],
+    model: str,
+    download_timeout: float,
+    download_fn=download_image_bytes,
+) -> tuple[list[list[dict]], list[dict]]:
+    """Download images and build Message Batches request chunks.
+
+    Returns (chunks, failures): chunks is a list of request-lists sized
+    under MAX_BATCH_REQUESTS / MAX_BATCH_BYTES; failures records rows whose
+    image could not be downloaded (they stay unrated — the
+    --flagged-unrated predicate re-selects them on the next run).
+    """
+    chunks: list[list[dict]] = []
+    current: list[dict] = []
+    current_bytes = 0
+    failures: list[dict] = []
+
+    for row in rows:
+        custom_id = f"{row['source_table']}:{row['record_id']}"
+        try:
+            image_bytes, content_type = download_fn(
+                row["image_url"], timeout=download_timeout,
+            )
+        except Exception as exc:
+            failures.append({"custom_id": custom_id, "error": str(exc)})
+            continue
+        media_type = detect_image_media_type(image_bytes, content_type)
+        b64 = base64.b64encode(image_bytes).decode("utf-8")
+        request = {
+            "custom_id": custom_id,
+            "params": {
+                "model": model,
+                "max_tokens": 600,
+                "messages": [{
+                    "role": "user",
+                    "content": [
+                        {"type": "image",
+                         "source": {"type": "base64",
+                                    "media_type": media_type,
+                                    "data": b64}},
+                        {"type": "text", "text": RATING_PROMPT},
+                    ],
+                }],
+            },
+        }
+        if (len(current) >= MAX_BATCH_REQUESTS
+                or current_bytes + len(b64) > MAX_BATCH_BYTES):
+            if current:
+                chunks.append(current)
+            current, current_bytes = [], 0
+        current.append(request)
+        current_bytes += len(b64)
+
+    if current:
+        chunks.append(current)
+    return chunks, failures
+```
+
+Note: the image/text content order matches `rate_with_anthropic` (image first, then `RATING_PROMPT`) so the sequential and batch paths send byte-identical prompts.
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `python3 -m pytest ml/test_llm_rater_triage.py -v`
+Expected: all PASS
+
+- [ ] **Step 6: Implement submission/polling + `main()` wiring**
+
+Add the runner (not unit-tested — exercised by the smoke slice in the runbook; keep it thin):
+
+```python
+def run_batch_chunks(
+    api_key: str,
+    chunks: list[list[dict]],
+    poll_seconds: int = 60,
+):
+    """Submit each chunk as a Message Batch, poll to completion, and yield
+    (custom_id, ok, payload, usage) tuples. payload is the parsed rating
+    dict when ok, else an error string; usage is (input_tokens,
+    output_tokens) for succeeded entries, (0, 0) otherwise."""
+    from anthropic import Anthropic
+
+    client = Anthropic(api_key=api_key)
+    for i, chunk in enumerate(chunks, 1):
+        batch = client.messages.batches.create(requests=chunk)
+        print(f"Batch {i}/{len(chunks)} submitted: {batch.id} "
+              f"({len(chunk)} requests)")
+        while True:
+            batch = client.messages.batches.retrieve(batch.id)
+            if batch.processing_status == "ended":
+                break
+            time.sleep(poll_seconds)
+        for result in client.messages.batches.results(batch.id):
+            if result.result.type == "succeeded":
+                message = result.result.message
+                usage = (message.usage.input_tokens, message.usage.output_tokens)
+                text = message.content[0].text.strip()
+                if text.startswith("```"):
+                    lines = text.split("\n")
+                    if lines[0].startswith("```"):
+                        lines = lines[1:]
+                    if lines and lines[-1].startswith("```"):
+                        lines = lines[:-1]
+                    text = "\n".join(lines).strip()
+                try:
+                    yield result.custom_id, True, json.loads(text), usage
+                except Exception as exc:
+                    yield result.custom_id, False, f"unparseable JSON: {exc}", (0, 0)
+            else:
+                yield result.custom_id, False, result.result.type, (0, 0)
+```
+
+Add the argparse flag (after `--flagged-unrated`):
+
+```python
+    parser.add_argument(
+        "--use-batch-api", action="store_true",
+        help="Anthropic only: submit via the Message Batches API (50%% "
+             "cheaper, hours not days). Requires --write-to-db; "
+             "incompatible with --dry-run. CSV/HTML reports are skipped — "
+             "the run manifest carries the accounting.",
+    )
+```
+
+In `main()`, immediately after args are resolved, validate:
+
+```python
+    if args.use_batch_api:
+        if args.provider != "anthropic":
+            sys.exit("--use-batch-api requires --provider anthropic")
+        if not args.write_to_db:
+            sys.exit("--use-batch-api requires --write-to-db (no CSV path)")
+        if args.dry_run:
+            sys.exit("--use-batch-api is incompatible with --dry-run")
+```
+
+Then, where the sequential rating loop would begin, branch: if `args.use_batch_api`, run this flow INSTEAD of the sequential loop (then fall through to the manifest write from Task 3, then exit):
+
+```python
+    if args.use_batch_api:
+        run_started_at_iso = datetime.now(timezone.utc).isoformat()
+        chunks, failures = build_batch_requests(
+            rows, model, args.download_timeout,
+        )
+        for f in failures:
+            print(f"  download failed, left unrated: {f['custom_id']}: {f['error']}")
+        db = DbWriter(database_url)
+        success_count, failure_count = 0, len(failures)
+        total_tokens_in = total_tokens_out = 0
+        for custom_id, ok, payload, usage in run_batch_chunks(api_key, chunks):
+            source_table, record_id = parse_custom_id(custom_id)
+            total_tokens_in += usage[0]
+            total_tokens_out += usage[1]
+            if not ok:
+                failure_count += 1
+                print(f"  batch entry failed, left unrated: {custom_id}: {payload}")
+                continue
+            rating = normalize_rating(payload)
+            db.write_rating(source_table, record_id, rating, model, args.provider)
+            success_count += 1
+        db.close()
+        attempted_count = len(rows)
+        # Sticker-rate estimate from real usage; the Batch API bills ~50% of
+        # this (and intro pricing less again) — the manifest field is an
+        # upper-bound estimate, actual billing is whatever Anthropic charges.
+        price = MODEL_PRICING_USD_PER_MTOK.get(model, {"input": 0.0, "output": 0.0})
+        est_cost = (total_tokens_in / 1e6) * price["input"] \
+            + (total_tokens_out / 1e6) * price["output"]
+        # ... Task 3 manifest write runs here ...
+        print(f"Batch run complete: {success_count} rated, {failure_count} failed/skipped "
+              f"of {attempted_count} selected.")
+        return
+```
+
+- [ ] **Step 7: Ensure the SDK version supports Message Batches**
+
+Check `ml/requirements.txt` for the `anthropic` line. If missing or older, set:
+
+```
+anthropic>=0.40
+```
+
+Then run: `python3 -c "import anthropic; print(anthropic.__version__); c=anthropic.Anthropic(api_key='x'); print(type(c.messages.batches))"`
+Expected: prints a version ≥ 0.40 and a Batches resource type (no AttributeError). If the import fails locally, `pip3 install -U anthropic` first.
+
+- [ ] **Step 8: Run the whole triage test file + ml suite**
+
+Run: `python3 -m pytest ml/ -v`
+Expected: all PASS
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add ml/llm_rater.py ml/test_llm_rater_triage.py ml/requirements.txt
+git commit -m "feat(ml): Message Batches mode for the triage pass (--use-batch-api)"
+```
+
+---
+
+### Task 5: `computeDisagreementKind` v2 — Claude adjudicates
+
+**Files:**
+- Modify: `app/api/cron/update-cameras/lib/aiScoring.ts` (function at ~line 217-257 + its doc comment)
+- Test: `app/api/cron/update-cameras/lib/aiScoring.test.ts` (describe block at ~line 264)
+
+**Interfaces:**
+- Consumes: existing masterConfig thresholds (Global Constraints).
+- Produces: unchanged signature `computeDisagreementKind(input: { binaryIsSunset?: boolean; aiRating?: number; llmQuality?: number | null; llmIsSunset?: boolean | null }): DisagreementKind | null`. New semantics: Claude-present ⇒ only model-vs-Claude kinds (with the two-judges-agree guard) or null; Claude-absent ⇒ binary-vs-regression rules unchanged. The recompute loop and live cron call sites need NO changes.
+
+- [ ] **Step 1: Write the failing tests**
+
+In `aiScoring.test.ts`, inside the existing `describe('computeDisagreementKind', ...)` block, add:
+
+```typescript
+  describe('v2: Claude adjudicates once present (2026-07-29 triage spec)', () => {
+    it('clears a binary-vs-regression flag when Claude has rated and no model-vs-Claude contest applies', () => {
+      // Dark frame: binary says no, regression 3.2 (>= 3.0 would have
+      // flagged it), Claude confirms not-a-sunset. Settled.
+      expect(
+        computeDisagreementKind({
+          binaryIsSunset: false,
+          aiRating: 3.2,
+          llmQuality: 0.05,
+          llmIsSunset: false,
+        }),
+      ).toBeNull();
+    });
+
+    it('two judges agreeing not-sunset settles even a high regression score', () => {
+      // Binary head AND Claude both say not-a-sunset: 2 of 3 judges agree,
+      // so no promotion to model_high_claude_not_sunset despite rating >= 3.5.
+      expect(
+        computeDisagreementKind({
+          binaryIsSunset: false,
+          aiRating: 4.2,
+          llmQuality: 0.05,
+          llmIsSunset: false,
+        }),
+      ).toBeNull();
+    });
+
+    it('still flags model_high_claude_not_sunset when the binary head sides with the regression head', () => {
+      expect(
+        computeDisagreementKind({
+          binaryIsSunset: true,
+          aiRating: 4.0,
+          llmQuality: 0.1,
+          llmIsSunset: false,
+        }),
+      ).toBe('model_high_claude_not_sunset');
+    });
+
+    it('keeps model_high_claude_not_sunset when the binary verdict is absent (June archive rows)', () => {
+      expect(
+        computeDisagreementKind({
+          aiRating: 4.0,
+          llmQuality: 0.1,
+          llmIsSunset: false,
+        }),
+      ).toBe('model_high_claude_not_sunset');
+    });
+
+    it('model_low_claude_sunset is unchanged', () => {
+      expect(
+        computeDisagreementKind({
+          binaryIsSunset: false,
+          aiRating: 1.5,
+          llmQuality: 0.8,
+          llmIsSunset: true,
+        }),
+      ).toBe('model_low_claude_sunset');
+    });
+
+    it('Claude-present with a mediocre verdict settles a binary_positive_regression_low flag', () => {
+      // Would be binary_positive_regression_low (yes + 1.8 <= 2.0) without
+      // Claude; Claude's mediocre-sunset verdict settles it.
+      expect(
+        computeDisagreementKind({
+          binaryIsSunset: true,
+          aiRating: 1.8,
+          llmQuality: 0.3,
+          llmIsSunset: true,
+        }),
+      ).toBeNull();
+    });
+
+    it('Claude-absent binary-vs-regression flags are unchanged (live cron path)', () => {
+      expect(
+        computeDisagreementKind({ binaryIsSunset: false, aiRating: 3.21 }),
+      ).toBe('binary_negative_regression_high');
+      expect(
+        computeDisagreementKind({ binaryIsSunset: true, aiRating: 1.9 }),
+      ).toBe('binary_positive_regression_low');
+    });
+  });
+```
+
+- [ ] **Step 2: Run tests to verify the new ones fail**
+
+Run: `npx vitest run app/api/cron/update-cameras/lib/aiScoring.test.ts`
+Expected: the first, second, and sixth new tests FAIL (old code falls through to binary rules / promotes without the binary guard); the rest of the new tests PASS; pre-existing tests PASS.
+
+- [ ] **Step 3: Implement**
+
+Replace the body of `computeDisagreementKind` (keep the signature and the doc comment's first paragraphs; extend the doc comment to describe adjudication):
+
+```typescript
+export function computeDisagreementKind(input: {
+  binaryIsSunset?: boolean;
+  aiRating?: number;
+  llmQuality?: number | null;
+  llmIsSunset?: boolean | null;
+}): DisagreementKind | null {
+  const { aiRating } = input;
+  const hasClaude =
+    typeof input.llmIsSunset === 'boolean' &&
+    typeof input.llmQuality === 'number';
+
+  // 1) Claude present → Claude adjudicates. Only genuine model-vs-Claude
+  //    contests survive; everything else is settled (null). Binary-vs-
+  //    regression flags are provisional pending this adjudication.
+  if (hasClaude && typeof aiRating === 'number') {
+    // miss: Claude confident it's a good sunset, model rated it low.
+    if (
+      input.llmIsSunset &&
+      (input.llmQuality as number) >= MODEL_VS_CLAUDE_CLAUDE_HIGH &&
+      aiRating <= MODEL_VS_CLAUDE_MODEL_LOW
+    ) {
+      return 'model_low_claude_sunset';
+    }
+    // false positive: model rated it high, Claude says it isn't a sunset —
+    // UNLESS the binary head also says not-a-sunset, in which case two of
+    // three judges agree and the case is settled (the regression head's
+    // overrating is captured by the Claude label itself).
+    if (
+      !input.llmIsSunset &&
+      aiRating >= MODEL_VS_CLAUDE_MODEL_HIGH &&
+      input.binaryIsSunset !== false
+    ) {
+      return 'model_high_claude_not_sunset';
+    }
+    return null;
+  }
+
+  // 2) Claude absent → the model's internal split provisionally flags the
+  //    frame for adjudication (live cron path; unchanged).
+  if (typeof input.binaryIsSunset === 'boolean' && typeof aiRating === 'number') {
+    if (!input.binaryIsSunset && aiRating >= SUNSET_DISAGREEMENT_HIGH) {
+      return 'binary_negative_regression_high';
+    }
+    if (input.binaryIsSunset && aiRating <= SUNSET_DISAGREEMENT_LOW) {
+      return 'binary_positive_regression_low';
+    }
+  }
+
+  return null;
+}
+```
+
+One behavior note for the doc comment: when Claude data is present but `aiRating` is undefined (no regression score), the function returns null — same as before, since every rule requires `aiRating`.
+
+- [ ] **Step 4: Run the aiScoring suite; reconcile any pre-existing tests**
+
+Run: `npx vitest run app/api/cron/update-cameras/lib/aiScoring.test.ts`
+Expected: all new tests PASS. If any PRE-EXISTING test fails, it encodes the old fall-through semantics (a case passing Claude data AND expecting a `binary_*` kind). For each such test: change the expectation to the v2 semantics (usually `null`) and add a one-line comment `// v2 (2026-07-29): Claude present ⇒ adjudicated, binary flags cleared`. Do NOT weaken tests that don't involve Claude data.
+
+- [ ] **Step 5: Run the full TS suite + typecheck**
+
+Run: `npx vitest run && npx tsc --noEmit`
+Expected: all tests pass. `tsc` has ONE pre-existing unrelated error in `app/api/cameras/[id]/snapshot/route.test.ts` (Buffer/BlobPart) — ignore that one; anything else must be fixed.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/api/cron/update-cameras/lib/aiScoring.ts app/api/cron/update-cameras/lib/aiScoring.test.ts
+git commit -m "feat(scoring): computeDisagreementKind v2 — Claude adjudicates, two agreeing judges settle"
+```
+
+---
+
+### Task 6: Operating guide — rating provenance + triage runbook
+
+**Files:**
+- Modify: `ml/OPERATING_GUIDE.md` (append two sections at the end)
+
+**Interfaces:**
+- Consumes: CLI flags from Tasks 1–4 (exact spellings: `--flagged-unrated`, `--use-batch-api`).
+- Produces: the operator-facing runbook; no code.
+
+- [ ] **Step 1: Append the two sections**
+
+Append to `ml/OPERATING_GUIDE.md`:
+
+```markdown
+## Rating provenance
+
+Every LLM rating is traceable; training exports may slice by any of these:
+
+- **Judge:** `llm_model` + `llm_provider` + `llm_rated_at` are stamped on
+  every `llm_*` write (e.g. `claude-sonnet-4-5` for the May/June campaigns,
+  `claude-sonnet-5` for the 2026-07 triage pass). `llm_metadata.prompt_version`
+  records the prompt revision. Exports that mix campaigns MUST carry
+  `llm_model` into the dataset manifest so labels can be filtered or
+  calibrated per judge.
+- **Source:** webcam frames live in `webcam_snapshots`, Flickr in
+  `external_images`. A webcam-only (or Flickr-free) model is a source filter
+  in `export_dataset.py` — no data changes needed.
+- **Model heads:** `ai_model_version_regression` / `ai_model_version_binary`
+  stamp which ONNX versions scored each frame.
+- **Campaign:** each non-dry `llm_rater.py` run writes
+  `ml/artifacts/llm_ratings/run_<timestamp>_manifest.json` (model, prompt
+  sha256, selection filters, counts, est. spend, timestamps).
+
+## Hard-example triage runbook (2026-07 backlog)
+
+Spec: `docs/superpowers/specs/2026-07-29-hard-example-triage-design.md`.
+Each step is a manual operator action — the script never auto-escalates spend.
+
+1. **Dry run (free):**
+   `python3 ml/llm_rater.py --provider anthropic --model claude-sonnet-5 --flagged-unrated --dry-run`
+   Check the selection count and eyeball the HTML sample.
+2. **Smoke slice (~$1.50):**
+   `python3 ml/llm_rater.py --provider anthropic --model claude-sonnet-5 --flagged-unrated --limit 500 --use-batch-api --write-to-db`
+   Then verify: `llm_*` columns landed (`llm_model = 'claude-sonnet-5'`);
+   within ~an hour the update-cameras cron's recompute step clears/promotes
+   those 500 flags; Hard Examples queue counts move the right way.
+3. **Full run (~$35–45):** same command without `--limit`.
+4. **Recompute reset (one-time, after the v2 rule deploys):**
+   ```sql
+   UPDATE webcam_snapshots
+   SET disagreement_computed_at = NULL
+   WHERE model_disagreement_kind IS NOT NULL
+     AND llm_quality IS NOT NULL;
+   ```
+   The hourly recompute loop then re-derives the June-rated rows under the
+   v2 rule, page by page.
+5. **Eyeball the queue.** Expect ~790 existing model-vs-Claude rows plus
+   ~10% of the backlog as genuine contests; if the live cron refills the
+   queue too fast afterward, see the spec's follow-ups (per-camera flag
+   throttling, `SUNSET_DISAGREEMENT_HIGH` tuning).
+
+Failed/errored frames stay unrated by design — re-running step 2/3 picks
+them up (`--flagged-unrated` selects `llm_quality IS NULL`).
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add ml/OPERATING_GUIDE.md
+git commit -m "docs(ml): rating-provenance contract + hard-example triage runbook"
+```
+
+---
+
+### Task 7: Final verification
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Full test suites**
+
+Run: `npx vitest run && python3 -m pytest ml/ -v && npx tsc --noEmit`
+Expected: all vitest + pytest pass; `tsc` shows only the one pre-existing `app/api/cameras/[id]/snapshot/route.test.ts` Buffer error.
+
+- [ ] **Step 2: CLI smoke (no network, no spend)**
+
+Run: `python3 ml/llm_rater.py --help | grep -E "flagged-unrated|use-batch-api"`
+Expected: both flags listed with their help text.
+
+- [ ] **Step 3: Push the branch**
+
+```bash
+git push -u origin feat/hard-example-triage
+```
+
+Then hand back to Jesse for the runbook (dry-run → smoke → full → reset SQL) and the PR.

--- a/docs/superpowers/plans/2026-07-29-register-time-pairing.md
+++ b/docs/superpowers/plans/2026-07-29-register-time-pairing.md
@@ -1,0 +1,289 @@
+# Register-Time Camera Pairing Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make a custom camera get its `webcams` pairing row + `cameras.webcam_id` at device-boot registration, in a pre-placement `testing` state, so it is snapshot-capable immediately and camera 2 self-heals on next reboot.
+
+**Architecture:** Add an idempotent `ensureDeploymentPairing(cameraId)` to `app/lib/cameraDeployment.ts` that inserts a minimal pre-placement deployment row (via a shared private `insertActiveDeployment` helper, also used by the existing `upsertActiveDeployment`) and sets the `webcam_id` back-pointer when no active deployment exists — a no-op when one already exists. Call it from `app/api/cameras/register/route.ts` on every register. Deliberately does not touch `terminator_webcam_state` (cron-owned) and adds no migration.
+
+**Tech Stack:** Next.js App Router (route handlers), TypeScript, `@/app/lib/db` tagged-template `sql`, Vitest with mocked `sql` (no live DB in tests).
+
+## Global Constraints
+
+- Branch: `feat/cloud-https-setup`. Plain branch in the main checkout — NO worktrees in this repo.
+- Tests mock `sql` via `vi.mock('@/app/lib/db', …)`; they never hit a real database. Match the existing suite's style.
+- No new migration. Uses only existing columns; depends on the un-applied `20260613_*` migrations being present in prod at deploy time (tracked separately, not in this plan).
+- `terminator_webcam_state` MUST NOT be written by onboarding code (cron-owned curated-winner cache).
+- Pre-placement state value is `'testing'`; placement columns are all `NULL` on the inserted row.
+- Before any commit, confirm the current branch is `feat/cloud-https-setup` (Jesse merges PRs in parallel).
+
+---
+
+### Task 1: Extract shared `insertActiveDeployment` helper + add `ensureDeploymentPairing`
+
+**Files:**
+- Modify: `app/lib/cameraDeployment.ts`
+- Test: `app/lib/cameraDeployment.test.ts`
+
+**Interfaces:**
+- Consumes: existing `getActiveDeployment(cameraId: number): Promise<DeploymentRow | null>`, `DeploymentRow`, `DeploymentState`, `DeploymentPlacementInput`, and the private `j()` JSON helper — all already in this file.
+- Produces:
+  - `insertActiveDeployment(cameraId: number, p: DeploymentPlacementInput, state: DeploymentState): Promise<DeploymentRow>` — private (not exported). INSERTs one `webcams` row (`source='custom'`, `custom_camera_id=cameraId`, `external_id='custom-{cameraId}-{Date.now()}'`, `title='Camera {cameraId}'`, `status='active'`, `state`, `paused=FALSE`, `started_at=NOW()`, placement columns from `p`) and then `UPDATE cameras SET webcam_id = <inserted.id>`. Returns the inserted `DeploymentRow`.
+  - `ensureDeploymentPairing(cameraId: number): Promise<DeploymentRow>` — exported. Returns the existing active deployment if one exists (no writes); otherwise inserts a pre-placement `testing` row (all placement fields `null`) via `insertActiveDeployment` and returns it.
+
+**Context — the existing insert lives inside `upsertActiveDeployment`** (`app/lib/cameraDeployment.ts:110-131`): the `INSERT INTO webcams (...) VALUES ('custom', ${cameraId}, ${externalId}, ...) RETURNING ...` followed by `UPDATE cameras SET webcam_id = ${inserted[0].id}`. Task extracts that block verbatim into `insertActiveDeployment` and has both callers use it.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `app/lib/cameraDeployment.test.ts` (follow the file's existing `sqlMock` setup — a `vi.fn()` bound to `@/app/lib/db`'s `sql`):
+
+```typescript
+describe('ensureDeploymentPairing', () => {
+  it('inserts a pre-placement testing row and sets webcam_id when none exists', async () => {
+    // getActiveDeployment query → no active deployment
+    sqlMock.mockResolvedValueOnce([]);
+    // INSERT ... RETURNING → the new row
+    sqlMock.mockResolvedValueOnce([{ id: 900, custom_camera_id: 2, state: 'testing' }]);
+    // UPDATE cameras SET webcam_id → (return value unused)
+    sqlMock.mockResolvedValueOnce([]);
+
+    const row = await ensureDeploymentPairing(2);
+
+    expect(row).toEqual({ id: 900, custom_camera_id: 2, state: 'testing' });
+    // 3 SQL calls: select active, insert webcams, update cameras.webcam_id
+    expect(sqlMock).toHaveBeenCalledTimes(3);
+    const insertSql = sqlMock.mock.calls[1][0].join('?');
+    expect(insertSql).toContain('INSERT INTO webcams');
+    // inserted with testing state and custom source
+    expect(sqlMock.mock.calls[1]).toContain('testing');
+    const updateSql = sqlMock.mock.calls[2][0].join('?');
+    expect(updateSql).toContain('UPDATE cameras SET webcam_id');
+  });
+
+  it('is a no-op when an active deployment already exists', async () => {
+    const existing = { id: 42, custom_camera_id: 2, state: 'deployed' };
+    sqlMock.mockResolvedValueOnce([existing]); // getActiveDeployment → found
+
+    const row = await ensureDeploymentPairing(2);
+
+    expect(row).toEqual(existing);
+    // Only the getActiveDeployment SELECT ran — no INSERT, no UPDATE.
+    expect(sqlMock).toHaveBeenCalledTimes(1);
+  });
+});
+```
+
+Ensure the import at the top of the test file includes `ensureDeploymentPairing`:
+
+```typescript
+import {
+  getActiveDeployment,
+  ensureDeploymentPairing,
+  // ...existing imports
+} from '@/app/lib/cameraDeployment';
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `npx vitest run app/lib/cameraDeployment.test.ts -t ensureDeploymentPairing`
+Expected: FAIL — `ensureDeploymentPairing is not a function` (not yet exported).
+
+- [ ] **Step 3: Extract the shared insert helper**
+
+In `app/lib/cameraDeployment.ts`, add a private helper above `upsertActiveDeployment`. Move the INSERT + back-pointer update out of `upsertActiveDeployment` into it:
+
+```typescript
+// Inserts a fresh active deployment row and repoints cameras.webcam_id at it.
+// Shared by upsertActiveDeployment (placed rows) and ensureDeploymentPairing
+// (pre-placement rows). external_id must be unique per deployment
+// (UNIQUE(source, external_id)).
+async function insertActiveDeployment(
+  cameraId: number,
+  p: DeploymentPlacementInput,
+  state: DeploymentState
+): Promise<DeploymentRow> {
+  const externalId = `custom-${cameraId}-${Date.now()}`;
+  const inserted = (await sql`
+    INSERT INTO webcams (
+      source, custom_camera_id, external_id, title, status,
+      state, paused, started_at,
+      lat, lng, elevation_m, timezone, azimuth_deg, tilt_deg,
+      horizon_altitude_deg, horizon_profile, azimuth_source, coarse, bracket,
+      phase_preference, delivery_preferences
+    ) VALUES (
+      'custom', ${cameraId}, ${externalId}, ${'Camera ' + cameraId}, 'active',
+      ${state}, FALSE, NOW(),
+      ${p.lat}, ${p.lng}, ${p.elevation_m}, ${p.timezone}, ${p.azimuth_deg}, ${p.tilt_deg},
+      ${p.horizon_altitude_deg}, ${j(p.horizon_profile)}::jsonb, ${p.azimuth_source}, ${p.coarse}, ${j(p.bracket)}::jsonb,
+      ${p.phase_preference}, ${j(p.delivery_preferences)}::jsonb
+    )
+    RETURNING id, custom_camera_id, state, paused, started_at, ended_at,
+              lat, lng, elevation_m, timezone, azimuth_deg, tilt_deg,
+              horizon_altitude_deg, horizon_profile, azimuth_source, coarse,
+              bracket, phase_preference, delivery_preferences
+  `) as DeploymentRow[];
+
+  await sql`UPDATE cameras SET webcam_id = ${inserted[0].id} WHERE id = ${cameraId}`;
+  return inserted[0];
+}
+```
+
+Then replace the insert block inside `upsertActiveDeployment` (currently `app/lib/cameraDeployment.ts:108-131`) with a call to it:
+
+```typescript
+  return insertActiveDeployment(cameraId, p, opts.state);
+```
+
+(This replaces the `const externalId = …`, the `const inserted = (await sql\`INSERT …\`)…`, the `UPDATE cameras …`, and `return inserted[0];` lines — the `mode==='new'` `UPDATE webcams SET ended_at …` line just above stays.)
+
+- [ ] **Step 4: Add `ensureDeploymentPairing`**
+
+Add below `upsertActiveDeployment` in `app/lib/cameraDeployment.ts`:
+
+```typescript
+const NULL_PLACEMENT: DeploymentPlacementInput = {
+  lat: null, lng: null, elevation_m: null, timezone: null,
+  azimuth_deg: null, tilt_deg: null, horizon_altitude_deg: null,
+  horizon_profile: null, azimuth_source: null, coarse: null,
+  bracket: null, phase_preference: null, delivery_preferences: null,
+};
+
+// Idempotently guarantees a custom camera has an active deployment (and thus a
+// cameras.webcam_id back-pointer) so it can accept snapshots. Called at device
+// registration. When no active deployment exists, opens a pre-placement one in
+// 'testing' state (null placement → stays off the public map until placed).
+// No-op when an active deployment already exists — never clobbers placement.
+export async function ensureDeploymentPairing(
+  cameraId: number
+): Promise<DeploymentRow> {
+  const active = await getActiveDeployment(cameraId);
+  if (active) return active;
+  return insertActiveDeployment(cameraId, NULL_PLACEMENT, 'testing');
+}
+```
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `npx vitest run app/lib/cameraDeployment.test.ts`
+Expected: PASS — the new `ensureDeploymentPairing` tests AND all pre-existing `cameraDeployment` tests (the `upsertActiveDeployment` refactor must not regress them).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git branch --show-current   # must print feat/cloud-https-setup
+git add app/lib/cameraDeployment.ts app/lib/cameraDeployment.test.ts
+git commit -m "feat(lib): ensureDeploymentPairing + shared insertActiveDeployment helper
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: Call `ensureDeploymentPairing` from the register route
+
+**Files:**
+- Modify: `app/api/cameras/register/route.ts`
+- Test: `app/api/cameras/register/route.test.ts`
+
+**Interfaces:**
+- Consumes: `ensureDeploymentPairing(cameraId: number): Promise<DeploymentRow>` from Task 1.
+- Produces: no new exports. Behavior change only — `register` now sets `cameras.webcam_id` (via the pairing) when a camera has no active deployment; response body shape is unchanged.
+
+**Context:** `register/route.ts` currently (step 4) updates device fields, then (step 5) calls `getActiveDeployment` + `derivePlacementStatus` for the response. Insert the `ensureDeploymentPairing` call between them. The route already imports from `@/app/lib/cameraDeployment`.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `app/api/cameras/register/route.test.ts` (follow the file's existing mock setup — it mocks `sql`, `getClaimCode`, and imports the route `POST`). Mock `ensureDeploymentPairing` on the `cameraDeployment` module and assert the route calls it with the resolved camera id:
+
+```typescript
+// In the existing vi.mock('@/app/lib/cameraDeployment', …) factory, add:
+//   ensureDeploymentPairing: vi.fn(),
+// and import the mocked fn for assertions.
+
+it('ensures the webcams pairing exists on register', async () => {
+  // ...arrange the same happy-path mocks the existing "registers" test uses
+  // (valid claim code, cameras row resolves to id 2, hardware_id matches) ...
+
+  const res = await POST(makeRegisterRequest({
+    claim_code: 'SUNSET-D3P4-K9WJ',
+    hardware_id: 'hw-sunset-cam-2',
+  }));
+
+  expect(res.status).toBe(200);
+  expect(ensureDeploymentPairing).toHaveBeenCalledWith(2);
+});
+```
+
+Model `makeRegisterRequest` and the mock arrangement on the existing happy-path test in this file (reuse its helpers/fixtures rather than inventing new ones).
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `npx vitest run app/api/cameras/register/route.test.ts -t "ensures the webcams pairing"`
+Expected: FAIL — `ensureDeploymentPairing` not called (route doesn't call it yet).
+
+- [ ] **Step 3: Wire the call into the route**
+
+In `app/api/cameras/register/route.ts`, extend the import:
+
+```typescript
+import {
+  getActiveDeployment,
+  derivePlacementStatus,
+  ensureDeploymentPairing,
+} from '@/app/lib/cameraDeployment';
+```
+
+Then, between step 4 (the `UPDATE cameras SET firmware_version …` block) and step 5 (`const d = await getActiveDeployment(cameraId);`), add:
+
+```typescript
+    // 4b. Guarantee the webcams pairing exists so the unit is snapshot-capable
+    //     immediately (pre-placement 'testing' row when unplaced). Idempotent.
+    await ensureDeploymentPairing(cameraId);
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `npx vitest run app/api/cameras/register/route.test.ts`
+Expected: PASS — the new test AND all pre-existing register-route tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git branch --show-current   # must print feat/cloud-https-setup
+git add app/api/cameras/register/route.ts app/api/cameras/register/route.test.ts
+git commit -m "feat(api): register ensures webcams pairing (snapshot-capable on boot)
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: Full-suite regression + typecheck gate
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Run the camera test suites**
+
+Run: `npx vitest run app/lib/cameraDeployment.test.ts app/api/cameras`
+Expected: PASS — all deployment lib + camera route tests green (confirms the `upsertActiveDeployment` refactor and register wiring broke nothing).
+
+- [ ] **Step 2: Typecheck**
+
+Run: `npx tsc --noEmit`
+Expected: no errors.
+
+- [ ] **Step 3: Confirm no `terminator_webcam_state` write crept in**
+
+Run: `git diff main -- app/lib/cameraDeployment.ts app/api/cameras/register/route.ts | grep -i terminator_webcam_state || echo "clean — no terminator_webcam_state writes"`
+Expected: `clean — no terminator_webcam_state writes`.
+
+---
+
+## Post-implementation: live verification against camera 2 (Jesse-gated)
+
+Not a code task — run with Jesse after the branch deploys (prod DB reads need his explicit OK; the `20260613_*` migrations must be applied to prod first):
+
+1. Reboot camera 2 (`ssh pi@192.168.0.103`) so it re-registers.
+2. Confirm `cameras.webcam_id` for `id = 2` is non-null.
+3. POST a snapshot with camera 2's device token → expect **202** (was 404).
+4. (Optional) Run the wizard placement to promote `testing → deployed` and confirm it appears on the public map.

--- a/docs/superpowers/specs/2026-07-29-hard-example-triage-design.md
+++ b/docs/superpowers/specs/2026-07-29-hard-example-triage-design.md
@@ -1,0 +1,207 @@
+---
+title: "Hard-example triage — Claude adjudicates the binary-vs-regression backlog"
+date: 2026-07-29
+status: spec
+---
+
+# Hard-example triage pass
+
+## Problem & goal
+
+Since the v4 binary head went live (June 14), the live cron has flagged
+~15,000 webcam snapshots as `binary_negative_regression_high` /
+`binary_positive_regression_low` that Claude has never rated (`llm_quality IS
+NULL`). They sit in the Hard Examples queue alongside the ~790 genuine
+model-vs-Claude contests from the June backfill, drowning the frames actually
+worth operator labeling. The skew (95% `binary_negative_regression_high`,
+concentrated in ~1,300 cameras) suggests most are dark/dusk frames where the
+regression head is noisy — not genuinely ambiguous sunsets.
+
+**Goal:** run the designed three-judge funnel to completion on the backlog.
+Claude (the third judge) rates every unrated flagged frame; the existing
+hourly recompute loop then re-derives each flag; the queue collapses to
+genuine model-vs-Claude contests ranked for operator labeling. Every rating is
+traceable to the judge that produced it.
+
+## Non-goals
+
+- No new labeling UI — the Hard Examples tab and `manual_labels` flow are
+  unchanged.
+- No model training — this produces labels for a future v5 export; it does
+  not train anything.
+- No change to how the live cron provisionally flags new frames (the
+  binary-vs-regression rules stay as the Claude-absent path).
+- No auto-labels from pixel statistics. An earlier sketch dropped near-black
+  frames via pixel stats; that is **out** — a skipped frame would stay flagged
+  forever, and a synthetic "dark ⇒ not sunset" label written into `llm_*`
+  columns would masquerade as Claude output (violates the no-silent-fallback
+  rule). Every flagged frame gets a real Claude verdict.
+- No per-camera dedupe. Flags clear per-frame, so rating 2–3 representatives
+  per camera would leave the unrated siblings in the queue forever. Cost is
+  controlled by the Batch API + `--limit` slicing instead.
+
+## Design
+
+### Component 1 — `ml/llm_rater.py` extensions (the rating pass)
+
+The existing rater already does image download, prompting, JSON parsing,
+resume, cost accounting, and the `llm_*` DB write. Four additions:
+
+1. **`--flagged-unrated` selection.** New selection mode for
+   `--source webcam`: `WHERE model_disagreement_kind IS NOT NULL AND
+   llm_quality IS NULL AND firebase_url IS NOT NULL`. Ordered by per-camera
+   round-robin (`ROW_NUMBER() OVER (PARTITION BY webcam_id ORDER BY
+   captured_at DESC)` as the primary sort key) so a `--limit N` slice spreads
+   across cameras instead of exhausting one camera's backlog first.
+2. **`claude-sonnet-5` support.** Add the model to the pricing table
+   ($3/$15 sticker; $2/$10 intro through 2026-08-31; Batch API halves either).
+   Remove `temperature=0.1` from `rate_with_anthropic` — Sonnet 5 rejects
+   non-default sampling parameters with a 400. (Gemini/OpenAI providers keep
+   their temperature settings; the change is Anthropic-path only.)
+3. **`--use-batch-api` mode (Anthropic provider only).** Chunk the selected
+   frames into Message Batches (~500–1,000 requests per batch, staying under
+   the 256 MB request cap with base64 images), submit, poll
+   `processing_status` until `ended`, then map results back by `custom_id`
+   (= `<table>:<row id>`) and write through the existing per-row DB update
+   path. Failed/errored/expired entries are logged and left unrated (a rerun
+   with `--flagged-unrated` picks them up — the selection predicate is the
+   resume mechanism). Sequential mode remains the default for small runs and
+   dry runs.
+4. **Run manifest (provenance).** Every non-dry run writes
+   `ml/artifacts/llm_ratings/run_<timestamp>_manifest.json`: model ID, a
+   sha256 of the exact prompt text sent (the rater has no version constant —
+   the hash is the version), provider, selection mode + filters, row-count attempted /
+   succeeded / failed, token totals, estimated spend, and start/end times.
+   This documents each rating campaign alongside the existing per-run ratings
+   CSV.
+
+### Component 2 — `computeDisagreementKind` v2 (Claude adjudicates)
+
+Today the binary-vs-regression rules fire even when Claude has already rated
+the frame, so Claude ratings never clear a flag — and a dark frame with
+regression ≥ 3.5 gets *promoted* to priority-100 `model_high_claude_not_sunset`,
+refilling the operator queue with junk. New semantics for the pure function in
+`app/api/cron/update-cameras/lib/aiScoring.ts`:
+
+**When Claude data is present** (`llmIsSunset` boolean + `llmQuality` number),
+Claude is the adjudicator — only model-vs-Claude contests survive:
+
+- `model_low_claude_sunset` (unchanged): Claude confident it's a good sunset
+  (`llmIsSunset && llmQuality >= 0.6`) while the model rated it ≤ 2.0.
+- `model_high_claude_not_sunset` (one new guard): model rated it ≥ 3.5,
+  Claude says it isn't a sunset, **and** the binary head does not also say
+  "not a sunset" (`binaryIsSunset !== false`). When the binary head and
+  Claude agree it isn't a sunset, two of three judges concur — the case is
+  settled and returns `null`. Rows without a binary verdict (June archive
+  backfill) keep today's behavior.
+- Anything else → `null` (settled). The frame leaves the queue; its Claude
+  label remains banked for training.
+
+**When Claude data is absent**, the binary-vs-regression rules apply exactly
+as today (this is how the live cron provisionally flags frames).
+
+Thresholds are unchanged (`masterConfig.ts`: 3.0/2.0 internal, 3.5/2.0/0.6
+model-vs-Claude).
+
+### Component 3 — recompute reset (one-time ops step)
+
+The hourly recompute loop's predicate only revisits rows where
+`disagreement_computed_at < llm_rated_at`, so:
+
+- **Newly rated rows** (this triage pass) are picked up automatically — no
+  work needed.
+- **June-rated rows** (the 3,410 Claude-rated frames still flagged
+  binary-vs-regression, plus the 592/197 model-vs-Claude rows) were computed
+  *after* their ratings landed, so the new rule never reaches them. One-time
+  SQL after the rule change deploys:
+
+  ```sql
+  UPDATE webcam_snapshots
+  SET disagreement_computed_at = NULL
+  WHERE model_disagreement_kind IS NOT NULL
+    AND llm_quality IS NOT NULL;
+  ```
+
+  The cron then re-derives them page by page under the v2 rule.
+
+### Data model & provenance (no schema changes)
+
+Traceability requirement: it must always be possible to reconstruct *which
+judge produced which label* and *which source produced which image*, so
+future training runs can slice the dataset (e.g. webcam-only, or
+sonnet-4-5-labels-only) without archaeology.
+
+Already satisfied by existing columns — this spec makes the contract explicit:
+
+- **Judge:** every `llm_*` write stamps `llm_model` (e.g.
+  `claude-sonnet-4-5` for the May/June campaigns, `claude-sonnet-5` for this
+  one) and `llm_rated_at`. Training exports that mix campaigns MUST carry
+  `llm_model` through to the dataset manifest so labels can be filtered or
+  calibrated per judge.
+- **Source:** webcam frames live in `webcam_snapshots`, Flickr in
+  `external_images` — a webcam-only model is a source filter in
+  `export_dataset.py`, no data changes needed.
+- **Model heads:** `ai_model_version_regression` / `ai_model_version_binary`
+  already stamp which ONNX versions scored each frame (PR #69 closes the gap
+  for live-cron rows).
+- **Campaign:** the new run manifest (Component 1.4) documents each rating
+  run's parameters and counts.
+
+`ml/OPERATING_GUIDE.md` gains a "Rating provenance" section stating the
+above, plus the triage runbook.
+
+### Cost & runbook
+
+Estimated full-backlog cost on `claude-sonnet-5` with Batch API + intro
+pricing: **~$35–45** (~15k images ≈ ~2k input + ~150 output tokens each).
+Hard checkpoints:
+
+1. `--flagged-unrated --dry-run` — selection counts + HTML sample report,
+   zero spend.
+2. `--flagged-unrated --limit 500 --use-batch-api` — ~$1.50 smoke slice;
+   verify `llm_*` rows land, recompute clears/promotes them, queue counts
+   move the right way.
+3. Full run (no `--limit`), then the Component-3 reset SQL, then eyeball the
+   Hard Examples tab.
+
+The operator (Jesse) runs each step; the script never auto-escalates spend.
+
+### Expected end state
+
+- Every flagged frame has a Claude verdict with judge provenance.
+- Queue drops from ~22.8k to the genuine contests: ~790 existing
+  model-vs-Claude rows plus an estimated ~10% of the backlog (~1–2k),
+  ranked by priority tier and disagreement gap.
+- The settled ~13k frames keep their Claude labels (cleanup already spares
+  `llm_quality IS NOT NULL` rows) as v5 training data.
+
+## Error handling
+
+- Batch entries that error or expire: logged with `custom_id`, row left
+  unrated; rerun picks them up via the selection predicate.
+- Unparseable Claude JSON: existing rater behavior (log, skip, no DB write).
+- Dead Firebase URLs: log and skip; the frame stays flagged — surfaced in the
+  manifest's failure count so a stubborn residue is visible rather than
+  silent.
+- Recompute is idempotent and already batched; the reset SQL only widens its
+  work set temporarily.
+
+## Testing
+
+- **TS (vitest, TDD):** `computeDisagreementKind` v2 — table-driven cases:
+  Claude-absent paths unchanged; Claude-present clears binary-vs-regression;
+  two-judges-agree returns null; missing-binary keeps
+  `model_high_claude_not_sunset`; both model-vs-Claude kinds still fire.
+  Recompute loop tests already cover the plumbing.
+- **Python (pytest, TDD):** selection SQL shape for `--flagged-unrated`
+  (predicate + round-robin ordering + limit); batch chunking respects size
+  caps; custom_id round-trip mapping; manifest contents; sonnet-5 request
+  contains no `temperature`.
+- **Manual:** the three-step runbook above is the integration test.
+
+## Open follow-ups (not in this spec)
+
+- Live-cron flag throttling (per-camera cap on new binary-vs-regression
+  flags) if the queue re-grows too fast after triage.
+- `SUNSET_DISAGREEMENT_HIGH` threshold tuning informed by the triage results.
+- v5 training export that joins `manual_labels` + per-judge `llm_*` labels.

--- a/ml/OPERATING_GUIDE.md
+++ b/ml/OPERATING_GUIDE.md
@@ -1738,7 +1738,8 @@ Every LLM rating is traceable; training exports may slice by any of these:
 Spec: `docs/superpowers/specs/2026-07-29-hard-example-triage-design.md`.
 Each step is a manual operator action — the script never auto-escalates spend.
 
-1. **Dry run (free):**
+1. **Dry run (~cents: rates `--dry-run-count` sample images for real,
+   costing cents — not free):**
    `python3 ml/llm_rater.py --provider anthropic --model claude-sonnet-5 --flagged-unrated --dry-run`
    Check the selection count and eyeball the HTML sample.
 2. **Smoke slice (~$1.50):**
@@ -1747,6 +1748,10 @@ Each step is a manual operator action — the script never auto-escalates spend.
    within ~an hour the update-cameras cron's recompute step clears/promotes
    those 500 flags; Hard Examples queue counts move the right way.
 3. **Full run (~$35–45):** same command without `--limit`.
+
+   Pre-check: `SELECT count(*) FROM webcam_snapshots WHERE llm_quality IS
+   NOT NULL AND llm_is_sunset IS NULL;` — should be 0; any such rows would
+   be recomputed under Claude-absent rules.
 4. **Recompute reset (one-time, after the v2 rule deploys):**
    ```sql
    UPDATE webcam_snapshots

--- a/ml/OPERATING_GUIDE.md
+++ b/ml/OPERATING_GUIDE.md
@@ -1713,3 +1713,55 @@ export const CLEANUP_ENABLED = true;
 
 The endpoint returns the count deleted and a list of any errors per
 snapshot.
+
+---
+
+## Rating provenance
+
+Every LLM rating is traceable; training exports may slice by any of these:
+
+- **Judge:** `llm_model` + `llm_provider` + `llm_rated_at` are stamped on
+  every `llm_*` write (e.g. `claude-sonnet-4-5` for the May/June campaigns,
+  `claude-sonnet-5` for the 2026-07 triage pass). `llm_metadata.prompt_version`
+  records the prompt revision. Exports that mix campaigns MUST carry
+  `llm_model` into the dataset manifest so labels can be filtered or
+  calibrated per judge.
+- **Source:** webcam frames live in `webcam_snapshots`, Flickr in
+  `external_images`. A webcam-only (or Flickr-free) model is a source filter
+  in `export_dataset.py` — no data changes needed.
+- **Model heads:** `ai_model_version_regression` / `ai_model_version_binary`
+  stamp which ONNX versions scored each frame.
+- **Campaign:** each non-dry `llm_rater.py` run writes
+  `ml/artifacts/llm_ratings/run_<timestamp>_manifest.json` (model, prompt
+  sha256, selection filters, counts, est. spend, timestamps).
+
+## Hard-example triage runbook (2026-07 backlog)
+
+Spec: `docs/superpowers/specs/2026-07-29-hard-example-triage-design.md`.
+Each step is a manual operator action — the script never auto-escalates spend.
+
+1. **Dry run (free):**
+   `python3 ml/llm_rater.py --provider anthropic --model claude-sonnet-5 --flagged-unrated --dry-run`
+   Check the selection count and eyeball the HTML sample.
+2. **Smoke slice (~$1.50):**
+   `python3 ml/llm_rater.py --provider anthropic --model claude-sonnet-5 --flagged-unrated --limit 500 --use-batch-api --write-to-db`
+   Then verify: `llm_*` columns landed (`llm_model = 'claude-sonnet-5'`);
+   within ~an hour the update-cameras cron's recompute step clears/promotes
+   those 500 flags; Hard Examples queue counts move the right way.
+3. **Full run (~$35–45):** same command without `--limit`.
+4. **Recompute reset (one-time, after the v2 rule deploys):**
+   ```sql
+   UPDATE webcam_snapshots
+   SET disagreement_computed_at = NULL
+   WHERE model_disagreement_kind IS NOT NULL
+     AND llm_quality IS NOT NULL;
+   ```
+   The hourly recompute loop then re-derives the June-rated rows under the
+   v2 rule, page by page.
+5. **Eyeball the queue.** Expect ~790 existing model-vs-Claude rows plus
+   ~10% of the backlog as genuine contests; if the live cron refills the
+   queue too fast afterward, see the spec's follow-ups (per-camera flag
+   throttling, `SUNSET_DISAGREEMENT_HIGH` tuning).
+
+Failed/errored frames stay unrated by design — re-running step 2/3 picks
+them up (`--flagged-unrated` selects `llm_quality IS NULL`).

--- a/ml/OPERATING_GUIDE.md
+++ b/ml/OPERATING_GUIDE.md
@@ -1714,8 +1714,6 @@ export const CLEANUP_ENABLED = true;
 The endpoint returns the count deleted and a list of any errors per
 snapshot.
 
----
-
 ## Rating provenance
 
 Every LLM rating is traceable; training exports may slice by any of these:

--- a/ml/llm_rater.py
+++ b/ml/llm_rater.py
@@ -210,6 +210,8 @@ API_KEY_ENV = {
 MODEL_PRICING_USD_PER_MTOK: dict[str, dict[str, float]] = {
     # Anthropic
     "claude-haiku-4-5":    {"input": 1.00, "output": 5.00},
+    # Sticker price; intro $2/$10 through 2026-08-31, Batch API halves either.
+    "claude-sonnet-5":     {"input": 3.00, "output": 15.00},
     "claude-sonnet-4-5":   {"input": 3.00, "output": 15.00},
     "claude-opus-4":       {"input": 15.00, "output": 75.00},
     "claude-3-5-haiku":    {"input": 0.80, "output": 4.00},
@@ -404,7 +406,6 @@ def rate_with_anthropic(
     response = client.messages.create(
         model=model,
         max_tokens=600,
-        temperature=0.1,
         messages=[
             {
                 "role": "user",

--- a/ml/llm_rater.py
+++ b/ml/llm_rater.py
@@ -154,6 +154,13 @@ def parse_args() -> argparse.Namespace:
              "(per-camera round-robin order). Implies --source webcam.",
     )
     parser.add_argument(
+        "--use-batch-api", action="store_true",
+        help="Anthropic only: submit via the Message Batches API (50%% "
+             "cheaper, hours not days). Requires --write-to-db; "
+             "incompatible with --dry-run. CSV/HTML reports are skipped — "
+             "the run manifest carries the accounting.",
+    )
+    parser.add_argument(
         "--write-to-db", action="store_true",
         help="Write LLM ratings back to the source database table",
     )
@@ -444,6 +451,142 @@ PROVIDER_RATE_FNS = {
 }
 
 
+def normalize_rating(result: dict) -> dict:
+    """Apply defaults + clamps to a raw LLM rating dict (shared by the
+    sequential path and the Batch API path)."""
+    result.setdefault("is_sunset", False)
+    result.setdefault("is_sunrise", False)
+    result.setdefault("quality", 0.0)
+    result.setdefault("confidence", 0.5)
+    result.setdefault("has_clouds", False)
+    result.setdefault("color_palette", "")
+    result.setdefault("obstruction", None)
+    result.setdefault("time_of_day", "unclear")
+    result.setdefault("sky_coverage", "partial")
+    result.setdefault("rating_explanation", "")
+    result["quality"] = max(0.0, min(1.0, float(result["quality"])))
+    result["confidence"] = max(0.0, min(1.0, float(result["confidence"])))
+    time_of_day = str(result["time_of_day"]).strip().lower()
+    if time_of_day not in {"golden_hour", "blue_hour", "twilight",
+                           "day", "night", "unclear"}:
+        time_of_day = "unclear"
+    result["time_of_day"] = time_of_day
+    sky_coverage = str(result["sky_coverage"]).strip().lower()
+    if sky_coverage not in {"none", "partial", "mostly", "full"}:
+        sky_coverage = "partial"
+    result["sky_coverage"] = sky_coverage
+    return result
+
+
+MAX_BATCH_REQUESTS = 1000
+MAX_BATCH_BYTES = 200_000_000  # ~200 MB of base64 payload per batch (API cap 256 MB)
+
+
+def parse_custom_id(custom_id: str) -> tuple[str, int]:
+    source_table, _, record_id = custom_id.partition(":")
+    return source_table, int(record_id)
+
+
+def build_batch_requests(
+    rows: list[dict],
+    model: str,
+    download_timeout: float,
+    download_fn=download_image_bytes,
+) -> tuple[list[list[dict]], list[dict]]:
+    """Download images and build Message Batches request chunks.
+
+    Returns (chunks, failures): chunks is a list of request-lists sized
+    under MAX_BATCH_REQUESTS / MAX_BATCH_BYTES; failures records rows whose
+    image could not be downloaded (they stay unrated — the
+    --flagged-unrated predicate re-selects them on the next run).
+    """
+    chunks: list[list[dict]] = []
+    current: list[dict] = []
+    current_bytes = 0
+    failures: list[dict] = []
+
+    for row in rows:
+        custom_id = f"{row['source_table']}:{row['record_id']}"
+        try:
+            image_bytes, content_type = download_fn(
+                row["image_url"], timeout=download_timeout,
+            )
+        except Exception as exc:
+            failures.append({"custom_id": custom_id, "error": str(exc)})
+            continue
+        media_type = detect_image_media_type(image_bytes, content_type)
+        b64 = base64.b64encode(image_bytes).decode("utf-8")
+        request = {
+            "custom_id": custom_id,
+            "params": {
+                "model": model,
+                "max_tokens": 600,
+                "messages": [{
+                    "role": "user",
+                    "content": [
+                        {"type": "image",
+                         "source": {"type": "base64",
+                                    "media_type": media_type,
+                                    "data": b64}},
+                        {"type": "text", "text": RATING_PROMPT},
+                    ],
+                }],
+            },
+        }
+        if (len(current) >= MAX_BATCH_REQUESTS
+                or current_bytes + len(b64) > MAX_BATCH_BYTES):
+            if current:
+                chunks.append(current)
+            current, current_bytes = [], 0
+        current.append(request)
+        current_bytes += len(b64)
+
+    if current:
+        chunks.append(current)
+    return chunks, failures
+
+
+def run_batch_chunks(
+    api_key: str,
+    chunks: list[list[dict]],
+    poll_seconds: int = 60,
+):
+    """Submit each chunk as a Message Batch, poll to completion, and yield
+    (custom_id, ok, payload, usage) tuples. payload is the parsed rating
+    dict when ok, else an error string; usage is (input_tokens,
+    output_tokens) for succeeded entries, (0, 0) otherwise."""
+    from anthropic import Anthropic
+
+    client = Anthropic(api_key=api_key)
+    for i, chunk in enumerate(chunks, 1):
+        batch = client.messages.batches.create(requests=chunk)
+        print(f"Batch {i}/{len(chunks)} submitted: {batch.id} "
+              f"({len(chunk)} requests)")
+        while True:
+            batch = client.messages.batches.retrieve(batch.id)
+            if batch.processing_status == "ended":
+                break
+            time.sleep(poll_seconds)
+        for result in client.messages.batches.results(batch.id):
+            if result.result.type == "succeeded":
+                message = result.result.message
+                usage = (message.usage.input_tokens, message.usage.output_tokens)
+                text = message.content[0].text.strip()
+                if text.startswith("```"):
+                    lines = text.split("\n")
+                    if lines[0].startswith("```"):
+                        lines = lines[1:]
+                    if lines and lines[-1].startswith("```"):
+                        lines = lines[:-1]
+                    text = "\n".join(lines).strip()
+                try:
+                    yield result.custom_id, True, json.loads(text), usage
+                except Exception as exc:
+                    yield result.custom_id, False, f"unparseable JSON: {exc}", (0, 0)
+            else:
+                yield result.custom_id, False, result.result.type, (0, 0)
+
+
 def rate_image(
     image_bytes: bytes,
     provider: str,
@@ -458,27 +601,7 @@ def rate_image(
     for attempt in range(MAX_RETRIES):
         try:
             result = rate_fn(image_bytes, model, api_key, timeout, media_type)
-            result.setdefault("is_sunset", False)
-            result.setdefault("is_sunrise", False)
-            result.setdefault("quality", 0.0)
-            result.setdefault("confidence", 0.5)
-            result.setdefault("has_clouds", False)
-            result.setdefault("color_palette", "")
-            result.setdefault("obstruction", None)
-            result.setdefault("time_of_day", "unclear")
-            result.setdefault("sky_coverage", "partial")
-            result.setdefault("rating_explanation", "")
-            result["quality"] = max(0.0, min(1.0, float(result["quality"])))
-            result["confidence"] = max(0.0, min(1.0, float(result["confidence"])))
-            time_of_day = str(result["time_of_day"]).strip().lower()
-            if time_of_day not in {"golden_hour", "blue_hour", "twilight",
-                                   "day", "night", "unclear"}:
-                time_of_day = "unclear"
-            result["time_of_day"] = time_of_day
-            sky_coverage = str(result["sky_coverage"]).strip().lower()
-            if sky_coverage not in {"none", "partial", "mostly", "full"}:
-                sky_coverage = "partial"
-            result["sky_coverage"] = sky_coverage
+            result = normalize_rating(result)
             return result
         except Exception as exc:
             if attempt == MAX_RETRIES - 1:
@@ -1213,6 +1336,15 @@ def write_run_manifest(
 
 def main() -> None:
     args = parse_args()
+
+    if args.use_batch_api:
+        if args.provider != "anthropic":
+            sys.exit("--use-batch-api requires --provider anthropic")
+        if not args.write_to_db:
+            sys.exit("--use-batch-api requires --write-to-db (no CSV path)")
+        if args.dry_run:
+            sys.exit("--use-batch-api is incompatible with --dry-run")
+
     model = resolve_model(args.provider, args.model)
     # Estimate-only doesn't make API calls, so skip the API key check.
     api_key = "" if args.estimate_only else resolve_api_key(
@@ -1241,6 +1373,7 @@ def main() -> None:
     print(f"  API timeout:      {args.api_timeout:.0f}s", flush=True)
     print(f"  Skip rated: {args.skip_rated}", flush=True)
     print(f"  Write to DB: {args.write_to_db}", flush=True)
+    print(f"  Use batch API: {args.use_batch_api}", flush=True)
     print(f"  Dry run: {args.dry_run}", flush=True)
     print(f"  Verbose: {args.verbose}", flush=True)
     print(f"  Output: {output_csv}", flush=True)
@@ -1391,6 +1524,59 @@ def main() -> None:
             )
             print(f"Run manifest: {manifest_path}")
         conn.close()
+        return
+
+    if args.use_batch_api:
+        # The rows are already fetched; drop the Postgres connection now
+        # rather than holding it idle through a submit/poll cycle that can
+        # run for hours (Neon aggressively closes idle connections — see
+        # open_db_connection's docstring).
+        conn.close()
+        run_started_at_iso = datetime.now(timezone.utc).isoformat()
+        chunks, failures = build_batch_requests(
+            rows, model, args.download_timeout,
+        )
+        for f in failures:
+            print(f"  download failed, left unrated: {f['custom_id']}: {f['error']}")
+        db = DbWriter(database_url)
+        success_count, failure_count = 0, len(failures)
+        total_tokens_in = total_tokens_out = 0
+        for custom_id, ok, payload, usage in run_batch_chunks(api_key, chunks):
+            source_table, record_id = parse_custom_id(custom_id)
+            total_tokens_in += usage[0]
+            total_tokens_out += usage[1]
+            if not ok:
+                failure_count += 1
+                print(f"  batch entry failed, left unrated: {custom_id}: {payload}")
+                continue
+            rating = normalize_rating(payload)
+            db.write_rating(source_table, record_id, rating, model, args.provider)
+            success_count += 1
+        db.close()
+        attempted_count = len(rows)
+        # Sticker-rate estimate from real usage; the Batch API bills ~50% of
+        # this (and intro pricing less again) — the manifest field is an
+        # upper-bound estimate, actual billing is whatever Anthropic charges.
+        price = MODEL_PRICING_USD_PER_MTOK.get(model, {"input": 0.0, "output": 0.0})
+        est_cost = (total_tokens_in / 1e6) * price["input"] \
+            + (total_tokens_out / 1e6) * price["output"]
+        manifest_path = write_run_manifest(
+            Path("ml/artifacts/llm_ratings"),
+            model=model,
+            provider=args.provider,
+            selection=build_selection_info(args),
+            attempted=attempted_count,
+            succeeded=success_count,
+            failed=failure_count,
+            tokens_in=total_tokens_in,
+            tokens_out=total_tokens_out,
+            est_cost_usd=round(est_cost, 2),
+            started_at=run_started_at_iso,
+            finished_at=datetime.now(timezone.utc).isoformat(),
+        )
+        print(f"Run manifest: {manifest_path}")
+        print(f"Batch run complete: {success_count} rated, {failure_count} failed/skipped "
+              f"of {attempted_count} selected.")
         return
 
     delay = 60.0 / args.rpm if args.rpm > 0 else 0

--- a/ml/llm_rater.py
+++ b/ml/llm_rater.py
@@ -41,6 +41,7 @@ from __future__ import annotations
 
 import argparse
 import base64
+import hashlib
 import io
 import json
 import sys
@@ -1154,6 +1155,46 @@ class DbWriter:
             pass
 
 
+def write_run_manifest(
+    out_dir: "str | Path",
+    *,
+    model: str,
+    provider: str,
+    selection: dict,
+    attempted: int,
+    succeeded: int,
+    failed: int,
+    tokens_in: int,
+    tokens_out: int,
+    est_cost_usd: float,
+    started_at: str,
+    finished_at: str,
+) -> Path:
+    """Write a per-campaign provenance manifest (2026-07-29 triage spec).
+
+    Documents exactly how a rating run was produced so training exports
+    can slice by judge/campaign later. The prompt has no version constant;
+    its sha256 IS the version.
+    """
+    out_dir = Path(out_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    stamp = datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
+    path = out_dir / f"run_{stamp}_manifest.json"
+    path.write_text(json.dumps({
+        "model": model,
+        "provider": provider,
+        "prompt_version": "v2_extended",
+        "prompt_sha256": hashlib.sha256(RATING_PROMPT.encode("utf-8")).hexdigest(),
+        "selection": selection,
+        "counts": {"attempted": attempted, "succeeded": succeeded, "failed": failed},
+        "tokens": {"input": tokens_in, "output": tokens_out},
+        "est_cost_usd": est_cost_usd,
+        "started_at": started_at,
+        "finished_at": finished_at,
+    }, indent=2))
+    return path
+
+
 def main() -> None:
     args = parse_args()
     model = resolve_model(args.provider, args.model)
@@ -1323,6 +1364,7 @@ def main() -> None:
     if not args.dry_run and args.write_to_db:
         db_writer = DbWriter(database_url)
     db_failures = 0
+    run_started_at_iso = datetime.now(timezone.utc).isoformat()
 
     progress = tqdm(
         rows, desc="Rating", unit="img", disable=args.no_progress,
@@ -1499,6 +1541,38 @@ def main() -> None:
     }
     print(f"\n--- Summary ---")
     print(json.dumps(summary, indent=2))
+
+    if not args.dry_run:
+        # Per-campaign provenance manifest (2026-07-29 triage spec). Reuse
+        # the same accumulators the summary above was built from; no
+        # per-call token usage is captured on this path today, so those
+        # totals stay 0 rather than being estimated/invented.
+        attempted_count = len(rows)
+        success_count = len(results)
+        failure_count = len(failures)
+        total_tokens_in = 0
+        total_tokens_out = 0
+        est_cost = 0.0
+        manifest_path = write_run_manifest(
+            Path("ml/artifacts/llm_ratings"),
+            model=model,
+            provider=args.provider,
+            selection={
+                "mode": "flagged_unrated" if args.flagged_unrated else args.source,
+                "limit": args.limit,
+                "skip_rated": args.skip_rated,
+                "use_batch_api": getattr(args, "use_batch_api", False),
+            },
+            attempted=attempted_count,
+            succeeded=success_count,
+            failed=failure_count,
+            tokens_in=total_tokens_in,
+            tokens_out=total_tokens_out,
+            est_cost_usd=round(est_cost, 2),
+            started_at=run_started_at_iso,
+            finished_at=datetime.now(timezone.utc).isoformat(),
+        )
+        print(f"Run manifest: {manifest_path}")
 
 
 if __name__ == "__main__":

--- a/ml/llm_rater.py
+++ b/ml/llm_rater.py
@@ -582,7 +582,10 @@ def run_batch_chunks(
                 try:
                     yield result.custom_id, True, json.loads(text), usage
                 except Exception as exc:
-                    yield result.custom_id, False, f"unparseable JSON: {exc}", (0, 0)
+                    # The message was still generated and billed — keep the
+                    # real usage so the manifest's token/cost accounting
+                    # stays honest even though the rating is unusable.
+                    yield result.custom_id, False, f"unparseable JSON: {exc}", usage
             else:
                 yield result.custom_id, False, result.result.type, (0, 0)
 
@@ -1541,42 +1544,51 @@ def main() -> None:
         db = DbWriter(database_url)
         success_count, failure_count = 0, len(failures)
         total_tokens_in = total_tokens_out = 0
-        for custom_id, ok, payload, usage in run_batch_chunks(api_key, chunks):
-            source_table, record_id = parse_custom_id(custom_id)
-            total_tokens_in += usage[0]
-            total_tokens_out += usage[1]
-            if not ok:
-                failure_count += 1
-                print(f"  batch entry failed, left unrated: {custom_id}: {payload}")
-                continue
-            rating = normalize_rating(payload)
-            db.write_rating(source_table, record_id, rating, model, args.provider)
-            success_count += 1
-        db.close()
-        attempted_count = len(rows)
-        # Sticker-rate estimate from real usage; the Batch API bills ~50% of
-        # this (and intro pricing less again) — the manifest field is an
-        # upper-bound estimate, actual billing is whatever Anthropic charges.
-        price = MODEL_PRICING_USD_PER_MTOK.get(model, {"input": 0.0, "output": 0.0})
-        est_cost = (total_tokens_in / 1e6) * price["input"] \
-            + (total_tokens_out / 1e6) * price["output"]
-        manifest_path = write_run_manifest(
-            Path("ml/artifacts/llm_ratings"),
-            model=model,
-            provider=args.provider,
-            selection=build_selection_info(args),
-            attempted=attempted_count,
-            succeeded=success_count,
-            failed=failure_count,
-            tokens_in=total_tokens_in,
-            tokens_out=total_tokens_out,
-            est_cost_usd=round(est_cost, 2),
-            started_at=run_started_at_iso,
-            finished_at=datetime.now(timezone.utc).isoformat(),
-        )
-        print(f"Run manifest: {manifest_path}")
-        print(f"Batch run complete: {success_count} rated, {failure_count} failed/skipped "
-              f"of {attempted_count} selected.")
+        try:
+            for custom_id, ok, payload, usage in run_batch_chunks(api_key, chunks):
+                source_table, record_id = parse_custom_id(custom_id)
+                total_tokens_in += usage[0]
+                total_tokens_out += usage[1]
+                if not ok:
+                    failure_count += 1
+                    print(f"  batch entry failed, left unrated: {custom_id}: {payload}")
+                    continue
+                rating = normalize_rating(payload)
+                db.write_rating(source_table, record_id, rating, model, args.provider)
+                success_count += 1
+        finally:
+            # A transient exception mid-poll (hours-long) must not swallow
+            # the ratings already committed to the DB by earlier chunks —
+            # write the manifest with whatever counts/tokens accumulated so
+            # far, then let the exception (if any) propagate. The operator
+            # sees the failure and reruns; --flagged-unrated picks up
+            # whatever is still unrated.
+            db.close()
+            attempted_count = len(rows)
+            # Sticker-rate estimate from real usage; the Batch API bills
+            # ~50% of this (and intro pricing less again) — the manifest
+            # field is an upper-bound estimate, actual billing is whatever
+            # Anthropic charges.
+            price = MODEL_PRICING_USD_PER_MTOK.get(model, {"input": 0.0, "output": 0.0})
+            est_cost = (total_tokens_in / 1e6) * price["input"] \
+                + (total_tokens_out / 1e6) * price["output"]
+            manifest_path = write_run_manifest(
+                Path("ml/artifacts/llm_ratings"),
+                model=model,
+                provider=args.provider,
+                selection=build_selection_info(args),
+                attempted=attempted_count,
+                succeeded=success_count,
+                failed=failure_count,
+                tokens_in=total_tokens_in,
+                tokens_out=total_tokens_out,
+                est_cost_usd=round(est_cost, 2),
+                started_at=run_started_at_iso,
+                finished_at=datetime.now(timezone.utc).isoformat(),
+            )
+            print(f"Run manifest: {manifest_path}")
+            print(f"Batch run complete: {success_count} rated, {failure_count} failed/skipped "
+                  f"of {attempted_count} selected.")
         return
 
     delay = 60.0 / args.rpm if args.rpm > 0 else 0

--- a/ml/llm_rater.py
+++ b/ml/llm_rater.py
@@ -525,7 +525,11 @@ MAX_BATCH_BYTES = 200_000_000  # ~200 MB of base64 payload per batch (API cap 25
 
 
 def parse_custom_id(custom_id: str) -> tuple[str, int]:
-    source_table, _, record_id = custom_id.partition(":")
+    """Split "<source_table>-<record_id>". Hyphen separator because the
+    Batch API requires custom_id to match ^[a-zA-Z0-9_-]{1,64}$ (a colon
+    separator was rejected with a live 400 on 2026-07-30). rpartition is
+    safe: record_id is numeric and never contains a hyphen."""
+    source_table, _, record_id = custom_id.rpartition("-")
     return source_table, int(record_id)
 
 
@@ -572,7 +576,7 @@ def build_batch_requests(
         current: list[dict] = []
         current_bytes = 0
         for row in rows:
-            custom_id = f"{row['source_table']}:{row['record_id']}"
+            custom_id = f"{row['source_table']}-{row['record_id']}"
             try:
                 image_bytes, content_type = download_fn(
                     row["image_url"], timeout=download_timeout,

--- a/ml/llm_rater.py
+++ b/ml/llm_rater.py
@@ -1155,6 +1155,22 @@ class DbWriter:
             pass
 
 
+def build_selection_info(args: argparse.Namespace) -> dict:
+    """Build the manifest `selection` dict from parsed CLI args.
+
+    Shared by both `write_run_manifest` call sites in `main()` (the
+    zero-rows early return and the end-of-run wiring) so the mode/limit
+    logic — including the `--flagged-unrated` override of `--source` —
+    lives in exactly one place.
+    """
+    return {
+        "mode": "flagged_unrated" if args.flagged_unrated else args.source,
+        "limit": args.limit,
+        "skip_rated": args.skip_rated,
+        "use_batch_api": getattr(args, "use_batch_api", False),
+    }
+
+
 def write_run_manifest(
     out_dir: "str | Path",
     *,
@@ -1249,6 +1265,7 @@ def main() -> None:
         rows = sample_rows(rows, args.dry_run_count, args.dry_run_sample_mode)
 
     print(f"  Images to rate: {len(rows)}")
+    run_started_at_iso = datetime.now(timezone.utc).isoformat()
 
     # --- Estimate-only preflight: print cost + time and exit ---
     if args.estimate_only:
@@ -1354,6 +1371,25 @@ def main() -> None:
 
     if not rows:
         print("Nothing to rate.")
+        if not args.dry_run:
+            # Zero rows is still a real run (e.g. --flagged-unrated with
+            # nothing left to triage) — write an honest, all-zero manifest
+            # rather than silently skipping provenance for this campaign.
+            manifest_path = write_run_manifest(
+                Path("ml/artifacts/llm_ratings"),
+                model=model,
+                provider=args.provider,
+                selection=build_selection_info(args),
+                attempted=0,
+                succeeded=0,
+                failed=0,
+                tokens_in=0,
+                tokens_out=0,
+                est_cost_usd=0.0,
+                started_at=run_started_at_iso,
+                finished_at=datetime.now(timezone.utc).isoformat(),
+            )
+            print(f"Run manifest: {manifest_path}")
         conn.close()
         return
 
@@ -1364,7 +1400,6 @@ def main() -> None:
     if not args.dry_run and args.write_to_db:
         db_writer = DbWriter(database_url)
     db_failures = 0
-    run_started_at_iso = datetime.now(timezone.utc).isoformat()
 
     progress = tqdm(
         rows, desc="Rating", unit="img", disable=args.no_progress,
@@ -1557,12 +1592,7 @@ def main() -> None:
             Path("ml/artifacts/llm_ratings"),
             model=model,
             provider=args.provider,
-            selection={
-                "mode": "flagged_unrated" if args.flagged_unrated else args.source,
-                "limit": args.limit,
-                "skip_rated": args.skip_rated,
-                "use_batch_api": getattr(args, "use_batch_api", False),
-            },
+            selection=build_selection_info(args),
             attempted=attempted_count,
             succeeded=success_count,
             failed=failure_count,

--- a/ml/llm_rater.py
+++ b/ml/llm_rater.py
@@ -254,6 +254,24 @@ def measure_image_tokens(image_bytes: bytes) -> tuple[int, int, int]:
     return w, h, img_tokens
 
 
+def lookup_model_pricing(model: str) -> dict:
+    """Longest-prefix-match lookup against MODEL_PRICING_USD_PER_MTOK.
+
+    Model names carry date suffixes (e.g. "claude-sonnet-5-20270101") that
+    won't exact-match a pricing key, so the longest matching prefix wins.
+    Returns {"input": 0.0, "output": 0.0} when no prefix matches — no
+    real pricing entry is ever all-zero, so callers can treat an all-zero
+    result as "unknown model" without a separate None-check.
+    """
+    pricing = {"input": 0.0, "output": 0.0}
+    best_prefix_len = 0
+    for prefix, rates in MODEL_PRICING_USD_PER_MTOK.items():
+        if model.startswith(prefix) and len(prefix) > best_prefix_len:
+            pricing = rates
+            best_prefix_len = len(prefix)
+    return pricing
+
+
 def estimate_cost_usd(
     model: str,
     n_images: int,
@@ -264,13 +282,8 @@ def estimate_cost_usd(
 
     Falls back to (0.0, None) when we don't have pricing data for the model.
     """
-    pricing = None
-    best_prefix_len = 0
-    for prefix, rates in MODEL_PRICING_USD_PER_MTOK.items():
-        if model.startswith(prefix) and len(prefix) > best_prefix_len:
-            pricing = rates
-            best_prefix_len = len(prefix)
-    if pricing is None:
+    pricing = lookup_model_pricing(model)
+    if pricing["input"] == 0.0 and pricing["output"] == 0.0:
         return 0.0, None
     in_cost  = n_images * tokens_in_per_image  / 1_000_000 * pricing["input"]
     out_cost = n_images * tokens_out_per_image / 1_000_000 * pricing["output"]
@@ -397,6 +410,39 @@ def rate_with_openai(
     return json.loads(response.choices[0].message.content)
 
 
+def extract_text_block(content: list) -> str:
+    """Return the `.text` of the first content block with `type == "text"`.
+
+    Models with adaptive/extended thinking (e.g. Sonnet 5) can prepend a
+    thinking block before the text block, so naively indexing content[0]
+    silently grabs the thinking block instead of the JSON response. Shared
+    by both the sequential (`rate_with_anthropic`) and Batch API
+    (`run_batch_chunks`) response readers.
+
+    Raises ValueError if no text block is present so callers treat it as
+    a parse failure rather than crashing on an AttributeError deep in
+    json.loads.
+    """
+    for block in content:
+        if getattr(block, "type", None) == "text":
+            return block.text
+    raise ValueError(f"no text content block in response (types: "
+                      f"{[getattr(b, 'type', None) for b in content]!r})")
+
+
+def _strip_markdown_fences(text: str) -> str:
+    """Strip accidental markdown code fences (```json ... ```) from a
+    Claude text response."""
+    if text.startswith("```"):
+        lines = text.split("\n")
+        if lines[0].startswith("```"):
+            lines = lines[1:]
+        if lines and lines[-1].startswith("```"):
+            lines = lines[:-1]
+        text = "\n".join(lines).strip()
+    return text
+
+
 def rate_with_anthropic(
     image_bytes: bytes, model: str, api_key: str,
     timeout: float = 60.0, media_type: str = "image/jpeg",
@@ -404,7 +450,10 @@ def rate_with_anthropic(
     """Rate via Anthropic Claude API.
 
     Claude does not have a native JSON response mode, so we strip any
-    accidental markdown fences from the response before parsing.
+    accidental markdown fences from the response before parsing. Thinking
+    is explicitly disabled: Sonnet 5's adaptive thinking otherwise eats the
+    600-token max_tokens budget on a thinking block, leaving no room for
+    (or even producing) the text response.
     """
     from anthropic import Anthropic
 
@@ -414,6 +463,7 @@ def rate_with_anthropic(
     response = client.messages.create(
         model=model,
         max_tokens=600,
+        thinking={"type": "disabled"},
         messages=[
             {
                 "role": "user",
@@ -432,15 +482,7 @@ def rate_with_anthropic(
         ],
     )
 
-    text = response.content[0].text.strip()
-    # Strip accidental markdown code fences (```json ... ```).
-    if text.startswith("```"):
-        lines = text.split("\n")
-        if lines[0].startswith("```"):
-            lines = lines[1:]
-        if lines and lines[-1].startswith("```"):
-            lines = lines[:-1]
-        text = "\n".join(lines).strip()
+    text = _strip_markdown_fences(extract_text_block(response.content).strip())
     return json.loads(text)
 
 
@@ -487,81 +529,112 @@ def parse_custom_id(custom_id: str) -> tuple[str, int]:
     return source_table, int(record_id)
 
 
+def payload_is_complete(payload: dict) -> bool:
+    """True if a parsed LLM rating payload has both required keys.
+
+    Batch-API-only guard: `normalize_rating()` defaults every missing
+    field, which would otherwise let a truncated/malformed model response
+    (e.g. valid JSON but missing fields) masquerade as a confident
+    "not a sunset, quality 0.0" verdict once written to the DB. The
+    sequential path doesn't need this — a malformed payload there just
+    gets defaulted the same way it always has, and operators reviewing
+    the CSV/HTML report can spot it; the batch path writes straight to
+    the DB with no human review step, so it gets the stricter check.
+    """
+    return "quality" in payload and "is_sunset" in payload
+
+
 def build_batch_requests(
     rows: list[dict],
     model: str,
     download_timeout: float,
     download_fn=download_image_bytes,
-) -> tuple[list[list[dict]], list[dict]]:
-    """Download images and build Message Batches request chunks.
+) -> tuple[Any, list[dict]]:
+    """Lazily download images and build Message Batches request chunks.
 
-    Returns (chunks, failures): chunks is a list of request-lists sized
-    under MAX_BATCH_REQUESTS / MAX_BATCH_BYTES; failures records rows whose
-    image could not be downloaded (they stay unrated — the
-    --flagged-unrated predicate re-selects them on the next run).
+    Returns (chunk_iterator, failures). chunk_iterator is a GENERATOR that
+    yields one chunk (a list of request dicts, sized under
+    MAX_BATCH_REQUESTS / MAX_BATCH_BYTES) at a time — images are downloaded
+    on demand as the generator is advanced, not all upfront, so memory
+    stays ~one chunk regardless of how many rows are selected, and a
+    caller (`run_batch_chunks`) can submit the first chunk before the rest
+    have even been downloaded.
+
+    `failures` is a list that the generator appends to AS IT ITERATES
+    (rows whose image could not be downloaded; they stay unrated — the
+    --flagged-unrated predicate re-selects them on the next run). It is
+    only complete once the chunk_iterator has been fully consumed —
+    inspect it after exhausting the generator, not before.
     """
-    chunks: list[list[dict]] = []
-    current: list[dict] = []
-    current_bytes = 0
     failures: list[dict] = []
 
-    for row in rows:
-        custom_id = f"{row['source_table']}:{row['record_id']}"
-        try:
-            image_bytes, content_type = download_fn(
-                row["image_url"], timeout=download_timeout,
-            )
-        except Exception as exc:
-            failures.append({"custom_id": custom_id, "error": str(exc)})
-            continue
-        media_type = detect_image_media_type(image_bytes, content_type)
-        b64 = base64.b64encode(image_bytes).decode("utf-8")
-        request = {
-            "custom_id": custom_id,
-            "params": {
-                "model": model,
-                "max_tokens": 600,
-                "messages": [{
-                    "role": "user",
-                    "content": [
-                        {"type": "image",
-                         "source": {"type": "base64",
-                                    "media_type": media_type,
-                                    "data": b64}},
-                        {"type": "text", "text": RATING_PROMPT},
-                    ],
-                }],
-            },
-        }
-        if (len(current) >= MAX_BATCH_REQUESTS
-                or current_bytes + len(b64) > MAX_BATCH_BYTES):
-            if current:
-                chunks.append(current)
-            current, current_bytes = [], 0
-        current.append(request)
-        current_bytes += len(b64)
+    def _chunks():
+        current: list[dict] = []
+        current_bytes = 0
+        for row in rows:
+            custom_id = f"{row['source_table']}:{row['record_id']}"
+            try:
+                image_bytes, content_type = download_fn(
+                    row["image_url"], timeout=download_timeout,
+                )
+            except Exception as exc:
+                failures.append({"custom_id": custom_id, "error": str(exc)})
+                continue
+            media_type = detect_image_media_type(image_bytes, content_type)
+            b64 = base64.b64encode(image_bytes).decode("utf-8")
+            request = {
+                "custom_id": custom_id,
+                "params": {
+                    "model": model,
+                    "max_tokens": 600,
+                    "thinking": {"type": "disabled"},
+                    "messages": [{
+                        "role": "user",
+                        "content": [
+                            {"type": "image",
+                             "source": {"type": "base64",
+                                        "media_type": media_type,
+                                        "data": b64}},
+                            {"type": "text", "text": RATING_PROMPT},
+                        ],
+                    }],
+                },
+            }
+            if (len(current) >= MAX_BATCH_REQUESTS
+                    or current_bytes + len(b64) > MAX_BATCH_BYTES):
+                if current:
+                    yield current
+                current, current_bytes = [], 0
+            current.append(request)
+            current_bytes += len(b64)
 
-    if current:
-        chunks.append(current)
-    return chunks, failures
+        if current:
+            yield current
+
+    return _chunks(), failures
 
 
 def run_batch_chunks(
     api_key: str,
-    chunks: list[list[dict]],
+    chunks,
     poll_seconds: int = 60,
 ):
     """Submit each chunk as a Message Batch, poll to completion, and yield
     (custom_id, ok, payload, usage) tuples. payload is the parsed rating
-    dict when ok, else an error string; usage is (input_tokens,
-    output_tokens) for succeeded entries, (0, 0) otherwise."""
+    dict when ok, else a readable error string; usage is (input_tokens,
+    output_tokens) for succeeded entries, (0, 0) otherwise.
+
+    `chunks` may be (and typically is) a GENERATOR — this function pulls
+    one chunk at a time and submits it immediately, so chunk N+1 isn't
+    downloaded (see `build_batch_requests`) until chunk N has been
+    submitted, polled to completion, and its results yielded.
+    """
     from anthropic import Anthropic
 
     client = Anthropic(api_key=api_key)
     for i, chunk in enumerate(chunks, 1):
         batch = client.messages.batches.create(requests=chunk)
-        print(f"Batch {i}/{len(chunks)} submitted: {batch.id} "
-              f"({len(chunk)} requests)")
+        print(f"Batch {i} submitted: {batch.id} ({len(chunk)} requests)")
         while True:
             batch = client.messages.batches.retrieve(batch.id)
             if batch.processing_status == "ended":
@@ -571,23 +644,25 @@ def run_batch_chunks(
             if result.result.type == "succeeded":
                 message = result.result.message
                 usage = (message.usage.input_tokens, message.usage.output_tokens)
-                text = message.content[0].text.strip()
-                if text.startswith("```"):
-                    lines = text.split("\n")
-                    if lines[0].startswith("```"):
-                        lines = lines[1:]
-                    if lines and lines[-1].startswith("```"):
-                        lines = lines[:-1]
-                    text = "\n".join(lines).strip()
+                # Text extraction happens INSIDE the try: an unexpected
+                # content shape (e.g. no text block, or non-JSON text)
+                # must yield a not-ok entry with the real usage rather than
+                # crash the generator and lose every later chunk's results.
                 try:
-                    yield result.custom_id, True, json.loads(text), usage
+                    text = _strip_markdown_fences(
+                        extract_text_block(message.content).strip()
+                    )
+                    payload = json.loads(text)
                 except Exception as exc:
                     # The message was still generated and billed — keep the
                     # real usage so the manifest's token/cost accounting
                     # stays honest even though the rating is unusable.
-                    yield result.custom_id, False, f"unparseable JSON: {exc}", usage
+                    yield result.custom_id, False, f"unparseable response: {exc}", usage
+                    continue
+                yield result.custom_id, True, payload, usage
             else:
-                yield result.custom_id, False, result.result.type, (0, 0)
+                error_str = f"{result.result.type}: {getattr(result.result, 'error', None)}"
+                yield result.custom_id, False, error_str, (0, 0)
 
 
 def rate_image(
@@ -1536,16 +1611,22 @@ def main() -> None:
         # open_db_connection's docstring).
         conn.close()
         run_started_at_iso = datetime.now(timezone.utc).isoformat()
-        chunks, failures = build_batch_requests(
+        # chunk_iter is a lazy generator (see build_batch_requests): images
+        # download as run_batch_chunks below pulls each chunk, not upfront.
+        # `failures` is the same list object the generator appends
+        # download failures to as it iterates — it isn't complete until
+        # chunk_iter has been fully consumed, so we read it after the loop,
+        # not here.
+        chunk_iter, failures = build_batch_requests(
             rows, model, args.download_timeout,
         )
-        for f in failures:
-            print(f"  download failed, left unrated: {f['custom_id']}: {f['error']}")
         db = DbWriter(database_url)
-        success_count, failure_count = 0, len(failures)
+        success_count = 0
+        failure_count = 0
+        db_failures = 0
         total_tokens_in = total_tokens_out = 0
         try:
-            for custom_id, ok, payload, usage in run_batch_chunks(api_key, chunks):
+            for custom_id, ok, payload, usage in run_batch_chunks(api_key, chunk_iter):
                 source_table, record_id = parse_custom_id(custom_id)
                 total_tokens_in += usage[0]
                 total_tokens_out += usage[1]
@@ -1553,8 +1634,22 @@ def main() -> None:
                     failure_count += 1
                     print(f"  batch entry failed, left unrated: {custom_id}: {payload}")
                     continue
+                if not payload_is_complete(payload):
+                    # Malformed-but-parseable JSON (missing quality/is_sunset)
+                    # must NOT be silently defaulted and written to the DB —
+                    # the batch path has no human reviewing the output before
+                    # it lands, unlike the sequential dry-run/CSV path.
+                    failure_count += 1
+                    print(f"  batch entry incomplete (missing quality/is_sunset), "
+                          f"left unrated: {custom_id}: {payload}")
+                    continue
                 rating = normalize_rating(payload)
-                db.write_rating(source_table, record_id, rating, model, args.provider)
+                try:
+                    db.write_rating(source_table, record_id, rating, model, args.provider)
+                except Exception as exc:
+                    db_failures += 1
+                    print(f"  DB write failed, left unrated: {custom_id}: {exc}")
+                    continue
                 success_count += 1
         finally:
             # A transient exception mid-poll (hours-long) must not swallow
@@ -1563,13 +1658,20 @@ def main() -> None:
             # far, then let the exception (if any) propagate. The operator
             # sees the failure and reruns; --flagged-unrated picks up
             # whatever is still unrated.
+            #
+            # By the time we get here (loop finished OR an exception
+            # propagated out of it), chunk_iter has stopped downloading, so
+            # `failures` reflects every download attempt that ran.
+            for f in failures:
+                print(f"  download failed, left unrated: {f['custom_id']}: {f['error']}")
+            failure_count += len(failures) + db_failures
             db.close()
             attempted_count = len(rows)
             # Sticker-rate estimate from real usage; the Batch API bills
             # ~50% of this (and intro pricing less again) — the manifest
             # field is an upper-bound estimate, actual billing is whatever
             # Anthropic charges.
-            price = MODEL_PRICING_USD_PER_MTOK.get(model, {"input": 0.0, "output": 0.0})
+            price = lookup_model_pricing(model)
             est_cost = (total_tokens_in / 1e6) * price["input"] \
                 + (total_tokens_out / 1e6) * price["output"]
             manifest_path = write_run_manifest(
@@ -1588,7 +1690,7 @@ def main() -> None:
             )
             print(f"Run manifest: {manifest_path}")
             print(f"Batch run complete: {success_count} rated, {failure_count} failed/skipped "
-                  f"of {attempted_count} selected.")
+                  f"of {attempted_count} selected (db_failures={db_failures}).")
         return
 
     delay = 60.0 / args.rpm if args.rpm > 0 else 0

--- a/ml/llm_rater.py
+++ b/ml/llm_rater.py
@@ -43,6 +43,7 @@ import argparse
 import base64
 import io
 import json
+import sys
 import time
 from datetime import datetime, timezone
 from html import escape as html_escape
@@ -144,6 +145,12 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--skip-rated", action="store_true",
         help="Skip images that already have an LLM rating in the database",
+    )
+    parser.add_argument(
+        "--flagged-unrated", action="store_true",
+        help="Triage mode: select only webcam snapshots with "
+             "model_disagreement_kind set and no llm_quality yet "
+             "(per-camera round-robin order). Implies --source webcam.",
     )
     parser.add_argument(
         "--write-to-db", action="store_true",
@@ -510,6 +517,46 @@ def fetch_webcam_rows(
     """
     with conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as cur:
         cur.execute(query)
+        return [dict(r) for r in cur.fetchall()]
+
+
+def build_flagged_unrated_query(limit: int) -> str:
+    """Selection SQL for the hard-example triage pass (2026-07-29 spec).
+
+    Every webcam snapshot the live cron flagged (model_disagreement_kind
+    set) that Claude has not yet rated. Per-camera round-robin ordering so
+    a --limit slice spreads coverage across cameras.
+    """
+    limit_clause = f"LIMIT {limit}" if limit > 0 else ""
+    return f"""
+    SELECT record_id, source_table, webcam_id, image_url,
+           human_calculated_rating, human_rating_count
+    FROM (
+      SELECT
+        s.id AS record_id,
+        'webcam' AS source_table,
+        s.webcam_id,
+        s.firebase_url AS image_url,
+        s.calculated_rating AS human_calculated_rating,
+        0 AS human_rating_count,
+        ROW_NUMBER() OVER (PARTITION BY s.webcam_id ORDER BY s.captured_at DESC) AS cam_rank
+      FROM webcam_snapshots s
+      WHERE s.firebase_url IS NOT NULL
+        AND s.model_disagreement_kind IS NOT NULL
+        AND s.llm_quality IS NULL
+    ) ranked
+    ORDER BY cam_rank, webcam_id
+    {limit_clause}
+    """
+
+
+def fetch_flagged_unrated_rows(
+    conn: psycopg2.extensions.connection,
+    limit: int,
+) -> list[dict[str, Any]]:
+    """Fetch flagged-but-Claude-unrated webcam snapshots (triage pass)."""
+    with conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as cur:
+        cur.execute(build_flagged_unrated_query(limit))
         return [dict(r) for r in cur.fetchall()]
 
 
@@ -1145,9 +1192,14 @@ def main() -> None:
     print("  connected.", flush=True)
 
     rows: list[dict[str, Any]] = []
-    if args.source in ("webcam", "all"):
+    if args.flagged_unrated:
+        if args.source != "webcam":
+            print("--flagged-unrated implies --source webcam; ignoring --source", file=sys.stderr)
+        rows = fetch_flagged_unrated_rows(conn, args.limit)
+    elif args.source in ("webcam", "all"):
         rows.extend(fetch_webcam_rows(conn, args.skip_rated, args.limit))
-    if args.source in ("external", "all"):
+
+    if args.source in ("external", "all") and not args.flagged_unrated:
         ext_limit = max(0, args.limit - len(rows)) if args.limit > 0 else 0
         rows.extend(fetch_external_rows(conn, args.skip_rated, ext_limit))
 

--- a/ml/test_llm_rater_triage.py
+++ b/ml/test_llm_rater_triage.py
@@ -203,3 +203,25 @@ def test_build_batch_requests_records_download_failures():
     assert len(failures) == 1
     assert failures[0]["custom_id"] == "webcam:1"
     assert sum(len(c) for c in chunks) == 2
+
+
+def test_build_batch_requests_chunks_by_cumulative_byte_cap(monkeypatch):
+    import llm_rater
+
+    # b"abcdef" is 6 raw bytes -> base64.b64encode gives exactly 8 chars
+    # (6 is a multiple of 3, so no padding). With the cap patched to 17,
+    # two requests (16 bytes) fit but a third (24 bytes) doesn't, so the
+    # third request must start a new chunk.
+    monkeypatch.setattr(llm_rater, "MAX_BATCH_BYTES", 17)
+
+    def fake_download(url, timeout=30.0):
+        return b"abcdef", "image/jpeg"
+
+    chunks, failures = llm_rater.build_batch_requests(
+        _fake_rows(3), "claude-sonnet-5", 30.0, download_fn=fake_download,
+    )
+    assert failures == []
+    assert [len(c) for c in chunks] == [2, 1]
+    assert chunks[0][0]["custom_id"] == "webcam:0"
+    assert chunks[0][1]["custom_id"] == "webcam:1"
+    assert chunks[1][0]["custom_id"] == "webcam:2"

--- a/ml/test_llm_rater_triage.py
+++ b/ml/test_llm_rater_triage.py
@@ -212,8 +212,8 @@ def test_normalize_rating_defaults_and_clamps():
 def test_parse_custom_id_round_trip():
     from llm_rater import parse_custom_id
 
-    assert parse_custom_id("webcam:123") == ("webcam", 123)
-    assert parse_custom_id("external:45") == ("external", 45)
+    assert parse_custom_id("webcam-123") == ("webcam", 123)
+    assert parse_custom_id("external-45") == ("external", 45)
 
 
 def _fake_rows(n):
@@ -240,7 +240,7 @@ def test_build_batch_requests_chunks_by_request_count():
     assert failures == []
     assert [len(c) for c in chunks] == [1000, 1000, 500]
     first = chunks[0][0]
-    assert first["custom_id"] == "webcam:0"
+    assert first["custom_id"] == "webcam-0"
     assert first["params"]["model"] == "claude-sonnet-5"
     assert first["params"]["max_tokens"] == 600
     assert first["params"]["thinking"] == {"type": "disabled"}
@@ -260,7 +260,7 @@ def test_build_batch_requests_records_download_failures():
     )
     chunks = list(chunk_iter)
     assert len(failures) == 1
-    assert failures[0]["custom_id"] == "webcam:1"
+    assert failures[0]["custom_id"] == "webcam-1"
     assert sum(len(c) for c in chunks) == 2
 
 
@@ -282,9 +282,9 @@ def test_build_batch_requests_chunks_by_cumulative_byte_cap(monkeypatch):
     chunks = list(chunk_iter)
     assert failures == []
     assert [len(c) for c in chunks] == [2, 1]
-    assert chunks[0][0]["custom_id"] == "webcam:0"
-    assert chunks[0][1]["custom_id"] == "webcam:1"
-    assert chunks[1][0]["custom_id"] == "webcam:2"
+    assert chunks[0][0]["custom_id"] == "webcam-0"
+    assert chunks[0][1]["custom_id"] == "webcam-1"
+    assert chunks[1][0]["custom_id"] == "webcam-2"
 
 
 def test_build_batch_requests_is_lazy_and_downloads_are_deferred():
@@ -312,3 +312,22 @@ def test_build_batch_requests_is_lazy_and_downloads_are_deferred():
     remaining = list(chunk_iter)
     assert sum(len(c) for c in remaining) == 1500
     assert len(downloaded_urls) == 2500
+
+
+def test_custom_id_matches_batch_api_pattern():
+    """Anthropic Message Batches rejects custom_ids not matching
+    ^[a-zA-Z0-9_-]{1,64}$ — colons caused a live 400 on 2026-07-30."""
+    import re
+
+    from llm_rater import build_batch_requests
+
+    def fake_download(url, timeout=30.0):
+        return b"tinyjpeg", "image/jpeg"
+
+    chunk_iter, _failures = build_batch_requests(
+        _fake_rows(3), "claude-sonnet-5", 30.0, download_fn=fake_download,
+    )
+    pattern = re.compile(r"^[a-zA-Z0-9_-]{1,64}$")
+    for chunk in chunk_iter:
+        for request in chunk:
+            assert pattern.match(request["custom_id"]), request["custom_id"]

--- a/ml/test_llm_rater_triage.py
+++ b/ml/test_llm_rater_triage.py
@@ -105,3 +105,37 @@ def test_run_manifest_contents(tmp_path):
     assert data["est_cost_usd"] == 4.13
     assert data["started_at"] == "2026-07-29T20:00:00Z"
     assert data["finished_at"] == "2026-07-29T21:30:00Z"
+
+
+from types import SimpleNamespace
+
+
+def test_build_selection_info_uses_flagged_unrated_mode_when_set():
+    from llm_rater import build_selection_info
+
+    args = SimpleNamespace(
+        flagged_unrated=True, source="webcam", limit=500, skip_rated=True,
+        use_batch_api=True,
+    )
+    assert build_selection_info(args) == {
+        "mode": "flagged_unrated",
+        "limit": 500,
+        "skip_rated": True,
+        "use_batch_api": True,
+    }
+
+
+def test_build_selection_info_falls_back_to_source_and_default_batch_flag():
+    from llm_rater import build_selection_info
+
+    # No `use_batch_api` attribute at all (Task 4 hasn't landed yet on some
+    # call site) — must default to False rather than raising.
+    args = SimpleNamespace(
+        flagged_unrated=False, source="external", limit=0, skip_rated=False,
+    )
+    assert build_selection_info(args) == {
+        "mode": "external",
+        "limit": 0,
+        "skip_rated": False,
+        "use_batch_api": False,
+    }

--- a/ml/test_llm_rater_triage.py
+++ b/ml/test_llm_rater_triage.py
@@ -41,6 +41,7 @@ def test_anthropic_request_sends_no_temperature(monkeypatch):
             captured.update(kwargs)
 
             class Block:
+                type = "text"
                 text = '{"quality": 0.5, "is_sunset": true}'
 
             class Resp:
@@ -60,6 +61,7 @@ def test_anthropic_request_sends_no_temperature(monkeypatch):
 
     assert "temperature" not in captured
     assert captured["model"] == "claude-sonnet-5"
+    assert captured["thinking"] == {"type": "disabled"}
     assert result["quality"] == 0.5
 
 
@@ -67,6 +69,58 @@ def test_sonnet_5_has_a_pricing_entry():
     from llm_rater import MODEL_PRICING_USD_PER_MTOK
     entry = MODEL_PRICING_USD_PER_MTOK["claude-sonnet-5"]
     assert entry == {"input": 3.00, "output": 15.00}
+
+
+def test_lookup_model_pricing_prefix_match_and_unknown():
+    from llm_rater import lookup_model_pricing
+
+    # A dated model id should match the longest applicable prefix entry.
+    assert lookup_model_pricing("claude-sonnet-5-20270101") == {
+        "input": 3.00, "output": 15.00,
+    }
+    # Unknown model → zeros, not a KeyError/None.
+    assert lookup_model_pricing("some-unreleased-model") == {
+        "input": 0.0, "output": 0.0,
+    }
+
+
+def test_extract_text_block_picks_text_block_over_thinking_block():
+    from llm_rater import extract_text_block
+
+    class FakeBlock:
+        def __init__(self, type_, text=None):
+            self.type = type_
+            self.text = text
+
+    content = [
+        FakeBlock("thinking", text="reasoning about the sky…"),
+        FakeBlock("text", text='{"quality": 0.5, "is_sunset": true}'),
+    ]
+    assert extract_text_block(content) == '{"quality": 0.5, "is_sunset": true}'
+
+
+def test_extract_text_block_raises_when_no_text_block_present():
+    from llm_rater import extract_text_block
+
+    class FakeBlock:
+        def __init__(self, type_):
+            self.type = type_
+
+    content = [FakeBlock("thinking")]
+    try:
+        extract_text_block(content)
+        assert False, "expected ValueError"
+    except ValueError:
+        pass
+
+
+def test_payload_is_complete_requires_quality_and_is_sunset():
+    from llm_rater import payload_is_complete
+
+    assert payload_is_complete({"quality": 0.5, "is_sunset": True}) is True
+    assert payload_is_complete({"quality": 0.5}) is False
+    assert payload_is_complete({"is_sunset": True}) is False
+    assert payload_is_complete({}) is False
 
 
 import hashlib
@@ -177,15 +231,19 @@ def test_build_batch_requests_chunks_by_request_count():
     def fake_download(url, timeout=30.0):
         return b"tinyjpeg", "image/jpeg"
 
-    chunks, failures = build_batch_requests(
+    chunk_iter, failures = build_batch_requests(
         _fake_rows(2500), "claude-sonnet-5", 30.0, download_fn=fake_download,
     )
+    # build_batch_requests returns a lazy generator: `failures` only
+    # reflects reality once the iterator has been fully consumed.
+    chunks = list(chunk_iter)
     assert failures == []
     assert [len(c) for c in chunks] == [1000, 1000, 500]
     first = chunks[0][0]
     assert first["custom_id"] == "webcam:0"
     assert first["params"]["model"] == "claude-sonnet-5"
     assert first["params"]["max_tokens"] == 600
+    assert first["params"]["thinking"] == {"type": "disabled"}
     assert "temperature" not in first["params"]
 
 
@@ -197,9 +255,10 @@ def test_build_batch_requests_records_download_failures():
             raise RuntimeError("404 dead url")
         return b"tinyjpeg", "image/jpeg"
 
-    chunks, failures = build_batch_requests(
+    chunk_iter, failures = build_batch_requests(
         _fake_rows(3), "claude-sonnet-5", 30.0, download_fn=flaky_download,
     )
+    chunks = list(chunk_iter)
     assert len(failures) == 1
     assert failures[0]["custom_id"] == "webcam:1"
     assert sum(len(c) for c in chunks) == 2
@@ -217,11 +276,39 @@ def test_build_batch_requests_chunks_by_cumulative_byte_cap(monkeypatch):
     def fake_download(url, timeout=30.0):
         return b"abcdef", "image/jpeg"
 
-    chunks, failures = llm_rater.build_batch_requests(
+    chunk_iter, failures = llm_rater.build_batch_requests(
         _fake_rows(3), "claude-sonnet-5", 30.0, download_fn=fake_download,
     )
+    chunks = list(chunk_iter)
     assert failures == []
     assert [len(c) for c in chunks] == [2, 1]
     assert chunks[0][0]["custom_id"] == "webcam:0"
     assert chunks[0][1]["custom_id"] == "webcam:1"
     assert chunks[1][0]["custom_id"] == "webcam:2"
+
+
+def test_build_batch_requests_is_lazy_and_downloads_are_deferred():
+    """Advancing the chunk iterator by one chunk must not download images
+    that belong to a later chunk — this is the whole point of converting
+    build_batch_requests to a generator (memory stays ~one chunk, and
+    run_batch_chunks can submit chunk 1 before chunk 2 is even fetched)."""
+    from llm_rater import build_batch_requests
+
+    downloaded_urls: list[str] = []
+
+    def tracking_download(url, timeout=30.0):
+        downloaded_urls.append(url)
+        return b"tinyjpeg", "image/jpeg"
+
+    chunk_iter, failures = build_batch_requests(
+        _fake_rows(2500), "claude-sonnet-5", 30.0, download_fn=tracking_download,
+    )
+    first_chunk = next(chunk_iter)
+    assert len(first_chunk) == 1000
+    # Only the first chunk's images (plus the lookahead row that triggered
+    # the chunk boundary) should have been downloaded so far.
+    assert len(downloaded_urls) <= 1001
+
+    remaining = list(chunk_iter)
+    assert sum(len(c) for c in remaining) == 1500
+    assert len(downloaded_urls) == 2500

--- a/ml/test_llm_rater_triage.py
+++ b/ml/test_llm_rater_triage.py
@@ -30,3 +30,40 @@ def test_flagged_unrated_orders_per_camera_round_robin():
 def test_flagged_unrated_omits_limit_clause_when_zero():
     q = build_flagged_unrated_query(limit=0)
     assert "LIMIT" not in q
+
+
+def test_anthropic_request_sends_no_temperature(monkeypatch):
+    """claude-sonnet-5 rejects non-default sampling params with a 400."""
+    captured = {}
+
+    class FakeMessages:
+        def create(self, **kwargs):
+            captured.update(kwargs)
+
+            class Block:
+                text = '{"quality": 0.5, "is_sunset": true}'
+
+            class Resp:
+                content = [Block()]
+
+            return Resp()
+
+    class FakeClient:
+        def __init__(self, **kwargs):
+            self.messages = FakeMessages()
+
+    import anthropic
+    monkeypatch.setattr(anthropic, "Anthropic", FakeClient)
+
+    from llm_rater import rate_with_anthropic
+    result = rate_with_anthropic(b"fakejpegbytes", "claude-sonnet-5", "key")
+
+    assert "temperature" not in captured
+    assert captured["model"] == "claude-sonnet-5"
+    assert result["quality"] == 0.5
+
+
+def test_sonnet_5_has_a_pricing_entry():
+    from llm_rater import MODEL_PRICING_USD_PER_MTOK
+    entry = MODEL_PRICING_USD_PER_MTOK["claude-sonnet-5"]
+    assert entry == {"input": 3.00, "output": 15.00}

--- a/ml/test_llm_rater_triage.py
+++ b/ml/test_llm_rater_triage.py
@@ -67,3 +67,41 @@ def test_sonnet_5_has_a_pricing_entry():
     from llm_rater import MODEL_PRICING_USD_PER_MTOK
     entry = MODEL_PRICING_USD_PER_MTOK["claude-sonnet-5"]
     assert entry == {"input": 3.00, "output": 15.00}
+
+
+import hashlib
+import json
+
+
+def test_run_manifest_contents(tmp_path):
+    from llm_rater import write_run_manifest, RATING_PROMPT
+
+    path = write_run_manifest(
+        tmp_path,
+        model="claude-sonnet-5",
+        provider="anthropic",
+        selection={"mode": "flagged_unrated", "limit": 500},
+        attempted=500,
+        succeeded=497,
+        failed=3,
+        tokens_in=1_000_000,
+        tokens_out=75_000,
+        est_cost_usd=4.13,
+        started_at="2026-07-29T20:00:00Z",
+        finished_at="2026-07-29T21:30:00Z",
+    )
+
+    assert path.name.startswith("run_") and path.name.endswith("_manifest.json")
+    data = json.loads(path.read_text())
+    assert data["model"] == "claude-sonnet-5"
+    assert data["provider"] == "anthropic"
+    assert data["prompt_version"] == "v2_extended"
+    assert data["prompt_sha256"] == hashlib.sha256(
+        RATING_PROMPT.encode("utf-8")
+    ).hexdigest()
+    assert data["selection"] == {"mode": "flagged_unrated", "limit": 500}
+    assert data["counts"] == {"attempted": 500, "succeeded": 497, "failed": 3}
+    assert data["tokens"] == {"input": 1_000_000, "output": 75_000}
+    assert data["est_cost_usd"] == 4.13
+    assert data["started_at"] == "2026-07-29T20:00:00Z"
+    assert data["finished_at"] == "2026-07-29T21:30:00Z"

--- a/ml/test_llm_rater_triage.py
+++ b/ml/test_llm_rater_triage.py
@@ -1,0 +1,32 @@
+"""Tests for the hard-example triage extensions to llm_rater.py."""
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+from llm_rater import build_flagged_unrated_query
+
+
+def test_flagged_unrated_selects_only_flagged_unrated_webcam_rows():
+    q = build_flagged_unrated_query(limit=0)
+    assert "model_disagreement_kind IS NOT NULL" in q
+    assert "llm_quality IS NULL" in q
+    assert "firebase_url IS NOT NULL" in q
+    assert "webcam_snapshots" in q
+
+
+def test_flagged_unrated_orders_per_camera_round_robin():
+    q = build_flagged_unrated_query(limit=500)
+    assert (
+        "ROW_NUMBER() OVER (PARTITION BY s.webcam_id "
+        "ORDER BY s.captured_at DESC)" in q
+    )
+    # Round-robin: rank across cameras is the primary sort key, so a
+    # --limit slice spreads across cameras instead of draining one.
+    assert "ORDER BY cam_rank, webcam_id" in q
+    assert q.rstrip().endswith("LIMIT 500")
+
+
+def test_flagged_unrated_omits_limit_clause_when_zero():
+    q = build_flagged_unrated_query(limit=0)
+    assert "LIMIT" not in q

--- a/ml/test_llm_rater_triage.py
+++ b/ml/test_llm_rater_triage.py
@@ -139,3 +139,67 @@ def test_build_selection_info_falls_back_to_source_and_default_batch_flag():
         "skip_rated": False,
         "use_batch_api": False,
     }
+
+
+def test_normalize_rating_defaults_and_clamps():
+    from llm_rater import normalize_rating
+
+    out = normalize_rating({"quality": 1.7, "confidence": -0.2,
+                            "time_of_day": "BOGUS", "sky_coverage": "nope"})
+    assert out["quality"] == 1.0
+    assert out["confidence"] == 0.0
+    assert out["is_sunset"] is False
+    assert out["is_sunrise"] is False
+    assert out["time_of_day"] == "unclear"
+    assert out["sky_coverage"] == "partial"
+    assert out["rating_explanation"] == ""
+
+
+def test_parse_custom_id_round_trip():
+    from llm_rater import parse_custom_id
+
+    assert parse_custom_id("webcam:123") == ("webcam", 123)
+    assert parse_custom_id("external:45") == ("external", 45)
+
+
+def _fake_rows(n):
+    return [
+        {"record_id": i, "source_table": "webcam", "webcam_id": i % 7,
+         "image_url": f"https://x/{i}.jpg",
+         "human_calculated_rating": None, "human_rating_count": 0}
+        for i in range(n)
+    ]
+
+
+def test_build_batch_requests_chunks_by_request_count():
+    from llm_rater import build_batch_requests
+
+    def fake_download(url, timeout=30.0):
+        return b"tinyjpeg", "image/jpeg"
+
+    chunks, failures = build_batch_requests(
+        _fake_rows(2500), "claude-sonnet-5", 30.0, download_fn=fake_download,
+    )
+    assert failures == []
+    assert [len(c) for c in chunks] == [1000, 1000, 500]
+    first = chunks[0][0]
+    assert first["custom_id"] == "webcam:0"
+    assert first["params"]["model"] == "claude-sonnet-5"
+    assert first["params"]["max_tokens"] == 600
+    assert "temperature" not in first["params"]
+
+
+def test_build_batch_requests_records_download_failures():
+    from llm_rater import build_batch_requests
+
+    def flaky_download(url, timeout=30.0):
+        if url.endswith("1.jpg"):
+            raise RuntimeError("404 dead url")
+        return b"tinyjpeg", "image/jpeg"
+
+    chunks, failures = build_batch_requests(
+        _fake_rows(3), "claude-sonnet-5", 30.0, download_fn=flaky_download,
+    )
+    assert len(failures) == 1
+    assert failures[0]["custom_id"] == "webcam:1"
+    assert sum(len(c) for c in chunks) == 2


### PR DESCRIPTION
## Summary

The Hard Examples queue can now be triaged down from ~22.8k flagged frames to the few hundred genuine model-vs-Claude contests worth hand-labeling, and every rating is traceable to the judge that produced it. Before this branch, the ~15k `binary_negative_regression_high` flags accumulated by the live cron since June had no adjudication path: Claude ratings couldn't clear a flag, and rating a frame could even *promote* it, so the operator queue kept filling with dark frames.

Three pieces:

- **Triage rating pass** (`ml/llm_rater.py`): a `--flagged-unrated` selection (flagged + Claude-unrated, per-camera round-robin so `--limit` slices spread coverage), `claude-sonnet-5` support (Sonnet 5 rejects sampling params and thinks by default — requests now send `thinking: disabled` and readers select the text block instead of `content[0]`), and a `--use-batch-api` mode: lazy chunked Message-Batches submission (≤1000 requests / ≤200 MB per batch, memory bounded to one chunk), `custom_id` round-trip, real token accounting from batch results, and a per-campaign provenance manifest (model, prompt sha256, selection filters, counts, spend estimate) that survives mid-poll failures via try/finally. Failed frames are never fabricated — they stay unrated and the selection predicate re-picks them next run.
- **`computeDisagreementKind` v2** (`aiScoring.ts`): once Claude has rated a frame, Claude adjudicates — only genuine model-vs-Claude contests stay flagged, and when two of the three judges agree it isn't a sunset the case settles. The Claude-absent path (live cron provisional flags) is byte-for-byte unchanged; no call-site changes needed.
- **Operator docs** (`ml/OPERATING_GUIDE.md`): the rating-provenance contract (judge per-row via `llm_model`/`llm_rated_at`, source via table, campaign via manifest — so a webcam-only or single-judge v5 training export stays a WHERE clause) and the spend runbook: dry-run → ~$1.50 smoke slice → ~$35–45 full run → one-time recompute-reset SQL. The script never auto-escalates spend.

## Test plan

TDD throughout: 33 Python tests (`.venv/bin/python -m pytest ml/`), 37 aiScoring vitest cases covering the v2 truth table (settle/promote/unchanged/live-cron paths), 587 app-suite tests green, no new tsc errors. Built via subagent-driven execution with per-task spec+quality reviews and a final whole-branch review (which caught the Sonnet-5 thinking-default bug before any money was spent).

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Claude_Fable_5-D97757?logo=claude&logoColor=white)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D8E9qBydzwwAuSx65VcVt6
