### PR TITLE
fix(mosaic): unshadow maxImageHeight prop; raise kiosk tile floor to 100px

### DIFF
--- a/app/components/MosaicCanvas/index.tsx
+++ b/app/components/MosaicCanvas/index.tsx
@@ -202,7 +202,7 @@ export function MosaicCanvas({
         const imageData: ImageData[] = [];
 
         let totalImageWidth = 0;
-        let maxImageHeight = 0;
+        let rowMaxHeight = 0;
 
         // Calculate dimensions for each image
         row.forEach((item) => {
@@ -236,7 +236,7 @@ export function MosaicCanvas({
           });
 
           totalImageWidth += imgWidth;
-          maxImageHeight = Math.max(maxImageHeight, imgHeight);
+          rowMaxHeight = Math.max(rowMaxHeight, imgHeight);
         });
 
         // Add padding between images
@@ -244,13 +244,13 @@ export function MosaicCanvas({
 
         // Store row data
         rowData.push({
-          height: maxImageHeight,
+          height: rowMaxHeight,
           y: 0, // Will be calculated below
           imageData,
           totalWidth: totalImageWidth,
         });
 
-        totalContentHeight += maxImageHeight + finalConfig.padding;
+        totalContentHeight += rowMaxHeight + finalConfig.padding;
       });
 
       // Calculate vertical offset to center content

--- a/app/lib/masterConfig.ts
+++ b/app/lib/masterConfig.ts
@@ -212,7 +212,7 @@ export const MOSAIC_SIZE_SCALE_MODE = 'linear';
 // Tile heights are larger than the default mosaic to fill the taller display.
 // Tune these visually using Chrome DevTools at 1080×1920.
 export const KIOSK_MOSAIC_MAX_IMAGE_HEIGHT_PX = 180;
-export const KIOSK_MOSAIC_MIN_IMAGE_HEIGHT_PX = 32;
+export const KIOSK_MOSAIC_MIN_IMAGE_HEIGHT_PX = 100;
 // More images than default (90) to fill the extra vertical height.
 export const KIOSK_CANVAS_MAX_IMAGES = 120;
 


### PR DESCRIPTION
## What
- Renames the row-measurement accumulator in `MosaicCanvas/index.tsx` (`maxImageHeight` → `rowMaxHeight`) — it was shadowing the `maxImageHeight` prop, so every tile's height calc got a ceiling of ~0 and clamped to the minimum.
- Bumps `KIOSK_MOSAIC_MIN_IMAGE_HEIGHT_PX` 32 → 100 (Jesse's ~3cm legibility floor for the 27" portrait kiosk monitors; provisional).

## Why
On the kiosk wall every tile rendered at exactly 32px: the mosaic collapsed into a thin centered horizontal strip and rating-driven sizing was mathematically invisible (all sizes clamped to the same floor). Found live during first dual-monitor bring-up.

## Verification
- Full suite: 644 tests green (excluding the stale `.claude/worktrees` copy, which fails pre-existing for duplicate-React reasons)
- `tsc --noEmit` clean
- Post-merge: will verify on the physical kiosk wall (tiles fill the 1080×1920 canvas, visible size variation by rating)

🤖 Generated with [Claude Code](https://claude.com/claude-code)