### PR TITLE
feat(ml): point the Random sample queue at random_ordinary_v3

### DIFF
--- a/app/components/HardExamples/HardExamplesQueue.tsx
+++ b/app/components/HardExamples/HardExamplesQueue.tsx
@@ -37,8 +37,10 @@ type SampleProgress = { name: string; size: number; labeled: number };
 // The ACTIVE pre-drawn random sample of ordinary frames — the unbiased eval
 // set, quarantined from all training. Bump this to the newest sample loaded by
 // `ml/load_label_sample.py --sample-name`; completed samples (v1: 200/200 on
-// 2026-08-29) stay in label_samples and keep their labels' origin stamp.
-const SAMPLE_NAME = 'random_ordinary_v2';
+// 2026-08-29, v2: 300/300 on 2026-08-30) stay in label_samples and keep their
+// labels' origin stamp. v3 (200 frames, seed 20260831) additionally excludes
+// the 3 cameras that entered v6 training after the holdout pool was built.
+const SAMPLE_NAME = 'random_ordinary_v3';
 
 const BATCH = 120;
 const SIDE = 2; // thumbs each side (symmetric)


### PR DESCRIPTION
Loads the third operator eval draw (200 frames / 141 cameras, seed 20260831, already in `label_samples` and auto-quarantined from training) and points the queue's **Random sample** toggle at it. The draw excludes the 3 cameras that entered v6 training after the holdout pool was built.

After merge: open Hard Examples → flip to **Random sample** → rate the 200 (about one sitting). That unlocks the v6 confirmation numbers and a legitimate gate re-derivation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NrXD5WLywFCjei3TLY18KU