### PR TITLE
docs: v5 deploy verified — .vercelignore trap + secret-less verification

### DIFF
--- a/docs/ml-deploy-runbook.md
+++ b/docs/ml-deploy-runbook.md
@@ -177,6 +177,9 @@ jq -r '.files[] | select(test("model.onnx"))' \
 
 If that prints model.onnx paths, your include is working. If empty, the route-key format is wrong.
 
+**Even a correct include can ship nothing** — tracing only sees files that
+survived the `.vercelignore` upload gate. See Trap 6.
+
 See `memory/feedback_vercel_nextjs_ml_bundling.md`.
 
 ### Trap 4: Bundle size approaches 250 MB
@@ -199,20 +202,65 @@ See `memory/feedback_vercel_nextjs_ml_bundling.md`.
    Saves ~86 MB. The `.pt` checkpoints remain for rollback via re-export.
 2. If still over, revisit the `outputFileTracingExcludes` in `next.config.ts` for onnxruntime-node — the existing excludes drop ~350 MB of unused platform binaries; if a newer version adds more, extend the list.
 
-### Trap 5: `CRON_SECRET` is wrong / unset between shells
+### Trap 5: `CRON_SECRET` cannot be pulled — it's a Sensitive env var
 
 **Symptom:** Smoke endpoint returns HTTP 401 plain text → `jq: parse error`.
+`vercel env pull` "succeeds" but writes `CRON_SECRET=""` — the variable is
+stored as **Sensitive** in Vercel, which means *nobody* can read it back, not
+the dashboard, not the CLI. An old `.env.production.local` may hold a stale
+pre-rotation value that also 401s (discovered 2026-08-30).
 
-**Fix:**
-```bash
-echo "len: ${#CRON_SECRET}"   # should be 23
-# if not 23, re-pull from Vercel
-npx vercel env pull --environment=production .env.production.tmp
-export CRON_SECRET=$(grep ^CRON_SECRET .env.production.tmp | cut -d= -f2- | tr -d '"')
-rm .env.production.tmp
+**Where real copies live:** the kiosk Pi's launch script
+(`ssh pi@sunsetdisplay`, URL has `secret=...`) — that's it. If the Pi is
+unreachable, you cannot recover the secret; you can only replace it
+(new value in Vercel **plus** redeploy — env vars bake in — plus updating the
+kiosk URL).
+
+**Don't block a deploy verification on it.** The DB gives stronger evidence
+than the smoke endpoint anyway — see "Verify without the secret" below.
+
+### Trap 6: `.vercelignore` whitelists model dirs BY VERSION — tracing can't include what was never uploaded
+
+**Symptom (2026-08-30, cost the v5 deploy):** build succeeds, functions come
+out ~78 MB instead of ~163 MB, every cron tick logs
+`Load model ... File doesn't exist`, frames are left unscored. The
+`outputFileTracingIncludes` entries are *correct*.
+
+**Why:** `.vercelignore` excludes `ml/artifacts/models/<type>/*` and
+re-includes pinned version dirs via `!` lines. Those lines name versions
+explicitly, so a model bump that updates `masterConfig` and `next.config.ts`
+but not `.vercelignore` strips the new ONNX from the upload before the
+tracer ever runs.
+
+**Fix:** a version bump touches **three** files together: `masterConfig`
+defaults, `next.config.ts` tracing includes, and the `.vercelignore` `!`
+lines. Since PR #83, `next.config.test.ts` derives all three checks from
+masterConfig and fails the build on drift.
+
+**Diagnosis signature:** `vercel inspect <deploy-url> --logs`, find
+"Serverless function size info". Healthy: `ml/artifacts/models: ~85 MB`
+listed as a contributor, functions ~163 MB. Broken: models absent, functions
+~78 MB.
+
+### Verify without the secret (DB model-version stamps)
+
+The live cron stamps `ai_model_version` / `ai_model_version_binary` on the
+**`webcams`** table (`webcam_snapshots` only gets rows conditionally), and
+the unscored path deliberately writes nothing — so fresh rows carrying the
+new tags are proof of real ONNX output, independent of the smoke endpoint:
+
+```sql
+SELECT ai_model_version, ai_model_version_binary, count(*),
+       max(updated_at)
+FROM webcams
+WHERE updated_at > now() - interval '20 minutes'
+GROUP BY 1, 2;
 ```
 
-If `len: 23` and STILL 401, the secret got rotated on Vercel — the env pull above already grabbed the new value, just retry.
+Cron runs `*/15`, so within ~18 minutes of a deploy going Ready you should
+see a batch stamped with both shipping tags. (Run it via a one-off script
+that reads `DATABASE_URL` from `.env.local`, like `scripts/usage-report.mjs`
+does.)
 
 ---
 

--- a/docs/superpowers/plans/2026-08-29-two-scale-model-STATE.md
+++ b/docs/superpowers/plans/2026-08-29-two-scale-model-STATE.md
@@ -288,7 +288,35 @@ Once the 200 are rated, that unblocks all three of the open questions above.
 
 ### Workstream 3 — Map display integration (product thread)
 
-**CODE COMPLETE on the branch (2026-08-30), awaiting deploy.** What changed:
+**DEPLOYED & VERIFIED in production, 2026-08-30 (~05:00 UTC).** The shipping
+pair is live: within 3 minutes of the deploy going Ready, one cron tick
+stamped 43 webcams with `20260829_062437_v5_binary_gold` +
+`20260830_003808_v5_quality_sunsets_only` on the `webcams` table — and since
+the unscored path writes no version strings, those stamps are proof of real
+ONNX output. Build bundled `ml/artifacts/models: 85.26 MB` (functions
+163.5 MB).
+
+**The deploy failed once first — the `.vercelignore` trap.** PR #81's bundle
+shipped model-less (78 MB functions): `.vercelignore` re-includes model dirs
+by explicit version (`!ml/artifacts/models/.../<version>`), and those lines
+still named the v4 dirs, so the v5 ONNX never reached the builder and
+tracing had nothing to include. Every tick logged `Load model ... File
+doesn't exist` and left frames unscored (fail-visible, as designed). Fixed
+by PR #83, which also extends `next.config.test.ts` to check the
+`.vercelignore` whitelist against masterConfig — a version bump now touches
+masterConfig + next.config.ts + .vercelignore or fails tests. Full story:
+`docs/ml-deploy-runbook.md` Trap 6.
+
+Two loose ends:
+- **Smoke-endpoint latency check still pending.** `CRON_SECRET` is Sensitive
+  in Vercel (unpullable — `env pull` writes `""`); the only recoverable copy
+  is in the kiosk Pi's launch script and the Pi was unreachable over
+  Tailscale on 2026-08-30. Not blocking — the DB stamps are stronger
+  evidence (runbook: "Verify without the secret").
+- **Confirm the 0.55 gate on `random_ordinary_v2`** (300 frames, drawn,
+  awaiting rating) before trusting it long-term.
+
+What the branch changed (context for the above):
 `imagePreprocess.ts` now matches training exactly (no ImageNet normalize —
 AND `fit:'fill'` squash instead of `'cover'` center-crop, a second silent
 mismatch found during the fix); masterConfig defaults pin the shipping pair
@@ -299,21 +327,18 @@ through the real `scoreImage` path on two eval frames (negative:
 p=0.0000/quality 0.26; operator-4: p=1.0000/quality 0.73 → aiRating 3.91),
 against the Python reference. 777 tests + production build pass.
 
-**To ship (Jesse):** (1) remove the v4 env overrides in Vercel — else they
-silently beat the new defaults: `AI_ONNX_BINARY_MODEL_PATH`,
-`AI_ONNX_REGRESSION_MODEL_PATH`, `AI_BINARY_MODEL_VERSION`,
-`AI_REGRESSION_MODEL_VERSION`, and `AI_BINARY_SUNSET_THRESHOLD` if set; keep
-`AI_BINARY_SCORING_ENABLED=true`. (2) merge the PR → deploy. (3) verify via
-`/api/debug/scoring-smoke`: `latencyMs` 100–500 ms, `modelVersion` strings =
-the two shipping tags, fallbacks ~0. Confirm the 0.55 gate on the v2 sample
-rating before trusting it long-term.
+Ship steps all done 2026-08-30: v4 env overrides removed before the deploy
+(`AI_BINARY_SUNSET_THRESHOLD` was never set; `AI_BINARY_SCORING_ENABLED=true`
+kept), PR #81 merged, PR #83 fixed the `.vercelignore` gap, verification via
+DB stamps as described above.
 
-
-Blocked on Workstream 1 producing a model worth shipping. Scope:
+Remaining scope (the model itself is now live):
 
 - Tile sizing driven by the quality head; six categories addressable.
-- **`AI_BINARY_SUNSET_THRESHOLD` must be re-derived** — currently 0.5, tuned for
-  v4's quality-threshold head, whose meaning has changed.
+- ~~`AI_BINARY_SUNSET_THRESHOLD` must be re-derived~~ **Done** — shipped as
+  `AI_BINARY_DECISION_THRESHOLD = 0.55` in masterConfig defaults (corrected
+  sweep: prec 0.891 / rec 0.774, F1 plateau 0.45–0.70). Confirm on the v2
+  sample.
 - **If the quality head ships as sunsets-only, the output contract changes.**
   `normalizeOnnxOutput` / `ratingFromRaw` in `app/lib/aiScoring.ts` and
   `customBackfill.ts` assume one five-level scale over all frames. Two heads


### PR DESCRIPTION
Session close-out for the v5 deploy (PRs #81/#83).

- **STATE doc, Workstream 3** → deployed & verified 2026-08-30: DB model-version stamps proved both v5 tags live within one cron tick; the .vercelignore incident and its new test guard; loose ends (smoke latency pending kiosk Pi reachability, 0.55 gate confirmation on `random_ordinary_v2`).
- **ml-deploy-runbook**: Trap 5 rewritten — `CRON_SECRET` is Sensitive in Vercel, `env pull` writes `""`, the kiosk Pi holds the only recoverable copy. New Trap 6 — `.vercelignore` re-includes model dirs by version, upstream of `outputFileTracingIncludes`. New section: verifying a deploy via `webcams`-table model-version stamps when the secret is unavailable.

Docs only, no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EAycWVMJcD7hEvL6k59RMd