### PR TITLE
Gallery presence-driven cadence + cost monitoring (Ops tab)

### DIFF
--- a/GALLERY_DISPLAY.md
+++ b/GALLERY_DISPLAY.md
@@ -85,3 +85,41 @@ These may need tuning for the vertical display format.
 - `DATABASE_URL` — Neon Postgres connection string
 - `NEXT_PUBLIC_MAPBOX_TOKEN` — Mapbox API key (may not be needed for mosaic-only views)
 - Firebase credentials (if snapshots are re-enabled)
+
+## Gallery mode runtime (2026-07)
+
+**Cadence:** kiosk pages POST `/api/kiosk/tick` every 60s while visible; a Redis
+lock caps the whole fleet at ~1 tick/minute. The `*/15` cron is the baseline
+when no screen is watching. Scoring re-ranks every minute; individual webcam
+images refresh on their upstream cadence (Windy ≈ 5–15 min).
+
+**Quiet hours:** default 01:00–08:00 local. Override per screen in the kiosk
+URL: `?quiet=off`, `?quiet=23-9`. Any interaction wakes a quiet-hours doze for
+30 minutes.
+
+**Doze controls:**
+- Remote (primary): Ops tab in the site drawer → "Doze kiosks" (owner-only).
+- Local: the `d` key toggles a sticky per-screen doze (only `d` wakes it).
+- Pi case button (Argon ONE, future firmware task): a short single press is
+  unused by the stock argonone daemon — extend it to inject `d` into both
+  Chromium windows via xdotool. Double-tap=reboot / 3s hold=shutdown /
+  5s=hard cut / press-from-off=boot are case-level and unchanged.
+
+**Button card (print and stick on the case):**
+
+| Press                | Does            |
+|----------------------|-----------------|
+| (off) short press    | power on        |
+| short press          | doze / wake     |
+| double tap           | reboot          |
+| hold 3 s             | safe shutdown   |
+| hold 5 s             | force power off |
+
+**Display power** is separate from doze: schedule DPMS off on the Pi (or a TV
+timer / smart plug) to save electricity; doze saves database compute.
+
+**Deploy checklist for this feature set:**
+1. Apply `database/migrations/20260731_provider_usage_and_cost_events.sql` via psql.
+2. Add `NEON_COST_API` to Vercel env (Production).
+3. After deploy, confirm ONNX on `/api/kiosk/tick` (real tick latencyMs 100–500 ms
+   per image; 10–20 ms = silent baseline fallback).

--- a/GALLERY_DISPLAY.md
+++ b/GALLERY_DISPLAY.md
@@ -121,5 +121,6 @@ timer / smart plug) to save electricity; doze saves database compute.
 **Deploy checklist for this feature set:**
 1. Apply `database/migrations/20260731_provider_usage_and_cost_events.sql` via psql.
 2. Add `NEON_COST_API` to Vercel env (Production).
-3. After deploy, confirm ONNX on `/api/kiosk/tick` (real tick latencyMs 100–500 ms
-   per image; 10–20 ms = silent baseline fallback).
+3. After deploy, confirm ONNX is live on the kiosk path: `GET /api/debug/scoring-smoke`
+   (per-image `latencyMs` 100–500 ms = working ONNX; 10–20 ms = silent baseline
+   fallback), and check a real kiosk tick's response has `tick.scoringPaths.onnx > 0`.

--- a/app/HomeClient.tsx
+++ b/app/HomeClient.tsx
@@ -23,6 +23,7 @@ import { AuthControl } from './components/auth/AuthControl';
 import { useIsOperator } from './components/auth/useIsOperator';
 import { LeaderboardTab } from './components/Leaderboard/LeaderboardTab';
 import { HardExamplesQueue } from './components/HardExamples/HardExamplesQueue';
+import { OpsTab } from './components/Ops/OpsTab';
 
 interface Props {
   manifestRuns: ManifestEntry[];
@@ -48,6 +49,7 @@ export function HomeClient({ manifestRuns }: Props) {
     { key: 'unrated', label: 'Unrated Queue', operatorOnly: true },
     { key: 'all', label: 'All Webcams', operatorOnly: true },
     { key: 'models', label: 'Model Analysis', operatorOnly: false },
+    { key: 'ops', label: '📊 Ops', operatorOnly: true },
   ] as const;
   const visibleTabs = ALL_TABS.filter((t) => isOperator || !t.operatorOnly);
 
@@ -245,6 +247,11 @@ export function HomeClient({ manifestRuns }: Props) {
               {tabKey === 'models' && (
                 <Box sx={{ height: '100%' }}>
                   <ModelAnalysisTab runs={manifestRuns} />
+                </Box>
+              )}
+              {tabKey === 'ops' && (
+                <Box>
+                  <OpsTab />
                 </Box>
               )}
             </Box>

--- a/app/api/admin/ops-stats/route.test.ts
+++ b/app/api/admin/ops-stats/route.test.ts
@@ -1,0 +1,55 @@
+// @vitest-environment node
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NextResponse } from 'next/server';
+
+const requireOwnerMock = vi.fn();
+vi.mock('@/app/lib/owner', () => ({
+  requireOwner: (...a: unknown[]) => requireOwnerMock(...a),
+}));
+
+const sqlMock = vi.fn();
+vi.mock('@/app/lib/db', () => ({
+  sql: (strings: TemplateStringsArray, ...values: unknown[]) =>
+    sqlMock(strings, ...values),
+}));
+
+import { GET } from './route';
+
+describe('GET /api/admin/ops-stats', () => {
+  beforeEach(() => {
+    requireOwnerMock.mockReset();
+    sqlMock.mockReset();
+  });
+
+  it('returns 403 when requireOwner denies', async () => {
+    requireOwnerMock.mockResolvedValueOnce(
+      NextResponse.json({ error: 'Forbidden' }, { status: 403 }),
+    );
+    const res = await GET();
+    expect(res.status).toBe(403);
+    expect(sqlMock).not.toHaveBeenCalled();
+  });
+
+  it('returns last daily stats rows for the owner', async () => {
+    requireOwnerMock.mockResolvedValueOnce(null);
+    sqlMock.mockResolvedValueOnce([
+      {
+        date: '2026-07-30',
+        model_version: 'v4',
+        webcams_scored: 500,
+        cache_hits: 400,
+        fallbacks: 2,
+        score_p50: 0.31,
+        score_p90: 0.71,
+        source_breakdown: { windy: { scored: 480, avg: 0.4 } },
+      },
+    ]);
+    const res = await GET();
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.dailyStats).toHaveLength(1);
+    expect(body.dailyStats[0].date).toBe('2026-07-30');
+    expect(body.providerUsage).toEqual([]);
+    expect(body.costEvents).toEqual([]);
+  });
+});

--- a/app/api/admin/ops-stats/route.test.ts
+++ b/app/api/admin/ops-stats/route.test.ts
@@ -30,26 +30,42 @@ describe('GET /api/admin/ops-stats', () => {
     expect(sqlMock).not.toHaveBeenCalled();
   });
 
-  it('returns last daily stats rows for the owner', async () => {
+  it('returns daily stats, provider usage, and cost events for the owner', async () => {
     requireOwnerMock.mockResolvedValueOnce(null);
-    sqlMock.mockResolvedValueOnce([
-      {
-        date: '2026-07-30',
-        model_version: 'v4',
-        webcams_scored: 500,
-        cache_hits: 400,
-        fallbacks: 2,
-        score_p50: 0.31,
-        score_p90: 0.71,
-        source_breakdown: { windy: { scored: 480, avg: 0.4 } },
-      },
-    ]);
+    sqlMock
+      .mockResolvedValueOnce([
+        {
+          date: '2026-07-30',
+          model_version: 'v4',
+          webcams_scored: 500,
+          cache_hits: 400,
+          fallbacks: 2,
+          score_p50: 0.31,
+          score_p90: 0.71,
+          source_breakdown: null,
+        },
+      ])
+      .mockResolvedValueOnce([
+        {
+          day: '2026-07-30',
+          project_id: 'noisy-leaf-96391119',
+          compute_time_s: '36000',
+        },
+      ])
+      .mockResolvedValueOnce([
+        {
+          occurred_on: '2026-07-31',
+          sha: null,
+          description: 'autoscale 0.25-1 CU',
+        },
+      ]);
     const res = await GET();
     expect(res.status).toBe(200);
     const body = await res.json();
     expect(body.dailyStats).toHaveLength(1);
     expect(body.dailyStats[0].date).toBe('2026-07-30');
-    expect(body.providerUsage).toEqual([]);
-    expect(body.costEvents).toEqual([]);
+    expect(body.providerUsage).toHaveLength(1);
+    expect(body.providerUsage[0].project_id).toBe('noisy-leaf-96391119');
+    expect(body.costEvents[0].description).toContain('autoscale');
   });
 });

--- a/app/api/admin/ops-stats/route.test.ts
+++ b/app/api/admin/ops-stats/route.test.ts
@@ -68,4 +68,19 @@ describe('GET /api/admin/ops-stats', () => {
     expect(body.providerUsage[0].project_id).toBe('noisy-leaf-96391119');
     expect(body.costEvents[0].description).toContain('autoscale');
   });
+
+  it('casts the provider-usage lookback interpolation to ::int so Postgres does not parse it as a date', async () => {
+    requireOwnerMock.mockResolvedValueOnce(null);
+    sqlMock
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([]);
+    await GET();
+    const providerUsageCall = sqlMock.mock.calls.find(([strings]) =>
+      (strings as TemplateStringsArray).join('').includes('provider_usage_daily'),
+    );
+    expect(providerUsageCall).toBeDefined();
+    const [strings] = providerUsageCall as [TemplateStringsArray, ...unknown[]];
+    expect(strings.join('')).toContain('::int');
+  });
 });

--- a/app/api/admin/ops-stats/route.ts
+++ b/app/api/admin/ops-stats/route.ts
@@ -1,0 +1,28 @@
+import { NextResponse } from 'next/server';
+import { requireOwner } from '@/app/lib/owner';
+import { sql } from '@/app/lib/db';
+import { OPS_STATS_DAYS } from '@/app/lib/masterConfig';
+import type { DailyStatsRow, OpsStatsResponse } from '@/app/lib/opsTypes';
+
+export const dynamic = 'force-dynamic';
+export const runtime = 'nodejs';
+
+export async function GET() {
+  const denied = await requireOwner();
+  if (denied) return denied;
+
+  const rows = (await sql`
+    SELECT date::text AS date, model_version, webcams_scored, cache_hits,
+           fallbacks, score_p50::float, score_p90::float, source_breakdown
+    FROM daily_sunset_stats
+    ORDER BY date DESC
+    LIMIT ${OPS_STATS_DAYS}
+  `) as unknown as DailyStatsRow[];
+
+  const body: OpsStatsResponse = {
+    dailyStats: rows.reverse(), // oldest → newest for charting
+    providerUsage: [],
+    costEvents: [],
+  };
+  return NextResponse.json(body);
+}

--- a/app/api/admin/ops-stats/route.ts
+++ b/app/api/admin/ops-stats/route.ts
@@ -27,7 +27,7 @@ export async function GET() {
   const providerUsage = (await sql`
     SELECT day::text AS day, project_id, compute_time_s::bigint AS compute_time_s
     FROM provider_usage_daily
-    WHERE day > CURRENT_DATE - ${PROVIDER_USAGE_LOOKBACK_DAYS}
+    WHERE day > CURRENT_DATE - ${PROVIDER_USAGE_LOOKBACK_DAYS}::int
     ORDER BY day ASC, project_id ASC
   `) as unknown as ProviderUsageRow[];
 

--- a/app/api/admin/ops-stats/route.ts
+++ b/app/api/admin/ops-stats/route.ts
@@ -1,8 +1,13 @@
 import { NextResponse } from 'next/server';
 import { requireOwner } from '@/app/lib/owner';
 import { sql } from '@/app/lib/db';
-import { OPS_STATS_DAYS } from '@/app/lib/masterConfig';
-import type { DailyStatsRow, OpsStatsResponse } from '@/app/lib/opsTypes';
+import { OPS_STATS_DAYS, PROVIDER_USAGE_LOOKBACK_DAYS } from '@/app/lib/masterConfig';
+import type {
+  DailyStatsRow,
+  OpsStatsResponse,
+  ProviderUsageRow,
+  CostEventRow,
+} from '@/app/lib/opsTypes';
 
 export const dynamic = 'force-dynamic';
 export const runtime = 'nodejs';
@@ -19,10 +24,26 @@ export async function GET() {
     LIMIT ${OPS_STATS_DAYS}
   `) as unknown as DailyStatsRow[];
 
+  const providerUsage = (await sql`
+    SELECT day::text AS day, project_id, compute_time_s::bigint AS compute_time_s
+    FROM provider_usage_daily
+    WHERE day > CURRENT_DATE - ${PROVIDER_USAGE_LOOKBACK_DAYS}
+    ORDER BY day ASC, project_id ASC
+  `) as unknown as ProviderUsageRow[];
+
+  const costEvents = (await sql`
+    SELECT occurred_on::text AS occurred_on, sha, description
+    FROM cost_events
+    ORDER BY occurred_on ASC
+  `) as unknown as CostEventRow[];
+
   const body: OpsStatsResponse = {
     dailyStats: rows.reverse(), // oldest → newest for charting
-    providerUsage: [],
-    costEvents: [],
+    providerUsage: providerUsage.map((r) => ({
+      ...r,
+      compute_time_s: Number(r.compute_time_s),
+    })),
+    costEvents,
   };
   return NextResponse.json(body);
 }

--- a/app/api/cron/update-cameras/lib/providerUsage.test.ts
+++ b/app/api/cron/update-cameras/lib/providerUsage.test.ts
@@ -1,0 +1,81 @@
+// @vitest-environment node
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const sqlMock = vi.fn();
+vi.mock('@/app/lib/db', () => ({
+  sql: (strings: TemplateStringsArray, ...values: unknown[]) =>
+    sqlMock(strings, ...values),
+}));
+
+import { captureProviderUsageDaily } from './providerUsage';
+
+const NOW = new Date('2026-08-02T00:20:00Z');
+
+describe('captureProviderUsageDaily', () => {
+  const fetchMock = vi.fn();
+  beforeEach(() => {
+    sqlMock.mockReset();
+    fetchMock.mockReset();
+    vi.stubGlobal('fetch', fetchMock);
+    process.env.NEON_COST_API = 'test-key';
+  });
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    delete process.env.NEON_COST_API;
+  });
+
+  it('skips when today already has rows', async () => {
+    sqlMock.mockResolvedValueOnce([{ count: 4 }]);
+    const result = await captureProviderUsageDaily(NOW);
+    expect(result).toEqual({ skipped: 'already-captured' });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('skips without the API key', async () => {
+    delete process.env.NEON_COST_API;
+    const result = await captureProviderUsageDaily(NOW);
+    expect(result).toEqual({ skipped: 'no-api-key' });
+    expect(sqlMock).not.toHaveBeenCalled();
+  });
+
+  it('fetches each project and upserts counters', async () => {
+    sqlMock.mockResolvedValueOnce([{ count: 0 }]); // guard
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        project: {
+          compute_time_seconds: 3600,
+          active_time_seconds: 7200,
+          data_transfer_bytes: 10,
+          synthetic_storage_size: 20,
+        },
+      }),
+    });
+    sqlMock.mockResolvedValue([]); // upserts
+    const result = await captureProviderUsageDaily(NOW);
+    expect(result).toEqual({ captured: 4 }); // 4 configured projects
+    expect(fetchMock).toHaveBeenCalledTimes(4);
+    const firstUrl = fetchMock.mock.calls[0][0] as string;
+    expect(firstUrl).toContain('https://console.neon.tech/api/v2/projects/');
+  });
+
+  it('tolerates one project failing (partial rows are fine)', async () => {
+    sqlMock.mockResolvedValueOnce([{ count: 0 }]);
+    fetchMock
+      .mockResolvedValueOnce({ ok: false, status: 500 })
+      .mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          project: {
+            compute_time_seconds: 1,
+            active_time_seconds: 1,
+            data_transfer_bytes: 1,
+            synthetic_storage_size: 1,
+          },
+        }),
+      });
+    sqlMock.mockResolvedValue([]);
+    const result = await captureProviderUsageDaily(NOW);
+    expect(result).toEqual({ captured: 3 });
+  });
+});

--- a/app/api/cron/update-cameras/lib/providerUsage.ts
+++ b/app/api/cron/update-cameras/lib/providerUsage.ts
@@ -1,0 +1,57 @@
+import { sql } from '@/app/lib/db';
+import { NEON_USAGE_PROJECT_IDS } from '@/app/lib/masterConfig';
+
+const NEON_API = 'https://console.neon.tech/api/v2';
+
+function utcDateString(d: Date): string {
+  return d.toISOString().slice(0, 10);
+}
+
+// Snapshot Neon month-to-date usage counters once per UTC day. Called from the
+// update-cameras cron; every failure path returns instead of throwing so the
+// scoring tick can never be broken by the cost dashboard.
+export async function captureProviderUsageDaily(
+  now: Date,
+): Promise<{ captured: number } | { skipped: string }> {
+  const apiKey = process.env.NEON_COST_API;
+  if (!apiKey) return { skipped: 'no-api-key' };
+
+  const day = utcDateString(now);
+  const existing = (await sql`
+    SELECT COUNT(*)::int AS count FROM provider_usage_daily WHERE day = ${day}
+  `) as unknown as { count: number }[];
+  if ((existing[0]?.count ?? 0) > 0) return { skipped: 'already-captured' };
+
+  let captured = 0;
+  for (const projectId of NEON_USAGE_PROJECT_IDS) {
+    try {
+      const res = await fetch(`${NEON_API}/projects/${projectId}`, {
+        headers: { Authorization: `Bearer ${apiKey}` },
+      });
+      if (!res.ok) {
+        console.warn(`[providerUsage] ${projectId} -> ${res.status}`);
+        continue;
+      }
+      const { project } = (await res.json()) as {
+        project: {
+          compute_time_seconds?: number;
+          active_time_seconds?: number;
+          data_transfer_bytes?: number;
+          synthetic_storage_size?: number;
+        };
+      };
+      await sql`
+        INSERT INTO provider_usage_daily
+          (day, project_id, compute_time_s, active_time_s, data_transfer_b, storage_b)
+        VALUES (${day}, ${projectId},
+          ${project.compute_time_seconds ?? 0}, ${project.active_time_seconds ?? 0},
+          ${project.data_transfer_bytes ?? 0}, ${project.synthetic_storage_size ?? 0})
+        ON CONFLICT (day, project_id) DO NOTHING
+      `;
+      captured++;
+    } catch (error) {
+      console.warn(`[providerUsage] ${projectId} failed:`, error);
+    }
+  }
+  return { captured };
+}

--- a/app/api/cron/update-cameras/route.test.ts
+++ b/app/api/cron/update-cameras/route.test.ts
@@ -3,6 +3,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 const fetchTerminatorWebcamsMock = vi.fn();
 const setCachedMock = vi.fn();
+const markKioskTickRanMock = vi.fn();
 const fetchBatchesMock = vi.fn();
 const upsertWebcamsMock = vi.fn();
 const classifyMock = vi.fn();
@@ -31,6 +32,7 @@ vi.mock('@/app/lib/terminatorPayload', () => ({
 }));
 vi.mock('@/app/lib/cache', () => ({
   setCachedTerminatorPayload: (...a: unknown[]) => setCachedMock(...a),
+  markKioskTickRan: () => markKioskTickRanMock(),
 }));
 vi.mock('@/app/lib/webcamSnapshot', () => ({
   downloadImage: (...a: unknown[]) => downloadMock(...a),
@@ -127,6 +129,7 @@ beforeEach(() => {
   upsertStatsMock.mockReset().mockResolvedValue(undefined);
   captureProviderUsageDailyMock.mockReset().mockResolvedValue({ captured: 0 });
   setCachedMock.mockReset().mockResolvedValue(undefined);
+  markKioskTickRanMock.mockReset().mockResolvedValue(undefined);
   fetchTerminatorWebcamsMock.mockReset().mockResolvedValue([]);
   computeTickStatsMock.mockReset().mockReturnValue({ modelVersion: 'v4', webcamsScored: 1, cacheHits: 0, fallbacks: 0, scoreAvg: 0.5, scoreP50: 0.5, scoreP90: 0.5, scoreP99: 0.5, aboveMinScoreToWinCount: 0, sourceBreakdown: { windy: { scored: 1, avg: 0.5 }, custom: { scored: 0, avg: null } } });
   verifyAuthMock.mockReset().mockReturnValue(true);
@@ -199,6 +202,12 @@ describe('GET /api/cron/update-cameras', () => {
     expect(res.status).toBe(401);
     expect(scoreMock).not.toHaveBeenCalled();
     expect(backfillMock).not.toHaveBeenCalled();
+  });
+
+  it('stamps the kiosk tick lock after a successful authed GET', async () => {
+    const res = await GET(makeReq());
+    expect(res.status).toBe(200);
+    expect(markKioskTickRanMock).toHaveBeenCalled();
   });
 
   it('unions custom cams into the upsert active set', async () => {

--- a/app/api/cron/update-cameras/route.test.ts
+++ b/app/api/cron/update-cameras/route.test.ts
@@ -16,6 +16,7 @@ const scoreMock = vi.fn();
 const backfillMock = vi.fn();
 const customClassifyMock = vi.fn();
 const upsertStatsMock = vi.fn();
+const captureProviderUsageDailyMock = vi.fn();
 const verifyAuthMock = vi.fn(() => true);
 const computeTickStatsMock = vi.fn();
 const computeDisagreementKindMock = vi.fn(() => null);
@@ -73,6 +74,10 @@ vi.mock('./lib/dailyStats', () => ({
   computeTickStats: (...a: unknown[]) => computeTickStatsMock(...a),
   upsertDailyStats: (...a: unknown[]) => upsertStatsMock(...a),
 }));
+vi.mock('./lib/providerUsage', () => ({
+  captureProviderUsageDaily: (...a: unknown[]) =>
+    captureProviderUsageDailyMock(...a),
+}));
 vi.mock('@/app/components/Map/lib/subsolarLocation', () => ({
   subsolarPoint: () => ({ raHours: 0, gmstHours: 0 }),
 }));
@@ -120,6 +125,7 @@ beforeEach(() => {
   backfillMock.mockReset().mockResolvedValue({ scored: 0, failed: 0, deadUrls: 0, fallbacks: 0, abortedOnFallback: false, modelVersion: null, scores: [] });
   customClassifyMock.mockReset().mockResolvedValue({ sunrise: [], sunset: [] });
   upsertStatsMock.mockReset().mockResolvedValue(undefined);
+  captureProviderUsageDailyMock.mockReset().mockResolvedValue({ captured: 0 });
   setCachedMock.mockReset().mockResolvedValue(undefined);
   fetchTerminatorWebcamsMock.mockReset().mockResolvedValue([]);
   computeTickStatsMock.mockReset().mockReturnValue({ modelVersion: 'v4', webcamsScored: 1, cacheHits: 0, fallbacks: 0, scoreAvg: 0.5, scoreP50: 0.5, scoreP90: 0.5, scoreP99: 0.5, aboveMinScoreToWinCount: 0, sourceBreakdown: { windy: { scored: 1, avg: 0.5 }, custom: { scored: 0, avg: null } } });
@@ -352,5 +358,12 @@ describe('GET /api/cron/update-cameras', () => {
     });
     await GET(makeReq());
     expect(insertWindyDisagreementSnapshotMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('captures provider usage without failing the tick when it errors', async () => {
+    captureProviderUsageDailyMock.mockRejectedValueOnce(new Error('neon down'));
+    const res = await GET(makeReq());
+    expect(res.status).toBe(200);
+    expect(captureProviderUsageDailyMock).toHaveBeenCalled();
   });
 });

--- a/app/api/cron/update-cameras/route.ts
+++ b/app/api/cron/update-cameras/route.ts
@@ -47,6 +47,7 @@ import {
 import { computeDisagreementKind, scoreImage } from './lib/aiScoring';
 import { backfillArchiveSnapshotScores } from './lib/archiveBackfill';
 import { computeTickStats, upsertDailyStats } from './lib/dailyStats';
+import { captureProviderUsageDaily } from './lib/providerUsage';
 import { downloadImage, uploadToFirebase } from '@/app/lib/webcamSnapshot';
 
 const TICK_DEADLINE_MS = 50_000;
@@ -386,6 +387,16 @@ export async function GET(req: Request) {
     console.error('[update-cameras] daily_sunset_stats UPSERT failed:', err);
   }
 
+  // Once per UTC day, snapshot Neon usage counters for the Ops tab. Never
+  // allowed to fail the tick.
+  let providerUsage: Awaited<ReturnType<typeof captureProviderUsageDaily>> | { error: true };
+  try {
+    providerUsage = await captureProviderUsageDaily(new Date());
+  } catch (error) {
+    console.warn('[update-cameras] provider usage capture failed:', error);
+    providerUsage = { error: true };
+  }
+
   return NextResponse.json({
     ok: true,
     sunrise: sunriseRows.length,
@@ -395,5 +406,6 @@ export async function GET(req: Request) {
     fallbacks,
     scoringPaths,
     archiveBackfill: backfillResult,
+    providerUsage,
   });
 }

--- a/app/api/cron/update-cameras/route.ts
+++ b/app/api/cron/update-cameras/route.ts
@@ -11,7 +11,7 @@
  */
 
 import { fetchTerminatorWebcams } from '@/app/lib/terminatorPayload';
-import { setCachedTerminatorPayload } from '@/app/lib/cache';
+import { setCachedTerminatorPayload, markKioskTickRan } from '@/app/lib/cache';
 import { NextResponse } from 'next/server';
 import { subsolarPoint } from '@/app/components/Map/lib/subsolarLocation';
 import { createTerminatorQueryRing } from '@/app/components/Map/lib/terminatorRing';
@@ -61,6 +61,10 @@ export async function GET(req: Request) {
   if (!verifyCronAuth(req)) {
     return new NextResponse('Unauthorized', { status: 401 });
   }
+
+  // Stamp the kiosk tick lock so a kiosk poll immediately after this cron
+  // tick is a no-op (shared once-per-minute budget).
+  void markKioskTickRan();
 
   console.log('🚀 Starting cron job...');
 

--- a/app/api/kiosk/doze/route.test.ts
+++ b/app/api/kiosk/doze/route.test.ts
@@ -1,0 +1,52 @@
+// @vitest-environment node
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NextResponse } from 'next/server';
+
+const requireOwnerMock = vi.fn();
+vi.mock('@/app/lib/owner', () => ({
+  requireOwner: (...a: unknown[]) => requireOwnerMock(...a),
+}));
+const setKioskDozeMock = vi.fn();
+vi.mock('@/app/lib/cache', () => ({
+  setKioskDoze: (on: boolean) => setKioskDozeMock(on),
+}));
+
+import { POST } from './route';
+
+function req(body: unknown): Request {
+  return new Request('http://test/api/kiosk/doze', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+describe('POST /api/kiosk/doze', () => {
+  beforeEach(() => {
+    requireOwnerMock.mockReset();
+    setKioskDozeMock.mockReset();
+  });
+
+  it('rejects non-owners', async () => {
+    requireOwnerMock.mockResolvedValueOnce(
+      NextResponse.json({ error: 'Forbidden' }, { status: 403 }),
+    );
+    const res = await POST(req({ doze: true }));
+    expect(res.status).toBe(403);
+    expect(setKioskDozeMock).not.toHaveBeenCalled();
+  });
+
+  it('sets the flag for the owner', async () => {
+    requireOwnerMock.mockResolvedValueOnce(null);
+    const res = await POST(req({ doze: true }));
+    expect(res.status).toBe(200);
+    expect(setKioskDozeMock).toHaveBeenCalledWith(true);
+    expect(await res.json()).toEqual({ doze: true });
+  });
+
+  it('400s on a malformed body', async () => {
+    requireOwnerMock.mockResolvedValueOnce(null);
+    const res = await POST(req({ doze: 'maybe' }));
+    expect(res.status).toBe(400);
+  });
+});

--- a/app/api/kiosk/doze/route.ts
+++ b/app/api/kiosk/doze/route.ts
@@ -1,0 +1,22 @@
+import { NextResponse } from 'next/server';
+import { requireOwner } from '@/app/lib/owner';
+import { setKioskDoze } from '@/app/lib/cache';
+
+export const dynamic = 'force-dynamic';
+
+export async function POST(request: Request) {
+  const denied = await requireOwner();
+  if (denied) return denied;
+
+  let doze: unknown;
+  try {
+    ({ doze } = await request.json());
+  } catch {
+    return NextResponse.json({ error: 'invalid JSON' }, { status: 400 });
+  }
+  if (typeof doze !== 'boolean') {
+    return NextResponse.json({ error: 'doze must be boolean' }, { status: 400 });
+  }
+  await setKioskDoze(doze);
+  return NextResponse.json({ doze });
+}

--- a/app/api/kiosk/state/route.test.ts
+++ b/app/api/kiosk/state/route.test.ts
@@ -1,0 +1,19 @@
+// @vitest-environment node
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const getKioskDozeMock = vi.fn();
+vi.mock('@/app/lib/cache', () => ({
+  getKioskDoze: () => getKioskDozeMock(),
+}));
+
+import { GET } from './route';
+
+describe('GET /api/kiosk/state', () => {
+  beforeEach(() => getKioskDozeMock.mockReset());
+  it('returns the doze flag', async () => {
+    getKioskDozeMock.mockResolvedValueOnce(true);
+    const res = await GET();
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ doze: true });
+  });
+});

--- a/app/api/kiosk/state/route.ts
+++ b/app/api/kiosk/state/route.ts
@@ -1,0 +1,10 @@
+import { NextResponse } from 'next/server';
+import { getKioskDoze } from '@/app/lib/cache';
+
+export const dynamic = 'force-dynamic';
+
+// Redis-only read: this is the endpoint dozing kiosks poll once a minute to
+// hear the wake command, so it must never touch Neon.
+export async function GET() {
+  return NextResponse.json({ doze: await getKioskDoze() });
+}

--- a/app/api/kiosk/tick/route.test.ts
+++ b/app/api/kiosk/tick/route.test.ts
@@ -1,0 +1,51 @@
+// @vitest-environment node
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NextResponse } from 'next/server';
+
+const acquireKioskTickLockMock = vi.fn();
+vi.mock('@/app/lib/cache', () => ({
+  acquireKioskTickLock: () => acquireKioskTickLockMock(),
+}));
+
+const cronGetMock = vi.fn();
+vi.mock('@/app/api/cron/update-cameras/route', () => ({
+  GET: (req: Request) => cronGetMock(req),
+}));
+
+import { POST } from './route';
+
+describe('POST /api/kiosk/tick', () => {
+  beforeEach(() => {
+    acquireKioskTickLockMock.mockReset();
+    cronGetMock.mockReset();
+    process.env.CRON_SECRET = 'shh';
+  });
+
+  it('throttles when the lock is held', async () => {
+    acquireKioskTickLockMock.mockResolvedValueOnce(false);
+    const res = await POST();
+    expect(res.status).toBe(202);
+    expect(await res.json()).toEqual({ throttled: true });
+    expect(cronGetMock).not.toHaveBeenCalled();
+  });
+
+  it('runs a tick with internal cron auth when the lock is acquired', async () => {
+    acquireKioskTickLockMock.mockResolvedValueOnce(true);
+    cronGetMock.mockResolvedValueOnce(
+      NextResponse.json({ ok: true, windyScored: 3 }),
+    );
+    const res = await POST();
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.tick.windyScored).toBe(3);
+    const forwarded = cronGetMock.mock.calls[0][0] as Request;
+    expect(forwarded.headers.get('authorization')).toBe('Bearer shh');
+  });
+
+  it('returns 500 when the tick itself fails', async () => {
+    acquireKioskTickLockMock.mockResolvedValueOnce(true);
+    cronGetMock.mockRejectedValueOnce(new Error('boom'));
+    const res = await POST();
+    expect(res.status).toBe(500);
+  });
+});

--- a/app/api/kiosk/tick/route.ts
+++ b/app/api/kiosk/tick/route.ts
@@ -1,0 +1,30 @@
+import { NextResponse } from 'next/server';
+import { acquireKioskTickLock } from '@/app/lib/cache';
+import { GET as runCronTick } from '@/app/api/cron/update-cameras/route';
+
+export const dynamic = 'force-dynamic';
+export const maxDuration = 60;
+
+// Presence-driven scoring: gallery kiosk screens POST here every minute while
+// visible. Unauthenticated by design (the kiosk page is public and cannot hold
+// a secret) — the Redis NX lock caps the worst case at ~1 tick/minute
+// globally, i.e. gallery-mode cost. The */15 cron remains the baseline.
+export async function POST() {
+  const acquired = await acquireKioskTickLock();
+  if (!acquired) {
+    return NextResponse.json({ throttled: true }, { status: 202 });
+  }
+  try {
+    // Re-invoke the cron handler in-process with internal auth. This keeps
+    // one source of truth for what "a tick" is (see spec Part B).
+    const req = new Request('http://kiosk.internal/api/cron/update-cameras', {
+      headers: { Authorization: `Bearer ${process.env.CRON_SECRET ?? ''}` },
+    });
+    const tickRes = await runCronTick(req);
+    const tick = await tickRes.json();
+    return NextResponse.json({ ok: true, tick }, { status: tickRes.status });
+  } catch (error) {
+    console.error('[kiosk/tick] failed:', error);
+    return NextResponse.json({ error: 'tick failed' }, { status: 500 });
+  }
+}

--- a/app/components/Ops/DozeControl.test.tsx
+++ b/app/components/Ops/DozeControl.test.tsx
@@ -1,0 +1,30 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { DozeControl } from './DozeControl';
+
+describe('DozeControl', () => {
+  const fetchMock = vi.fn();
+  beforeEach(() => {
+    fetchMock.mockReset();
+    vi.stubGlobal('fetch', fetchMock);
+  });
+  afterEach(() => vi.unstubAllGlobals());
+
+  it('shows awake state and dozes on click', async () => {
+    fetchMock
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ doze: false }) }) // initial GET
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ doze: true }) }); // POST
+    render(<DozeControl />);
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: /doze kiosks/i })).toBeInTheDocument(),
+    );
+    await userEvent.click(screen.getByRole('button', { name: /doze kiosks/i }));
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: /wake kiosks/i })).toBeInTheDocument(),
+    );
+    const postCall = fetchMock.mock.calls.find((c) => c[1]?.method === 'POST');
+    expect(String(postCall![0])).toContain('/api/kiosk/doze');
+    expect(JSON.parse(postCall![1].body as string)).toEqual({ doze: true });
+  });
+});

--- a/app/components/Ops/DozeControl.tsx
+++ b/app/components/Ops/DozeControl.tsx
@@ -1,0 +1,43 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { Box, Button, Typography } from '@mui/material';
+
+export function DozeControl() {
+  const [doze, setDoze] = useState<boolean | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  useEffect(() => {
+    fetch('/api/kiosk/state')
+      .then((r) => r.json())
+      .then((b: { doze: boolean }) => setDoze(b.doze))
+      .catch(() => setDoze(null));
+  }, []);
+
+  const toggle = async () => {
+    if (doze === null || busy) return;
+    setBusy(true);
+    try {
+      const res = await fetch('/api/kiosk/doze', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ doze: !doze }),
+      });
+      if (res.ok) setDoze(((await res.json()) as { doze: boolean }).doze);
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  if (doze === null) return null;
+  return (
+    <Box sx={{ display: 'flex', alignItems: 'center', gap: 2, mb: 2 }}>
+      <Typography sx={{ color: '#9ca3af' }}>
+        Gallery kiosks: {doze ? 'dozing 🌙' : 'awake ☀️'}
+      </Typography>
+      <Button variant="outlined" size="small" disabled={busy} onClick={toggle}>
+        {doze ? 'Wake kiosks' : 'Doze kiosks'}
+      </Button>
+    </Box>
+  );
+}

--- a/app/components/Ops/OpsPanels.test.tsx
+++ b/app/components/Ops/OpsPanels.test.tsx
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { OpsPanels } from './OpsPanels';
+import type { OpsStatsResponse } from '@/app/lib/opsTypes';
+
+const data: OpsStatsResponse = {
+  dailyStats: [
+    {
+      date: '2026-07-29',
+      model_version: 'v4',
+      webcams_scored: 500,
+      cache_hits: 400,
+      fallbacks: 5,
+      score_p50: 0.3,
+      score_p90: 0.7,
+      source_breakdown: { windy: { scored: 480, avg: 0.4 } },
+    },
+    {
+      date: '2026-07-30',
+      model_version: 'v4',
+      webcams_scored: 0, // null-score day, like 2026-06-03
+      cache_hits: 0,
+      fallbacks: 0,
+      score_p50: null,
+      score_p90: null,
+      source_breakdown: null,
+    },
+  ],
+  providerUsage: [],
+  costEvents: [],
+};
+
+describe('OpsPanels', () => {
+  it('renders fallback % and cache-hit % from the latest full day', () => {
+    render(<OpsPanels data={data} />);
+    // latest day with webcams_scored > 0 is 2026-07-29: 5/500 = 1%, 400/500 = 80%
+    expect(screen.getByText(/fallbacks/i).parentElement!.textContent).toContain('1%');
+    expect(screen.getByText(/cache hits/i).parentElement!.textContent).toContain('80%');
+    expect(screen.getByText('v4')).toBeInTheDocument();
+  });
+
+  it('renders an empty state when there is no data', () => {
+    render(<OpsPanels data={{ dailyStats: [], providerUsage: [], costEvents: [] }} />);
+    expect(screen.getByText(/no data yet/i)).toBeInTheDocument();
+  });
+});

--- a/app/components/Ops/OpsPanels.tsx
+++ b/app/components/Ops/OpsPanels.tsx
@@ -3,6 +3,7 @@ import type { OpsStatsResponse } from '@/app/lib/opsTypes';
 import { pct } from './opsMath';
 import { Sparkline } from './Sparkline';
 import { UsageChart } from './UsageChart';
+import { DozeControl } from './DozeControl';
 
 function Stat({
   label,
@@ -38,6 +39,7 @@ export function OpsPanels({ data }: { data: OpsStatsResponse }) {
   const cachePct = pct(latest.cache_hits, latest.webcams_scored);
   return (
     <>
+      <DozeControl />
       <Box sx={{ display: 'flex', gap: 2, flexWrap: 'wrap' }}>
         <Stat
           label="fallbacks (spike = scoring broke)"

--- a/app/components/Ops/OpsPanels.tsx
+++ b/app/components/Ops/OpsPanels.tsx
@@ -30,40 +30,47 @@ function Stat({
 export function OpsPanels({ data }: { data: OpsStatsResponse }) {
   const days = data.dailyStats;
   const latest = [...days].reverse().find((d) => d.webcams_scored > 0);
-  if (!latest) {
-    return (
-      <Typography sx={{ color: '#9ca3af', p: 2 }}>No data yet.</Typography>
-    );
-  }
-  const fallbackPct = pct(latest.fallbacks, latest.webcams_scored);
-  const cachePct = pct(latest.cache_hits, latest.webcams_scored);
   return (
     <>
       <DozeControl />
-      <Box sx={{ display: 'flex', gap: 2, flexWrap: 'wrap' }}>
-        <Stat
-          label="fallbacks (spike = scoring broke)"
-          value={fallbackPct === null ? '—' : `${fallbackPct}%`}
-          spark={days.map((d) => pct(d.fallbacks, d.webcams_scored))}
-        />
-        <Stat
-          label="cache hits (dedup working)"
-          value={cachePct === null ? '—' : `${cachePct}%`}
-          spark={days.map((d) => pct(d.cache_hits, d.webcams_scored))}
-        />
-        <Stat
-          label="webcams scored"
-          value={String(latest.webcams_scored)}
-          spark={days.map((d) => d.webcams_scored)}
-        />
-        <Stat
-          label="score p50 / p90"
-          value={`${latest.score_p50 ?? '—'} / ${latest.score_p90 ?? '—'}`}
-          spark={days.map((d) => d.score_p50)}
-        />
-        <Stat label="model" value={latest.model_version} />
-      </Box>
-      <UsageChart usage={data.providerUsage} events={data.costEvents} />
+      {!latest ? (
+        <Typography sx={{ color: '#9ca3af', p: 2 }}>No data yet.</Typography>
+      ) : (
+        <>
+          {(() => {
+            const fallbackPct = pct(latest.fallbacks, latest.webcams_scored);
+            const cachePct = pct(latest.cache_hits, latest.webcams_scored);
+            return (
+              <>
+                <Box sx={{ display: 'flex', gap: 2, flexWrap: 'wrap' }}>
+                  <Stat
+                    label="fallbacks (spike = scoring broke)"
+                    value={fallbackPct === null ? '—' : `${fallbackPct}%`}
+                    spark={days.map((d) => pct(d.fallbacks, d.webcams_scored))}
+                  />
+                  <Stat
+                    label="cache hits (dedup working)"
+                    value={cachePct === null ? '—' : `${cachePct}%`}
+                    spark={days.map((d) => pct(d.cache_hits, d.webcams_scored))}
+                  />
+                  <Stat
+                    label="webcams scored"
+                    value={String(latest.webcams_scored)}
+                    spark={days.map((d) => d.webcams_scored)}
+                  />
+                  <Stat
+                    label="score p50 / p90"
+                    value={`${latest.score_p50 ?? '—'} / ${latest.score_p90 ?? '—'}`}
+                    spark={days.map((d) => d.score_p50)}
+                  />
+                  <Stat label="model" value={latest.model_version} />
+                </Box>
+                <UsageChart usage={data.providerUsage} events={data.costEvents} />
+              </>
+            );
+          })()}
+        </>
+      )}
     </>
   );
 }

--- a/app/components/Ops/OpsPanels.tsx
+++ b/app/components/Ops/OpsPanels.tsx
@@ -1,0 +1,63 @@
+import { Box, Typography } from '@mui/material';
+import type { OpsStatsResponse } from '@/app/lib/opsTypes';
+import { pct } from './opsMath';
+import { Sparkline } from './Sparkline';
+
+function Stat({
+  label,
+  value,
+  spark,
+}: {
+  label: string;
+  value: string;
+  spark?: (number | null)[];
+}) {
+  return (
+    <Box sx={{ minWidth: 160, p: 1.5, borderRadius: 2, backgroundColor: '#374151' }}>
+      <Typography variant="caption" sx={{ color: '#9ca3af' }}>
+        {label}
+      </Typography>
+      <Typography variant="h6" sx={{ color: 'white' }}>
+        {value}
+      </Typography>
+      {spark && <Sparkline values={spark} />}
+    </Box>
+  );
+}
+
+export function OpsPanels({ data }: { data: OpsStatsResponse }) {
+  const days = data.dailyStats;
+  const latest = [...days].reverse().find((d) => d.webcams_scored > 0);
+  if (!latest) {
+    return (
+      <Typography sx={{ color: '#9ca3af', p: 2 }}>No data yet.</Typography>
+    );
+  }
+  const fallbackPct = pct(latest.fallbacks, latest.webcams_scored);
+  const cachePct = pct(latest.cache_hits, latest.webcams_scored);
+  return (
+    <Box sx={{ display: 'flex', gap: 2, flexWrap: 'wrap' }}>
+      <Stat
+        label="fallbacks (spike = scoring broke)"
+        value={fallbackPct === null ? '—' : `${fallbackPct}%`}
+        spark={days.map((d) => pct(d.fallbacks, d.webcams_scored))}
+      />
+      <Stat
+        label="cache hits (dedup working)"
+        value={cachePct === null ? '—' : `${cachePct}%`}
+        spark={days.map((d) => pct(d.cache_hits, d.webcams_scored))}
+      />
+      <Stat
+        label="webcams scored"
+        value={String(latest.webcams_scored)}
+        spark={days.map((d) => d.webcams_scored)}
+      />
+      <Stat
+        label="score p50 / p90"
+        value={`${latest.score_p50 ?? '—'} / ${latest.score_p90 ?? '—'}`}
+        spark={days.map((d) => d.score_p50)}
+      />
+      <Stat label="model" value={latest.model_version} />
+    </Box>
+  );
+}

--- a/app/components/Ops/OpsPanels.tsx
+++ b/app/components/Ops/OpsPanels.tsx
@@ -2,6 +2,7 @@ import { Box, Typography } from '@mui/material';
 import type { OpsStatsResponse } from '@/app/lib/opsTypes';
 import { pct } from './opsMath';
 import { Sparkline } from './Sparkline';
+import { UsageChart } from './UsageChart';
 
 function Stat({
   label,
@@ -36,28 +37,31 @@ export function OpsPanels({ data }: { data: OpsStatsResponse }) {
   const fallbackPct = pct(latest.fallbacks, latest.webcams_scored);
   const cachePct = pct(latest.cache_hits, latest.webcams_scored);
   return (
-    <Box sx={{ display: 'flex', gap: 2, flexWrap: 'wrap' }}>
-      <Stat
-        label="fallbacks (spike = scoring broke)"
-        value={fallbackPct === null ? '—' : `${fallbackPct}%`}
-        spark={days.map((d) => pct(d.fallbacks, d.webcams_scored))}
-      />
-      <Stat
-        label="cache hits (dedup working)"
-        value={cachePct === null ? '—' : `${cachePct}%`}
-        spark={days.map((d) => pct(d.cache_hits, d.webcams_scored))}
-      />
-      <Stat
-        label="webcams scored"
-        value={String(latest.webcams_scored)}
-        spark={days.map((d) => d.webcams_scored)}
-      />
-      <Stat
-        label="score p50 / p90"
-        value={`${latest.score_p50 ?? '—'} / ${latest.score_p90 ?? '—'}`}
-        spark={days.map((d) => d.score_p50)}
-      />
-      <Stat label="model" value={latest.model_version} />
-    </Box>
+    <>
+      <Box sx={{ display: 'flex', gap: 2, flexWrap: 'wrap' }}>
+        <Stat
+          label="fallbacks (spike = scoring broke)"
+          value={fallbackPct === null ? '—' : `${fallbackPct}%`}
+          spark={days.map((d) => pct(d.fallbacks, d.webcams_scored))}
+        />
+        <Stat
+          label="cache hits (dedup working)"
+          value={cachePct === null ? '—' : `${cachePct}%`}
+          spark={days.map((d) => pct(d.cache_hits, d.webcams_scored))}
+        />
+        <Stat
+          label="webcams scored"
+          value={String(latest.webcams_scored)}
+          spark={days.map((d) => d.webcams_scored)}
+        />
+        <Stat
+          label="score p50 / p90"
+          value={`${latest.score_p50 ?? '—'} / ${latest.score_p90 ?? '—'}`}
+          spark={days.map((d) => d.score_p50)}
+        />
+        <Stat label="model" value={latest.model_version} />
+      </Box>
+      <UsageChart usage={data.providerUsage} events={data.costEvents} />
+    </>
   );
 }

--- a/app/components/Ops/OpsTab.tsx
+++ b/app/components/Ops/OpsTab.tsx
@@ -1,0 +1,20 @@
+'use client';
+
+import useSWR from 'swr';
+import { Typography } from '@mui/material';
+import type { OpsStatsResponse } from '@/app/lib/opsTypes';
+import { OpsPanels } from './OpsPanels';
+
+const fetcher = (url: string) =>
+  fetch(url).then((r) => {
+    if (!r.ok) throw new Error(`ops-stats ${r.status}`);
+    return r.json() as Promise<OpsStatsResponse>;
+  });
+
+export function OpsTab() {
+  const { data, error, isLoading } = useSWR('/api/admin/ops-stats', fetcher);
+  if (isLoading) return <Typography sx={{ color: '#9ca3af', p: 2 }}>Loading…</Typography>;
+  if (error || !data)
+    return <Typography sx={{ color: '#f87171', p: 2 }}>Failed to load ops stats.</Typography>;
+  return <OpsPanels data={data} />;
+}

--- a/app/components/Ops/Sparkline.tsx
+++ b/app/components/Ops/Sparkline.tsx
@@ -1,0 +1,27 @@
+export function Sparkline({
+  values,
+  width = 120,
+  height = 28,
+}: {
+  values: (number | null)[];
+  width?: number;
+  height?: number;
+}) {
+  const nums = values.filter((v): v is number => v !== null);
+  if (nums.length < 2) return <svg width={width} height={height} />;
+  const min = Math.min(...nums);
+  const max = Math.max(...nums);
+  const span = max - min || 1;
+  const step = width / (values.length - 1);
+  const points = values
+    .map((v, i) =>
+      v === null ? null : `${i * step},${height - ((v - min) / span) * (height - 2) - 1}`,
+    )
+    .filter(Boolean)
+    .join(' ');
+  return (
+    <svg width={width} height={height} role="img" aria-label="sparkline">
+      <polyline points={points} fill="none" stroke="#60a5fa" strokeWidth={1.5} />
+    </svg>
+  );
+}

--- a/app/components/Ops/UsageChart.test.tsx
+++ b/app/components/Ops/UsageChart.test.tsx
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest';
+import { render } from '@testing-library/react';
+import { UsageChart } from './UsageChart';
+
+const P = 'noisy-leaf-96391119';
+
+describe('UsageChart', () => {
+  it('renders a point per derived day and a marker per event', () => {
+    const { container } = render(
+      <UsageChart
+        usage={[
+          { day: '2026-08-01', project_id: P, compute_time_s: 36000 },
+          { day: '2026-08-02', project_id: P, compute_time_s: 72000 },
+          { day: '2026-08-03', project_id: P, compute_time_s: 90000 },
+        ]}
+        events={[{ occurred_on: '2026-08-02', sha: null, description: 'autoscale' }]}
+      />,
+    );
+    // 2 derived days (deltas skip the baseline day) -> polyline with 2 points
+    const polyline = container.querySelector('polyline');
+    expect(polyline?.getAttribute('points')?.split(' ')).toHaveLength(2);
+    // 1 event marker line with its description in a <title>
+    expect(container.querySelectorAll('line.cost-event')).toHaveLength(1);
+    expect(container.querySelector('title')?.textContent).toContain('autoscale');
+  });
+
+  it('renders an empty state with fewer than 2 snapshot days', () => {
+    const { getByText } = render(<UsageChart usage={[]} events={[]} />);
+    expect(getByText(/usage snapshots will appear/i)).toBeInTheDocument();
+  });
+});

--- a/app/components/Ops/UsageChart.tsx
+++ b/app/components/Ops/UsageChart.tsx
@@ -1,0 +1,69 @@
+import { Box, Typography } from '@mui/material';
+import type { ProviderUsageRow, CostEventRow } from '@/app/lib/opsTypes';
+import { deriveDailyDeltas } from './opsMath';
+
+const WEBCAM_PROJECT = 'noisy-leaf-96391119';
+const W = 560;
+const H = 140;
+
+export function UsageChart({
+  usage,
+  events,
+}: {
+  usage: ProviderUsageRow[];
+  events: CostEventRow[];
+}) {
+  const deltas = deriveDailyDeltas(usage);
+  const days = [...new Set(deltas.map((d) => d.day))].sort();
+  if (days.length === 0) {
+    return (
+      <Typography sx={{ color: '#9ca3af', p: 2 }}>
+        Usage snapshots will appear after two daily captures.
+      </Typography>
+    );
+  }
+  const webcam = days.map(
+    (day) =>
+      deltas.find((d) => d.day === day && d.project_id === WEBCAM_PROJECT)
+        ?.computeHours ?? 0,
+  );
+  const others = days.map((day) =>
+    deltas
+      .filter((d) => d.day === day && d.project_id !== WEBCAM_PROJECT)
+      .reduce((sum, d) => sum + d.computeHours, 0),
+  );
+  const max = Math.max(...webcam, ...others, 1);
+  const x = (i: number) => (days.length === 1 ? W / 2 : (i / (days.length - 1)) * W);
+  const y = (v: number) => H - (v / max) * (H - 10) - 5;
+  const line = (vals: number[]) => vals.map((v, i) => `${x(i)},${y(v)}`).join(' ');
+
+  return (
+    <Box sx={{ mt: 2, overflowX: 'auto' }}>
+      <Typography variant="caption" sx={{ color: '#9ca3af' }}>
+        Neon compute hours/day — webcams (bold) vs other projects (thin), markers = cost changes
+      </Typography>
+      <svg width={W} height={H} role="img" aria-label="compute hours per day">
+        <polyline points={line(webcam)} fill="none" stroke="#60a5fa" strokeWidth={2} />
+        {days.length > 1 && (
+          <polyline points={line(others)} fill="none" stroke="#9ca3af" strokeWidth={1} />
+        )}
+        {events
+          .filter((e) => days.includes(e.occurred_on))
+          .map((e) => (
+            <line
+              key={`${e.occurred_on}-${e.description}`}
+              className="cost-event"
+              x1={x(days.indexOf(e.occurred_on))}
+              x2={x(days.indexOf(e.occurred_on))}
+              y1={0}
+              y2={H}
+              stroke="#f59e0b"
+              strokeDasharray="4 3"
+            >
+              <title>{`${e.occurred_on}: ${e.description}`}</title>
+            </line>
+          ))}
+      </svg>
+    </Box>
+  );
+}

--- a/app/components/Ops/opsMath.test.ts
+++ b/app/components/Ops/opsMath.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest';
+import { pct, deriveDailyDeltas } from './opsMath';
+
+describe('pct', () => {
+  it('computes a rounded percentage', () => {
+    expect(pct(400, 500)).toBe(80);
+    expect(pct(1, 3)).toBe(33.3);
+  });
+  it('returns null for a zero denominator', () => {
+    expect(pct(5, 0)).toBeNull();
+  });
+});
+
+describe('deriveDailyDeltas', () => {
+  const P = 'noisy-leaf-96391119';
+  it('derives per-day compute hours from month-to-date counters', () => {
+    const out = deriveDailyDeltas([
+      { day: '2026-08-01', project_id: P, compute_time_s: 36000 }, // 10h MTD
+      { day: '2026-08-02', project_id: P, compute_time_s: 72000 }, // 20h MTD
+    ]);
+    expect(out).toEqual([
+      { day: '2026-08-02', project_id: P, computeHours: 10 },
+    ]);
+  });
+  it('uses the raw value on month rollover (counter reset)', () => {
+    const out = deriveDailyDeltas([
+      { day: '2026-08-31', project_id: P, compute_time_s: 900000 },
+      { day: '2026-09-01', project_id: P, compute_time_s: 18000 }, // reset, 5h
+    ]);
+    expect(out).toEqual([
+      { day: '2026-09-01', project_id: P, computeHours: 5 },
+    ]);
+  });
+  it('keeps projects independent', () => {
+    const out = deriveDailyDeltas([
+      { day: '2026-08-01', project_id: 'a', compute_time_s: 3600 },
+      { day: '2026-08-01', project_id: 'b', compute_time_s: 7200 },
+      { day: '2026-08-02', project_id: 'a', compute_time_s: 7200 },
+      { day: '2026-08-02', project_id: 'b', compute_time_s: 7200 },
+    ]);
+    expect(out).toEqual([
+      { day: '2026-08-02', project_id: 'a', computeHours: 1 },
+      { day: '2026-08-02', project_id: 'b', computeHours: 0 },
+    ]);
+  });
+});

--- a/app/components/Ops/opsMath.ts
+++ b/app/components/Ops/opsMath.ts
@@ -1,0 +1,37 @@
+import type { ProviderUsageRow } from '@/app/lib/opsTypes';
+
+export function pct(numerator: number, denominator: number): number | null {
+  if (denominator === 0) return null;
+  return Math.round((numerator / denominator) * 1000) / 10;
+}
+
+// provider_usage_daily stores Neon's month-to-date counters (that is all the
+// non-Scale API exposes), so per-day usage is the day-over-day delta. A
+// negative delta means the month rolled over and the counter reset — the raw
+// value IS that day's usage.
+export function deriveDailyDeltas(
+  rows: ProviderUsageRow[],
+): { day: string; project_id: string; computeHours: number }[] {
+  const byProject = new Map<string, ProviderUsageRow[]>();
+  for (const row of rows) {
+    const list = byProject.get(row.project_id) ?? [];
+    list.push(row);
+    byProject.set(row.project_id, list);
+  }
+  const out: { day: string; project_id: string; computeHours: number }[] = [];
+  for (const list of byProject.values()) {
+    const sorted = [...list].sort((a, b) => a.day.localeCompare(b.day));
+    for (let i = 1; i < sorted.length; i++) {
+      const delta = sorted[i].compute_time_s - sorted[i - 1].compute_time_s;
+      const seconds = delta < 0 ? sorted[i].compute_time_s : delta;
+      out.push({
+        day: sorted[i].day,
+        project_id: sorted[i].project_id,
+        computeHours: Math.round((seconds / 3600) * 100) / 100,
+      });
+    }
+  }
+  return out.sort(
+    (a, b) => a.day.localeCompare(b.day) || a.project_id.localeCompare(b.project_id),
+  );
+}

--- a/app/kiosk/KioskDozeOverlay.tsx
+++ b/app/kiosk/KioskDozeOverlay.tsx
@@ -1,0 +1,20 @@
+'use client';
+
+// Dim "dozing" state — a slow 2s fade so a deliberate doze reads as
+// intentional, per the spec ("the pause is visible").
+export function KioskDozeOverlay({ dozing }: { dozing: boolean }) {
+  return (
+    <div
+      aria-hidden
+      style={{
+        position: 'fixed',
+        inset: 0,
+        background: '#000',
+        opacity: dozing ? 0.97 : 0,
+        pointerEvents: 'none',
+        transition: 'opacity 2s ease',
+        zIndex: 50,
+      }}
+    />
+  );
+}

--- a/app/kiosk/kioskSchedule.test.ts
+++ b/app/kiosk/kioskSchedule.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from 'vitest';
+import {
+  parseQuietParam,
+  isInQuietHours,
+  isDozing,
+  shouldRunTick,
+  type KioskGate,
+} from './kioskSchedule';
+
+describe('parseQuietParam', () => {
+  it('defaults to 1-8', () => {
+    expect(parseQuietParam(null)).toEqual({ start: 1, end: 8 });
+  });
+  it('parses off and custom windows', () => {
+    expect(parseQuietParam('off')).toBeNull();
+    expect(parseQuietParam('23-9')).toEqual({ start: 23, end: 9 });
+  });
+  it('falls back to default on garbage', () => {
+    expect(parseQuietParam('banana')).toEqual({ start: 1, end: 8 });
+  });
+});
+
+describe('isInQuietHours', () => {
+  it('handles a simple window', () => {
+    expect(isInQuietHours(3, { start: 1, end: 8 })).toBe(true);
+    expect(isInQuietHours(8, { start: 1, end: 8 })).toBe(false); // half-open
+    expect(isInQuietHours(12, { start: 1, end: 8 })).toBe(false);
+  });
+  it('handles a window crossing midnight', () => {
+    expect(isInQuietHours(23, { start: 23, end: 9 })).toBe(true);
+    expect(isInQuietHours(2, { start: 23, end: 9 })).toBe(true);
+    expect(isInQuietHours(10, { start: 23, end: 9 })).toBe(false);
+  });
+  it('is always false when disabled', () => {
+    expect(isInQuietHours(3, null)).toBe(false);
+  });
+});
+
+const base: KioskGate = {
+  visible: true,
+  localDoze: false,
+  remoteDoze: false,
+  quiet: { start: 1, end: 8 },
+  hourLocal: 12,
+  msSinceInteraction: null,
+  wakeMinutes: 30,
+};
+
+describe('isDozing / shouldRunTick', () => {
+  it('runs normally in the day', () => {
+    expect(isDozing(base)).toBe(false);
+    expect(shouldRunTick(base)).toBe(true);
+  });
+  it('dozes during quiet hours with no interaction', () => {
+    const g = { ...base, hourLocal: 3 };
+    expect(isDozing(g)).toBe(true);
+    expect(shouldRunTick(g)).toBe(false);
+  });
+  it('a recent interaction wakes it through quiet hours', () => {
+    const g = { ...base, hourLocal: 3, msSinceInteraction: 5 * 60_000 };
+    expect(isDozing(g)).toBe(false);
+    expect(shouldRunTick(g)).toBe(true);
+  });
+  it('the wake window expires', () => {
+    const g = { ...base, hourLocal: 3, msSinceInteraction: 31 * 60_000 };
+    expect(isDozing(g)).toBe(true);
+  });
+  it('local and remote doze are sticky regardless of interaction', () => {
+    expect(isDozing({ ...base, localDoze: true, msSinceInteraction: 0 })).toBe(true);
+    expect(isDozing({ ...base, remoteDoze: true, msSinceInteraction: 0 })).toBe(true);
+  });
+  it('never ticks while hidden', () => {
+    expect(shouldRunTick({ ...base, visible: false })).toBe(false);
+  });
+});

--- a/app/kiosk/kioskSchedule.ts
+++ b/app/kiosk/kioskSchedule.ts
@@ -1,0 +1,45 @@
+import { KIOSK_QUIET_DEFAULT } from '@/app/lib/masterConfig';
+
+export type QuietWindow = { start: number; end: number } | null;
+
+export function parseQuietParam(raw: string | null): QuietWindow {
+  const value = raw?.trim() || KIOSK_QUIET_DEFAULT;
+  if (value === 'off') return null;
+  const match = /^(\d{1,2})-(\d{1,2})$/.exec(value);
+  if (!match) return parseQuietParam(KIOSK_QUIET_DEFAULT);
+  const start = Number(match[1]);
+  const end = Number(match[2]);
+  if (start > 23 || end > 23) return parseQuietParam(KIOSK_QUIET_DEFAULT);
+  return { start, end };
+}
+
+// Half-open [start, end); a window crossing midnight (23-9) wraps.
+export function isInQuietHours(hourLocal: number, quiet: QuietWindow): boolean {
+  if (!quiet) return false;
+  const { start, end } = quiet;
+  if (start === end) return false;
+  if (start < end) return hourLocal >= start && hourLocal < end;
+  return hourLocal >= start || hourLocal < end;
+}
+
+export interface KioskGate {
+  visible: boolean;
+  localDoze: boolean;
+  remoteDoze: boolean;
+  quiet: QuietWindow;
+  hourLocal: number;
+  msSinceInteraction: number | null;
+  wakeMinutes: number;
+}
+
+export function isDozing(gate: KioskGate): boolean {
+  if (gate.localDoze || gate.remoteDoze) return true;
+  const awakeByInteraction =
+    gate.msSinceInteraction !== null &&
+    gate.msSinceInteraction < gate.wakeMinutes * 60_000;
+  return isInQuietHours(gate.hourLocal, gate.quiet) && !awakeByInteraction;
+}
+
+export function shouldRunTick(gate: KioskGate): boolean {
+  return gate.visible && !isDozing(gate);
+}

--- a/app/kiosk/sunrise/page.test.tsx
+++ b/app/kiosk/sunrise/page.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import { useTerminatorStore } from '@/app/store/useTerminatorStore';
+import { useLoadTerminatorWebcams } from '@/app/store/useLoadTerminatorWebcams';
 import SunriseKioskPage from './page';
 
 // MosaicCanvas uses HTMLCanvasElement which jsdom doesn't support — mock it
@@ -22,13 +23,15 @@ vi.mock('@/app/store/useTerminatorStore', () => ({
   ),
 }));
 
+const useKioskRuntimeMock = vi.fn(() => ({ dozing: false }));
 vi.mock('../useKioskRuntime', () => ({
-  useKioskRuntime: () => ({ dozing: false }),
+  useKioskRuntime: () => useKioskRuntimeMock(),
 }));
 
 describe('SunriseKioskPage', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    useKioskRuntimeMock.mockReturnValue({ dozing: false });
   });
 
   it('renders MosaicCanvas', () => {
@@ -45,5 +48,11 @@ describe('SunriseKioskPage', () => {
     render(<SunriseKioskPage />);
     const canvas = screen.getByTestId('mosaic-canvas');
     expect(canvas.getAttribute('data-count')).toBe('2');
+  });
+
+  it('pauses the terminator-webcams poll when the kiosk is dozing', () => {
+    useKioskRuntimeMock.mockReturnValue({ dozing: true });
+    render(<SunriseKioskPage />);
+    expect(useLoadTerminatorWebcams).toHaveBeenCalledWith({ paused: true });
   });
 });

--- a/app/kiosk/sunrise/page.test.tsx
+++ b/app/kiosk/sunrise/page.test.tsx
@@ -22,6 +22,10 @@ vi.mock('@/app/store/useTerminatorStore', () => ({
   ),
 }));
 
+vi.mock('../useKioskRuntime', () => ({
+  useKioskRuntime: () => ({ dozing: false }),
+}));
+
 describe('SunriseKioskPage', () => {
   beforeEach(() => {
     vi.clearAllMocks();

--- a/app/kiosk/sunrise/page.tsx
+++ b/app/kiosk/sunrise/page.tsx
@@ -13,9 +13,9 @@ import {
 } from '@/app/lib/masterConfig';
 
 export default function SunriseKioskPage() {
-  useLoadTerminatorWebcams();
-  const webcams = useTerminatorStore((t) => t.sunrise);
   const { dozing } = useKioskRuntime();
+  useLoadTerminatorWebcams({ paused: dozing });
+  const webcams = useTerminatorStore((t) => t.sunrise);
 
   const [dimensions, setDimensions] = useState({
     width: typeof window !== 'undefined' ? window.innerWidth : 1080,

--- a/app/kiosk/sunrise/page.tsx
+++ b/app/kiosk/sunrise/page.tsx
@@ -4,6 +4,8 @@ import { useEffect, useState } from 'react';
 import { MosaicCanvas } from '@/app/components/MosaicCanvas';
 import { useTerminatorStore } from '@/app/store/useTerminatorStore';
 import { useLoadTerminatorWebcams } from '@/app/store/useLoadTerminatorWebcams';
+import { useKioskRuntime } from '../useKioskRuntime';
+import { KioskDozeOverlay } from '../KioskDozeOverlay';
 import {
   KIOSK_MOSAIC_MAX_IMAGE_HEIGHT_PX,
   KIOSK_MOSAIC_MIN_IMAGE_HEIGHT_PX,
@@ -13,6 +15,7 @@ import {
 export default function SunriseKioskPage() {
   useLoadTerminatorWebcams();
   const webcams = useTerminatorStore((t) => t.sunrise);
+  const { dozing } = useKioskRuntime();
 
   const [dimensions, setDimensions] = useState({
     width: typeof window !== 'undefined' ? window.innerWidth : 1080,
@@ -31,17 +34,20 @@ export default function SunriseKioskPage() {
   }, []);
 
   return (
-    <MosaicCanvas
-      webcams={webcams}
-      width={dimensions.width}
-      height={dimensions.height}
-      maxImages={KIOSK_CANVAS_MAX_IMAGES}
-      padding={2}
-      ratingSizeEffect={0.75}
-      viewSizeEffect={0.1}
-      fillScreenHeight={true}
-      maxImageHeight={KIOSK_MOSAIC_MAX_IMAGE_HEIGHT_PX}
-      minImageHeight={KIOSK_MOSAIC_MIN_IMAGE_HEIGHT_PX}
-    />
+    <>
+      <MosaicCanvas
+        webcams={webcams}
+        width={dimensions.width}
+        height={dimensions.height}
+        maxImages={KIOSK_CANVAS_MAX_IMAGES}
+        padding={2}
+        ratingSizeEffect={0.75}
+        viewSizeEffect={0.1}
+        fillScreenHeight={true}
+        maxImageHeight={KIOSK_MOSAIC_MAX_IMAGE_HEIGHT_PX}
+        minImageHeight={KIOSK_MOSAIC_MIN_IMAGE_HEIGHT_PX}
+      />
+      <KioskDozeOverlay dozing={dozing} />
+    </>
   );
 }

--- a/app/kiosk/sunset/page.test.tsx
+++ b/app/kiosk/sunset/page.test.tsx
@@ -19,6 +19,10 @@ vi.mock('@/app/store/useTerminatorStore', () => ({
   ),
 }));
 
+vi.mock('../useKioskRuntime', () => ({
+  useKioskRuntime: () => ({ dozing: false }),
+}));
+
 describe('SunsetKioskPage', () => {
   beforeEach(() => {
     vi.clearAllMocks();

--- a/app/kiosk/sunset/page.test.tsx
+++ b/app/kiosk/sunset/page.test.tsx
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import SunsetKioskPage from './page';
 import { useTerminatorStore } from '@/app/store/useTerminatorStore';
+import { useLoadTerminatorWebcams } from '@/app/store/useLoadTerminatorWebcams';
 
 vi.mock('@/app/components/MosaicCanvas', () => ({
   MosaicCanvas: ({ webcams }: { webcams: unknown[] }) => (
@@ -19,13 +20,15 @@ vi.mock('@/app/store/useTerminatorStore', () => ({
   ),
 }));
 
+const useKioskRuntimeMock = vi.fn(() => ({ dozing: false }));
 vi.mock('../useKioskRuntime', () => ({
-  useKioskRuntime: () => ({ dozing: false }),
+  useKioskRuntime: () => useKioskRuntimeMock(),
 }));
 
 describe('SunsetKioskPage', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    useKioskRuntimeMock.mockReturnValue({ dozing: false });
     vi.mocked(useTerminatorStore).mockImplementation(
       (selector: (state: { sunset: unknown[] }) => unknown) =>
         selector({ sunset: [] })
@@ -46,5 +49,11 @@ describe('SunsetKioskPage', () => {
     render(<SunsetKioskPage />);
     const canvas = screen.getByTestId('mosaic-canvas');
     expect(canvas.getAttribute('data-count')).toBe('3');
+  });
+
+  it('pauses the terminator-webcams poll when the kiosk is dozing', () => {
+    useKioskRuntimeMock.mockReturnValue({ dozing: true });
+    render(<SunsetKioskPage />);
+    expect(useLoadTerminatorWebcams).toHaveBeenCalledWith({ paused: true });
   });
 });

--- a/app/kiosk/sunset/page.tsx
+++ b/app/kiosk/sunset/page.tsx
@@ -4,6 +4,8 @@ import { useEffect, useState } from 'react';
 import { MosaicCanvas } from '@/app/components/MosaicCanvas';
 import { useTerminatorStore } from '@/app/store/useTerminatorStore';
 import { useLoadTerminatorWebcams } from '@/app/store/useLoadTerminatorWebcams';
+import { useKioskRuntime } from '../useKioskRuntime';
+import { KioskDozeOverlay } from '../KioskDozeOverlay';
 import {
   KIOSK_MOSAIC_MAX_IMAGE_HEIGHT_PX,
   KIOSK_MOSAIC_MIN_IMAGE_HEIGHT_PX,
@@ -13,6 +15,7 @@ import {
 export default function SunsetKioskPage() {
   useLoadTerminatorWebcams();
   const webcams = useTerminatorStore((t) => t.sunset);
+  const { dozing } = useKioskRuntime();
 
   const [dimensions, setDimensions] = useState({
     width: typeof window !== 'undefined' ? window.innerWidth : 1080,
@@ -31,17 +34,20 @@ export default function SunsetKioskPage() {
   }, []);
 
   return (
-    <MosaicCanvas
-      webcams={webcams}
-      width={dimensions.width}
-      height={dimensions.height}
-      maxImages={KIOSK_CANVAS_MAX_IMAGES}
-      padding={2}
-      ratingSizeEffect={0.75}
-      viewSizeEffect={0.1}
-      fillScreenHeight={true}
-      maxImageHeight={KIOSK_MOSAIC_MAX_IMAGE_HEIGHT_PX}
-      minImageHeight={KIOSK_MOSAIC_MIN_IMAGE_HEIGHT_PX}
-    />
+    <>
+      <MosaicCanvas
+        webcams={webcams}
+        width={dimensions.width}
+        height={dimensions.height}
+        maxImages={KIOSK_CANVAS_MAX_IMAGES}
+        padding={2}
+        ratingSizeEffect={0.75}
+        viewSizeEffect={0.1}
+        fillScreenHeight={true}
+        maxImageHeight={KIOSK_MOSAIC_MAX_IMAGE_HEIGHT_PX}
+        minImageHeight={KIOSK_MOSAIC_MIN_IMAGE_HEIGHT_PX}
+      />
+      <KioskDozeOverlay dozing={dozing} />
+    </>
   );
 }

--- a/app/kiosk/sunset/page.tsx
+++ b/app/kiosk/sunset/page.tsx
@@ -13,9 +13,9 @@ import {
 } from '@/app/lib/masterConfig';
 
 export default function SunsetKioskPage() {
-  useLoadTerminatorWebcams();
-  const webcams = useTerminatorStore((t) => t.sunset);
   const { dozing } = useKioskRuntime();
+  useLoadTerminatorWebcams({ paused: dozing });
+  const webcams = useTerminatorStore((t) => t.sunset);
 
   const [dimensions, setDimensions] = useState({
     width: typeof window !== 'undefined' ? window.innerWidth : 1080,

--- a/app/kiosk/useKioskRuntime.test.tsx
+++ b/app/kiosk/useKioskRuntime.test.tsx
@@ -1,0 +1,62 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useKioskRuntime } from './useKioskRuntime';
+
+describe('useKioskRuntime', () => {
+  const fetchMock = vi.fn();
+  beforeEach(() => {
+    vi.useFakeTimers();
+    // Noon local, outside default quiet hours
+    vi.setSystemTime(new Date(2026, 7, 1, 12, 0, 0));
+    fetchMock.mockResolvedValue({ ok: true, json: async () => ({ doze: false }) });
+    vi.stubGlobal('fetch', fetchMock);
+    window.history.replaceState({}, '', '/kiosk/sunset');
+  });
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.useRealTimers();
+  });
+
+  it('polls state and fires a tick each minute while awake', async () => {
+    renderHook(() => useKioskRuntime());
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(61_000);
+    });
+    const urls = fetchMock.mock.calls.map((c) => String(c[0]));
+    expect(urls.filter((u) => u.includes('/api/kiosk/state')).length).toBeGreaterThanOrEqual(2);
+    expect(urls.filter((u) => u.includes('/api/kiosk/tick')).length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('the d key toggles sticky local doze and stops ticks', async () => {
+    const { result } = renderHook(() => useKioskRuntime());
+    act(() => {
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: 'd' }));
+    });
+    expect(result.current.dozing).toBe(true);
+    // an ordinary interaction must NOT wake a manual doze
+    act(() => {
+      window.dispatchEvent(new Event('pointerdown'));
+    });
+    expect(result.current.dozing).toBe(true);
+    fetchMock.mockClear();
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(61_000);
+    });
+    const urls = fetchMock.mock.calls.map((c) => String(c[0]));
+    expect(urls.some((u) => u.includes('/api/kiosk/tick'))).toBe(false);
+    expect(urls.some((u) => u.includes('/api/kiosk/state'))).toBe(true); // still listens
+    act(() => {
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: 'd' }));
+    });
+    expect(result.current.dozing).toBe(false);
+  });
+
+  it('remote doze from the state poll dozes the kiosk', async () => {
+    fetchMock.mockResolvedValue({ ok: true, json: async () => ({ doze: true }) });
+    const { result } = renderHook(() => useKioskRuntime());
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1_000);
+    });
+    expect(result.current.dozing).toBe(true);
+  });
+});

--- a/app/kiosk/useKioskRuntime.ts
+++ b/app/kiosk/useKioskRuntime.ts
@@ -1,0 +1,98 @@
+'use client';
+
+import { useEffect, useRef, useState, useCallback } from 'react';
+import {
+  parseQuietParam,
+  isDozing,
+  shouldRunTick,
+  type QuietWindow,
+} from './kioskSchedule';
+import {
+  KIOSK_TICK_INTERVAL_MS,
+  KIOSK_WAKE_MINUTES,
+} from '@/app/lib/masterConfig';
+
+export function useKioskRuntime(): { dozing: boolean } {
+  const [visible, setVisible] = useState(true);
+  const [localDoze, setLocalDoze] = useState(false);
+  const [remoteDoze, setRemoteDoze] = useState(false);
+  const [, forceRender] = useState(0);
+  const quietRef = useRef<QuietWindow>(null);
+  const lastInteractionRef = useRef<number | null>(null);
+  const localDozeRef = useRef(false);
+  const remoteDozeRef = useRef(false);
+  const visibleRef = useRef(true);
+  localDozeRef.current = localDoze;
+  remoteDozeRef.current = remoteDoze;
+  visibleRef.current = visible;
+
+  const gate = useCallback(
+    () => ({
+      visible: visibleRef.current,
+      localDoze: localDozeRef.current,
+      remoteDoze: remoteDozeRef.current,
+      quiet: quietRef.current,
+      hourLocal: new Date().getHours(),
+      msSinceInteraction:
+        lastInteractionRef.current === null
+          ? null
+          : Date.now() - lastInteractionRef.current,
+      wakeMinutes: KIOSK_WAKE_MINUTES,
+    }),
+    [],
+  );
+
+  useEffect(() => {
+    quietRef.current = parseQuietParam(
+      new URLSearchParams(window.location.search).get('quiet'),
+    );
+
+    const onVisibility = () =>
+      setVisible(document.visibilityState === 'visible');
+    const onKeydown = (e: KeyboardEvent) => {
+      if (e.key === 'd') {
+        setLocalDoze((v) => !v);
+        return; // the toggle itself is not a wake interaction
+      }
+      lastInteractionRef.current = Date.now();
+    };
+    const onInteraction = () => {
+      lastInteractionRef.current = Date.now();
+    };
+    document.addEventListener('visibilitychange', onVisibility);
+    window.addEventListener('keydown', onKeydown);
+    window.addEventListener('pointerdown', onInteraction);
+    window.addEventListener('pointermove', onInteraction);
+
+    const poll = async () => {
+      try {
+        const res = await fetch('/api/kiosk/state');
+        if (res.ok) {
+          const { doze } = (await res.json()) as { doze: boolean };
+          setRemoteDoze(doze);
+          remoteDozeRef.current = doze;
+        }
+      } catch {
+        /* state poll failures are non-fatal */
+      }
+      if (shouldRunTick(gate())) {
+        fetch('/api/kiosk/tick', { method: 'POST' }).catch(() => {});
+      }
+    };
+    void poll();
+    const interval = setInterval(poll, KIOSK_TICK_INTERVAL_MS);
+    // Cheap re-render so hourLocal / wake-window expiry are reflected in UI.
+    const renderTick = setInterval(() => forceRender((n) => n + 1), 30_000);
+
+    return () => {
+      document.removeEventListener('visibilitychange', onVisibility);
+      window.removeEventListener('keydown', onKeydown);
+      window.removeEventListener('pointerdown', onInteraction);
+      window.removeEventListener('pointermove', onInteraction);
+      clearInterval(interval);
+      clearInterval(renderTick);
+    };
+  }, [gate]);
+
+  return { dozing: isDozing(gate()) };
+}

--- a/app/kiosk/useKioskRuntime.ts
+++ b/app/kiosk/useKioskRuntime.ts
@@ -13,7 +13,9 @@ import {
 } from '@/app/lib/masterConfig';
 
 export function useKioskRuntime(): { dozing: boolean } {
-  const [visible, setVisible] = useState(true);
+  const [visible, setVisible] = useState(
+    () => typeof document === 'undefined' || document.visibilityState === 'visible',
+  );
   const [localDoze, setLocalDoze] = useState(false);
   const [remoteDoze, setRemoteDoze] = useState(false);
   const [, forceRender] = useState(0);

--- a/app/lib/cache.test.ts
+++ b/app/lib/cache.test.ts
@@ -65,3 +65,45 @@ describe('terminator payload cache', () => {
     ).resolves.toBeUndefined();
   });
 });
+
+describe('kiosk helpers', () => {
+  it('acquireKioskTickLock passes NX+PX and reports acquisition', async () => {
+    setMock.mockResolvedValueOnce('OK');
+    const { acquireKioskTickLock } = await import('./cache');
+    await expect(acquireKioskTickLock()).resolves.toBe(true);
+    expect(setMock).toHaveBeenCalledWith(
+      'kiosk:tick:lock',
+      '1',
+      expect.objectContaining({ nx: true, px: 55000 }),
+    );
+  });
+
+  it('acquireKioskTickLock returns false when the lock is held', async () => {
+    setMock.mockResolvedValueOnce(null); // upstash returns null when NX fails
+    const { acquireKioskTickLock } = await import('./cache');
+    await expect(acquireKioskTickLock()).resolves.toBe(false);
+  });
+
+  it('markKioskTickRan sets the lock without NX', async () => {
+    const { markKioskTickRan } = await import('./cache');
+    await markKioskTickRan();
+    expect(setMock).toHaveBeenCalledWith(
+      'kiosk:tick:lock',
+      '1',
+      expect.objectContaining({ px: 55000 }),
+    );
+    expect(setMock.mock.calls.at(-1)![2]).not.toHaveProperty('nx');
+  });
+
+  it('doze flag round-trips', async () => {
+    const { setKioskDoze, getKioskDoze } = await import('./cache');
+    await setKioskDoze(true);
+    expect(setMock).toHaveBeenCalledWith('kiosk:doze', '1');
+    getMock.mockResolvedValueOnce('1');
+    await expect(getKioskDoze()).resolves.toBe(true);
+    await setKioskDoze(false);
+    expect(delMock).toHaveBeenCalledWith('kiosk:doze');
+    getMock.mockResolvedValueOnce(null);
+    await expect(getKioskDoze()).resolves.toBe(false);
+  });
+});

--- a/app/lib/cache.ts
+++ b/app/lib/cache.ts
@@ -1,7 +1,10 @@
 import { Redis } from '@upstash/redis';
+import { KIOSK_TICK_LOCK_TTL_MS } from '@/app/lib/masterConfig';
 
 const TERMINATOR_KEY = 'terminator:current';
 const TERMINATOR_TTL_SECONDS = 300;
+const KIOSK_TICK_LOCK_KEY = 'kiosk:tick:lock';
+const KIOSK_DOZE_KEY = 'kiosk:doze';
 
 let client: Redis | null = null;
 
@@ -50,6 +53,57 @@ export async function invalidateTerminatorPayload(): Promise<void> {
     await c.del(TERMINATOR_KEY);
   } catch (error) {
     console.error('Cache invalidate failed:', error);
+  }
+}
+
+// True iff this caller won the right to run a scoring tick this minute.
+// Fail-closed: no Redis -> no kiosk ticks (the */15 cron remains the floor).
+export async function acquireKioskTickLock(): Promise<boolean> {
+  const c = getClient();
+  if (!c) return false;
+  try {
+    const result = await c.set(KIOSK_TICK_LOCK_KEY, '1', {
+      nx: true,
+      px: KIOSK_TICK_LOCK_TTL_MS,
+    });
+    return result === 'OK';
+  } catch (error) {
+    console.warn('[cache] acquireKioskTickLock failed:', error);
+    return false;
+  }
+}
+
+// The cron stamps the lock unconditionally so a kiosk poll right after a cron
+// tick is a no-op.
+export async function markKioskTickRan(): Promise<void> {
+  const c = getClient();
+  if (!c) return;
+  try {
+    await c.set(KIOSK_TICK_LOCK_KEY, '1', { px: KIOSK_TICK_LOCK_TTL_MS });
+  } catch (error) {
+    console.warn('[cache] markKioskTickRan failed:', error);
+  }
+}
+
+export async function getKioskDoze(): Promise<boolean> {
+  const c = getClient();
+  if (!c) return false;
+  try {
+    return Boolean(await c.get(KIOSK_DOZE_KEY));
+  } catch (error) {
+    console.warn('[cache] getKioskDoze failed:', error);
+    return false;
+  }
+}
+
+export async function setKioskDoze(on: boolean): Promise<void> {
+  const c = getClient();
+  if (!c) return;
+  try {
+    if (on) await c.set(KIOSK_DOZE_KEY, '1');
+    else await c.del(KIOSK_DOZE_KEY);
+  } catch (error) {
+    console.warn('[cache] setKioskDoze failed:', error);
   }
 }
 

--- a/app/lib/masterConfig.ts
+++ b/app/lib/masterConfig.ts
@@ -229,6 +229,10 @@ export const YOUTUBE_FETCH_DELAY_BETWEEN_BATCHES_MS = 800;
 // sparklines; the query is one cheap indexed scan on the PK.
 export const OPS_STATS_DAYS = 14;
 
+// How far back the Ops usage chart reaches. 60 days spans two billing cycles
+// so month-rollover deltas are visible and testable.
+export const PROVIDER_USAGE_LOOKBACK_DAYS = 60;
+
 // Neon projects in the Vercel-managed org whose month-to-date usage counters
 // the cron snapshots daily into provider_usage_daily. Project ids are not
 // secrets (the API key NEON_COST_API is, and lives only in env).

--- a/app/lib/masterConfig.ts
+++ b/app/lib/masterConfig.ts
@@ -250,3 +250,10 @@ export const NEON_USAGE_PROJECT_IDS = [
 // re-acquire even if clocks drift. One global lock = at most ~1 tick/minute
 // regardless of how many kiosk screens are open.
 export const KIOSK_TICK_LOCK_TTL_MS = 55_000;
+// Quiet hours default: gallery-local hours during which the kiosk dozes
+// (no scoring ticks). Override per install with ?quiet=off or ?quiet=23-9.
+export const KIOSK_QUIET_DEFAULT = '1-8';
+// How long one interaction keeps a quiet-hours kiosk awake.
+export const KIOSK_WAKE_MINUTES = 30;
+// Poll cadences (tick + doze-state check). Two cheap requests per minute.
+export const KIOSK_TICK_INTERVAL_MS = 60_000;

--- a/app/lib/masterConfig.ts
+++ b/app/lib/masterConfig.ts
@@ -242,3 +242,11 @@ export const NEON_USAGE_PROJECT_IDS = [
   'holy-shadow-28821259', // land_buyback (idle)
   'small-tree-05551811', // nextjs-dashboard-postgres (idle)
 ];
+
+// ---------------------------------------------------------------------------
+// Kiosk gallery mode (presence-driven scoring cadence + doze)
+// ---------------------------------------------------------------------------
+// Tick lock TTL: slightly under the 60s poll interval so the next poll can
+// re-acquire even if clocks drift. One global lock = at most ~1 tick/minute
+// regardless of how many kiosk screens are open.
+export const KIOSK_TICK_LOCK_TTL_MS = 55_000;

--- a/app/lib/masterConfig.ts
+++ b/app/lib/masterConfig.ts
@@ -221,3 +221,10 @@ export const KIOSK_CANVAS_MAX_IMAGES = 120;
 // ---------------------------------------------------------------------------
 export const YOUTUBE_FETCH_BATCH_SIZE = 5;
 export const YOUTUBE_FETCH_DELAY_BETWEEN_BATCHES_MS = 800;
+
+// ---------------------------------------------------------------------------
+// Ops tab (owner-only cost/health panel in the drawer)
+// ---------------------------------------------------------------------------
+// How many daily_sunset_stats rows the Ops tab shows. Two weeks reads well as
+// sparklines; the query is one cheap indexed scan on the PK.
+export const OPS_STATS_DAYS = 14;

--- a/app/lib/masterConfig.ts
+++ b/app/lib/masterConfig.ts
@@ -228,3 +228,13 @@ export const YOUTUBE_FETCH_DELAY_BETWEEN_BATCHES_MS = 800;
 // How many daily_sunset_stats rows the Ops tab shows. Two weeks reads well as
 // sparklines; the query is one cheap indexed scan on the PK.
 export const OPS_STATS_DAYS = 14;
+
+// Neon projects in the Vercel-managed org whose month-to-date usage counters
+// the cron snapshots daily into provider_usage_daily. Project ids are not
+// secrets (the API key NEON_COST_API is, and lives only in env).
+export const NEON_USAGE_PROJECT_IDS = [
+  'noisy-leaf-96391119', // sunrise-sunset-webcams (this app)
+  'rough-resonance-57753560', // nwac-observations (Weather_Web_App)
+  'holy-shadow-28821259', // land_buyback (idle)
+  'small-tree-05551811', // nextjs-dashboard-postgres (idle)
+];

--- a/app/lib/opsTypes.ts
+++ b/app/lib/opsTypes.ts
@@ -1,0 +1,33 @@
+// Shared shapes for the owner-only Ops tab. Kept out of the route file so the
+// client component can import types without pulling server code.
+export interface DailyStatsRow {
+  date: string; // 'YYYY-MM-DD'
+  model_version: string;
+  webcams_scored: number;
+  cache_hits: number;
+  fallbacks: number;
+  score_p50: number | null;
+  score_p90: number | null;
+  source_breakdown: Record<
+    string,
+    { scored: number; avg: number | null }
+  > | null;
+}
+
+export interface ProviderUsageRow {
+  day: string; // 'YYYY-MM-DD'
+  project_id: string;
+  compute_time_s: number;
+}
+
+export interface CostEventRow {
+  occurred_on: string; // 'YYYY-MM-DD'
+  sha: string | null;
+  description: string;
+}
+
+export interface OpsStatsResponse {
+  dailyStats: DailyStatsRow[];
+  providerUsage: ProviderUsageRow[];
+  costEvents: CostEventRow[];
+}

--- a/app/store/useLoadTerminatorWebcams.ts
+++ b/app/store/useLoadTerminatorWebcams.ts
@@ -6,7 +6,9 @@ import { useTerminatorStore } from './useTerminatorStore';
 
 const fetcher = (url: string) => fetch(url).then((r) => r.json());
 
-export function useLoadTerminatorWebcams() {
+export function useLoadTerminatorWebcams({
+  paused = false,
+}: { paused?: boolean } = {}) {
   const setTerimantorWebcams = useTerminatorStore(
     (s) => s.setTerimantorWebcams
   );
@@ -18,7 +20,8 @@ export function useLoadTerminatorWebcams() {
     '/api/db-terminator-webcams',
     fetcher,
     {
-      refreshInterval: 60_000,
+      refreshInterval: paused ? 0 : 60_000,
+      isPaused: () => paused,
     }
   );
 

--- a/database/migrations/20260731_provider_usage_and_cost_events.sql
+++ b/database/migrations/20260731_provider_usage_and_cost_events.sql
@@ -1,0 +1,36 @@
+-- Provider usage snapshots + cost change log for the owner-only Ops tab.
+-- Neon's daily consumption-history API is Scale-plan gated, so we snapshot the
+-- month-to-date counters from GET /projects/{id} once per UTC day and derive
+-- daily deltas at read time.
+-- Forward-only, idempotent. Apply manually via:
+--   psql "$DATABASE_URL" -f database/migrations/20260731_provider_usage_and_cost_events.sql
+
+CREATE TABLE IF NOT EXISTS provider_usage_daily (
+  day             DATE        NOT NULL,
+  project_id      TEXT        NOT NULL,
+  compute_time_s  BIGINT      NOT NULL DEFAULT 0,
+  active_time_s   BIGINT      NOT NULL DEFAULT 0,
+  data_transfer_b BIGINT      NOT NULL DEFAULT 0,
+  storage_b       BIGINT      NOT NULL DEFAULT 0,
+  captured_at     TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  PRIMARY KEY (day, project_id)
+);
+
+CREATE TABLE IF NOT EXISTS cost_events (
+  id          SERIAL PRIMARY KEY,
+  occurred_on DATE NOT NULL,
+  sha         TEXT,
+  description TEXT NOT NULL
+);
+
+-- Seed known cost-relevant changes (idempotent via the WHERE NOT EXISTS guard).
+INSERT INTO cost_events (occurred_on, sha, description)
+SELECT d::date, s, t FROM (VALUES
+  ('2026-06-04', NULL,
+   'cron */1 -> */15; image-hash dedup moved from Upstash to Neon column'),
+  ('2026-07-31', NULL,
+   'webcam endpoint autoscale 0.25-1 CU; nwac 0.25 CU + clustered crons; stale 9 CU branch deleted')
+) AS seed(d, s, t)
+WHERE NOT EXISTS (
+  SELECT 1 FROM cost_events e WHERE e.occurred_on = seed.d::date AND e.description = seed.t
+);

--- a/next.config.test.ts
+++ b/next.config.test.ts
@@ -18,7 +18,11 @@ import nextConfig from './next.config';
  * This test fails the build if anyone re-broadens the globs or bundles v2.
  */
 
-const MODEL_ROUTES = ['/api/cron/update-cameras', '/api/debug/scoring-smoke'];
+const MODEL_ROUTES = [
+  '/api/cron/update-cameras',
+  '/api/debug/scoring-smoke',
+  '/api/kiosk/tick',
+];
 // v4 regression (43M) + v4 binary (43M) = 86M. The threshold sits above that
 // but well below the 172M you'd get if a v2 model crept back in.
 const MAX_BUNDLED_MODEL_BYTES = 120 * 1024 * 1024;

--- a/next.config.ts
+++ b/next.config.ts
@@ -53,6 +53,10 @@ const nextConfig: NextConfig = {
       './ml/artifacts/models/regression_resnet18/20260513_113243_v4_regression_llm_with_flickr/**/*',
       './ml/artifacts/models/binary_resnet18/20260601_063518_v4_binary_llm_with_flickr/**/*',
     ],
+    '/api/kiosk/tick': [
+      './ml/artifacts/models/regression_resnet18/20260513_113243_v4_regression_llm_with_flickr/**/*',
+      './ml/artifacts/models/binary_resnet18/20260601_063518_v4_binary_llm_with_flickr/**/*',
+    ],
   },
 };
 


### PR DESCRIPTION
## What this does

Two features from the 2026-07-31 cost work, built per the spec (`docs/superpowers/specs/2026-07-31-gallery-cadence-and-cost-monitoring-design.md`):

**Ops tab (owner-only, in the home drawer)**
- `GET /api/admin/ops-stats` (owner-gated): last 14 days of `daily_sunset_stats` + provider usage + cost events
- Stat tiles with sparklines: fallback %, cache-hit %, webcams scored, p50/p90, model version
- Daily Neon compute-hours chart (webcams bold vs other projects thin) with cost-change markers — our substitute for Neon's Scale-gated history API
- Remote kiosk doze toggle (Redis flag)

**Gallery presence-driven cadence**
- `POST /api/kiosk/tick`: unauthenticated but Redis-NX-lock-capped at ~1 tick/min globally; re-invokes the cron tick in-process with internal auth. `*/15` cron stays as baseline and stamps the same lock.
- Kiosk pages tick every 60s only while visible; quiet hours 01–08 local (`?quiet=off` / `?quiet=23-9`), any interaction wakes for 30 min
- Doze: remote (Ops tab → Redis flag) or local sticky `d`-key (Argon case button will inject this); fade overlay; dozing pauses the terminator SWR poll too, so a dozing kiosk makes zero Neon wakes
- Model bundling: `/api/kiosk/tick` added to `outputFileTracingIncludes` + guard test

**Data**: migration `20260731_provider_usage_and_cost_events.sql` (provider_usage_daily, cost_events + seeded history); cron captures Neon usage counters once/UTC-day (guarded, non-fatal).

## Deploy checklist (before/with merge)
1. `psql "$DATABASE_URL" -f database/migrations/20260731_provider_usage_and_cost_events.sql`
2. Add `NEON_COST_API` to Vercel env (Production)
3. Post-deploy: `GET /api/debug/scoring-smoke` (latencyMs 100–500ms = ONNX live) and a kiosk tick's `tick.scoringPaths.onnx > 0`

## Testing
637 tests / 124 files green; every task TDD'd with per-task review; final whole-branch review caught and fixed a live-verified Neon driver date-param bug (`::int` cast), a background-tab tick leak, and the dozing-SWR Neon wake.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GzfuV33i6bcFj2Gp8XupEh
