### PR TITLE
fix(map): compose the two-scale signal — detection gates, quality sizes

### DIFF
--- a/app/lib/qualitySignal.test.ts
+++ b/app/lib/qualitySignal.test.ts
@@ -4,12 +4,47 @@ import type { WindyWebcam } from './types';
 
 const base = { webcamId: 1, viewCount: 0, location: { latitude: 0, longitude: 0 } } as WindyWebcam;
 
-describe('getQualityScore', () => {
-  it('returns aiRatingRegression when present', () => {
+// aiRatingBinary is the detection probability mapped to 1-5 (1 + p*4), so
+// the 0.55 gate sits at 3.2 on that scale.
+const SHOWN = 3.3; // p = 0.575, above the gate
+const REJECTED = 1.1; // p = 0.025, well below the gate
+
+describe('getQualityScore (composed two-scale signal)', () => {
+  it('returns the quality rating when detection says sunset', () => {
+    expect(
+      getQualityScore({ ...base, aiRatingBinary: SHOWN, aiRatingRegression: 3.7 })
+    ).toBe(3.7);
+  });
+
+  it('floors the score when detection rejects the frame', () => {
+    // The v6 quality head is sunsets-only trained: its output on a
+    // non-sunset frame is undefined. Whatever it says, a rejected frame
+    // renders minimal (floor of the 1-5 scale), never mid-pack.
+    expect(
+      getQualityScore({ ...base, aiRatingBinary: REJECTED, aiRatingRegression: 4.2 })
+    ).toBe(1);
+  });
+
+  it('is exactly the gate-inclusive boundary at 0.55', () => {
+    const atGate = 1 + 0.55 * 4; // 3.2
+    expect(
+      getQualityScore({ ...base, aiRatingBinary: atGate, aiRatingRegression: 2.5 })
+    ).toBe(2.5);
+  });
+
+  it('falls back to quality alone when the binary head has not scored', () => {
+    // Cams scored before the binary head shipped (or fail-visible skips)
+    // keep the old single-head behavior rather than being floored.
     expect(getQualityScore({ ...base, aiRatingRegression: 3.7 })).toBe(3.7);
   });
+
   it('returns null when no regression score (legacy aiRating is NOT used)', () => {
     expect(getQualityScore({ ...base, aiRating: 4.5 } as WindyWebcam)).toBeNull();
     expect(getQualityScore(base)).toBeNull();
+  });
+
+  it('a rejected frame with no quality score is still floored, not null', () => {
+    // Detection alone is enough to know the tile should be minimal.
+    expect(getQualityScore({ ...base, aiRatingBinary: REJECTED })).toBe(1);
   });
 });

--- a/app/lib/qualitySignal.ts
+++ b/app/lib/qualitySignal.ts
@@ -1,10 +1,29 @@
+import { AI_BINARY_DECISION_THRESHOLD } from './masterConfig';
 import type { WindyWebcam } from './types';
+
+// The detection gate expressed on the 1-5 rating scale that
+// aiScoring.ts stores (rating = 1 + probability * 4).
+const GATE_AS_RATING = 1 + AI_BINARY_DECISION_THRESHOLD * 4;
 
 /**
  * THE quality signal. The single place that decides which model's score
- * drives composition sizing. Today: the live v4 ONNX regression (1–5).
- * When a newer model ships, change this file and every surface follows.
+ * drives composition sizing.
+ *
+ * Since the v6 warm-started pair this is the COMPOSED two-scale signal:
+ * the detection head decides whether the frame counts as a sunset, the
+ * quality head sizes it. The quality head is sunsets-only trained, so its
+ * output on a frame detection rejects is undefined - ranking by it alone
+ * let night frames outrank real mid-grade sunsets. A rejected frame
+ * floors to 1 (minimal tile, still shown - product intent is "show every
+ * image, just small", never hidden).
+ *
+ * Cams without a binary score (scored before the binary head shipped, or
+ * a fail-visible skip) keep the single-head behavior.
  */
 export function getQualityScore(webcam: WindyWebcam): number | null {
+  const detection = webcam.aiRatingBinary;
+  if (typeof detection === 'number' && detection < GATE_AS_RATING) {
+    return 1;
+  }
   return webcam.aiRatingRegression ?? null;
 }


### PR DESCRIPTION
Fixes the tile-scaling gap Jesse spotted after the v6 deploy — the one the STATE doc predicted ("two heads composing is a different shape").

**Symptom:** tiles not scaling sensibly — non-sunset frames sized mid-pack or large.

**Cause:** `getQualityScore` (the single sizing signal for GeoMosaic) read only `aiRatingRegression`. The v6 quality head is sunsets-only trained, so its output on detection-rejected frames is undefined garbage, and percentile ranking put those frames anywhere.

**Fix:** compose in the one place built for it: below the 0.55 detection gate the score floors to 1 (minimal tile, still shown — the below-gate-renders-minimal design note from STATE); at/above the gate the quality head sizes as before; cams with no binary score keep the old behavior. TDD'd; 782 tests pass.

After merge + auto-deploy, the map should re-rank on the next render (scores are already in the DB; this is client-side composition).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NrXD5WLywFCjei3TLY18KU