### PR TITLE
fix(hard-examples): stop the paging tests starving the suite

### DIFF
--- a/app/components/HardExamples/HardExamplesQueue.test.tsx
+++ b/app/components/HardExamples/HardExamplesQueue.test.tsx
@@ -206,8 +206,13 @@ describe('HardExamplesQueue counts bar', () => {
   });
 });
 
-// A full-size page, so the component's prefetch-near-the-end path actually runs.
-const BATCH = 120;
+// A full page as far as the component is concerned, so the prefetch-near-the-end
+// path actually runs — but small, and passed in as `batchSize`. The boundary
+// logic is the same at 10 as at the production 120; the only difference is that
+// reaching it costs 8 ratings instead of 118. At 118 each of these tests did
+// ~0.5s of real renders and POSTs, which stretched past the 5s timeout when the
+// rest of the suite was competing for CPU.
+const BATCH = 10;
 const makePage = (prefix: string, n = BATCH) =>
   Array.from({ length: n }, (_, i) => ({
     id: `${prefix}-${i}`,
@@ -255,15 +260,15 @@ describe('HardExamplesQueue pagination', () => {
     const { fn, calls } = pagingFetch();
     vi.stubGlobal('fetch', fn);
     const user = userEvent.setup();
-    render(<HardExamplesQueue />);
+    render(<HardExamplesQueue batchSize={BATCH} />);
     await waitFor(() => expect(calls.length).toBe(1));
 
-    // Rate 116 and skip 2 — the cursor lands two from the end and trips the
+    // Rate 6 and skip 2 — the cursor lands two from the end and trips the
     // prefetch. Labeled frames leave the server's unlabeled set, so four of the
-    // 120 loaded frames are still in it: the 2 skipped and the 2 not yet
-    // reached. Paging by the loaded length (offset 120) would jump the 116
+    // 10 loaded frames are still in it: the 2 skipped and the 2 not yet
+    // reached. Paging by the loaded length (offset 10) would jump the 6
     // unseen frames that took the labeled ones' place.
-    await user.keyboard('4'.repeat(116));
+    await user.keyboard('4'.repeat(BATCH - 4));
     await user.keyboard('  ');
 
     await waitFor(() => expect(calls.length).toBe(2));
@@ -301,16 +306,16 @@ describe('HardExamplesQueue pagination', () => {
       }),
     );
     const user = userEvent.setup();
-    render(<HardExamplesQueue />);
+    render(<HardExamplesQueue batchSize={BATCH} />);
     await waitFor(() => expect(calls.length).toBe(1));
 
-    await user.keyboard('4'.repeat(118)); // trips the prefetch at frame 118
+    await user.keyboard('4'.repeat(BATCH - 2)); // trips the prefetch at frame 8
     await waitFor(() => expect(calls.length).toBe(2));
 
-    // Frames 118 and 119 close out page one; frame 120 must be next. Paging by
-    // the loaded length lands on frame 238 here and loses the 118 in between.
+    // Frames 8 and 9 close out page one; frame 10 must be next. Paging by the
+    // loaded length lands on frame 18 here and loses the 8 in between.
     await user.keyboard('4'.repeat(2));
-    await waitFor(() => expect(screen.getByText('pool frame 120')).toBeTruthy());
+    await waitFor(() => expect(screen.getByText('pool frame 10')).toBeTruthy());
   });
 
   it('stops paging once the server returns a short page', async () => {
@@ -330,7 +335,7 @@ describe('HardExamplesQueue pagination', () => {
       }),
     );
     const user = userEvent.setup();
-    render(<HardExamplesQueue />);
+    render(<HardExamplesQueue batchSize={BATCH} />);
     await waitFor(() => expect(calls.length).toBe(1));
 
     // A page shorter than BATCH means the queue is drained; running off the end
@@ -362,7 +367,7 @@ describe('HardExamplesQueue rapid rating', () => {
         } as Response;
       }),
     );
-    render(<HardExamplesQueue />);
+    render(<HardExamplesQueue batchSize={BATCH} />);
     await waitFor(() => expect(screen.getByText('burst frame 0')).toBeTruthy());
 
     // Five keydowns in one tick — the worst case a blocked main thread can

--- a/app/components/HardExamples/HardExamplesQueue.tsx
+++ b/app/components/HardExamples/HardExamplesQueue.tsx
@@ -125,8 +125,13 @@ const Badge = ({ p, small }: { p: Provenance; small?: boolean }) => (
 
 export function HardExamplesQueue({
   hotkeysEnabled = true,
+  // Page size. Overridable so the paging tests can reach the prefetch boundary
+  // in a handful of ratings instead of 118 — at the default they took ~0.5s of
+  // real renders each, which flaked against the 5s timeout under suite load.
+  batchSize = BATCH,
 }: {
   hotkeysEnabled?: boolean;
+  batchSize?: number;
 }) {
   const [blind, setBlind] = useState(true);
   const [view, setView] = useState<'queue' | 'grid'>('queue');
@@ -181,7 +186,7 @@ export function HardExamplesQueue({
       try {
         const srcParam = source === 'all' ? '' : `&source=${source}`;
         const r = await fetch(
-          `/api/snapshots?mode=verification&disagreements_only=true&limit=${BATCH}&offset=${offset}${srcParam}`,
+          `/api/snapshots?mode=verification&disagreements_only=true&limit=${batchSize}&offset=${offset}${srcParam}`,
         );
         if (!r.ok)
           throw new Error(
@@ -199,14 +204,14 @@ export function HardExamplesQueue({
           labeledRef.current = new Set();
           loadedRef.current = new Set(incoming.map(keyOf));
           setFrames(incoming);
-          setExhausted(incoming.length < BATCH);
+          setExhausted(incoming.length < batchSize);
         } else {
           const fresh = incoming.filter((s) => !loadedRef.current.has(keyOf(s)));
           fresh.forEach((s) => loadedRef.current.add(keyOf(s)));
           if (fresh.length) setFrames([...snapshotsRef.current, ...fresh]);
           // A page that adds nothing new would otherwise re-trip the prefetch
           // effect forever, so treat it as the end of the queue too.
-          setExhausted(incoming.length < BATCH || fresh.length === 0);
+          setExhausted(incoming.length < batchSize || fresh.length === 0);
         }
       } catch (e) {
         setError(e instanceof Error ? e.message : 'Failed to load');
@@ -215,7 +220,7 @@ export function HardExamplesQueue({
         setLoading(false);
       }
     },
-    [source, setFrames],
+    [source, setFrames, batchSize],
   );
 
   useEffect(() => {

--- a/app/components/ModelAnalysis/GlossaryTerm.test.tsx
+++ b/app/components/ModelAnalysis/GlossaryTerm.test.tsx
@@ -23,7 +23,12 @@ describe('GlossaryTerm', () => {
     const user = userEvent.setup();
     render(<GlossaryTerm slug="val_f1">F1</GlossaryTerm>);
     await user.tab();
-    expect(await screen.findByText(/precision \+ recall/i)).toBeInTheDocument();
+    // The tooltip has a real 200ms enterDelay, so this wait has a hard floor
+    // rather than resolving on the next tick. findBy's 1000ms default left only
+    // ~4x headroom, the tightest margin in this directory; be explicit instead.
+    expect(
+      await screen.findByText(/precision \+ recall/i, {}, { timeout: 5000 }),
+    ).toBeInTheDocument();
   });
 
   it('renders an info icon next to the label when withIcon is true', () => {


### PR DESCRIPTION
## Why

A full-suite run failed 4 tests while every file passed in isolation, and three
consecutive runs failed three *different* sets of tests. That makes a red suite
uninformative — you can't tell a real regression from noise.

## Root cause

**The HardExamplesQueue paging tests were the load source.** They had to rate
118 frames to reach the prefetch boundary at the default `BATCH`, which is
~0.5s of real renders each. Under parallel suite load that blew the 5s timeout
— and starved the other workers badly enough to time out unrelated files.

That is why the failing set kept moving: `ModelAnalysisTab` and
`ModelLeaderboard` were collateral, not independently flaky.

## What changed

**`HardExamplesQueue`** takes an optional `batchSize` prop defaulting to
`BATCH`, so the paging tests reach the prefetch boundary in a handful of
ratings instead of 118. It is a test seam, but the default preserves runtime
behavior exactly — every production call site is unchanged.

**`GlossaryTerm`** waits explicitly. The tooltip has a real 200ms `enterDelay`,
so that assertion has a hard floor rather than resolving on the next tick;
`findBy`'s 1000ms default left only ~4x headroom, the tightest margin in the
directory.

## Verification

| Run | Result |
|---|---|
| main, full suite | 4 files failed (HardExamplesQueue, GlossaryTerm, ModelAnalysisTab, ModelLeaderboard) |
| main, files in isolation | pass |
| **this branch, full suite** | **139 files / 760 tests green** |

The two untouched files now pass too, which is the evidence for the
load-starvation diagnosis.

One green run does not prove a flake is gone. The reason for confidence is the
mechanism: the change removes the CPU hog that was causing the timeouts.

## Note

Authored in a parallel session. It landed here because a broad `git add` in a
concurrent kiosk session swept these files into that branch; they were split
back out onto their own branch off main so the fix is reviewable on its own.
Happy for the authoring session to rewrite this description.
