### PR TITLE
fix(deploy): .vercelignore whitelist still pointed at v4 — v5 models never uploaded

### DIFF
--- a/.vercelignore
+++ b/.vercelignore
@@ -31,16 +31,17 @@ coverage
 # ---------------------------------------------------------------------------
 # ML artifacts — the reason this file exists.
 #
-# ml/ is 2.1 GB on disk but the build only needs the two v4 ONNX models that
-# next.config.ts pins via outputFileTracingIncludes (86 MB total). Everything
+# ml/ is 2.1 GB on disk but the build only needs the shipping ONNX pair that
+# next.config.ts pins via outputFileTracingIncludes (~90 MB total). Everything
 # else is training-time data that has no business in a deploy upload.
 #
 # Do NOT collapse this to a blanket `ml/artifacts/models/` exclude: gitignore
 # semantics can't re-include a path underneath an excluded directory, so the
-# `dir/*` + `!dir/keep` shape below is load-bearing. If the models move, update
-# next.config.ts and these four lines together — next.config.test.ts guards the
-# config side, but nothing guards this file, and a missing model degrades
-# silently to the baseline heuristic instead of failing the build.
+# `dir/*` + `!dir/keep` shape below is load-bearing. When the shipping pair
+# changes, update masterConfig, next.config.ts AND these four lines together —
+# next.config.test.ts now guards all three against masterConfig (a stale
+# whitelist here shipped a model-less bundle on 2026-08-30: tracing can only
+# include files that survived this upload gate).
 # ---------------------------------------------------------------------------
 ml/.venv
 ml/artifacts/image_cache
@@ -53,10 +54,10 @@ ml/artifacts/datasets
 ml/artifacts/datasets_regression
 
 ml/artifacts/models/regression_resnet18/*
-!ml/artifacts/models/regression_resnet18/20260513_113243_v4_regression_llm_with_flickr
+!ml/artifacts/models/regression_resnet18/20260830_003808_v5_quality_sunsets_only
 
 ml/artifacts/models/binary_resnet18/*
-!ml/artifacts/models/binary_resnet18/20260601_063518_v4_binary_llm_with_flickr
+!ml/artifacts/models/binary_resnet18/20260829_062437_v5_binary_gold
 
 # ---------------------------------------------------------------------------
 # Docs / scratch — not needed to build or serve

--- a/next.config.test.ts
+++ b/next.config.test.ts
@@ -69,6 +69,34 @@ describe('next.config outputFileTracingIncludes (bundle-size guard)', () => {
     }
   });
 
+  it('re-includes exactly the shipping pair in .vercelignore (the upload gate tracing depends on)', () => {
+    // .vercelignore excludes ml/artifacts/models/<type>/* and re-includes
+    // pinned version dirs with `!` lines. outputFileTracingIncludes can only
+    // trace files that survived that gate — a stale whitelist ships a bundle
+    // with no model and scoring dies at runtime (2026-08-30 deploy).
+    const lines = fs
+      .readFileSync('.vercelignore', 'utf8')
+      .split('\n')
+      .map((l) => l.trim());
+    const unignored = new Set(
+      lines
+        .filter((l) => l.startsWith('!ml/artifacts/models/'))
+        .map((l) => l.slice(1).replace(/\/$/, '')),
+    );
+    for (const dir of SHIPPING_DIRS) {
+      expect(
+        unignored.has(dir),
+        `.vercelignore does not re-include shipping dir: !${dir}`,
+      ).toBe(true);
+    }
+    for (const dir of unignored) {
+      expect(
+        SHIPPING_DIRS.has(dir),
+        `.vercelignore re-includes a non-shipping model dir: !${dir}`,
+      ).toBe(true);
+    }
+  });
+
   it('keeps total bundled model weight under the size budget', () => {
     const seen = new Set<string>();
     let total = 0;


### PR DESCRIPTION
The #81 deploy shipped a model-less bundle. `outputFileTracingIncludes` pinned the v5 dirs, but `.vercelignore`'s `!` re-include lines still named the **v4** dirs — and tracing can only include files that survived the upload gate. Evidence: yesterday's prod build bundled `ml/artifacts/models: 85.26 MB` (163.53 MB functions); the #81 build bundled none (78.28 MB), and the 04:45 UTC cron tick logged `Load model .../20260830_003808_v5_quality_sunsets_only/model.onnx failed. File doesn't exist`.

- `.vercelignore`: whitelist the v5 shipping pair instead of v4
- `next.config.test.ts`: new guard parses `.vercelignore` and asserts its re-includes are exactly the masterConfig shipping dirs — the file's old comment literally said "nothing guards this file"; now something does

After merge: verify `/api/debug/scoring-smoke` (latency 100–500 ms, both v5 tags, fallbacks ~0) and that the next cron tick writes `ai_model_version_*` = the v5 tags.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EAycWVMJcD7hEvL6k59RMd