### PR TITLE
Ops chart: label sunset vs NWAC vs other projects

### DIFF
--- a/app/components/Ops/UsageChart.test.tsx
+++ b/app/components/Ops/UsageChart.test.tsx
@@ -3,8 +3,33 @@ import { render } from '@testing-library/react';
 import { UsageChart } from './UsageChart';
 
 const P = 'noisy-leaf-96391119';
+const NWAC = 'rough-resonance-57753560';
 
 describe('UsageChart', () => {
+  it('labels the sunset and nwac series separately', () => {
+    const { container, getByText } = render(
+      <UsageChart
+        usage={[
+          { day: '2026-08-01', project_id: P, compute_time_s: 36000 },
+          { day: '2026-08-02', project_id: P, compute_time_s: 72000 },
+          { day: '2026-08-03', project_id: P, compute_time_s: 108000 },
+          { day: '2026-08-01', project_id: NWAC, compute_time_s: 3600 },
+          { day: '2026-08-02', project_id: NWAC, compute_time_s: 10800 },
+          { day: '2026-08-03', project_id: NWAC, compute_time_s: 14400 },
+        ]}
+        events={[]}
+      />,
+    );
+    expect(getByText('sunrise-sunset (this site)')).toBeInTheDocument();
+    expect(getByText('nwac-observations')).toBeInTheDocument();
+    const sunset = container.querySelector('polyline[data-series="sunset"]');
+    const nwac = container.querySelector('polyline[data-series="nwac"]');
+    expect(sunset).not.toBeNull();
+    expect(nwac).not.toBeNull();
+    // distinct data: sunset delta 10h vs nwac delta 2h -> different y coords
+    expect(sunset!.getAttribute('points')).not.toEqual(nwac!.getAttribute('points'));
+  });
+
   it('renders a point per derived day and a marker per event', () => {
     const { container } = render(
       <UsageChart

--- a/app/components/Ops/UsageChart.tsx
+++ b/app/components/Ops/UsageChart.tsx
@@ -3,8 +3,17 @@ import type { ProviderUsageRow, CostEventRow } from '@/app/lib/opsTypes';
 import { deriveDailyDeltas } from './opsMath';
 
 const WEBCAM_PROJECT = 'noisy-leaf-96391119';
+const NWAC_PROJECT = 'rough-resonance-57753560';
 const W = 560;
 const H = 140;
+
+// Named series so the chart is honest about what shares the Neon bill: this
+// site, the (unrelated) NWAC weather DB, and the idle leftovers.
+const SERIES = [
+  { key: 'sunset', label: 'sunrise-sunset (this site)', stroke: '#60a5fa', strokeWidth: 2 },
+  { key: 'nwac', label: 'nwac-observations', stroke: '#9ca3af', strokeWidth: 1 },
+  { key: 'other', label: 'other projects', stroke: '#9ca3af', strokeWidth: 1, dash: '2 3' },
+] as const;
 
 export function UsageChart({
   usage,
@@ -22,17 +31,18 @@ export function UsageChart({
       </Typography>
     );
   }
-  const webcam = days.map(
-    (day) =>
-      deltas.find((d) => d.day === day && d.project_id === WEBCAM_PROJECT)
-        ?.computeHours ?? 0,
-  );
-  const others = days.map((day) =>
-    deltas
-      .filter((d) => d.day === day && d.project_id !== WEBCAM_PROJECT)
-      .reduce((sum, d) => sum + d.computeHours, 0),
-  );
-  const max = Math.max(...webcam, ...others, 1);
+  const perDay = (match: (projectId: string) => boolean) =>
+    days.map((day) =>
+      deltas
+        .filter((d) => d.day === day && match(d.project_id))
+        .reduce((sum, d) => sum + d.computeHours, 0),
+    );
+  const values: Record<(typeof SERIES)[number]['key'], number[]> = {
+    sunset: perDay((p) => p === WEBCAM_PROJECT),
+    nwac: perDay((p) => p === NWAC_PROJECT),
+    other: perDay((p) => p !== WEBCAM_PROJECT && p !== NWAC_PROJECT),
+  };
+  const max = Math.max(...Object.values(values).flat(), 1);
   const x = (i: number) => (days.length === 1 ? W / 2 : (i / (days.length - 1)) * W);
   const y = (v: number) => H - (v / max) * (H - 10) - 5;
   const line = (vals: number[]) => vals.map((v, i) => `${x(i)},${y(v)}`).join(' ');
@@ -40,12 +50,44 @@ export function UsageChart({
   return (
     <Box sx={{ mt: 2, overflowX: 'auto' }}>
       <Typography variant="caption" sx={{ color: '#9ca3af' }}>
-        Neon compute hours/day — webcams (bold) vs other projects (thin), markers = cost changes
+        Neon compute hours/day — markers = cost changes
       </Typography>
+      <Box sx={{ display: 'flex', gap: 2, mb: 0.5 }}>
+        {SERIES.map((s) => (
+          <Typography
+            key={s.key}
+            variant="caption"
+            sx={{ color: '#9ca3af', display: 'flex', alignItems: 'center', gap: 0.5 }}
+          >
+            <svg width={18} height={8} aria-hidden>
+              <line
+                x1={0}
+                y1={4}
+                x2={18}
+                y2={4}
+                stroke={s.stroke}
+                strokeWidth={s.strokeWidth}
+                strokeDasharray={'dash' in s ? s.dash : undefined}
+              />
+            </svg>
+            {s.label}
+          </Typography>
+        ))}
+      </Box>
       <svg width={W} height={H} role="img" aria-label="compute hours per day">
-        <polyline points={line(webcam)} fill="none" stroke="#60a5fa" strokeWidth={2} />
-        {days.length > 1 && (
-          <polyline points={line(others)} fill="none" stroke="#9ca3af" strokeWidth={1} />
+        {SERIES.map(
+          (s) =>
+            (s.key === 'sunset' || days.length > 1) && (
+              <polyline
+                key={s.key}
+                data-series={s.key}
+                points={line(values[s.key])}
+                fill="none"
+                stroke={s.stroke}
+                strokeWidth={s.strokeWidth}
+                strokeDasharray={'dash' in s ? s.dash : undefined}
+              />
+            ),
         )}
         {events
           .filter((e) => days.includes(e.occurred_on))


### PR DESCRIPTION
The Neon usage chart on the Ops tab previously lumped everything that isn't the sunset site into one anonymous thin line — which in practice is mostly the unrelated NWAC weather DB. Since the chart is hosted on the sunset site, the series are now explicitly named with a legend: **sunrise-sunset (this site)** (bold blue), **nwac-observations** (thin gray), **other projects** (dotted gray, normally zero).

New test asserts the two series render separately with distinct data. Full suite green (638 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GzfuV33i6bcFj2Gp8XupEh