### PR TITLE
Daily usage digest email + terminal usage report

### DIFF
--- a/app/api/cron/update-cameras/lib/dailyDigest.test.ts
+++ b/app/api/cron/update-cameras/lib/dailyDigest.test.ts
@@ -1,0 +1,86 @@
+// @vitest-environment node
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const sqlMock = vi.fn();
+vi.mock('@/app/lib/db', () => ({
+  sql: (strings: TemplateStringsArray, ...values: unknown[]) =>
+    sqlMock(strings, ...values),
+}));
+
+import { sendDailyUsageDigest } from './dailyDigest';
+
+const NOW = new Date('2026-08-03T00:20:00Z');
+const SUNSET = 'noisy-leaf-96391119';
+const NWAC = 'rough-resonance-57753560';
+
+const usageRows = [
+  { day: '2026-08-01', project_id: SUNSET, compute_time_s: '18000' }, // 5h MTD
+  { day: '2026-08-02', project_id: SUNSET, compute_time_s: '39600' }, // 11h MTD (+6h)
+  { day: '2026-08-01', project_id: NWAC, compute_time_s: '3600' }, // 1h MTD
+  { day: '2026-08-02', project_id: NWAC, compute_time_s: '7200' }, // 2h MTD (+1h)
+];
+const eventRows = [
+  { occurred_on: '2026-08-01', sha: null, description: 'autoscale 0.25-1 CU' },
+];
+
+describe('sendDailyUsageDigest', () => {
+  const fetchMock = vi.fn();
+  beforeEach(() => {
+    sqlMock.mockReset();
+    fetchMock.mockReset();
+    vi.stubGlobal('fetch', fetchMock);
+    process.env.RESEND_API_KEY = 'test-key';
+    process.env.DIGEST_EMAIL_TO = 'jesse@example.com';
+  });
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    delete process.env.RESEND_API_KEY;
+    delete process.env.DIGEST_EMAIL_TO;
+  });
+
+  it('skips without RESEND_API_KEY', async () => {
+    delete process.env.RESEND_API_KEY;
+    const result = await sendDailyUsageDigest(NOW);
+    expect(result).toEqual({ skipped: 'no-resend-key' });
+    expect(sqlMock).not.toHaveBeenCalled();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('skips without DIGEST_EMAIL_TO', async () => {
+    delete process.env.DIGEST_EMAIL_TO;
+    const result = await sendDailyUsageDigest(NOW);
+    expect(result).toEqual({ skipped: 'no-recipient' });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('sends an email whose html carries per-project deltas, dollars, and events', async () => {
+    sqlMock
+      .mockResolvedValueOnce(usageRows) // provider_usage_daily
+      .mockResolvedValueOnce(eventRows); // cost_events
+    fetchMock.mockResolvedValueOnce({ ok: true, json: async () => ({ id: 'em_1' }) });
+
+    const result = await sendDailyUsageDigest(NOW);
+    expect(result).toEqual({ sent: true });
+
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(String(url)).toBe('https://api.resend.com/emails');
+    expect(init.headers.Authorization).toBe('Bearer test-key');
+    const body = JSON.parse(init.body);
+    expect(body.to).toEqual(['jesse@example.com']);
+    // subject leads with yesterday's sunset-site hours
+    expect(body.subject).toContain('6');
+    // html: named series, yesterday's deltas, MTD dollar estimate, cost event
+    expect(body.html).toContain('sunrise-sunset');
+    expect(body.html).toContain('nwac-observations');
+    expect(body.html).toContain('6.0'); // sunset delta hours on 08-02
+    expect(body.html).toContain('$'); // dollar estimate present
+    expect(body.html).toContain('autoscale 0.25-1 CU');
+  });
+
+  it('returns skipped when the send fails, never throws', async () => {
+    sqlMock.mockResolvedValueOnce(usageRows).mockResolvedValueOnce([]);
+    fetchMock.mockRejectedValueOnce(new Error('resend down'));
+    const result = await sendDailyUsageDigest(NOW);
+    expect(result).toEqual({ skipped: 'send-failed' });
+  });
+});

--- a/app/api/cron/update-cameras/lib/dailyDigest.ts
+++ b/app/api/cron/update-cameras/lib/dailyDigest.ts
@@ -1,0 +1,141 @@
+import { sql } from '@/app/lib/db';
+import { deriveDailyDeltas } from '@/app/components/Ops/opsMath';
+import type { ProviderUsageRow, CostEventRow } from '@/app/lib/opsTypes';
+import {
+  NEON_COST_PER_CU_HOUR,
+  DIGEST_LOOKBACK_DAYS,
+} from '@/app/lib/masterConfig';
+
+const SUNSET_PROJECT = 'noisy-leaf-96391119';
+const NWAC_PROJECT = 'rough-resonance-57753560';
+
+const LABELS: Record<string, string> = {
+  [SUNSET_PROJECT]: 'sunrise-sunset (this site)',
+  [NWAC_PROJECT]: 'nwac-observations',
+};
+
+// Daily usage digest email, sent right after the once-per-UTC-day provider
+// snapshot lands (the caller gates on that, which gives once-a-day semantics
+// for free). Reads the same table the Ops chart reads, so the email can never
+// disagree with the dashboard. Non-fatal by contract: every failure path
+// returns instead of throwing.
+export async function sendDailyUsageDigest(
+  now: Date,
+): Promise<{ sent: true } | { skipped: string }> {
+  const apiKey = process.env.RESEND_API_KEY;
+  if (!apiKey) return { skipped: 'no-resend-key' };
+  const to = process.env.DIGEST_EMAIL_TO;
+  if (!to) return { skipped: 'no-recipient' };
+
+  try {
+    const usage = (await sql`
+      SELECT day::text AS day, project_id, compute_time_s::bigint AS compute_time_s
+      FROM provider_usage_daily
+      WHERE day > CURRENT_DATE - ${DIGEST_LOOKBACK_DAYS}::int
+      ORDER BY day ASC, project_id ASC
+    `) as unknown as ProviderUsageRow[];
+    const events = (await sql`
+      SELECT occurred_on::text AS occurred_on, sha, description
+      FROM cost_events
+      WHERE occurred_on > CURRENT_DATE - ${DIGEST_LOOKBACK_DAYS}::int
+      ORDER BY occurred_on ASC
+    `) as unknown as CostEventRow[];
+
+    const rows = usage.map((r) => ({ ...r, compute_time_s: Number(r.compute_time_s) }));
+    const deltas = deriveDailyDeltas(rows);
+    const days = [...new Set(deltas.map((d) => d.day))].sort();
+    const latestDay = days.at(-1);
+    const hoursFor = (day: string, projectId: string | null) =>
+      deltas
+        .filter(
+          (d) =>
+            d.day === day &&
+            (projectId === null
+              ? d.project_id !== SUNSET_PROJECT && d.project_id !== NWAC_PROJECT
+              : d.project_id === projectId),
+        )
+        .reduce((sum, d) => sum + d.computeHours, 0);
+
+    // Month-to-date: the latest snapshot per project IS the MTD counter.
+    const mtdHours = Object.values(
+      rows.reduce<Record<string, ProviderUsageRow>>((acc, r) => {
+        if (!acc[r.project_id] || acc[r.project_id].day < r.day) acc[r.project_id] = r;
+        return acc;
+      }, {}),
+    ).reduce((sum, r) => sum + Number(r.compute_time_s) / 3600, 0);
+    const mtdDollars = mtdHours * NEON_COST_PER_CU_HOUR;
+    const dayOfMonth = now.getUTCDate();
+    const paceDollars = dayOfMonth > 0 ? (mtdDollars / dayOfMonth) * 30 : mtdDollars;
+
+    const ySunset = latestDay ? hoursFor(latestDay, SUNSET_PROJECT) : 0;
+    const yNwac = latestDay ? hoursFor(latestDay, NWAC_PROJECT) : 0;
+
+    const maxHours = Math.max(...days.map((d) => hoursFor(d, SUNSET_PROJECT)), 1);
+    const bar = (hours: number, color: string) =>
+      `<td style="padding:1px 0"><div style="height:10px;width:${Math.max(
+        2,
+        Math.round((hours / maxHours) * 220),
+      )}px;background:${color}"></div></td><td style="padding:0 6px;font:11px monospace">${hours.toFixed(1)}h</td>`;
+    const eventByDay = new Map(events.map((e) => [e.occurred_on, e.description]));
+    const chartRows = days
+      .map(
+        (d) => `<tr>
+          <td style="font:11px monospace;padding-right:8px">${d.slice(5)}${eventByDay.has(d) ? ' ⚑' : ''}</td>
+          ${bar(hoursFor(d, SUNSET_PROJECT), '#3b82f6')}
+          ${bar(hoursFor(d, NWAC_PROJECT), '#9ca3af')}
+        </tr>`,
+      )
+      .join('');
+    const eventList = events.length
+      ? `<h3 style="font:bold 13px sans-serif">Cost changes (⚑)</h3><ul style="font:12px sans-serif">${events
+          .map((e) => `<li><b>${e.occurred_on}</b> — ${e.description}</li>`)
+          .join('')}</ul>`
+      : '';
+
+    const html = `
+      <div style="font:14px sans-serif;max-width:560px">
+        <h2 style="font:bold 16px sans-serif">Sunset infra — daily usage</h2>
+        <p>
+          Yesterday: <b>sunrise-sunset (this site) ${ySunset.toFixed(1)} CU-hr</b>,
+          nwac-observations ${yNwac.toFixed(1)} CU-hr.<br/>
+          Month to date: <b>${mtdHours.toFixed(1)} CU-hr ≈ $${mtdDollars.toFixed(2)}</b>
+          (pace ≈ $${paceDollars.toFixed(0)}/mo compute, + Vercel plan fee).
+        </p>
+        ${
+          days.length
+            ? `<table cellspacing="0" cellpadding="0"><tr>
+                 <td></td><td colspan="2" style="font:11px sans-serif;color:#3b82f6">sunrise-sunset</td>
+                 <td colspan="2" style="font:11px sans-serif;color:#6b7280">nwac-observations</td>
+               </tr>${chartRows}</table>`
+            : '<p style="font:12px sans-serif">Daily chart appears after two snapshots.</p>'
+        }
+        ${eventList}
+        <p style="font:11px sans-serif;color:#6b7280">
+          Same data as the Ops tab. Estimate uses $${NEON_COST_PER_CU_HOUR}/CU-hr;
+          the invoice of record is Vercel → Settings → Billing.
+        </p>
+      </div>`;
+
+    const res = await fetch('https://api.resend.com/emails', {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        from: process.env.DIGEST_EMAIL_FROM ?? 'onboarding@resend.dev',
+        to: [to],
+        subject: `Sunset infra: ${ySunset.toFixed(1)} CU-hr yesterday · $${mtdDollars.toFixed(2)} MTD`,
+        html,
+      }),
+    });
+    if (!res.ok) {
+      console.warn('[dailyDigest] resend responded', res.status);
+      return { skipped: 'send-failed' };
+    }
+    return { sent: true };
+  } catch (error) {
+    console.warn('[dailyDigest] failed:', error);
+    return { skipped: 'send-failed' };
+  }
+}

--- a/app/api/cron/update-cameras/route.test.ts
+++ b/app/api/cron/update-cameras/route.test.ts
@@ -80,6 +80,10 @@ vi.mock('./lib/providerUsage', () => ({
   captureProviderUsageDaily: (...a: unknown[]) =>
     captureProviderUsageDailyMock(...a),
 }));
+const sendDailyUsageDigestMock = vi.fn();
+vi.mock('./lib/dailyDigest', () => ({
+  sendDailyUsageDigest: (...a: unknown[]) => sendDailyUsageDigestMock(...a),
+}));
 vi.mock('@/app/components/Map/lib/subsolarLocation', () => ({
   subsolarPoint: () => ({ raHours: 0, gmstHours: 0 }),
 }));
@@ -128,6 +132,7 @@ beforeEach(() => {
   customClassifyMock.mockReset().mockResolvedValue({ sunrise: [], sunset: [] });
   upsertStatsMock.mockReset().mockResolvedValue(undefined);
   captureProviderUsageDailyMock.mockReset().mockResolvedValue({ captured: 0 });
+  sendDailyUsageDigestMock.mockReset().mockResolvedValue({ sent: true });
   setCachedMock.mockReset().mockResolvedValue(undefined);
   markKioskTickRanMock.mockReset().mockResolvedValue(undefined);
   fetchTerminatorWebcamsMock.mockReset().mockResolvedValue([]);
@@ -374,5 +379,28 @@ describe('GET /api/cron/update-cameras', () => {
     const res = await GET(makeReq());
     expect(res.status).toBe(200);
     expect(captureProviderUsageDailyMock).toHaveBeenCalled();
+  });
+
+  it('sends the daily digest only on the tick that landed a fresh capture', async () => {
+    captureProviderUsageDailyMock.mockResolvedValueOnce({ captured: 4 });
+    const res = await GET(makeReq());
+    expect(res.status).toBe(200);
+    expect(sendDailyUsageDigestMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('skips the digest when the capture was skipped', async () => {
+    captureProviderUsageDailyMock.mockResolvedValueOnce({ skipped: 'already-captured' });
+    const res = await GET(makeReq());
+    const body = await res.json();
+    expect(sendDailyUsageDigestMock).not.toHaveBeenCalled();
+    expect(body.digest).toEqual({ skipped: 'no-fresh-capture' });
+  });
+
+  it('a digest failure never fails the tick', async () => {
+    captureProviderUsageDailyMock.mockResolvedValueOnce({ captured: 4 });
+    sendDailyUsageDigestMock.mockRejectedValueOnce(new Error('resend down'));
+    const res = await GET(makeReq());
+    expect(res.status).toBe(200);
+    expect((await res.json()).digest).toEqual({ skipped: 'send-failed' });
   });
 });

--- a/app/api/cron/update-cameras/route.ts
+++ b/app/api/cron/update-cameras/route.ts
@@ -48,6 +48,7 @@ import { computeDisagreementKind, scoreImage } from './lib/aiScoring';
 import { backfillArchiveSnapshotScores } from './lib/archiveBackfill';
 import { computeTickStats, upsertDailyStats } from './lib/dailyStats';
 import { captureProviderUsageDaily } from './lib/providerUsage';
+import { sendDailyUsageDigest } from './lib/dailyDigest';
 import { downloadImage, uploadToFirebase } from '@/app/lib/webcamSnapshot';
 
 const TICK_DEADLINE_MS = 50_000;
@@ -401,6 +402,20 @@ export async function GET(req: Request) {
     providerUsage = { error: true };
   }
 
+  // The digest rides the once-per-day capture: it only sends on the tick that
+  // actually landed a fresh snapshot. Same non-fatal contract.
+  let digest: Awaited<ReturnType<typeof sendDailyUsageDigest>> | { skipped: string };
+  if ('captured' in providerUsage && providerUsage.captured > 0) {
+    try {
+      digest = await sendDailyUsageDigest(new Date());
+    } catch (error) {
+      console.warn('[update-cameras] daily digest failed:', error);
+      digest = { skipped: 'send-failed' };
+    }
+  } else {
+    digest = { skipped: 'no-fresh-capture' };
+  }
+
   return NextResponse.json({
     ok: true,
     sunrise: sunriseRows.length,
@@ -411,5 +426,6 @@ export async function GET(req: Request) {
     scoringPaths,
     archiveBackfill: backfillResult,
     providerUsage,
+    digest,
   });
 }

--- a/app/lib/masterConfig.ts
+++ b/app/lib/masterConfig.ts
@@ -229,6 +229,12 @@ export const YOUTUBE_FETCH_DELAY_BETWEEN_BATCHES_MS = 800;
 // sparklines; the query is one cheap indexed scan on the PK.
 export const OPS_STATS_DAYS = 14;
 
+// Rough Neon usage rate for the digest email's dollar estimate. The invoice
+// of record is Vercel; this exists so the email can say "~$14 so far" without
+// an extra API. Update if Neon/Vercel repricing makes it drift.
+export const NEON_COST_PER_CU_HOUR = 0.14;
+// Days of history in the daily digest email's inline bar chart.
+export const DIGEST_LOOKBACK_DAYS = 14;
 // How far back the Ops usage chart reaches. 60 days spans two billing cycles
 // so month-rollover deltas are visible and testable.
 export const PROVIDER_USAGE_LOOKBACK_DAYS = 60;

--- a/scripts/usage-report.mjs
+++ b/scripts/usage-report.mjs
@@ -1,0 +1,74 @@
+// Prints the Neon usage log the Ops tab reads: daily compute-hours per
+// project, cost-change events, and a month-to-date dollar estimate.
+// Run from the repo root (needs DATABASE_URL in .env.local):
+//   node scripts/usage-report.mjs [days]   (default 30)
+import { neon } from '@neondatabase/serverless';
+import { readFileSync } from 'fs';
+
+const LABELS = {
+  'noisy-leaf-96391119': 'sunset ',
+  'rough-resonance-57753560': 'nwac   ',
+};
+const COST_PER_CU_HOUR = 0.14; // estimate; invoice of record is Vercel billing
+
+const days = Number(process.argv[2] ?? 30);
+const url = readFileSync('.env.local', 'utf8').match(/^DATABASE_URL=["']?([^"'\n]+)/m)?.[1];
+if (!url) throw new Error('DATABASE_URL not found in .env.local — run from the repo root');
+const sql = neon(url);
+
+const usage = await sql.query(
+  `SELECT day::text AS day, project_id, compute_time_s::bigint AS s
+   FROM provider_usage_daily WHERE day > CURRENT_DATE - $1::int
+   ORDER BY day, project_id`,
+  [days],
+);
+const events = await sql.query(
+  `SELECT occurred_on::text AS d, description FROM cost_events ORDER BY occurred_on`,
+);
+const rows = (usage.rows ?? usage).map((r) => ({ ...r, s: Number(r.s) }));
+const eventsByDay = new Map((events.rows ?? events).map((e) => [e.d, e.description]));
+
+// day-over-day deltas per project; counter resets at month start
+const byProject = new Map();
+for (const r of rows) {
+  if (!byProject.has(r.project_id)) byProject.set(r.project_id, []);
+  byProject.get(r.project_id).push(r);
+}
+const deltas = new Map(); // day -> {project: hours}
+for (const [pid, list] of byProject) {
+  for (let i = 1; i < list.length; i++) {
+    const d = list[i].s - list[i - 1].s;
+    const hours = (d < 0 ? list[i].s : d) / 3600;
+    if (!deltas.has(list[i].day)) deltas.set(list[i].day, {});
+    deltas.get(list[i].day)[pid] = hours;
+  }
+}
+
+console.log('day         sunset  nwac    other   events');
+for (const day of [...deltas.keys()].sort()) {
+  const v = deltas.get(day);
+  let sunset = 0, nwac = 0, other = 0;
+  for (const [pid, h] of Object.entries(v)) {
+    if (pid === 'noisy-leaf-96391119') sunset = h;
+    else if (pid === 'rough-resonance-57753560') nwac = h;
+    else other += h;
+  }
+  const flag = eventsByDay.has(day) ? `  ⚑ ${eventsByDay.get(day).slice(0, 50)}` : '';
+  console.log(
+    `${day}  ${sunset.toFixed(1).padStart(5)}h ${nwac.toFixed(1).padStart(5)}h ${other.toFixed(1).padStart(5)}h${flag}`,
+  );
+}
+if (deltas.size === 0) console.log('(no deltas yet — needs two daily snapshots)');
+
+// MTD from latest counter per project
+let mtd = 0;
+console.log('\nmonth-to-date counters:');
+for (const [pid, list] of byProject) {
+  const h = list.at(-1).s / 3600;
+  mtd += h;
+  console.log(`  ${LABELS[pid] ?? pid}  ${h.toFixed(1)} CU-hr (as of ${list.at(-1).day})`);
+}
+console.log(`  TOTAL   ${mtd.toFixed(1)} CU-hr ≈ $${(mtd * COST_PER_CU_HOUR).toFixed(2)} compute MTD`);
+
+console.log('\ncost events:');
+for (const [d, desc] of eventsByDay) console.log(`  ${d} — ${desc}`);


### PR DESCRIPTION
Adds the daily cost-visibility layer on top of the PR #72 snapshot infrastructure:

**Digest email** (`lib/dailyDigest.ts`): rides the once-per-UTC-day provider capture in the update-cameras cron — sends only on the tick that landed a fresh snapshot, reads the same tables as the Ops chart (so email and dashboard can never disagree), and mails via Resend: yesterday's CU-hours per project (sunset vs nwac, named), an inline HTML bar chart with ⚑ cost-event markers, and a month-to-date dollar estimate with monthly pace. Non-fatal everywhere; skips cleanly until `RESEND_API_KEY` + `DIGEST_EMAIL_TO` env vars exist, so merging is safe before Resend setup.

**Terminal report** (`scripts/usage-report.mjs`): `node scripts/usage-report.mjs [days]` prints the same log — daily deltas per project, cost events, MTD estimate — for diagnosis from any session.

7 new tests (digest skip/send/fail paths, cron gating on fresh-capture); full suite 644 green.

**To activate after merge**: create a free Resend account → API key → `vercel env add RESEND_API_KEY production` and `vercel env add DIGEST_EMAIL_TO production` (your email). First email arrives after the next UTC-midnight cron tick.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GzfuV33i6bcFj2Gp8XupEh