### PR TITLE
security(cron): stop logging CRON_SECRET; fail closed when unset

### DIFF
--- a/app/api/cron/update-cameras/lib/auth.test.ts
+++ b/app/api/cron/update-cameras/lib/auth.test.ts
@@ -1,0 +1,72 @@
+// @vitest-environment node
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { verifyCronAuth } from './auth';
+
+const SECRET = 'super-secret-value';
+
+function req(init: { auth?: string; urlSecret?: string } = {}) {
+  const url = init.urlSecret
+    ? `http://t/api/cron/update-cameras?secret=${encodeURIComponent(init.urlSecret)}`
+    : 'http://t/api/cron/update-cameras';
+  return new Request(url, {
+    headers: init.auth ? { authorization: init.auth } : {},
+  });
+}
+
+beforeEach(() => {
+  process.env.CRON_SECRET = SECRET;
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('verifyCronAuth', () => {
+  it('accepts the Vercel cron bearer header', () => {
+    expect(verifyCronAuth(req({ auth: `Bearer ${SECRET}` }))).toBe(true);
+  });
+
+  it('accepts the ?secret= URL fallback', () => {
+    expect(verifyCronAuth(req({ urlSecret: SECRET }))).toBe(true);
+  });
+
+  it('rejects a wrong bearer and a wrong URL secret', () => {
+    expect(verifyCronAuth(req({ auth: 'Bearer nope' }))).toBe(false);
+    expect(verifyCronAuth(req({ urlSecret: 'nope' }))).toBe(false);
+    expect(verifyCronAuth(req())).toBe(false);
+  });
+
+  // Regression: the check used to be `authHeader === \`Bearer ${process.env.CRON_SECRET}\``,
+  // which collapses to the literal "Bearer undefined" when the env var is missing —
+  // letting anyone who sends that exact header run the cron.
+  it('rejects "Bearer undefined" when CRON_SECRET is unset', () => {
+    delete process.env.CRON_SECRET;
+    expect(verifyCronAuth(req({ auth: 'Bearer undefined' }))).toBe(false);
+    expect(verifyCronAuth(req({ urlSecret: 'undefined' }))).toBe(false);
+  });
+
+  it('rejects an empty-string CRON_SECRET rather than authorizing on it', () => {
+    process.env.CRON_SECRET = '';
+    expect(verifyCronAuth(req({ auth: 'Bearer ' }))).toBe(false);
+    expect(verifyCronAuth(req({ urlSecret: '' }))).toBe(false);
+  });
+
+  // Regression: the secret was being written to stdout on every invocation
+  // (both the raw env var and the `Bearer <secret>` header), which put it in
+  // Vercel's runtime logs ~once a minute via the kiosk tick path.
+  it('never writes the secret to the console', () => {
+    const log = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const error = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    verifyCronAuth(req({ auth: `Bearer ${SECRET}` }));
+    verifyCronAuth(req({ urlSecret: SECRET }));
+
+    const emitted = [...log.mock.calls, ...error.mock.calls, ...warn.mock.calls]
+      .flat()
+      .map((a) => String(a))
+      .join('\n');
+
+    expect(emitted).not.toContain(SECRET);
+  });
+});

--- a/app/api/cron/update-cameras/lib/auth.ts
+++ b/app/api/cron/update-cameras/lib/auth.ts
@@ -4,25 +4,23 @@
  */
 
 export function verifyCronAuth(req: Request): boolean {
-  // Check if this is a Vercel cron request
-  const authHeader = req.headers.get('authorization');
-  const isVercelCron =
-    authHeader === `Bearer ${process.env.CRON_SECRET}`;
+  const expected = process.env.CRON_SECRET;
+  // Without a configured secret there is nothing to authenticate against, so
+  // fail closed. Comparing directly against `Bearer ${process.env.CRON_SECRET}`
+  // would collapse to the literal "Bearer undefined" and authorize anyone who
+  // sends it.
+  if (!expected) return false;
 
-  // Also check URL parameter as fallback
+  // Vercel Cron sends the secret as a bearer token.
+  const isVercelCron = req.headers.get('authorization') === `Bearer ${expected}`;
+
+  // Also check URL parameter as fallback.
   const { searchParams } = new URL(req.url);
-  const secret = searchParams.get('secret');
-  const isUrlSecret = secret === process.env.CRON_SECRET;
+  const isUrlSecret = searchParams.get('secret') === expected;
 
-  console.log('🔍 Debug - Vercel cron header:', authHeader);
-  console.log('🔍 Debug - Secret from URL:', secret);
-  console.log(
-    '🔍 Debug - CRON_SECRET env var:',
-    process.env.CRON_SECRET
-  );
-  console.log('🔍 Debug - Is Vercel cron:', isVercelCron);
-  console.log('🔍 Debug - Is URL secret valid:', isUrlSecret);
-
+  // Deliberately no logging here: this runs on every cron tick and every kiosk
+  // tick, and both the raw env var and the `Bearer <secret>` header would land
+  // in Vercel's runtime logs. See auth.test.ts.
   return isVercelCron || isUrlSecret;
 }
 

--- a/app/api/cron/update-youtube/route.ts
+++ b/app/api/cron/update-youtube/route.ts
@@ -69,21 +69,15 @@ async function searchYouTubeLiveNear(
 }
 
 export async function GET(req: Request) {
-  const authHeader = req.headers.get('authorization');
+  // Fail closed when no secret is configured — see update-cameras/lib/auth.ts.
+  // No logging of the header or the secret: both would leak it into Vercel's
+  // runtime logs on every invocation.
+  const expected = process.env.CRON_SECRET;
   const isVercelCron =
-    authHeader === `Bearer ${process.env.CRON_SECRET}`;
+    Boolean(expected) && req.headers.get('authorization') === `Bearer ${expected}`;
   const { searchParams } = new URL(req.url);
-  const secret = searchParams.get('secret');
-  const isUrlSecret = secret === process.env.CRON_SECRET;
-
-  console.log('🔍 Debug - Vercel cron header:', authHeader);
-  console.log('🔍 Debug - Secret from URL:', secret);
-  console.log(
-    '🔍 Debug - CRON_SECRET env var:',
-    process.env.CRON_SECRET ? 'SET' : 'NOT SET'
-  );
-  console.log('🔍 Debug - Is Vercel cron:', isVercelCron);
-  console.log('🔍 Debug - Is URL secret valid:', isUrlSecret);
+  const isUrlSecret =
+    Boolean(expected) && searchParams.get('secret') === expected;
 
   if (!isVercelCron && !isUrlSecret) {
     return new NextResponse('Unauthorized', { status: 401 });


### PR DESCRIPTION
## What

Two cron auth paths were writing `CRON_SECRET` into Vercel's runtime logs on every invocation, and both would authorize an attacker if the env var were ever unset.

Found while debugging an unrelated Auth.js outage — the secret was sitting in plaintext in the log stream.

## The leak

Vercel Cron authenticates by sending `Authorization: Bearer <CRON_SECRET>`. Both handlers logged that header raw:

- `app/api/cron/update-cameras/lib/auth.ts:17`
- `app/api/cron/update-youtube/route.ts:79`

`update-cameras` additionally logged `process.env.CRON_SECRET` verbatim (`:21`).

Exposure is worse than the `*/15` cron schedule implies: `/api/kiosk/tick` re-invokes the cron handler in-process with the same bearer token, so **every gallery kiosk screen triggered a leak up to once a minute**.

## The auth bug

Both compared against:

```ts
authHeader === `Bearer ${process.env.CRON_SECRET}`
```

With `CRON_SECRET` unset that template collapses to the literal `"Bearer undefined"` — anyone sending that header authenticates. Both now fail closed on an unset or empty secret, matching the guard already present in `admin/claim-codes/route.ts:9` and `cameras/provision/route.ts:10`.

## Tests

New `auth.test.ts` — 6 tests. The two regression cases fail on `main` and pass here:

- rejects `"Bearer undefined"` when `CRON_SECRET` is unset
- never writes the secret to console (spies on `log`/`warn`/`error`)

Plus happy paths: valid bearer, valid `?secret=`, wrong-secret rejection, empty-string rejection.

## Verification

- `vitest run app/api/cron app/api/kiosk app/api/cameras app/api/admin` — 424 passed
- `eslint` on changed files — clean
- `tsc --noEmit` — 89 errors, identical count on `main`; none in changed files

## ⚠️ Required follow-up

**Merging this does not close the exposure.** The old secret is already in the logs and must be rotated *after* this deploys — rotating first just re-leaks the new value on the next tick.

No external coordination needed: every consumer reads `process.env.CRON_SECRET` at runtime, Vercel injects the cron header itself, and there are no hardcoded copies in the repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DkZxY3TasGn3oE467kgEqU