### PR TITLE
fix(tests): HardExamplesQueue asserts the live SAMPLE_NAME (main is red without this)

### DIFF
--- a/app/components/HardExamples/HardExamplesQueue.test.tsx
+++ b/app/components/HardExamples/HardExamplesQueue.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import HardExamplesQueue from './HardExamplesQueue';
+import HardExamplesQueue, { SAMPLE_NAME } from './HardExamplesQueue';
 
 // Two frames with different provenance so we can assert the right bucket moves.
 const FRAMES = [
@@ -457,7 +457,7 @@ describe('HardExamplesQueue random-sample queue', () => {
   it('asks for the named sample instead of the disagreement ranking', async () => {
     await switchToSample();
     const last = urls.filter((u) => u.startsWith('/api/snapshots')).at(-1) ?? '';
-    expect(last).toContain('sample=random_ordinary_v2');
+    expect(last).toContain(`sample=${SAMPLE_NAME}`);
     // Both at once would be incoherent: the sample is exactly the frames the
     // disagreement filter excludes, so it has to replace that filter.
     expect(last).not.toContain('disagreements_only=true');
@@ -478,7 +478,7 @@ describe('HardExamplesQueue random-sample queue', () => {
       (c) => String(c[0]).startsWith('/api/manual-labels'),
     );
     expect(JSON.parse(String((post?.[1] as RequestInit)?.body)).origin).toBe(
-      'random_ordinary_v2',
+      SAMPLE_NAME,
     );
   });
 

--- a/app/components/HardExamples/HardExamplesQueue.tsx
+++ b/app/components/HardExamples/HardExamplesQueue.tsx
@@ -40,7 +40,9 @@ type SampleProgress = { name: string; size: number; labeled: number };
 // 2026-08-29, v2: 300/300 on 2026-08-30) stay in label_samples and keep their
 // labels' origin stamp. v3 (200 frames, seed 20260831) additionally excludes
 // the 3 cameras that entered v6 training after the holdout pool was built.
-const SAMPLE_NAME = 'random_ordinary_v3';
+// Exported so the tests assert against the live value — PR #89 bumped this
+// to v3 while two test expectations still hardcoded v2, and main went red.
+export const SAMPLE_NAME = 'random_ordinary_v3';
 
 const BATCH = 120;
 const SIDE = 2; // thumbs each side (symmetric)


### PR DESCRIPTION
PR #89 pointed the queue at `random_ordinary_v3` while two test expectations still hardcoded `v2` — main currently fails those two tests (flagged by the kiosk session). `SAMPLE_NAME` is now exported and asserted directly, so a future sample bump can't strand the tests again. 791 tests pass.

Merge this ahead of the queue — it unblocks CI for everything else in flight (#91, #92, #93).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NrXD5WLywFCjei3TLY18KU