### PR TITLE
feat(console): show each model head's judgment; remove manual per-webcam rating

### DIFF
--- a/app/components/WebcamConsole.tsx
+++ b/app/components/WebcamConsole.tsx
@@ -4,7 +4,64 @@ import Image from 'next/image';
 import { useState } from 'react';
 import type { WindyWebcam, Orientation } from '@/app/lib/types';
 import { useAllWebcamsStore } from '@/app/store/useAllWebcamsStore';
+import {
+  detectionReadout,
+  qualityReadout,
+  shortModelName,
+} from '@/app/lib/modelReadout';
 import StarRating from './console/StarRating';
+
+/**
+ * What the two model heads said about this cam, stated separately —
+ * detection (is a sunset happening?) and quality (how good is it?).
+ * Manual per-webcam rating controls were removed 2026-08-30: frame labels
+ * come from the Hard Examples / Random sample queues now, and this console
+ * reports the models' own judgments instead.
+ */
+function ModelReadout({ webcam }: { webcam: WindyWebcam }) {
+  const detection = detectionReadout(webcam);
+  const quality = qualityReadout(webcam);
+  const detectionModel = shortModelName(webcam.aiModelVersionBinary);
+  const qualityModel = shortModelName(webcam.aiModelVersionRegression);
+
+  return (
+    <div className="mt-1">
+      <p className="webcam-console-details">
+        Detection{detectionModel ? ` (${detectionModel})` : ''}:{' '}
+        {detection ? (
+          <span
+            className={
+              detection.verdict === 'sunset'
+                ? 'font-semibold text-orange-600'
+                : 'text-gray-500'
+            }
+          >
+            {detection.verdict} · {Math.round(detection.probability * 100)}%
+          </span>
+        ) : (
+          <span className="text-gray-400">not scored yet</span>
+        )}
+      </p>
+      <div className="webcam-console-details">
+        Quality{qualityModel ? ` (${qualityModel})` : ''}:{' '}
+        {quality !== null ? (
+          <>
+            <StarRating rating={quality} />
+            <span className="ml-1">{quality.toFixed(1)} / 5</span>
+            {detection && detection.verdict === 'not a sunset' && (
+              <span className="text-gray-400">
+                {' '}
+                (below gate — renders minimal)
+              </span>
+            )}
+          </>
+        ) : (
+          <span className="text-gray-400">not scored yet</span>
+        )}
+      </div>
+    </div>
+  );
+}
 
 export function WebcamConsole({
   webcams,
@@ -13,29 +70,10 @@ export function WebcamConsole({
   webcams: WindyWebcam[];
   title: string;
 }) {
-  const setRating = useAllWebcamsStore((s) => s.setRating);
   const setOrientation = useAllWebcamsStore((s) => s.setOrientation);
   const [updatingWebcams, setUpdatingWebcams] = useState<Set<number>>(
     new Set()
   );
-
-  const handleRatingChange = async (
-    webcamId: number,
-    rating: number
-  ) => {
-    setUpdatingWebcams((prev) => new Set(prev).add(webcamId));
-    try {
-      await setRating(webcamId, rating);
-    } catch (error) {
-      console.error('Failed to update rating:', error);
-    } finally {
-      setUpdatingWebcams((prev) => {
-        const newSet = new Set(prev);
-        newSet.delete(webcamId);
-        return newSet;
-      });
-    }
-  };
 
   const handleOrientationChange = async (
     webcamId: number,
@@ -121,45 +159,8 @@ export function WebcamConsole({
                 ID: {webcam.webcamId}
               </p>
 
-              {/* Rating */}
-              <div className="webcam-console-details">
-                Saved Rating:{' '}
-                {<StarRating rating={webcam.rating ?? 0} />}
-              </div>
-
-              {/* Rating Controls */}
-              <div className="rating-controls">
-                <label className="webcam-console-details">
-                  Set Rating:
-                </label>
-                <div className="flex gap-1">
-                  {[1, 2, 3, 4, 5].map((rating) => (
-                    <button
-                      key={rating}
-                      onClick={() =>
-                        handleRatingChange(webcam.webcamId, rating)
-                      }
-                      disabled={updatingWebcams.has(webcam.webcamId)}
-                      className={`rating-button ${
-                        webcam.rating === rating
-                          ? 'rating-button-active'
-                          : 'rating-button-inactive'
-                      } ${
-                        updatingWebcams.has(webcam.webcamId)
-                          ? 'rating-button-disabled'
-                          : ''
-                      }`}
-                    >
-                      {rating}
-                    </button>
-                  ))}
-                </div>
-              </div>
-
-              {/* Rating */}
-              <p className="webcam-console-details">
-                Orientation: {webcam.orientation}
-              </p>
+              {/* Model judgments — detection head + quality head */}
+              <ModelReadout webcam={webcam} />
 
               {/* Orientation Controls */}
               <div className="mt-2">

--- a/app/lib/modelReadout.test.ts
+++ b/app/lib/modelReadout.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest';
+import { detectionReadout, qualityReadout, shortModelName } from './modelReadout';
+import type { WindyWebcam } from './types';
+
+const base = { webcamId: 1, viewCount: 0, location: { latitude: 0, longitude: 0 } } as WindyWebcam;
+
+describe('detectionReadout', () => {
+  it('reads a confident sunset', () => {
+    // aiRatingBinary stores 1 + p*4, so 4.6 is p = 0.90.
+    expect(
+      detectionReadout({ ...base, aiRatingBinary: 4.6 })
+    ).toEqual({ verdict: 'sunset', probability: 0.9 });
+  });
+
+  it('reads a confident rejection', () => {
+    expect(
+      detectionReadout({ ...base, aiRatingBinary: 1.2 })
+    ).toEqual({ verdict: 'not a sunset', probability: 0.05 });
+  });
+
+  it('applies the production gate (0.55) at the boundary', () => {
+    expect(detectionReadout({ ...base, aiRatingBinary: 3.2 })?.verdict).toBe('sunset');
+    expect(detectionReadout({ ...base, aiRatingBinary: 3.1 })?.verdict).toBe(
+      'not a sunset'
+    );
+  });
+
+  it('returns null when the detection head has not scored this cam', () => {
+    expect(detectionReadout(base)).toBeNull();
+  });
+});
+
+describe('qualityReadout', () => {
+  it('passes the 1-5 rating through', () => {
+    expect(qualityReadout({ ...base, aiRatingRegression: 3.7 })).toBe(3.7);
+  });
+  it('returns null when unscored', () => {
+    expect(qualityReadout(base)).toBeNull();
+  });
+});
+
+describe('shortModelName', () => {
+  it('strips the timestamp prefix from a version stamp', () => {
+    expect(shortModelName('20260829_062437_v5_binary_gold')).toBe('v5_binary_gold');
+  });
+  it('leaves legacy names alone', () => {
+    expect(shortModelName('binary-v1')).toBe('binary-v1');
+    expect(shortModelName(undefined)).toBeNull();
+  });
+});

--- a/app/lib/modelReadout.ts
+++ b/app/lib/modelReadout.ts
@@ -1,0 +1,37 @@
+import { AI_BINARY_DECISION_THRESHOLD } from './masterConfig';
+import type { WindyWebcam } from './types';
+
+/**
+ * Human-readable readouts of what each model head said about a webcam,
+ * for surfaces that show the models' own judgments (the home console,
+ * the kiosk overlay) instead of a manual rating UI.
+ *
+ * Ratings are stored as 1 + value*4 (see aiScoring.ts), so the raw
+ * probability/quality is recovered with (rating - 1) / 4.
+ */
+
+export function detectionReadout(
+  webcam: WindyWebcam
+): { verdict: 'sunset' | 'not a sunset'; probability: number } | null {
+  const r = webcam.aiRatingBinary;
+  if (typeof r !== 'number') return null;
+  const probability = Math.round(((r - 1) / 4) * 100) / 100;
+  return {
+    verdict:
+      probability >= AI_BINARY_DECISION_THRESHOLD ? 'sunset' : 'not a sunset',
+    probability,
+  };
+}
+
+/** The quality head's 1-5 rating, or null when this cam is unscored. */
+export function qualityReadout(webcam: WindyWebcam): number | null {
+  return typeof webcam.aiRatingRegression === 'number'
+    ? webcam.aiRatingRegression
+    : null;
+}
+
+/** `20260829_062437_v5_binary_gold` -> `v5_binary_gold`; legacy names pass through. */
+export function shortModelName(version: string | undefined | null): string | null {
+  if (!version) return null;
+  return version.replace(/^\d{8}_\d{6}_/, '');
+}


### PR DESCRIPTION
Per Jesse's request: the home console's **Set Rating** buttons and **Saved Rating** stars are gone. Each card now states what the two models said, separately and labeled with the model that said it:

- **Detection** (`v5_binary_gold`): *sunset · 83%* or *not a sunset · 9%* — same 0.55 gate as the map
- **Quality** (`v5_quality_llm_backbone_finetune`): stars + *3.7 / 5*, with a note when the card is below the gate (renders minimal on the map)

Unscored cams say *not scored yet* instead of faking a value. Orientation controls remain (metadata, not rating). `app/lib/modelReadout.ts` is shared so the kiosk overlay (being built in the mosaic-versioning lane) shows identical readouts.

790 tests + production build pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NrXD5WLywFCjei3TLY18KU