### PR TITLE
Kiosk per-tile model-info overlay (?models=1)

### DIFF
--- a/app/components/mosaic/v1/GeoMosaic.tsx
+++ b/app/components/mosaic/v1/GeoMosaic.tsx
@@ -7,6 +7,7 @@ import { compose } from './engine/compose';
 import type { CompositionConfig } from './engine/types';
 import { useLoadedTiles } from './useLoadedTiles';
 import { SetupOverlay } from './SetupOverlay';
+import { ModelInfoOverlay } from './ModelInfoOverlay';
 
 interface HitRect {
   x: number;
@@ -22,6 +23,7 @@ export function GeoMosaic(props: {
   height: number;
   feed: 'sunrise' | 'sunset';
   setupMode?: boolean;
+  modelsMode?: boolean;
   onSelect?: (webcam: WindyWebcam) => void;
   config?: Partial<CompositionConfig>;
 }) {
@@ -31,6 +33,7 @@ export function GeoMosaic(props: {
     height,
     feed,
     setupMode = false,
+    modelsMode = false,
     onSelect,
     config,
   } = props;
@@ -134,6 +137,7 @@ export function GeoMosaic(props: {
       {setupMode && (
         <SetupOverlay layout={layout} feed={feed} skipped={skipped} />
       )}
+      {modelsMode && <ModelInfoOverlay layout={layout} byId={byId} />}
     </div>
   );
 }

--- a/app/components/mosaic/v1/ModelInfoOverlay.test.tsx
+++ b/app/components/mosaic/v1/ModelInfoOverlay.test.tsx
@@ -1,0 +1,101 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { ModelInfoOverlay } from './ModelInfoOverlay';
+import type { Layout } from './engine/types';
+import type { WindyWebcam } from '@/app/lib/types';
+
+// Stored ratings are 1 + probability*4 (aiScoring.ts), so:
+//   binary 4.32 -> p 0.83 (sunset at the 0.55 gate)
+//   binary 1.36 -> p 0.09 (not a sunset)
+function cam(id: number, overrides: Partial<WindyWebcam>): WindyWebcam {
+  return {
+    webcamId: id,
+    viewCount: 0,
+    location: { latitude: 0, longitude: 0 },
+    ...overrides,
+  } as WindyWebcam;
+}
+
+function tile(id: number): Layout['tiles'][number] {
+  return {
+    id,
+    lat: 0,
+    lng: 0,
+    srcWidth: 400,
+    srcHeight: 224,
+    score: 3,
+    percentile: 0.5,
+    width: 178,
+    height: 100,
+    x: 0,
+    y: (id - 1) * 110,
+  };
+}
+
+function renderOverlay(webcams: WindyWebcam[]) {
+  const layout: Layout = {
+    tiles: webcams.map((w) => tile(w.webcamId as number)),
+    dropped: [],
+    viewport: { width: 1080, height: 1920 },
+  };
+  const byId = new Map(
+    webcams.map((w) => [
+      w.webcamId as number,
+      { img: {} as HTMLImageElement, webcam: w },
+    ])
+  );
+  return render(<ModelInfoOverlay layout={layout} byId={byId} />);
+}
+
+describe('ModelInfoOverlay', () => {
+  it('shows the detection verdict with its probability', () => {
+    renderOverlay([
+      cam(1, { aiRatingBinary: 4.32, aiRatingRegression: 3.7 }),
+    ]);
+    expect(screen.getByText(/sunset · 83%/)).toBeDefined();
+  });
+
+  it('shows a below-gate verdict as "not a sunset"', () => {
+    renderOverlay([
+      cam(1, { aiRatingBinary: 1.36, aiRatingRegression: 2.1 }),
+    ]);
+    expect(screen.getByText(/not a sunset · 9%/)).toBeDefined();
+  });
+
+  it('shows the quality rating out of 5', () => {
+    renderOverlay([
+      cam(1, { aiRatingBinary: 4.32, aiRatingRegression: 3.7 }),
+    ]);
+    expect(screen.getByText(/3\.7\/5/)).toBeDefined();
+  });
+
+  it('annotates the quality line when detection gated the tile minimal', () => {
+    renderOverlay([
+      cam(1, { aiRatingBinary: 1.36, aiRatingRegression: 2.1 }),
+    ]);
+    expect(screen.getByText(/2\.1\/5 · gated/)).toBeDefined();
+  });
+
+  it('shows "not scored" instead of faking values for unstamped cams', () => {
+    renderOverlay([cam(1, {})]);
+    expect(screen.getByText(/not scored/)).toBeDefined();
+  });
+
+  it('renders one chip per placed tile, keyed to that tile\'s webcam', () => {
+    renderOverlay([
+      cam(1, { aiRatingBinary: 4.32, aiRatingRegression: 3.7 }),
+      cam(2, { aiRatingBinary: 1.36, aiRatingRegression: 2.1 }),
+    ]);
+    expect(screen.getAllByTestId('model-chip')).toHaveLength(2);
+  });
+
+  it('skips tiles whose webcam is not in byId (image never resolved)', () => {
+    const layout: Layout = {
+      tiles: [tile(1)],
+      dropped: [],
+      viewport: { width: 1080, height: 1920 },
+    };
+    render(<ModelInfoOverlay layout={layout} byId={new Map()} />);
+    expect(screen.queryAllByTestId('model-chip')).toHaveLength(0);
+  });
+});

--- a/app/components/mosaic/v1/ModelInfoOverlay.tsx
+++ b/app/components/mosaic/v1/ModelInfoOverlay.tsx
@@ -1,0 +1,78 @@
+import type { WindyWebcam } from '@/app/lib/types';
+import { detectionReadout, qualityReadout } from '@/app/lib/modelReadout';
+import type { Layout } from './engine/types';
+
+/**
+ * Per-tile model-judgment chips (?models=1): what the detection head said
+ * (verdict + probability) and what the quality head rated. Read-only
+ * decoration over the composed layout — sizing already happened in the
+ * engine; a "gated" annotation marks tiles the detection gate floored to
+ * minimal. Same contract as SetupOverlay: absolutely positioned within a
+ * position:relative parent, never intercepts pointer events.
+ */
+export function ModelInfoOverlay({
+  layout,
+  byId,
+}: {
+  layout: Layout;
+  byId: Map<number, { img: HTMLImageElement; webcam: WindyWebcam }>;
+}) {
+  return (
+    <div style={{ position: 'absolute', inset: 0, pointerEvents: 'none' }}>
+      {layout.tiles.map((tile) => {
+        const entry = byId.get(tile.id);
+        if (!entry) return null;
+        return (
+          <div
+            key={tile.id}
+            data-testid="model-chip"
+            style={{
+              position: 'absolute',
+              left: tile.x + 3,
+              top: tile.y + tile.height - 3,
+              transform: 'translateY(-100%)',
+              maxWidth: tile.width - 6,
+              overflow: 'hidden',
+              color: '#fff',
+              fontFamily: 'monospace',
+              fontSize: 10,
+              lineHeight: 1.35,
+              whiteSpace: 'nowrap',
+              padding: '1px 4px',
+              borderRadius: 3,
+              background: 'rgba(0,0,0,0.55)',
+            }}
+          >
+            <ChipText webcam={entry.webcam} />
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+function ChipText({ webcam }: { webcam: WindyWebcam }) {
+  const detection = detectionReadout(webcam);
+  const quality = qualityReadout(webcam);
+
+  if (!detection && quality === null) {
+    return <div style={{ opacity: 0.6 }}>not scored</div>;
+  }
+
+  const gated = detection?.verdict === 'not a sunset';
+
+  return (
+    <>
+      {detection && (
+        <div style={{ opacity: gated ? 0.6 : 1 }}>
+          {`${detection.verdict} · ${Math.round(detection.probability * 100)}%`}
+        </div>
+      )}
+      {quality !== null && (
+        <div style={{ opacity: gated ? 0.6 : 1 }}>
+          {`${quality.toFixed(1)}/5${gated ? ' · gated' : ''}`}
+        </div>
+      )}
+    </>
+  );
+}

--- a/app/components/mosaic/v1/adapter.test.tsx
+++ b/app/components/mosaic/v1/adapter.test.tsx
@@ -44,6 +44,16 @@ describe('MosaicV1 adapter', () => {
     expect(renderedProps().config).toEqual({});
   });
 
+  it('enables modelsMode with ?models=1', () => {
+    render(<MosaicV1 {...base} search="models=1" />);
+    expect(renderedProps().modelsMode).toBe(true);
+  });
+
+  it('leaves modelsMode off by default and for other values', () => {
+    render(<MosaicV1 {...base} search="models=0" />);
+    expect(renderedProps().modelsMode).toBe(false);
+  });
+
   it('forwards the core mosaic props untouched', () => {
     render(<MosaicV1 {...base} setupMode search="" />);
     const props = renderedProps();

--- a/app/components/mosaic/v1/index.tsx
+++ b/app/components/mosaic/v1/index.tsx
@@ -12,9 +12,13 @@ import { parseCompositionOverrides } from './compositionOverrides';
  * ideas go in a new version folder, not here.
  */
 export function MosaicV1({ search = '', ...rest }: MosaicProps) {
-  const overrides = useMemo(
-    () => parseCompositionOverrides(new URLSearchParams(search)),
-    [search]
-  );
-  return <GeoMosaic {...rest} config={overrides} />;
+  const { overrides, modelsMode } = useMemo(() => {
+    const params = new URLSearchParams(search);
+    return {
+      overrides: parseCompositionOverrides(params),
+      // ?models=1 — per-tile model-judgment chips, default off.
+      modelsMode: params.get('models') === '1',
+    };
+  }, [search]);
+  return <GeoMosaic {...rest} config={overrides} modelsMode={modelsMode} />;
 }

--- a/app/lib/modelReadout.ts
+++ b/app/lib/modelReadout.ts
@@ -1,0 +1,37 @@
+import { AI_BINARY_DECISION_THRESHOLD } from './masterConfig';
+import type { WindyWebcam } from './types';
+
+/**
+ * Human-readable readouts of what each model head said about a webcam,
+ * for surfaces that show the models' own judgments (the home console,
+ * the kiosk overlay) instead of a manual rating UI.
+ *
+ * Ratings are stored as 1 + value*4 (see aiScoring.ts), so the raw
+ * probability/quality is recovered with (rating - 1) / 4.
+ */
+
+export function detectionReadout(
+  webcam: WindyWebcam
+): { verdict: 'sunset' | 'not a sunset'; probability: number } | null {
+  const r = webcam.aiRatingBinary;
+  if (typeof r !== 'number') return null;
+  const probability = Math.round(((r - 1) / 4) * 100) / 100;
+  return {
+    verdict:
+      probability >= AI_BINARY_DECISION_THRESHOLD ? 'sunset' : 'not a sunset',
+    probability,
+  };
+}
+
+/** The quality head's 1-5 rating, or null when this cam is unscored. */
+export function qualityReadout(webcam: WindyWebcam): number | null {
+  return typeof webcam.aiRatingRegression === 'number'
+    ? webcam.aiRatingRegression
+    : null;
+}
+
+/** `20260829_062437_v5_binary_gold` -> `v5_binary_gold`; legacy names pass through. */
+export function shortModelName(version: string | undefined | null): string | null {
+  if (!version) return null;
+  return version.replace(/^\d{8}_\d{6}_/, '');
+}


### PR DESCRIPTION
## What

`/kiosk/sunrise?models=1` (or sunset) adds a small chip to each tile showing what the model heads actually said:

- **Detection**: `sunset · 83%` / `not a sunset · 9%` — same 0.55 gate as production sizing
- **Quality**: `3.7/5`, dimmed + annotated `gated` on below-gate tiles (those render minimal by design; the chip explains why)
- Unstamped cams show `not scored` — never a faked value

Default **off**; the plain kiosk view is untouched. Composable with `?setup=1` and the composition override params. Read-only decoration — sizing still flows through `getQualityScore` in the engine, unchanged.

## Depends on #92

Readouts use the shared `app/lib/modelReadout.ts` helpers, carried **verbatim** from #92 so overlay and console can never disagree on gate/probability math. When #92 merges, that file drops out of this diff. Merge #92 first (or together — identical content merges clean).

## Verification

- 9 new tests (overlay rendering incl. gated/unscored states, `?models=1` adapter parsing); mosaic suite 79/79
- Full suite 798/800 — the 2 failures are `HardExamplesQueue` expectations stale since #89 (`random_ordinary_v2` vs `v3`), zero diff vs main in that folder; flagged to the session that owns it

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HnKdTWaHnjMKn3kfVbhJrK