### PR TITLE
feat(studio): kiosk studio phase 1 — settings plumbing + /studio control page

### DIFF
--- a/app/api/kiosk/settings/deploy/route.test.ts
+++ b/app/api/kiosk/settings/deploy/route.test.ts
@@ -1,0 +1,60 @@
+// @vitest-environment node
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NextResponse } from 'next/server';
+
+const requireOwnerMock = vi.fn();
+vi.mock('@/app/lib/owner', () => ({
+  requireOwner: (...a: unknown[]) => requireOwnerMock(...a),
+}));
+
+const copyProfileMock = vi.fn();
+vi.mock('@/app/lib/settings/store', () => ({
+  copyProfile: (f: unknown, t: unknown) => copyProfileMock(f, t),
+}));
+
+const setKioskLiveSettingsCacheMock = vi.fn();
+vi.mock('@/app/lib/cache', () => ({
+  setKioskLiveSettingsCache: (s: unknown) => setKioskLiveSettingsCacheMock(s),
+}));
+
+import { POST } from './route';
+
+function reqPost(): Request {
+  return new Request('http://test/api/kiosk/settings/deploy', {
+    method: 'POST',
+  });
+}
+
+describe('POST /api/kiosk/settings/deploy', () => {
+  beforeEach(() => {
+    requireOwnerMock.mockReset();
+    copyProfileMock.mockReset();
+    setKioskLiveSettingsCacheMock.mockReset();
+  });
+
+  it('rejects non-owners', async () => {
+    requireOwnerMock.mockResolvedValueOnce(
+      NextResponse.json({ error: 'Forbidden' }, { status: 403 }),
+    );
+    const res = await POST();
+    expect(res.status).toBe(403);
+    expect(copyProfileMock).not.toHaveBeenCalled();
+    expect(setKioskLiveSettingsCacheMock).not.toHaveBeenCalled();
+  });
+
+  it('copies studio to live and sets cache', async () => {
+    const liveSettings = {
+      namespaces: { v1: { floorPx: 150 } },
+      revision: 1,
+    };
+    requireOwnerMock.mockResolvedValueOnce(null);
+    copyProfileMock.mockResolvedValueOnce(liveSettings);
+
+    const res = await POST(reqPost());
+    expect(res.status).toBe(200);
+    expect(copyProfileMock).toHaveBeenCalledWith('studio', 'live');
+    expect(setKioskLiveSettingsCacheMock).toHaveBeenCalledWith(liveSettings);
+    const body = await res.json();
+    expect(body).toEqual({ live: liveSettings });
+  });
+});

--- a/app/api/kiosk/settings/deploy/route.ts
+++ b/app/api/kiosk/settings/deploy/route.ts
@@ -1,0 +1,15 @@
+import { NextResponse } from 'next/server';
+import { requireOwner } from '@/app/lib/owner';
+import { copyProfile } from '@/app/lib/settings/store';
+import { setKioskLiveSettingsCache } from '@/app/lib/cache';
+
+export const dynamic = 'force-dynamic';
+export const runtime = 'nodejs';
+
+export async function POST() {
+  const denied = await requireOwner();
+  if (denied) return denied;
+  const live = await copyProfile('studio', 'live');
+  await setKioskLiveSettingsCache(live);
+  return NextResponse.json({ live });
+}

--- a/app/api/kiosk/settings/revert/route.test.ts
+++ b/app/api/kiosk/settings/revert/route.test.ts
@@ -1,0 +1,60 @@
+// @vitest-environment node
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NextResponse } from 'next/server';
+
+const requireOwnerMock = vi.fn();
+vi.mock('@/app/lib/owner', () => ({
+  requireOwner: (...a: unknown[]) => requireOwnerMock(...a),
+}));
+
+const copyProfileMock = vi.fn();
+vi.mock('@/app/lib/settings/store', () => ({
+  copyProfile: (f: unknown, t: unknown) => copyProfileMock(f, t),
+}));
+
+const setKioskLiveSettingsCacheMock = vi.fn();
+vi.mock('@/app/lib/cache', () => ({
+  setKioskLiveSettingsCache: (s: unknown) => setKioskLiveSettingsCacheMock(s),
+}));
+
+import { POST } from './route';
+
+function reqPost(): Request {
+  return new Request('http://test/api/kiosk/settings/revert', {
+    method: 'POST',
+  });
+}
+
+describe('POST /api/kiosk/settings/revert', () => {
+  beforeEach(() => {
+    requireOwnerMock.mockReset();
+    copyProfileMock.mockReset();
+    setKioskLiveSettingsCacheMock.mockReset();
+  });
+
+  it('rejects non-owners', async () => {
+    requireOwnerMock.mockResolvedValueOnce(
+      NextResponse.json({ error: 'Forbidden' }, { status: 403 }),
+    );
+    const res = await POST();
+    expect(res.status).toBe(403);
+    expect(copyProfileMock).not.toHaveBeenCalled();
+    expect(setKioskLiveSettingsCacheMock).not.toHaveBeenCalled();
+  });
+
+  it('copies live to studio and does not set cache', async () => {
+    const studioSettings = {
+      namespaces: { v1: { floorPx: 100 } },
+      revision: 0,
+    };
+    requireOwnerMock.mockResolvedValueOnce(null);
+    copyProfileMock.mockResolvedValueOnce(studioSettings);
+
+    const res = await POST(reqPost());
+    expect(res.status).toBe(200);
+    expect(copyProfileMock).toHaveBeenCalledWith('live', 'studio');
+    expect(setKioskLiveSettingsCacheMock).not.toHaveBeenCalled();
+    const body = await res.json();
+    expect(body).toEqual({ studio: studioSettings });
+  });
+});

--- a/app/api/kiosk/settings/revert/route.ts
+++ b/app/api/kiosk/settings/revert/route.ts
@@ -1,0 +1,13 @@
+import { NextResponse } from 'next/server';
+import { requireOwner } from '@/app/lib/owner';
+import { copyProfile } from '@/app/lib/settings/store';
+
+export const dynamic = 'force-dynamic';
+export const runtime = 'nodejs';
+
+export async function POST() {
+  const denied = await requireOwner();
+  if (denied) return denied;
+  const studio = await copyProfile('live', 'studio');
+  return NextResponse.json({ studio });
+}

--- a/app/api/kiosk/settings/route.test.ts
+++ b/app/api/kiosk/settings/route.test.ts
@@ -1,0 +1,183 @@
+// @vitest-environment node
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NextResponse } from 'next/server';
+
+const requireOwnerMock = vi.fn();
+vi.mock('@/app/lib/owner', () => ({
+  requireOwner: (...a: unknown[]) => requireOwnerMock(...a),
+}));
+
+const getProfileSettingsMock = vi.fn();
+const putStudioNamespaceMock = vi.fn();
+vi.mock('@/app/lib/settings/store', () => ({
+  getProfileSettings: (p: string) => getProfileSettingsMock(p),
+  putStudioNamespace: (n: string, d: unknown) => putStudioNamespaceMock(n, d),
+}));
+
+const getKioskLastPollMock = vi.fn();
+vi.mock('@/app/lib/cache', () => ({
+  getKioskLastPoll: () => getKioskLastPollMock(),
+}));
+
+vi.mock('@/app/components/mosaic/registry', () => ({
+  MOSAIC_VERSIONS: { v1: {} },
+  DEFAULT_MOSAIC_VERSION: 'v1',
+  MOSAIC_SETTINGS_SCHEMAS: {
+    v1: [
+      {
+        key: 'floorPx',
+        kind: 'number',
+        min: 20,
+        max: 800,
+        step: 10,
+        default: 100,
+        label: 'floor (px)',
+        description: 'Minimum tile size',
+        section: 'sizing',
+      },
+    ] as const,
+  },
+}));
+
+import { GET, PATCH } from './route';
+
+function reqGet(): Request {
+  return new Request('http://test/api/kiosk/settings', {
+    method: 'GET',
+  });
+}
+
+function reqPatch(body: unknown): Request {
+  return new Request('http://test/api/kiosk/settings', {
+    method: 'PATCH',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+describe('GET /api/kiosk/settings', () => {
+  beforeEach(() => {
+    requireOwnerMock.mockReset();
+    getProfileSettingsMock.mockReset();
+    getKioskLastPollMock.mockReset();
+  });
+
+  it('rejects non-owners', async () => {
+    requireOwnerMock.mockResolvedValueOnce(
+      NextResponse.json({ error: 'Forbidden' }, { status: 403 }),
+    );
+    const res = await GET();
+    expect(res.status).toBe(403);
+  });
+
+  it('returns studio, live, and lastPollAt', async () => {
+    requireOwnerMock.mockResolvedValueOnce(null);
+    getProfileSettingsMock.mockResolvedValueOnce({
+      namespaces: { v1: { floorPx: 150 } },
+      revision: 1,
+    });
+    getProfileSettingsMock.mockResolvedValueOnce({
+      namespaces: { v1: { floorPx: 100 } },
+      revision: 0,
+    });
+    getKioskLastPollMock.mockResolvedValueOnce('2026-08-30T12:00:00Z');
+
+    const res = await GET();
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toEqual({
+      studio: { namespaces: { v1: { floorPx: 150 } }, revision: 1 },
+      live: { namespaces: { v1: { floorPx: 100 } }, revision: 0 },
+      lastPollAt: '2026-08-30T12:00:00Z',
+    });
+  });
+});
+
+describe('PATCH /api/kiosk/settings', () => {
+  beforeEach(() => {
+    requireOwnerMock.mockReset();
+    putStudioNamespaceMock.mockReset();
+  });
+
+  it('rejects non-owners', async () => {
+    requireOwnerMock.mockResolvedValueOnce(
+      NextResponse.json({ error: 'Forbidden' }, { status: 403 }),
+    );
+    const res = await PATCH(reqPatch({ namespace: 'v1', values: {} }));
+    expect(res.status).toBe(403);
+    expect(putStudioNamespaceMock).not.toHaveBeenCalled();
+  });
+
+  it('400s on invalid JSON', async () => {
+    requireOwnerMock.mockResolvedValueOnce(null);
+    const req = new Request('http://test/api/kiosk/settings', {
+      method: 'PATCH',
+      headers: { 'content-type': 'application/json' },
+      body: '{invalid json}',
+    });
+    const res = await PATCH(req);
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe('invalid JSON');
+  });
+
+  it('400s on missing namespace', async () => {
+    requireOwnerMock.mockResolvedValueOnce(null);
+    const res = await PATCH(reqPatch({ values: {} }));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe('namespace must be a string');
+  });
+
+  it('400s on non-string namespace', async () => {
+    requireOwnerMock.mockResolvedValueOnce(null);
+    const res = await PATCH(reqPatch({ namespace: 123, values: {} }));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe('namespace must be a string');
+  });
+
+  it('400s on unknown namespace', async () => {
+    requireOwnerMock.mockResolvedValueOnce(null);
+    const res = await PATCH(reqPatch({ namespace: 'unknown', values: {} }));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe('unknown namespace: unknown');
+  });
+
+  it('sanitizes values: clamps numbers, drops unknown keys', async () => {
+    requireOwnerMock.mockResolvedValueOnce(null);
+    putStudioNamespaceMock.mockResolvedValueOnce(2);
+
+    const res = await PATCH(
+      reqPatch({ namespace: 'v1', values: { floorPx: 5000, ghost: 1 } }),
+    );
+    expect(res.status).toBe(200);
+    expect(putStudioNamespaceMock).toHaveBeenCalledWith('v1', { floorPx: 800 });
+    const body = await res.json();
+    expect(body).toEqual({ revision: 2 });
+  });
+
+  it('strips defaults: omits values equal to schema defaults', async () => {
+    requireOwnerMock.mockResolvedValueOnce(null);
+    putStudioNamespaceMock.mockResolvedValueOnce(1);
+
+    const res = await PATCH(reqPatch({ namespace: 'v1', values: { floorPx: 100 } }));
+    expect(res.status).toBe(200);
+    expect(putStudioNamespaceMock).toHaveBeenCalledWith('v1', {});
+    const body = await res.json();
+    expect(body).toEqual({ revision: 1 });
+  });
+
+  it('returns the new revision', async () => {
+    requireOwnerMock.mockResolvedValueOnce(null);
+    putStudioNamespaceMock.mockResolvedValueOnce(42);
+
+    const res = await PATCH(
+      reqPatch({ namespace: 'v1', values: { floorPx: 200 } }),
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toEqual({ revision: 42 });
+  });
+});

--- a/app/api/kiosk/settings/route.ts
+++ b/app/api/kiosk/settings/route.ts
@@ -1,0 +1,48 @@
+import { NextResponse } from 'next/server';
+import { requireOwner } from '@/app/lib/owner';
+import { getProfileSettings, putStudioNamespace } from '@/app/lib/settings/store';
+import { getKioskLastPoll } from '@/app/lib/cache';
+import { sanitizeValues, stripDefaults } from '@/app/lib/settings/schema';
+import { SHARED_NAMESPACE, SHARED_SCHEMA } from '@/app/lib/settings/sharedSchema';
+import { MOSAIC_SETTINGS_SCHEMAS } from '@/app/components/mosaic/registry';
+
+export const dynamic = 'force-dynamic';
+export const runtime = 'nodejs';
+
+function schemaFor(namespace: string) {
+  if (namespace === SHARED_NAMESPACE) return SHARED_SCHEMA;
+  return MOSAIC_SETTINGS_SCHEMAS[namespace] ?? null;
+}
+
+export async function GET() {
+  const denied = await requireOwner();
+  if (denied) return denied;
+  const [studio, live, lastPollAt] = await Promise.all([
+    getProfileSettings('studio'),
+    getProfileSettings('live'),
+    getKioskLastPoll(),
+  ]);
+  return NextResponse.json({ studio, live, lastPollAt });
+}
+
+export async function PATCH(request: Request) {
+  const denied = await requireOwner();
+  if (denied) return denied;
+  let body: { namespace?: unknown; values?: unknown };
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: 'invalid JSON' }, { status: 400 });
+  }
+  const { namespace, values } = body;
+  if (typeof namespace !== 'string') {
+    return NextResponse.json({ error: 'namespace must be a string' }, { status: 400 });
+  }
+  const schema = schemaFor(namespace);
+  if (!schema) {
+    return NextResponse.json({ error: `unknown namespace: ${namespace}` }, { status: 400 });
+  }
+  const deviations = stripDefaults(schema, sanitizeValues(schema, values));
+  const revision = await putStudioNamespace(namespace, deviations);
+  return NextResponse.json({ revision });
+}

--- a/app/api/kiosk/state/route.test.ts
+++ b/app/api/kiosk/state/route.test.ts
@@ -2,18 +2,53 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 const getKioskDozeMock = vi.fn();
+const markKioskPollMock = vi.fn();
 vi.mock('@/app/lib/cache', () => ({
   getKioskDoze: () => getKioskDozeMock(),
+  markKioskPoll: () => markKioskPollMock(),
+}));
+
+const getLiveSettingsCachedMock = vi.fn();
+vi.mock('@/app/lib/settings/liveSettings', () => ({
+  getLiveSettingsCached: () => getLiveSettingsCachedMock(),
 }));
 
 import { GET } from './route';
 
 describe('GET /api/kiosk/state', () => {
-  beforeEach(() => getKioskDozeMock.mockReset());
-  it('returns the doze flag', async () => {
+  beforeEach(() => {
+    getKioskDozeMock.mockReset();
+    markKioskPollMock.mockReset();
+    getLiveSettingsCachedMock.mockReset();
+    markKioskPollMock.mockResolvedValue(undefined);
+  });
+
+  it('returns the doze flag and live settings', async () => {
+    const settings = { namespaces: { v1: { floorPx: 150 } }, revision: 2 };
     getKioskDozeMock.mockResolvedValueOnce(true);
+    getLiveSettingsCachedMock.mockResolvedValueOnce(settings);
+
     const res = await GET();
+
     expect(res.status).toBe(200);
-    expect(await res.json()).toEqual({ doze: true });
+    expect(await res.json()).toEqual({ doze: true, settings });
+  });
+
+  it('fires markKioskPoll without awaiting it', async () => {
+    getKioskDozeMock.mockResolvedValueOnce(false);
+    getLiveSettingsCachedMock.mockResolvedValueOnce(null);
+
+    await GET();
+
+    expect(markKioskPollMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns settings: null when the settings fetch fails to resolve a value', async () => {
+    getKioskDozeMock.mockResolvedValueOnce(false);
+    getLiveSettingsCachedMock.mockResolvedValueOnce(null);
+
+    const res = await GET();
+
+    expect(await res.json()).toEqual({ doze: false, settings: null });
   });
 });

--- a/app/api/kiosk/state/route.test.ts
+++ b/app/api/kiosk/state/route.test.ts
@@ -13,7 +13,12 @@ vi.mock('@/app/lib/settings/liveSettings', () => ({
   getLiveSettingsCached: () => getLiveSettingsCachedMock(),
 }));
 
+import { NextRequest } from 'next/server';
 import { GET } from './route';
+
+function request(url: string) {
+  return new NextRequest(new URL(url, 'https://example.com'));
+}
 
 describe('GET /api/kiosk/state', () => {
   beforeEach(() => {
@@ -28,26 +33,35 @@ describe('GET /api/kiosk/state', () => {
     getKioskDozeMock.mockResolvedValueOnce(true);
     getLiveSettingsCachedMock.mockResolvedValueOnce(settings);
 
-    const res = await GET();
+    const res = await GET(request('/api/kiosk/state?kiosk=1'));
 
     expect(res.status).toBe(200);
     expect(await res.json()).toEqual({ doze: true, settings });
   });
 
-  it('fires markKioskPoll without awaiting it', async () => {
+  it('marks poll freshness when the request carries ?kiosk=1', async () => {
     getKioskDozeMock.mockResolvedValueOnce(false);
     getLiveSettingsCachedMock.mockResolvedValueOnce(null);
 
-    await GET();
+    await GET(request('/api/kiosk/state?kiosk=1'));
 
     expect(markKioskPollMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not mark poll freshness for a plain request (e.g. the Ops drawer DozeControl)', async () => {
+    getKioskDozeMock.mockResolvedValueOnce(false);
+    getLiveSettingsCachedMock.mockResolvedValueOnce(null);
+
+    await GET(request('/api/kiosk/state'));
+
+    expect(markKioskPollMock).not.toHaveBeenCalled();
   });
 
   it('returns settings: null when the settings fetch fails to resolve a value', async () => {
     getKioskDozeMock.mockResolvedValueOnce(false);
     getLiveSettingsCachedMock.mockResolvedValueOnce(null);
 
-    const res = await GET();
+    const res = await GET(request('/api/kiosk/state'));
 
     expect(await res.json()).toEqual({ doze: false, settings: null });
   });

--- a/app/api/kiosk/state/route.ts
+++ b/app/api/kiosk/state/route.ts
@@ -1,4 +1,4 @@
-import { NextResponse } from 'next/server';
+import { NextRequest, NextResponse } from 'next/server';
 import { getKioskDoze, markKioskPoll } from '@/app/lib/cache';
 import { getLiveSettingsCached } from '@/app/lib/settings/liveSettings';
 
@@ -6,13 +6,20 @@ export const dynamic = 'force-dynamic';
 
 // Redis-first read: this is the endpoint dozing kiosks poll once a minute, so
 // the hot path must never touch Neon. Live settings ride the same response via
-// a Redis mirror (written on Deploy); Neon is read ONLY on a cold cache miss,
-// and the result immediately re-warms the mirror.
-export async function GET() {
+// a Redis mirror (written on Deploy, TTL'd at 300s); Neon is read ONLY on a
+// cold cache miss, and the result immediately re-warms the mirror — so a
+// failed or stale write self-heals within minutes rather than staying wrong
+// indefinitely.
+//
+// This route is also hit by callers that aren't the kiosk's own poll loop
+// (e.g. the Ops drawer's DozeControl), so "poll freshness" is only marked
+// when the request carries ?kiosk=1 — the marker used by useKioskRuntime.
+export async function GET(request: NextRequest) {
+  const isKioskPoll = request.nextUrl.searchParams.get('kiosk') === '1';
   const [doze, settings] = await Promise.all([
     getKioskDoze(),
     getLiveSettingsCached(),
   ]);
-  void markKioskPoll();
+  if (isKioskPoll) void markKioskPoll();
   return NextResponse.json({ doze, settings });
 }

--- a/app/api/kiosk/state/route.ts
+++ b/app/api/kiosk/state/route.ts
@@ -1,10 +1,18 @@
 import { NextResponse } from 'next/server';
-import { getKioskDoze } from '@/app/lib/cache';
+import { getKioskDoze, markKioskPoll } from '@/app/lib/cache';
+import { getLiveSettingsCached } from '@/app/lib/settings/liveSettings';
 
 export const dynamic = 'force-dynamic';
 
-// Redis-only read: this is the endpoint dozing kiosks poll once a minute to
-// hear the wake command, so it must never touch Neon.
+// Redis-first read: this is the endpoint dozing kiosks poll once a minute, so
+// the hot path must never touch Neon. Live settings ride the same response via
+// a Redis mirror (written on Deploy); Neon is read ONLY on a cold cache miss,
+// and the result immediately re-warms the mirror.
 export async function GET() {
-  return NextResponse.json({ doze: await getKioskDoze() });
+  const [doze, settings] = await Promise.all([
+    getKioskDoze(),
+    getLiveSettingsCached(),
+  ]);
+  void markKioskPoll();
+  return NextResponse.json({ doze, settings });
 }

--- a/app/components/Kiosk/KioskTab.test.tsx
+++ b/app/components/Kiosk/KioskTab.test.tsx
@@ -70,4 +70,12 @@ describe('KioskTab', () => {
     render(<KioskTab />);
     expect(screen.getByText(/quiet=off/)).toBeTruthy();
   });
+
+  it('links to the studio dial page, opened in a new tab', () => {
+    render(<KioskTab />);
+    const link = screen.getByRole('link', { name: /studio/i }) as HTMLAnchorElement;
+
+    expect(link.getAttribute('href')).toBe('/studio');
+    expect(link.target).toBe('_blank');
+  });
 });

--- a/app/components/Kiosk/KioskTab.tsx
+++ b/app/components/Kiosk/KioskTab.tsx
@@ -76,6 +76,28 @@ export function KioskTab() {
             </MuiLink>
           ))
         )}
+        <MuiLink
+          href="/studio"
+          target="_blank"
+          rel="noopener noreferrer"
+          sx={{
+            display: 'flex',
+            alignItems: 'center',
+            px: 2,
+            py: 1.25,
+            minWidth: 150,
+            borderRadius: 1,
+            border: '1px solid #374151',
+            background: '#111827',
+            textDecoration: 'none',
+            color: '#e5e7eb',
+            fontWeight: 600,
+            fontSize: 14,
+            '&:hover': { borderColor: '#6b7280', background: '#1f2937' },
+          }}
+        >
+          🎛 Studio
+        </MuiLink>
       </Box>
 
       <Typography sx={{ fontWeight: 700, mb: 0.5 }}>Tuning</Typography>

--- a/app/components/mosaic/registry.test.tsx
+++ b/app/components/mosaic/registry.test.tsx
@@ -3,6 +3,7 @@ import {
   MOSAIC_VERSIONS,
   DEFAULT_MOSAIC_VERSION,
   resolveMosaic,
+  resolveMosaicName,
 } from './registry';
 import { MosaicV1 } from './v1';
 
@@ -30,5 +31,13 @@ describe('mosaic registry', () => {
     expect(resolveMosaic('v999')).toBe(
       MOSAIC_VERSIONS[DEFAULT_MOSAIC_VERSION]
     );
+  });
+
+  it('resolveMosaicName resolves a known version to itself', () => {
+    expect(resolveMosaicName('v1')).toBe('v1');
+  });
+
+  it('resolveMosaicName falls back to the default name for an unknown version', () => {
+    expect(resolveMosaicName('nope')).toBe('v1');
   });
 });

--- a/app/components/mosaic/registry.ts
+++ b/app/components/mosaic/registry.ts
@@ -28,3 +28,12 @@ export function resolveMosaic(version: string | null | undefined): MosaicCompone
     MOSAIC_VERSIONS[DEFAULT_MOSAIC_VERSION]
   );
 }
+
+/**
+ * Same fallback rule as resolveMosaic, but returns the resolved registry
+ * key rather than the component — for looking up the matching settings
+ * namespace (`liveSettings.namespaces[resolveMosaicName(...)]`).
+ */
+export function resolveMosaicName(version: string | null | undefined): string {
+  return version && version in MOSAIC_VERSIONS ? version : DEFAULT_MOSAIC_VERSION;
+}

--- a/app/components/mosaic/registry.ts
+++ b/app/components/mosaic/registry.ts
@@ -1,5 +1,7 @@
 import type { MosaicComponent } from './types';
 import { MosaicV1 } from './v1';
+import { V1_SETTINGS_SCHEMA } from './v1/settingsSchema';
+import type { SettingsSchema } from '@/app/lib/settings/schema';
 
 /**
  * Every mosaic version deployed, side by side. All versions ship in one
@@ -13,6 +15,11 @@ export const MOSAIC_VERSIONS: Record<string, MosaicComponent> = {
 };
 
 export const DEFAULT_MOSAIC_VERSION = 'v1';
+
+/** Settings schemas for each mosaic version. */
+export const MOSAIC_SETTINGS_SCHEMAS: Record<string, SettingsSchema> = {
+  v1: V1_SETTINGS_SCHEMA,
+};
 
 /** Unknown or missing names fall back to the pinned default. */
 export function resolveMosaic(version: string | null | undefined): MosaicComponent {

--- a/app/components/mosaic/types.ts
+++ b/app/components/mosaic/types.ts
@@ -16,6 +16,8 @@ export interface MosaicProps {
   onSelect?: (webcam: WindyWebcam) => void;
   /** Raw query string of the hosting page, for version-specific params. */
   search?: string;
+  /** Merged-or-deviation knob values for THIS version's namespace (server profile). */
+  settings?: Record<string, number | boolean | string>;
 }
 
 export type MosaicComponent = (props: MosaicProps) => React.ReactNode;

--- a/app/components/mosaic/v1/adapter.test.tsx
+++ b/app/components/mosaic/v1/adapter.test.tsx
@@ -26,22 +26,35 @@ const base = {
 describe('MosaicV1 adapter', () => {
   beforeEach(() => vi.clearAllMocks());
 
-  it('passes empty overrides when the query string has no tuning params', () => {
+  // Since Task 8, the adapter always merges settings (profile-or-default)
+  // into config, so "no tuning params" means the resolved config equals the
+  // schema defaults (which mirror COMPOSITION_CONFIG) rather than {}.
+  const defaultSettingsConfig = {
+    floorPx: COMPOSITION_CONFIG.floorPx,
+    ceilPx: COMPOSITION_CONFIG.ceilPx,
+    upscaleMax: COMPOSITION_CONFIG.upscaleMax,
+    maxGrowth: COMPOSITION_CONFIG.maxGrowth,
+    padding: COMPOSITION_CONFIG.padding,
+    cullOverflow: COMPOSITION_CONFIG.cullOverflow,
+  };
+
+  it('passes settings-schema-default overrides when the query string has no tuning params', () => {
     render(<MosaicV1 {...base} search="setup=1&v=v1" />);
-    expect(renderedProps().config).toEqual({});
+    expect(renderedProps().config).toEqual(defaultSettingsConfig);
   });
 
   it('parses v1 composition overrides out of the query string', () => {
     render(<MosaicV1 {...base} search="floor=120&cull=0" />);
     expect(renderedProps().config).toEqual({
+      ...defaultSettingsConfig,
       floorPx: 120,
       cullOverflow: false,
     });
   });
 
-  it('defaults to no overrides when search is omitted', () => {
+  it('defaults to settings-schema defaults when search is omitted', () => {
     render(<MosaicV1 {...base} />);
-    expect(renderedProps().config).toEqual({});
+    expect(renderedProps().config).toEqual(defaultSettingsConfig);
   });
 
   it('enables modelsMode with ?models=1', () => {

--- a/app/components/mosaic/v1/index.test.tsx
+++ b/app/components/mosaic/v1/index.test.tsx
@@ -1,0 +1,51 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render } from '@testing-library/react';
+import type { CompositionConfig } from './engine/types';
+
+let capturedProps: { config?: Partial<CompositionConfig>; modelsMode?: boolean } = {};
+
+vi.mock('./GeoMosaic', () => ({
+  GeoMosaic: (props: { config?: Partial<CompositionConfig>; modelsMode?: boolean }) => {
+    capturedProps = props;
+    return null;
+  },
+}));
+
+import { MosaicV1 } from './index';
+
+describe('MosaicV1', () => {
+  const baseProps = {
+    webcams: [],
+    width: 1080,
+    height: 1920,
+    feed: 'sunset' as const,
+  };
+
+  it('lets profile settings reach the composition config', () => {
+    render(<MosaicV1 {...baseProps} settings={{ floorPx: 140 }} />);
+    expect(capturedProps.config?.floorPx).toBe(140);
+  });
+
+  it('lets a URL override win over a profile setting', () => {
+    render(
+      <MosaicV1 {...baseProps} settings={{ floorPx: 140 }} search="floor=60" />
+    );
+    expect(capturedProps.config?.floorPx).toBe(60);
+  });
+
+  it('turns modelsMode on when the profile sets showModelReadout', () => {
+    render(<MosaicV1 {...baseProps} settings={{ showModelReadout: true }} />);
+    expect(capturedProps.modelsMode).toBe(true);
+  });
+
+  it('lets an explicit ?models=0 beat a profile showModelReadout: true', () => {
+    render(
+      <MosaicV1
+        {...baseProps}
+        settings={{ showModelReadout: true }}
+        search="models=0"
+      />
+    );
+    expect(capturedProps.modelsMode).toBe(false);
+  });
+});

--- a/app/components/mosaic/v1/index.tsx
+++ b/app/components/mosaic/v1/index.tsx
@@ -4,21 +4,34 @@ import { useMemo } from 'react';
 import type { MosaicProps } from '../types';
 import { GeoMosaic } from './GeoMosaic';
 import { parseCompositionOverrides } from './compositionOverrides';
+import { V1_SETTINGS_SCHEMA, configFromSettings } from './settingsSchema';
+import { mergeSettings } from '@/app/lib/settings/schema';
 
 /**
  * v1 — the geographic composition engine shipped in PR #76 (percentile
  * sizing, greedy N→S/W→E rows, latitude-gap space distribution, cull-vs-
  * compress overflow). FROZEN as the reference version; new composition
  * ideas go in a new version folder, not here.
+ *
+ * Precedence: URL params (parseCompositionOverrides, ?models=) beat profile
+ * settings, which beat code defaults. Profile settings arrive as a raw
+ * deviation record and are merged against V1_SETTINGS_SCHEMA before use.
  */
-export function MosaicV1({ search = '', ...rest }: MosaicProps) {
+export function MosaicV1({ search = '', settings, ...rest }: MosaicProps) {
   const { overrides, modelsMode } = useMemo(() => {
     const params = new URLSearchParams(search);
+    const merged = mergeSettings(V1_SETTINGS_SCHEMA, settings);
     return {
-      overrides: parseCompositionOverrides(params),
-      // ?models=1 — per-tile model-judgment chips, default off.
-      modelsMode: params.get('models') === '1',
+      overrides: {
+        ...configFromSettings(merged),
+        ...parseCompositionOverrides(params), // URL keeps the last word
+      },
+      // ?models=1/0 — per-tile model-judgment chips; explicit URL param
+      // beats the profile's showModelReadout knob.
+      modelsMode: params.has('models')
+        ? params.get('models') === '1'
+        : merged.showModelReadout === true,
     };
-  }, [search]);
+  }, [search, settings]);
   return <GeoMosaic {...rest} config={overrides} modelsMode={modelsMode} />;
 }

--- a/app/components/mosaic/v1/qualitySignal.test.ts
+++ b/app/components/mosaic/v1/qualitySignal.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { getQualityScore } from './qualitySignal';
+import { getQualityScore, passesGate } from './qualitySignal';
 import type { WindyWebcam } from '@/app/lib/types';
 
 const base = { webcamId: 1, viewCount: 0, location: { latitude: 0, longitude: 0 } } as WindyWebcam;
@@ -46,5 +46,24 @@ describe('getQualityScore (composed two-scale signal)', () => {
   it('a rejected frame with no quality score is still floored, not null', () => {
     // Detection alone is enough to know the tile should be minimal.
     expect(getQualityScore({ ...base, aiRatingBinary: REJECTED })).toBe(1);
+  });
+});
+
+describe('passesGate', () => {
+  it('passes when the detection score sits exactly at the gate', () => {
+    const atGate = 1 + 0.55 * 4; // 3.2
+    expect(passesGate({ ...base, aiRatingBinary: atGate })).toBe(true);
+  });
+
+  it('fails when the detection score is below the gate', () => {
+    expect(passesGate({ ...base, aiRatingBinary: REJECTED })).toBe(false);
+  });
+
+  it('fails when the webcam has no detection score', () => {
+    expect(passesGate(base)).toBe(false);
+  });
+
+  it('passes when the detection score is well above the gate', () => {
+    expect(passesGate({ ...base, aiRatingBinary: SHOWN })).toBe(true);
   });
 });

--- a/app/components/mosaic/v1/qualitySignal.ts
+++ b/app/components/mosaic/v1/qualitySignal.ts
@@ -27,3 +27,15 @@ export function getQualityScore(webcam: WindyWebcam): number | null {
   }
   return webcam.aiRatingRegression ?? null;
 }
+
+/**
+ * Whether the detection head considers this frame a sunset — the same
+ * `aiRatingBinary >= GATE_AS_RATING` check `getQualityScore` uses to decide
+ * between floor-to-1 and the real quality score. Exposed for callers (the
+ * studio status strip) that want a per-feed pass/fail count without
+ * duplicating the gate constant.
+ */
+export function passesGate(webcam: WindyWebcam): boolean {
+  const score = webcam.aiRatingBinary;
+  return typeof score === 'number' && score >= GATE_AS_RATING;
+}

--- a/app/components/mosaic/v1/settingsSchema.test.ts
+++ b/app/components/mosaic/v1/settingsSchema.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest';
+import { V1_SETTINGS_SCHEMA, configFromSettings } from './settingsSchema';
+import { schemaDefaults, mergeSettings } from '@/app/lib/settings/schema';
+import { COMPOSITION_CONFIG } from './config';
+
+describe('V1_SETTINGS_SCHEMA', () => {
+  it('defaults match the frozen v1 COMPOSITION_CONFIG so dials start where code is', () => {
+    const d = schemaDefaults(V1_SETTINGS_SCHEMA);
+    expect(d.floorPx).toBe(COMPOSITION_CONFIG.floorPx);
+    expect(d.ceilPx).toBe(COMPOSITION_CONFIG.ceilPx);
+    expect(d.upscaleMax).toBe(COMPOSITION_CONFIG.upscaleMax);
+    expect(d.maxGrowth).toBe(COMPOSITION_CONFIG.maxGrowth);
+    expect(d.padding).toBe(COMPOSITION_CONFIG.padding);
+    expect(d.cullOverflow).toBe(COMPOSITION_CONFIG.cullOverflow);
+    expect(d.showModelReadout).toBe(false);
+  });
+});
+
+describe('configFromSettings', () => {
+  it('maps merged knob values onto CompositionConfig fields and nothing else', () => {
+    const merged = mergeSettings(V1_SETTINGS_SCHEMA, { floorPx: 140, showModelReadout: true });
+    const cfg = configFromSettings(merged);
+    expect(cfg.floorPx).toBe(140);
+    expect('showModelReadout' in cfg).toBe(false);
+  });
+  it('returns an empty partial when given nothing, deferring to code defaults', () => {
+    expect(configFromSettings(undefined)).toEqual({});
+  });
+});

--- a/app/components/mosaic/v1/settingsSchema.ts
+++ b/app/components/mosaic/v1/settingsSchema.ts
@@ -1,0 +1,104 @@
+import { SettingsSchema, SettingsValues } from '@/app/lib/settings/schema';
+import type { CompositionConfig } from './engine/types';
+import { COMPOSITION_CONFIG } from './config';
+
+/**
+ * V1 mosaic composition settings schema. Each knob maps 1:1 to a
+ * CompositionConfig field (except showModelReadout, which is display-only).
+ * Defaults match COMPOSITION_CONFIG exactly so dials start where the code runs.
+ */
+export const V1_SETTINGS_SCHEMA: SettingsSchema = [
+  {
+    key: 'floorPx',
+    kind: 'number',
+    min: 20,
+    max: 800,
+    step: 10,
+    default: COMPOSITION_CONFIG.floorPx,
+    label: 'floor (px)',
+    description: 'Minimum tile size',
+    section: 'sizing',
+  },
+  {
+    key: 'ceilPx',
+    kind: 'number',
+    min: 50,
+    max: 1000,
+    step: 10,
+    default: COMPOSITION_CONFIG.ceilPx,
+    label: 'ceil (px)',
+    description: 'Maximum tile size',
+    section: 'sizing',
+  },
+  {
+    key: 'upscaleMax',
+    kind: 'number',
+    min: 1,
+    max: 3,
+    step: 0.1,
+    default: COMPOSITION_CONFIG.upscaleMax,
+    label: 'upscale max',
+    description: 'Maximum upscale factor',
+    section: 'sizing',
+  },
+  {
+    key: 'maxGrowth',
+    kind: 'number',
+    min: 1,
+    max: 5,
+    step: 0.1,
+    default: COMPOSITION_CONFIG.maxGrowth,
+    label: 'max growth',
+    description: 'Maximum growth factor',
+    section: 'sizing',
+  },
+  {
+    key: 'padding',
+    kind: 'number',
+    min: 0,
+    max: 20,
+    step: 1,
+    default: COMPOSITION_CONFIG.padding,
+    label: 'padding (px)',
+    description: 'Space between tiles',
+    section: 'arrangement',
+  },
+  {
+    key: 'cullOverflow',
+    kind: 'boolean',
+    default: COMPOSITION_CONFIG.cullOverflow,
+    label: 'cull overflow',
+    description: 'Remove tiles that overflow the viewport',
+    section: 'arrangement',
+  },
+  {
+    key: 'showModelReadout',
+    kind: 'boolean',
+    default: false,
+    label: 'show model readout',
+    description: 'Display model prediction overlay',
+    section: 'overlays',
+  },
+] as const;
+
+/**
+ * Maps merged settings values into CompositionConfig field names.
+ * Only includes the subset of keys that belong in CompositionConfig.
+ */
+const CONFIG_KEYS = [
+  'floorPx',
+  'ceilPx',
+  'upscaleMax',
+  'maxGrowth',
+  'padding',
+  'cullOverflow',
+] as const;
+
+export function configFromSettings(values?: SettingsValues): Partial<CompositionConfig> {
+  if (!values) return {};
+  const out: Record<string, unknown> = {};
+  for (const key of CONFIG_KEYS) {
+    if (key in values) out[key] = values[key];
+  }
+  return out as Partial<CompositionConfig>;
+}

--- a/app/kiosk/sunrise/page.tsx
+++ b/app/kiosk/sunrise/page.tsx
@@ -2,7 +2,9 @@
 
 import { Suspense, useEffect, useMemo, useState } from 'react';
 import { useSearchParams } from 'next/navigation';
-import { resolveMosaic } from '@/app/components/mosaic/registry';
+import { resolveMosaic, resolveMosaicName } from '@/app/components/mosaic/registry';
+import { SHARED_SCHEMA } from '@/app/lib/settings/sharedSchema';
+import { mergeSettings } from '@/app/lib/settings/schema';
 import { useTerminatorStore } from '@/app/store/useTerminatorStore';
 import { useLoadTerminatorWebcams } from '@/app/store/useLoadTerminatorWebcams';
 import { useKioskRuntime } from '../useKioskRuntime';
@@ -11,12 +13,15 @@ import { parsePanelPreview } from '../panelPreview';
 import { PanelFrame } from '../PanelFrame';
 
 function SunriseKioskContent() {
-  const { dozing } = useKioskRuntime();
+  const { dozing, liveSettings } = useKioskRuntime();
   useLoadTerminatorWebcams({ paused: dozing });
   const webcams = useTerminatorStore((t) => t.sunrise);
   const searchParams = useSearchParams();
   const queryString = searchParams.toString();
-  const Mosaic = resolveMosaic(searchParams.get('v'));
+  const liveShared = mergeSettings(SHARED_SCHEMA, liveSettings?.namespaces.shared);
+  const versionParam = searchParams.get('v') ?? (liveShared.activeVersion as string);
+  const Mosaic = resolveMosaic(versionParam);
+  const versionName = resolveMosaicName(versionParam);
   const panel = useMemo(
     () => parsePanelPreview(new URLSearchParams(queryString)),
     [queryString]
@@ -49,6 +54,7 @@ function SunriseKioskContent() {
         feed="sunrise"
         setupMode={searchParams.get('setup') === '1'}
         search={queryString}
+        settings={liveSettings?.namespaces[versionName]}
       />
       <KioskDozeOverlay dozing={dozing} />
     </>

--- a/app/kiosk/sunset/page.tsx
+++ b/app/kiosk/sunset/page.tsx
@@ -2,7 +2,9 @@
 
 import { Suspense, useEffect, useMemo, useState } from 'react';
 import { useSearchParams } from 'next/navigation';
-import { resolveMosaic } from '@/app/components/mosaic/registry';
+import { resolveMosaic, resolveMosaicName } from '@/app/components/mosaic/registry';
+import { SHARED_SCHEMA } from '@/app/lib/settings/sharedSchema';
+import { mergeSettings } from '@/app/lib/settings/schema';
 import { useTerminatorStore } from '@/app/store/useTerminatorStore';
 import { useLoadTerminatorWebcams } from '@/app/store/useLoadTerminatorWebcams';
 import { useKioskRuntime } from '../useKioskRuntime';
@@ -11,12 +13,15 @@ import { parsePanelPreview } from '../panelPreview';
 import { PanelFrame } from '../PanelFrame';
 
 function SunsetKioskContent() {
-  const { dozing } = useKioskRuntime();
+  const { dozing, liveSettings } = useKioskRuntime();
   useLoadTerminatorWebcams({ paused: dozing });
   const webcams = useTerminatorStore((t) => t.sunset);
   const searchParams = useSearchParams();
   const queryString = searchParams.toString();
-  const Mosaic = resolveMosaic(searchParams.get('v'));
+  const liveShared = mergeSettings(SHARED_SCHEMA, liveSettings?.namespaces.shared);
+  const versionParam = searchParams.get('v') ?? (liveShared.activeVersion as string);
+  const Mosaic = resolveMosaic(versionParam);
+  const versionName = resolveMosaicName(versionParam);
   const panel = useMemo(
     () => parsePanelPreview(new URLSearchParams(queryString)),
     [queryString]
@@ -49,6 +54,7 @@ function SunsetKioskContent() {
         feed="sunset"
         setupMode={searchParams.get('setup') === '1'}
         search={queryString}
+        settings={liveSettings?.namespaces[versionName]}
       />
       <KioskDozeOverlay dozing={dozing} />
     </>

--- a/app/kiosk/useKioskRuntime.test.tsx
+++ b/app/kiosk/useKioskRuntime.test.tsx
@@ -23,7 +23,12 @@ describe('useKioskRuntime', () => {
       await vi.advanceTimersByTimeAsync(61_000);
     });
     const urls = fetchMock.mock.calls.map((c) => String(c[0]));
-    expect(urls.filter((u) => u.includes('/api/kiosk/state')).length).toBeGreaterThanOrEqual(2);
+    const statePolls = urls.filter((u) => u.includes('/api/kiosk/state'));
+    expect(statePolls.length).toBeGreaterThanOrEqual(2);
+    // Marked with ?kiosk=1 so the route's markKioskPoll only fires for the
+    // kiosk's own poll loop, not other callers of this endpoint (e.g. the
+    // Ops drawer's DozeControl).
+    expect(statePolls.every((u) => u.includes('kiosk=1'))).toBe(true);
     expect(urls.filter((u) => u.includes('/api/kiosk/tick')).length).toBeGreaterThanOrEqual(1);
   });
 

--- a/app/kiosk/useKioskRuntime.test.tsx
+++ b/app/kiosk/useKioskRuntime.test.tsx
@@ -59,4 +59,24 @@ describe('useKioskRuntime', () => {
     });
     expect(result.current.dozing).toBe(true);
   });
+
+  it('surfaces settings from a poll response and keeps them on a failed poll', async () => {
+    const settings = { namespaces: { v1: { floorPx: 150 } }, revision: 2 };
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ doze: false, settings }),
+    });
+    const { result } = renderHook(() => useKioskRuntime());
+    expect(result.current.liveSettings).toBeNull();
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1_000);
+    });
+    expect(result.current.liveSettings).toEqual(settings);
+
+    fetchMock.mockRejectedValueOnce(new Error('network down'));
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(61_000);
+    });
+    expect(result.current.liveSettings).toEqual(settings);
+  });
 });

--- a/app/kiosk/useKioskRuntime.ts
+++ b/app/kiosk/useKioskRuntime.ts
@@ -11,13 +11,18 @@ import {
   KIOSK_TICK_INTERVAL_MS,
   KIOSK_WAKE_MINUTES,
 } from '@/app/lib/masterConfig';
+import type { ProfileSettings } from '@/app/lib/settings/store';
 
-export function useKioskRuntime(): { dozing: boolean } {
+export function useKioskRuntime(): {
+  dozing: boolean;
+  liveSettings: ProfileSettings | null;
+} {
   const [visible, setVisible] = useState(
     () => typeof document === 'undefined' || document.visibilityState === 'visible',
   );
   const [localDoze, setLocalDoze] = useState(false);
   const [remoteDoze, setRemoteDoze] = useState(false);
+  const [liveSettings, setLiveSettings] = useState<ProfileSettings | null>(null);
   const [, forceRender] = useState(0);
   const quietRef = useRef<QuietWindow>(null);
   const lastInteractionRef = useRef<number | null>(null);
@@ -70,9 +75,13 @@ export function useKioskRuntime(): { dozing: boolean } {
       try {
         const res = await fetch('/api/kiosk/state');
         if (res.ok) {
-          const { doze } = (await res.json()) as { doze: boolean };
+          const { doze, settings } = (await res.json()) as {
+            doze: boolean;
+            settings?: ProfileSettings | null;
+          };
           setRemoteDoze(doze);
           remoteDozeRef.current = doze;
+          if (settings) setLiveSettings(settings);
         }
       } catch {
         /* state poll failures are non-fatal */
@@ -96,5 +105,5 @@ export function useKioskRuntime(): { dozing: boolean } {
     };
   }, [gate]);
 
-  return { dozing: isDozing(gate()) };
+  return { dozing: isDozing(gate()), liveSettings };
 }

--- a/app/kiosk/useKioskRuntime.ts
+++ b/app/kiosk/useKioskRuntime.ts
@@ -73,7 +73,7 @@ export function useKioskRuntime(): {
 
     const poll = async () => {
       try {
-        const res = await fetch('/api/kiosk/state');
+        const res = await fetch('/api/kiosk/state?kiosk=1');
         if (res.ok) {
           const { doze, settings } = (await res.json()) as {
             doze: boolean;

--- a/app/lib/cache.test.ts
+++ b/app/lib/cache.test.ts
@@ -107,3 +107,57 @@ describe('kiosk helpers', () => {
     await expect(getKioskDoze()).resolves.toBe(false);
   });
 });
+
+describe('kiosk live settings cache', () => {
+  it('round-trips a ProfileSettings object through kiosk:liveSettings', async () => {
+    const { setKioskLiveSettingsCache, getKioskLiveSettingsCache } = await import('./cache');
+    await setKioskLiveSettingsCache({ namespaces: { v1: { floorPx: 140 } }, revision: 15 });
+    expect(setMock).toHaveBeenCalledWith(
+      'kiosk:liveSettings',
+      expect.anything(),
+    );
+    getMock.mockResolvedValueOnce(setMock.mock.calls[0][1]);
+    await expect(getKioskLiveSettingsCache()).resolves.toEqual({
+      namespaces: { v1: { floorPx: 140 } },
+      revision: 15,
+    });
+  });
+
+  it('returns null on a cache miss', async () => {
+    const { getKioskLiveSettingsCache } = await import('./cache');
+    getMock.mockResolvedValueOnce(null);
+    await expect(getKioskLiveSettingsCache()).resolves.toBeNull();
+  });
+
+  it('fails soft to null when redis rejects, so a cache outage never breaks the kiosk', async () => {
+    const { getKioskLiveSettingsCache } = await import('./cache');
+    getMock.mockRejectedValueOnce(new Error('down'));
+    await expect(getKioskLiveSettingsCache()).resolves.toBeNull();
+  });
+
+  it('setKioskLiveSettingsCache swallows Redis errors (fire-and-forget safe)', async () => {
+    const { setKioskLiveSettingsCache } = await import('./cache');
+    setMock.mockRejectedValueOnce(new Error('down'));
+    await expect(
+      setKioskLiveSettingsCache({ namespaces: {}, revision: 1 }),
+    ).resolves.toBeUndefined();
+  });
+
+  it('markKioskPoll stores an ISO timestamp readable by getKioskLastPoll', async () => {
+    const { markKioskPoll } = await import('./cache');
+    await markKioskPoll();
+    const written = setMock.mock.calls.at(-1)!;
+    expect(written[0]).toBe('kiosk:lastPoll');
+    expect(new Date(String(written[1])).toISOString()).toBe(String(written[1]));
+  });
+
+  it('getKioskLastPoll returns the stored timestamp, or null on miss/failure', async () => {
+    const { getKioskLastPoll } = await import('./cache');
+    getMock.mockResolvedValueOnce('2026-08-30T00:00:00.000Z');
+    await expect(getKioskLastPoll()).resolves.toBe('2026-08-30T00:00:00.000Z');
+    getMock.mockResolvedValueOnce(null);
+    await expect(getKioskLastPoll()).resolves.toBeNull();
+    getMock.mockRejectedValueOnce(new Error('down'));
+    await expect(getKioskLastPoll()).resolves.toBeNull();
+  });
+});

--- a/app/lib/cache.test.ts
+++ b/app/lib/cache.test.ts
@@ -109,12 +109,13 @@ describe('kiosk helpers', () => {
 });
 
 describe('kiosk live settings cache', () => {
-  it('round-trips a ProfileSettings object through kiosk:liveSettings', async () => {
+  it('round-trips a ProfileSettings object through kiosk:liveSettings with a 300s TTL', async () => {
     const { setKioskLiveSettingsCache, getKioskLiveSettingsCache } = await import('./cache');
     await setKioskLiveSettingsCache({ namespaces: { v1: { floorPx: 140 } }, revision: 15 });
     expect(setMock).toHaveBeenCalledWith(
       'kiosk:liveSettings',
       expect.anything(),
+      { ex: 300 },
     );
     getMock.mockResolvedValueOnce(setMock.mock.calls[0][1]);
     await expect(getKioskLiveSettingsCache()).resolves.toEqual({

--- a/app/lib/cache.ts
+++ b/app/lib/cache.ts
@@ -7,6 +7,7 @@ const TERMINATOR_TTL_SECONDS = 300;
 const KIOSK_TICK_LOCK_KEY = 'kiosk:tick:lock';
 const KIOSK_DOZE_KEY = 'kiosk:doze';
 const KIOSK_LIVE_SETTINGS_KEY = 'kiosk:liveSettings';
+const KIOSK_LIVE_SETTINGS_TTL_SECONDS = 300;
 const KIOSK_LAST_POLL_KEY = 'kiosk:lastPoll';
 
 let client: Redis | null = null;
@@ -127,7 +128,7 @@ export async function setKioskLiveSettingsCache(s: ProfileSettings): Promise<voi
   const c = getClient();
   if (!c) return;
   try {
-    await c.set(KIOSK_LIVE_SETTINGS_KEY, s);
+    await c.set(KIOSK_LIVE_SETTINGS_KEY, s, { ex: KIOSK_LIVE_SETTINGS_TTL_SECONDS });
   } catch (error) {
     console.warn('[cache] setKioskLiveSettingsCache failed:', error);
   }

--- a/app/lib/cache.ts
+++ b/app/lib/cache.ts
@@ -1,10 +1,13 @@
 import { Redis } from '@upstash/redis';
 import { KIOSK_TICK_LOCK_TTL_MS } from '@/app/lib/masterConfig';
+import type { ProfileSettings } from '@/app/lib/settings/store';
 
 const TERMINATOR_KEY = 'terminator:current';
 const TERMINATOR_TTL_SECONDS = 300;
 const KIOSK_TICK_LOCK_KEY = 'kiosk:tick:lock';
 const KIOSK_DOZE_KEY = 'kiosk:doze';
+const KIOSK_LIVE_SETTINGS_KEY = 'kiosk:liveSettings';
+const KIOSK_LAST_POLL_KEY = 'kiosk:lastPoll';
 
 let client: Redis | null = null;
 
@@ -104,6 +107,50 @@ export async function setKioskDoze(on: boolean): Promise<void> {
     else await c.del(KIOSK_DOZE_KEY);
   } catch (error) {
     console.warn('[cache] setKioskDoze failed:', error);
+  }
+}
+
+// Redis mirror of the live settings profile, kept fresh by the studio's
+// publish path so the kiosk's 60s poll never hits Neon directly.
+export async function getKioskLiveSettingsCache(): Promise<ProfileSettings | null> {
+  const c = getClient();
+  if (!c) return null;
+  try {
+    return (await c.get<ProfileSettings>(KIOSK_LIVE_SETTINGS_KEY)) ?? null;
+  } catch (error) {
+    console.warn('[cache] getKioskLiveSettingsCache failed:', error);
+    return null;
+  }
+}
+
+export async function setKioskLiveSettingsCache(s: ProfileSettings): Promise<void> {
+  const c = getClient();
+  if (!c) return;
+  try {
+    await c.set(KIOSK_LIVE_SETTINGS_KEY, s);
+  } catch (error) {
+    console.warn('[cache] setKioskLiveSettingsCache failed:', error);
+  }
+}
+
+export async function markKioskPoll(): Promise<void> {
+  const c = getClient();
+  if (!c) return;
+  try {
+    await c.set(KIOSK_LAST_POLL_KEY, new Date().toISOString());
+  } catch (error) {
+    console.warn('[cache] markKioskPoll failed:', error);
+  }
+}
+
+export async function getKioskLastPoll(): Promise<string | null> {
+  const c = getClient();
+  if (!c) return null;
+  try {
+    return (await c.get<string>(KIOSK_LAST_POLL_KEY)) ?? null;
+  } catch (error) {
+    console.warn('[cache] getKioskLastPoll failed:', error);
+    return null;
   }
 }
 

--- a/app/lib/settings/liveSettings.test.ts
+++ b/app/lib/settings/liveSettings.test.ts
@@ -1,0 +1,52 @@
+// @vitest-environment node
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const getKioskLiveSettingsCacheMock = vi.fn();
+const setKioskLiveSettingsCacheMock = vi.fn();
+vi.mock('@/app/lib/cache', () => ({
+  getKioskLiveSettingsCache: () => getKioskLiveSettingsCacheMock(),
+  setKioskLiveSettingsCache: (s: unknown) => setKioskLiveSettingsCacheMock(s),
+}));
+
+const getProfileSettingsMock = vi.fn();
+vi.mock('@/app/lib/settings/store', () => ({
+  getProfileSettings: (p: unknown) => getProfileSettingsMock(p),
+}));
+
+import { getLiveSettingsCached } from './liveSettings';
+
+describe('getLiveSettingsCached', () => {
+  beforeEach(() => {
+    getKioskLiveSettingsCacheMock.mockReset();
+    setKioskLiveSettingsCacheMock.mockReset();
+    getProfileSettingsMock.mockReset();
+  });
+
+  it('returns the cached value without touching the store on a cache hit', async () => {
+    const cached = { namespaces: { v1: { floorPx: 150 } }, revision: 2 };
+    getKioskLiveSettingsCacheMock.mockResolvedValueOnce(cached);
+
+    expect(await getLiveSettingsCached()).toEqual(cached);
+    expect(getProfileSettingsMock).not.toHaveBeenCalled();
+    expect(setKioskLiveSettingsCacheMock).not.toHaveBeenCalled();
+  });
+
+  it('reads the store once and re-warms the cache on a miss', async () => {
+    const fromStore = { namespaces: { v1: { floorPx: 150 } }, revision: 3 };
+    getKioskLiveSettingsCacheMock.mockResolvedValueOnce(null);
+    getProfileSettingsMock.mockResolvedValueOnce(fromStore);
+
+    expect(await getLiveSettingsCached()).toEqual(fromStore);
+    expect(getProfileSettingsMock).toHaveBeenCalledTimes(1);
+    expect(getProfileSettingsMock).toHaveBeenCalledWith('live');
+    expect(setKioskLiveSettingsCacheMock).toHaveBeenCalledWith(fromStore);
+  });
+
+  it('returns null without throwing when both the cache and the store fail', async () => {
+    getKioskLiveSettingsCacheMock.mockResolvedValueOnce(null);
+    getProfileSettingsMock.mockRejectedValueOnce(new Error('neon down'));
+
+    await expect(getLiveSettingsCached()).resolves.toBeNull();
+    expect(setKioskLiveSettingsCacheMock).not.toHaveBeenCalled();
+  });
+});

--- a/app/lib/settings/liveSettings.ts
+++ b/app/lib/settings/liveSettings.ts
@@ -7,7 +7,11 @@ import { getProfileSettings, type ProfileSettings } from '@/app/lib/settings/sto
 
 // Redis-first read of the live settings profile. Falls back to Neon exactly
 // once on a cache miss, then re-warms the Redis mirror so the next poll hits
-// the cache. Returns null only if both the cache and the Neon read fail.
+// the cache. The mirror carries a 300s TTL (see setKioskLiveSettingsCache),
+// so a failed or stale write self-heals through this same Neon-miss path
+// within minutes — bounded to roughly one Neon read per 5 minutes per cold
+// key, while the hot path stays Redis-first. Returns null only if both the
+// cache and the Neon read fail.
 export async function getLiveSettingsCached(): Promise<ProfileSettings | null> {
   const cached = await getKioskLiveSettingsCache();
   if (cached) return cached;

--- a/app/lib/settings/liveSettings.ts
+++ b/app/lib/settings/liveSettings.ts
@@ -1,0 +1,23 @@
+import 'server-only';
+import {
+  getKioskLiveSettingsCache,
+  setKioskLiveSettingsCache,
+} from '@/app/lib/cache';
+import { getProfileSettings, type ProfileSettings } from '@/app/lib/settings/store';
+
+// Redis-first read of the live settings profile. Falls back to Neon exactly
+// once on a cache miss, then re-warms the Redis mirror so the next poll hits
+// the cache. Returns null only if both the cache and the Neon read fail.
+export async function getLiveSettingsCached(): Promise<ProfileSettings | null> {
+  const cached = await getKioskLiveSettingsCache();
+  if (cached) return cached;
+
+  try {
+    const fromStore = await getProfileSettings('live');
+    await setKioskLiveSettingsCache(fromStore);
+    return fromStore;
+  } catch (error) {
+    console.warn('[liveSettings] getLiveSettingsCached Neon fallback failed:', error);
+    return null;
+  }
+}

--- a/app/lib/settings/schema.test.ts
+++ b/app/lib/settings/schema.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from 'vitest';
+import {
+  schemaDefaults, sanitizeValues, stripDefaults, mergeSettings, diffKeys,
+  type SettingsSchema,
+} from './schema';
+
+const SCHEMA: SettingsSchema = [
+  { key: 'floorPx', kind: 'number', min: 20, max: 800, step: 10, default: 100,
+    label: 'floor', description: 'min tile px', section: 'sizing' },
+  { key: 'cullOverflow', kind: 'boolean', default: true,
+    label: 'cull', description: 'drop overflow', section: 'arrangement' },
+  { key: 'activeVersion', kind: 'enum', options: ['v1', 'v2'], default: 'v1',
+    label: 'version', description: 'mosaic on glass', section: 'glass' },
+];
+
+describe('schemaDefaults', () => {
+  it('returns every knob at its code default', () => {
+    expect(schemaDefaults(SCHEMA)).toEqual({
+      floorPx: 100, cullOverflow: true, activeVersion: 'v1',
+    });
+  });
+});
+
+describe('sanitizeValues', () => {
+  it('drops unknown keys so removed knobs never poison a stored blob', () => {
+    expect(sanitizeValues(SCHEMA, { floorPx: 140, ghost: 9 })).toEqual({ floorPx: 140 });
+  });
+  it('clamps numbers into their declared range', () => {
+    expect(sanitizeValues(SCHEMA, { floorPx: 5000 })).toEqual({ floorPx: 800 });
+  });
+  it('omits wrong-typed and non-finite values instead of coercing', () => {
+    expect(sanitizeValues(SCHEMA, {
+      floorPx: 'big', cullOverflow: 'yes', activeVersion: 'v9',
+    })).toEqual({});
+    expect(sanitizeValues(SCHEMA, { floorPx: NaN })).toEqual({});
+  });
+  it('returns empty for non-object input', () => {
+    expect(sanitizeValues(SCHEMA, null)).toEqual({});
+    expect(sanitizeValues(SCHEMA, [1, 2])).toEqual({});
+  });
+});
+
+describe('stripDefaults', () => {
+  it('keeps only deviations so the DB stores nothing redundant', () => {
+    expect(stripDefaults(SCHEMA, { floorPx: 100, cullOverflow: false }))
+      .toEqual({ cullOverflow: false });
+  });
+});
+
+describe('mergeSettings', () => {
+  it('applies default, then profile deviation, then URL override, in that order', () => {
+    expect(mergeSettings(SCHEMA, { floorPx: 140 }, { floorPx: 60 }).floorPx).toBe(60);
+    expect(mergeSettings(SCHEMA, { floorPx: 140 }).floorPx).toBe(140);
+    expect(mergeSettings(SCHEMA).floorPx).toBe(100);
+  });
+  it('ignores unknown keys from stored blobs', () => {
+    expect(mergeSettings(SCHEMA, { retired: 1 })).toEqual(schemaDefaults(SCHEMA));
+  });
+});
+
+describe('diffKeys', () => {
+  it('reports keys whose effective values differ — the diff badge count', () => {
+    expect(diffKeys(SCHEMA, { floorPx: 140 }, {})).toEqual(['floorPx']);
+  });
+  it('treats an explicit default and an absent key as identical', () => {
+    expect(diffKeys(SCHEMA, { floorPx: 100 }, {})).toEqual([]);
+  });
+});

--- a/app/lib/settings/schema.test.ts
+++ b/app/lib/settings/schema.test.ts
@@ -45,6 +45,10 @@ describe('stripDefaults', () => {
     expect(stripDefaults(SCHEMA, { floorPx: 100, cullOverflow: false }))
       .toEqual({ cullOverflow: false });
   });
+  it('omits keys absent from a partial input instead of writing undefined entries', () => {
+    const out = stripDefaults(SCHEMA, { cullOverflow: false });
+    expect(Object.keys(out)).toEqual(['cullOverflow']);
+  });
 });
 
 describe('mergeSettings', () => {

--- a/app/lib/settings/schema.ts
+++ b/app/lib/settings/schema.ts
@@ -1,0 +1,101 @@
+export type KnobValue = number | boolean | string;
+export type SettingsValues = Record<string, KnobValue>;
+
+export interface KnobBase {
+  key: string;
+  label: string;
+  description: string;
+  section: string; // folder name in the rail: 'sizing' | 'arrangement' | 'overlays' | 'glass' | ...
+}
+
+export interface NumberKnob extends KnobBase {
+  kind: 'number';
+  min: number;
+  max: number;
+  step: number;
+  default: number;
+}
+
+export interface BooleanKnob extends KnobBase {
+  kind: 'boolean';
+  default: boolean;
+}
+
+export interface EnumKnob extends KnobBase {
+  kind: 'enum';
+  options: readonly string[];
+  default: string;
+}
+
+export type KnobDescriptor = NumberKnob | BooleanKnob | EnumKnob;
+export type SettingsSchema = readonly KnobDescriptor[];
+
+export function schemaDefaults(schema: SettingsSchema): SettingsValues {
+  const out: SettingsValues = {};
+  for (const knob of schema) {
+    out[knob.key] = knob.default;
+  }
+  return out;
+}
+
+export function sanitizeValues(schema: SettingsSchema, input: unknown): SettingsValues {
+  if (typeof input !== 'object' || input === null || Array.isArray(input)) return {};
+  const raw = input as Record<string, unknown>;
+  const out: SettingsValues = {};
+  for (const knob of schema) {
+    if (!(knob.key in raw)) continue;
+    const v = raw[knob.key];
+    if (knob.kind === 'number') {
+      if (typeof v !== 'number' || !Number.isFinite(v)) continue;
+      out[knob.key] = Math.min(knob.max, Math.max(knob.min, v));
+    } else if (knob.kind === 'boolean') {
+      if (typeof v !== 'boolean') continue;
+      out[knob.key] = v;
+    } else {
+      if (typeof v !== 'string' || !knob.options.includes(v)) continue;
+      out[knob.key] = v;
+    }
+  }
+  return out;
+}
+
+export function stripDefaults(schema: SettingsSchema, values: SettingsValues): SettingsValues {
+  const out: SettingsValues = {};
+  for (const knob of schema) {
+    const value = values[knob.key];
+    if (value !== knob.default) {
+      out[knob.key] = value;
+    }
+  }
+  return out;
+}
+
+export function mergeSettings(
+  schema: SettingsSchema,
+  deviations?: SettingsValues,
+  overrides?: SettingsValues
+): SettingsValues {
+  const dev = sanitizeValues(schema, deviations ?? {});
+  const ovr = sanitizeValues(schema, overrides ?? {});
+  const out: SettingsValues = {};
+  for (const knob of schema) {
+    out[knob.key] = ovr[knob.key] ?? dev[knob.key] ?? knob.default;
+  }
+  return out;
+}
+
+export function diffKeys(
+  schema: SettingsSchema,
+  a?: SettingsValues,
+  b?: SettingsValues
+): string[] {
+  const mergedA = mergeSettings(schema, a);
+  const mergedB = mergeSettings(schema, b);
+  const keys: string[] = [];
+  for (const knob of schema) {
+    if (mergedA[knob.key] !== mergedB[knob.key]) {
+      keys.push(knob.key);
+    }
+  }
+  return keys;
+}

--- a/app/lib/settings/schema.ts
+++ b/app/lib/settings/schema.ts
@@ -62,6 +62,7 @@ export function sanitizeValues(schema: SettingsSchema, input: unknown): Settings
 export function stripDefaults(schema: SettingsSchema, values: SettingsValues): SettingsValues {
   const out: SettingsValues = {};
   for (const knob of schema) {
+    if (!(knob.key in values)) continue;
     const value = values[knob.key];
     if (value !== knob.default) {
       out[knob.key] = value;

--- a/app/lib/settings/sharedSchema.test.ts
+++ b/app/lib/settings/sharedSchema.test.ts
@@ -1,0 +1,18 @@
+import { describe, it, expect } from 'vitest';
+import { SHARED_SCHEMA, SHARED_NAMESPACE } from './sharedSchema';
+import { schemaDefaults } from './schema';
+import { DEFAULT_MOSAIC_VERSION } from '@/app/components/mosaic/registry';
+
+describe('SHARED_SCHEMA', () => {
+  it('activeVersion defaults to the registry pin so an empty DB changes nothing', () => {
+    expect(schemaDefaults(SHARED_SCHEMA).activeVersion).toBe(DEFAULT_MOSAIC_VERSION);
+  });
+  it('panelPreset options are the named panelPreview presets', () => {
+    const knob = SHARED_SCHEMA.find((k) => k.key === 'panelPreset');
+    expect(knob?.kind).toBe('enum');
+    expect(knob && 'options' in knob ? [...knob.options] : []).toEqual(['dell', 'ktc']);
+  });
+  it('exports the namespace constant used by storage rows', () => {
+    expect(SHARED_NAMESPACE).toBe('shared');
+  });
+});

--- a/app/lib/settings/sharedSchema.ts
+++ b/app/lib/settings/sharedSchema.ts
@@ -1,0 +1,30 @@
+import { SettingsSchema } from './schema';
+import { MOSAIC_VERSIONS, DEFAULT_MOSAIC_VERSION } from '@/app/components/mosaic/registry';
+
+export const SHARED_NAMESPACE = 'shared';
+
+/**
+ * Shared settings apply across all mosaic versions and the UI.
+ * activeVersion selects which mosaic to render (?v= param default).
+ * panelPreset selects the physical screen dimensions for the kiosk.
+ */
+export const SHARED_SCHEMA: SettingsSchema = [
+  {
+    key: 'activeVersion',
+    kind: 'enum',
+    options: Object.keys(MOSAIC_VERSIONS),
+    default: DEFAULT_MOSAIC_VERSION,
+    label: 'active version',
+    description: 'Which mosaic version to display',
+    section: 'glass',
+  },
+  {
+    key: 'panelPreset',
+    kind: 'enum',
+    options: ['dell', 'ktc'] as const,
+    default: 'dell',
+    label: 'panel',
+    description: 'Panel size: dell = 1080×1920, ktc = 1440×2560. Both physical screens share one geometry.',
+    section: 'glass',
+  },
+] as const;

--- a/app/lib/settings/store.test.ts
+++ b/app/lib/settings/store.test.ts
@@ -1,15 +1,23 @@
 // @vitest-environment node
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
+type SqlTag = {
+  (strings: TemplateStringsArray, ...values: unknown[]): unknown;
+  transaction: unknown;
+  __sqlMock: unknown;
+  __txnMock: unknown;
+};
+
 vi.mock('@/app/lib/db', async () => {
   const sqlMockFn = vi.fn();
   const txnMockFn = vi.fn();
 
   const tag = (strings: TemplateStringsArray, ...values: unknown[]) =>
     sqlMockFn(strings, ...values);
-  (tag as any).transaction = txnMockFn;
-  (tag as any).__sqlMock = sqlMockFn;
-  (tag as any).__txnMock = txnMockFn;
+  const tagWithMocks = tag as unknown as SqlTag;
+  tagWithMocks.transaction = txnMockFn;
+  tagWithMocks.__sqlMock = sqlMockFn;
+  tagWithMocks.__txnMock = txnMockFn;
 
   return { sql: tag };
 });
@@ -17,8 +25,8 @@ vi.mock('@/app/lib/db', async () => {
 import { getProfileSettings, putStudioNamespace, copyProfile } from './store';
 import { sql } from '@/app/lib/db';
 
-const sqlMock = (sql as any).__sqlMock;
-const txnMock = (sql as any).__txnMock;
+const sqlMock = (sql as unknown as SqlTag).__sqlMock;
+const txnMock = (sql as unknown as SqlTag).__txnMock;
 
 beforeEach(() => {
   sqlMock.mockReset();

--- a/app/lib/settings/store.test.ts
+++ b/app/lib/settings/store.test.ts
@@ -1,0 +1,75 @@
+// @vitest-environment node
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('@/app/lib/db', async () => {
+  const sqlMockFn = vi.fn();
+  const txnMockFn = vi.fn();
+
+  const tag = (strings: TemplateStringsArray, ...values: unknown[]) =>
+    sqlMockFn(strings, ...values);
+  (tag as any).transaction = txnMockFn;
+  (tag as any).__sqlMock = sqlMockFn;
+  (tag as any).__txnMock = txnMockFn;
+
+  return { sql: tag };
+});
+
+import { getProfileSettings, putStudioNamespace, copyProfile } from './store';
+import { sql } from '@/app/lib/db';
+
+const sqlMock = (sql as any).__sqlMock;
+const txnMock = (sql as any).__txnMock;
+
+beforeEach(() => {
+  sqlMock.mockReset();
+  txnMock.mockReset();
+});
+
+describe('getProfileSettings', () => {
+  it('folds rows into a namespace map with the max revision', async () => {
+    sqlMock.mockResolvedValueOnce([
+      { namespace: 'shared', data: { activeVersion: 'v1' }, revision: 3 },
+      { namespace: 'v1', data: { floorPx: 140 }, revision: 7 },
+    ]);
+    expect(await getProfileSettings('live')).toEqual({
+      namespaces: { shared: { activeVersion: 'v1' }, v1: { floorPx: 140 } },
+      revision: 7,
+    });
+  });
+  it('returns an empty profile at revision 0 when no rows exist', async () => {
+    sqlMock.mockResolvedValueOnce([]);
+    expect(await getProfileSettings('studio')).toEqual({ namespaces: {}, revision: 0 });
+  });
+});
+
+describe('putStudioNamespace', () => {
+  it('upserts deviations and returns the bumped revision', async () => {
+    sqlMock.mockResolvedValueOnce([{ revision: 8 }]);
+    expect(await putStudioNamespace('v1', { floorPx: 140 })).toBe(8);
+    const [strings] = sqlMock.mock.calls[0];
+    expect(strings.join('?')).toContain('ON CONFLICT');
+  });
+  it('deletes the row when every knob is back at default, keeping storage deviations-only', async () => {
+    sqlMock.mockResolvedValueOnce([]);   // DELETE
+    sqlMock.mockResolvedValueOnce([{ max: 5 }]); // revision re-read
+    expect(await putStudioNamespace('v1', {})).toBe(5);
+    const [strings] = sqlMock.mock.calls[0];
+    expect(strings.join('?')).toContain('DELETE FROM kiosk_settings');
+  });
+});
+
+describe('copyProfile', () => {
+  it('runs prune + upsert in one transaction, then returns the new target state', async () => {
+    // Mock the two sql calls within the transaction array
+    sqlMock.mockResolvedValueOnce([]);   // DELETE result
+    sqlMock.mockResolvedValueOnce([]);   // INSERT result
+    txnMock.mockResolvedValueOnce([[], []]);
+    // Mock the sql call in getProfileSettings after transaction
+    sqlMock.mockResolvedValueOnce([
+      { namespace: 'v1', data: { floorPx: 140 }, revision: 15 },
+    ]);
+    const result = await copyProfile('studio', 'live');
+    expect(txnMock).toHaveBeenCalledTimes(1);
+    expect(result.revision).toBe(15);
+  });
+});

--- a/app/lib/settings/store.ts
+++ b/app/lib/settings/store.ts
@@ -1,0 +1,65 @@
+import 'server-only';
+import { sql } from '@/app/lib/db';
+import type { SettingsValues } from './schema';
+
+export type SettingsProfile = 'studio' | 'live';
+export interface ProfileSettings {
+  namespaces: Record<string, SettingsValues>;
+  revision: number;
+}
+
+interface Row { namespace: string; data: SettingsValues; revision: number }
+
+export async function getProfileSettings(profile: SettingsProfile): Promise<ProfileSettings> {
+  const rows = (await sql`
+    SELECT namespace, data, revision FROM kiosk_settings WHERE profile = ${profile}
+  `) as unknown as Row[];
+  const namespaces: Record<string, SettingsValues> = {};
+  let revision = 0;
+  for (const r of rows) {
+    namespaces[r.namespace] = r.data;
+    revision = Math.max(revision, r.revision);
+  }
+  return { namespaces, revision };
+}
+
+export async function putStudioNamespace(
+  namespace: string, deviations: SettingsValues
+): Promise<number> {
+  if (Object.keys(deviations).length === 0) {
+    await sql`DELETE FROM kiosk_settings WHERE profile = 'studio' AND namespace = ${namespace}`;
+    const rows = (await sql`
+      SELECT COALESCE(MAX(revision), 0) AS max FROM kiosk_settings WHERE profile = 'studio'
+    `) as unknown as { max: number }[];
+    return Number(rows[0]?.max ?? 0);
+  }
+  const json = JSON.stringify(deviations);
+  const rows = (await sql`
+    INSERT INTO kiosk_settings (profile, namespace, data)
+    VALUES ('studio', ${namespace}, ${json}::jsonb)
+    ON CONFLICT (profile, namespace)
+    DO UPDATE SET data = ${json}::jsonb,
+                  revision = kiosk_settings.revision + 1,
+                  updated_at = now()
+    RETURNING revision
+  `) as unknown as { revision: number }[];
+  return Number(rows[0].revision);
+}
+
+export async function copyProfile(
+  from: SettingsProfile, to: SettingsProfile
+): Promise<ProfileSettings> {
+  await sql.transaction([
+    sql`DELETE FROM kiosk_settings
+        WHERE profile = ${to}
+          AND namespace NOT IN
+            (SELECT namespace FROM kiosk_settings WHERE profile = ${from})`,
+    sql`INSERT INTO kiosk_settings (profile, namespace, data)
+        SELECT ${to}, namespace, data FROM kiosk_settings WHERE profile = ${from}
+        ON CONFLICT (profile, namespace)
+        DO UPDATE SET data = EXCLUDED.data,
+                      revision = kiosk_settings.revision + 1,
+                      updated_at = now()`,
+  ]);
+  return getProfileSettings(to);
+}

--- a/app/studio/DeployButton.test.tsx
+++ b/app/studio/DeployButton.test.tsx
@@ -103,6 +103,46 @@ describe('DeployButton', () => {
     expect(screen.getByText('4 differ')).toBeInTheDocument();
   });
 
+  it('does not call onDeploy a second time from a completed hold while the first deploy is in flight, and allows a new hold once it resolves', async () => {
+    let resolveDeploy: () => void = () => {};
+    const onDeploy = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveDeploy = resolve;
+        })
+    );
+    render(<DeployButton diffCount={2} onDeploy={onDeploy} onRevert={vi.fn()} />);
+
+    const button = screen.getByRole('button', { name: /hold to deploy/i });
+
+    // First hold completes and kicks off the (still-pending) deploy.
+    fireEvent.pointerDown(button);
+    await act(async () => {
+      vi.advanceTimersByTime(DEPLOY_HOLD_MS);
+    });
+    expect(onDeploy).toHaveBeenCalledTimes(1);
+
+    // A second completed hold while the promise is still pending must not
+    // call onDeploy again.
+    fireEvent.pointerDown(button);
+    await act(async () => {
+      vi.advanceTimersByTime(DEPLOY_HOLD_MS);
+    });
+    expect(onDeploy).toHaveBeenCalledTimes(1);
+
+    // Resolve the in-flight deploy — a fresh hold should now work again.
+    await act(async () => {
+      resolveDeploy();
+      await Promise.resolve();
+    });
+
+    fireEvent.pointerDown(button);
+    await act(async () => {
+      vi.advanceTimersByTime(DEPLOY_HOLD_MS);
+    });
+    expect(onDeploy).toHaveBeenCalledTimes(2);
+  });
+
   it('compact variant still fires onDeploy on a completed hold', async () => {
     const onDeploy = vi.fn().mockResolvedValue(undefined);
     render(<DeployButton diffCount={2} onDeploy={onDeploy} onRevert={vi.fn()} compact />);

--- a/app/studio/DeployButton.test.tsx
+++ b/app/studio/DeployButton.test.tsx
@@ -1,0 +1,119 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import { DeployButton, DEPLOY_HOLD_MS } from './DeployButton';
+
+describe('DeployButton', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('armed face shows the diff count and HOLD TO DEPLOY', () => {
+    render(<DeployButton diffCount={3} onDeploy={vi.fn()} onRevert={vi.fn()} />);
+
+    expect(screen.getByText('HOLD TO DEPLOY')).toBeInTheDocument();
+    expect(screen.getByText('▲ 3 settings differ')).toBeInTheDocument();
+  });
+
+  it('shows singular copy for a single differing setting', () => {
+    render(<DeployButton diffCount={1} onDeploy={vi.fn()} onRevert={vi.fn()} />);
+
+    expect(screen.getByText('▲ 1 setting differs')).toBeInTheDocument();
+  });
+
+  it('completing a hold calls onDeploy exactly once', async () => {
+    const onDeploy = vi.fn().mockResolvedValue(undefined);
+    render(<DeployButton diffCount={2} onDeploy={onDeploy} onRevert={vi.fn()} />);
+
+    const button = screen.getByRole('button', { name: /hold to deploy/i });
+
+    fireEvent.pointerDown(button);
+    await act(async () => {
+      vi.advanceTimersByTime(DEPLOY_HOLD_MS);
+    });
+
+    expect(onDeploy).toHaveBeenCalledTimes(1);
+  });
+
+  it('early release does not call onDeploy', async () => {
+    const onDeploy = vi.fn().mockResolvedValue(undefined);
+    render(<DeployButton diffCount={2} onDeploy={onDeploy} onRevert={vi.fn()} />);
+
+    const button = screen.getByRole('button', { name: /hold to deploy/i });
+
+    fireEvent.pointerDown(button);
+    await act(async () => {
+      vi.advanceTimersByTime(DEPLOY_HOLD_MS - 1);
+    });
+    fireEvent.pointerUp(button);
+
+    await act(async () => {
+      vi.advanceTimersByTime(10_000);
+    });
+
+    expect(onDeploy).not.toHaveBeenCalled();
+  });
+
+  it('diffCount 0 shows the in-sync face', () => {
+    render(<DeployButton diffCount={0} onDeploy={vi.fn()} onRevert={vi.fn()} />);
+
+    expect(screen.getByText('IN SYNC WITH GLASS ✓')).toBeInTheDocument();
+    expect(screen.getByText('dials match the deployed state')).toBeInTheDocument();
+  });
+
+  it('a completed hold on the in-sync face does not call onDeploy', async () => {
+    const onDeploy = vi.fn().mockResolvedValue(undefined);
+    render(<DeployButton diffCount={0} onDeploy={onDeploy} onRevert={vi.fn()} />);
+
+    const button = screen.getByRole('button', { name: /in sync with glass/i });
+
+    fireEvent.pointerDown(button);
+    await act(async () => {
+      vi.advanceTimersByTime(DEPLOY_HOLD_MS);
+    });
+
+    expect(onDeploy).not.toHaveBeenCalled();
+  });
+
+  it('revert button is disabled when in sync', () => {
+    render(<DeployButton diffCount={0} onDeploy={vi.fn()} onRevert={vi.fn()} />);
+
+    const revertButton = screen.getByRole('button', { name: /revert to glass/i });
+    expect(revertButton).toBeDisabled();
+  });
+
+  it('revert button is enabled and calls onRevert when armed', () => {
+    const onRevert = vi.fn().mockResolvedValue(undefined);
+    render(<DeployButton diffCount={1} onDeploy={vi.fn()} onRevert={onRevert} />);
+
+    const revertButton = screen.getByRole('button', { name: /revert to glass/i });
+    expect(revertButton).not.toBeDisabled();
+
+    fireEvent.click(revertButton);
+    expect(onRevert).toHaveBeenCalledTimes(1);
+  });
+
+  it('compact variant renders DEPLOY and an N differ chip', () => {
+    render(<DeployButton diffCount={4} onDeploy={vi.fn()} onRevert={vi.fn()} compact />);
+
+    expect(screen.getByText('DEPLOY')).toBeInTheDocument();
+    expect(screen.getByText('4 differ')).toBeInTheDocument();
+  });
+
+  it('compact variant still fires onDeploy on a completed hold', async () => {
+    const onDeploy = vi.fn().mockResolvedValue(undefined);
+    render(<DeployButton diffCount={2} onDeploy={onDeploy} onRevert={vi.fn()} compact />);
+
+    const button = screen.getByRole('button', { name: /deploy/i });
+
+    fireEvent.pointerDown(button);
+    await act(async () => {
+      vi.advanceTimersByTime(DEPLOY_HOLD_MS);
+    });
+
+    expect(onDeploy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/app/studio/DeployButton.test.tsx
+++ b/app/studio/DeployButton.test.tsx
@@ -96,6 +96,37 @@ describe('DeployButton', () => {
     expect(onRevert).toHaveBeenCalledTimes(1);
   });
 
+  it('shows a failure line when onRevert rejects (no unhandled rejection), and a subsequent successful revert clears it', async () => {
+    const onRevert = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('revert failed: 500'))
+      .mockResolvedValueOnce(undefined);
+    render(<DeployButton diffCount={2} onDeploy={vi.fn()} onRevert={onRevert} />);
+
+    const revertButton = screen.getByRole('button', { name: /revert to glass/i });
+
+    fireEvent.click(revertButton);
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(onRevert).toHaveBeenCalledTimes(1);
+    expect(screen.getByText('revert failed — try again')).toBeInTheDocument();
+
+    // A subsequent click (now labeled "revert failed — try again") retries
+    // and, on success, clears the failure line.
+    fireEvent.click(screen.getByRole('button', { name: /revert failed/i }));
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(onRevert).toHaveBeenCalledTimes(2);
+    expect(screen.queryByText('revert failed — try again')).not.toBeInTheDocument();
+    expect(screen.getByText('↩ revert to glass')).toBeInTheDocument();
+  });
+
   it('compact variant renders DEPLOY and an N differ chip', () => {
     render(<DeployButton diffCount={4} onDeploy={vi.fn()} onRevert={vi.fn()} compact />);
 

--- a/app/studio/DeployButton.test.tsx
+++ b/app/studio/DeployButton.test.tsx
@@ -143,6 +143,58 @@ describe('DeployButton', () => {
     expect(onDeploy).toHaveBeenCalledTimes(2);
   });
 
+  it('shows a failure line when onDeploy rejects, and it clears on the next successful hold', async () => {
+    const onDeploy = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('deploy failed: 500'))
+      .mockResolvedValueOnce(undefined);
+    render(<DeployButton diffCount={2} onDeploy={onDeploy} onRevert={vi.fn()} />);
+
+    const button = screen.getByRole('button', { name: /hold to deploy/i });
+
+    fireEvent.pointerDown(button);
+    await act(async () => {
+      vi.advanceTimersByTime(DEPLOY_HOLD_MS);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(screen.getByText('deploy failed — try again')).toBeInTheDocument();
+
+    // A fresh hold clears the failure line and (this time) succeeds.
+    fireEvent.pointerDown(button);
+    await act(async () => {
+      vi.advanceTimersByTime(DEPLOY_HOLD_MS);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(screen.queryByText('deploy failed — try again')).not.toBeInTheDocument();
+    expect(onDeploy).toHaveBeenCalledTimes(2);
+  });
+
+  it('clears the failure line when diffCount changes', async () => {
+    const onDeploy = vi.fn().mockRejectedValueOnce(new Error('deploy failed: 500'));
+    const { rerender } = render(
+      <DeployButton diffCount={2} onDeploy={onDeploy} onRevert={vi.fn()} />
+    );
+
+    const button = screen.getByRole('button', { name: /hold to deploy/i });
+
+    fireEvent.pointerDown(button);
+    await act(async () => {
+      vi.advanceTimersByTime(DEPLOY_HOLD_MS);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(screen.getByText('deploy failed — try again')).toBeInTheDocument();
+
+    rerender(<DeployButton diffCount={3} onDeploy={onDeploy} onRevert={vi.fn()} />);
+
+    expect(screen.queryByText('deploy failed — try again')).not.toBeInTheDocument();
+  });
+
   it('compact variant still fires onDeploy on a completed hold', async () => {
     const onDeploy = vi.fn().mockResolvedValue(undefined);
     render(<DeployButton diffCount={2} onDeploy={onDeploy} onRevert={vi.fn()} compact />);

--- a/app/studio/DeployButton.tsx
+++ b/app/studio/DeployButton.tsx
@@ -74,10 +74,19 @@ export function DeployButton({
   // non-ok response) — cleared at the start of the next hold and whenever
   // diffCount changes (a new edit, or the deploy actually going through).
   const [deployFailed, setDeployFailed] = useState(false);
+  // Same pattern for revert() — cleared at the start of the next revert
+  // click and whenever diffCount changes.
+  const [revertFailed, setRevertFailed] = useState(false);
 
   useEffect(() => {
     setDeployFailed(false);
+    setRevertFailed(false);
   }, [diffCount]);
+
+  const handleRevertClick = () => {
+    setRevertFailed(false);
+    void onRevert().catch(() => setRevertFailed(true));
+  };
 
   const { holding, handlers } = useHoldToFire({
     ms: DEPLOY_HOLD_MS,
@@ -227,9 +236,7 @@ export function DeployButton({
       </button>
       <button
         type="button"
-        onClick={() => {
-          void onRevert();
-        }}
+        onClick={handleRevertClick}
         disabled={inSync}
         style={{
           display: 'block',
@@ -237,7 +244,7 @@ export function DeployButton({
           width: '100%',
           background: 'transparent',
           border: 'none',
-          color: '#8b95a7',
+          color: revertFailed ? FAIL_FG : '#8b95a7',
           fontFamily: mono,
           fontSize: 11,
           padding: '4px 0',
@@ -245,7 +252,7 @@ export function DeployButton({
           opacity: inSync ? 0.35 : 1,
         }}
       >
-        ↩ revert to glass
+        {revertFailed ? 'revert failed — try again' : '↩ revert to glass'}
       </button>
     </div>
   );

--- a/app/studio/DeployButton.tsx
+++ b/app/studio/DeployButton.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useHoldToFire, DEPLOY_HOLD_MS } from './useHoldToFire';
 
 export { DEPLOY_HOLD_MS };
@@ -20,6 +20,11 @@ const SYNC_FG = '#5a6375';
 const CHIP_BG = '#3a2a12';
 const CHIP_FG = '#f5a344';
 const CHIP_BORDER = '#6b4a1a';
+
+// Deploy-failure line — #e5484d family, distinct from the armed red gradient.
+const FAIL_FG = '#e5484d';
+const FAIL_CHIP_BG = '#3a1216';
+const FAIL_CHIP_BORDER = '#6b1f26';
 
 const FILL_STYLE = `
 .studio-deploy-fill {
@@ -65,12 +70,23 @@ export function DeployButton({
   // data; this guard exists purely so the UI doesn't lie about being ready
   // to fire again while a deploy is still in flight.
   const [isDeploying, setIsDeploying] = useState(false);
+  // Set when the last deploy attempt rejected (deploy() throws on a
+  // non-ok response) — cleared at the start of the next hold and whenever
+  // diffCount changes (a new edit, or the deploy actually going through).
+  const [deployFailed, setDeployFailed] = useState(false);
+
+  useEffect(() => {
+    setDeployFailed(false);
+  }, [diffCount]);
 
   const { holding, handlers } = useHoldToFire({
     ms: DEPLOY_HOLD_MS,
     onFire: () => {
       setIsDeploying(true);
-      void onDeploy().finally(() => setIsDeploying(false));
+      setDeployFailed(false);
+      void onDeploy()
+        .catch(() => setDeployFailed(true))
+        .finally(() => setIsDeploying(false));
     },
     disabled: inSync || isDeploying,
   });
@@ -114,21 +130,38 @@ export function DeployButton({
         >
           <span className={fillClassName} aria-hidden />
           <span style={{ position: 'relative' }}>DEPLOY</span>
-          {diffCount > 0 && (
+          {deployFailed && !isDeploying ? (
             <span
               style={{
                 position: 'relative',
-                background: CHIP_BG,
-                color: CHIP_FG,
-                border: `1px solid ${CHIP_BORDER}`,
+                background: FAIL_CHIP_BG,
+                color: FAIL_FG,
+                border: `1px solid ${FAIL_CHIP_BORDER}`,
                 borderRadius: 999,
                 padding: '1px 6px',
                 fontSize: 10,
                 fontWeight: 700,
               }}
             >
-              {diffCount} differ
+              deploy failed — try again
             </span>
+          ) : (
+            diffCount > 0 && (
+              <span
+                style={{
+                  position: 'relative',
+                  background: CHIP_BG,
+                  color: CHIP_FG,
+                  border: `1px solid ${CHIP_BORDER}`,
+                  borderRadius: 999,
+                  padding: '1px 6px',
+                  fontSize: 10,
+                  fontWeight: 700,
+                }}
+              >
+                {diffCount} differ
+              </span>
+            )
           )}
         </button>
       </>
@@ -180,9 +213,16 @@ export function DeployButton({
             fontFamily: mono,
             fontSize: 11,
             opacity: inSync ? 1 : 0.85,
+            color: deployFailed && !isDeploying && !inSync ? FAIL_FG : undefined,
           }}
         >
-          {inSync ? 'dials match the deployed state' : isDeploying ? 'deploying…' : subline(diffCount)}
+          {inSync
+            ? 'dials match the deployed state'
+            : isDeploying
+              ? 'deploying…'
+              : deployFailed
+                ? 'deploy failed — try again'
+                : subline(diffCount)}
         </span>
       </button>
       <button

--- a/app/studio/DeployButton.tsx
+++ b/app/studio/DeployButton.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useState } from 'react';
 import { useHoldToFire, DEPLOY_HOLD_MS } from './useHoldToFire';
 
 export { DEPLOY_HOLD_MS };
@@ -57,13 +58,21 @@ export function DeployButton({
   compact?: boolean;
 }) {
   const inSync = diffCount === 0;
+  // diffCount only updates once the deploy's mutate() resolves, so without
+  // this the button stays armed (and holdable) for the whole fetch — a
+  // second completed hold during that window would call onDeploy again.
+  // The server-side deploy is a copy, so a double-POST is harmless to the
+  // data; this guard exists purely so the UI doesn't lie about being ready
+  // to fire again while a deploy is still in flight.
+  const [isDeploying, setIsDeploying] = useState(false);
 
   const { holding, handlers } = useHoldToFire({
     ms: DEPLOY_HOLD_MS,
     onFire: () => {
-      void onDeploy();
+      setIsDeploying(true);
+      void onDeploy().finally(() => setIsDeploying(false));
     },
-    disabled: inSync,
+    disabled: inSync || isDeploying,
   });
 
   const fillClassName = `studio-deploy-fill${holding ? ' studio-deploy-fill--holding' : ''}`;
@@ -75,8 +84,14 @@ export function DeployButton({
         <button
           type="button"
           {...handlers}
-          disabled={inSync}
-          aria-label={inSync ? 'in sync with glass' : `deploy — ${diffCount} differ`}
+          disabled={inSync || isDeploying}
+          aria-label={
+            inSync
+              ? 'in sync with glass'
+              : isDeploying
+                ? 'deploying'
+                : `deploy — ${diffCount} differ`
+          }
           style={{
             position: 'relative',
             display: 'flex',
@@ -92,8 +107,9 @@ export function DeployButton({
             fontWeight: 700,
             letterSpacing: '0.06em',
             padding: '4px 10px',
-            cursor: inSync ? 'default' : 'pointer',
+            cursor: inSync || isDeploying ? 'default' : 'pointer',
             boxShadow: inSync ? 'none' : ARMED_GLOW,
+            opacity: isDeploying ? 0.6 : 1,
           }}
         >
           <span className={fillClassName} aria-hidden />
@@ -125,7 +141,7 @@ export function DeployButton({
       <button
         type="button"
         {...handlers}
-        disabled={inSync}
+        disabled={inSync || isDeploying}
         aria-label={inSync ? 'IN SYNC WITH GLASS ✓' : 'HOLD TO DEPLOY'}
         style={{
           position: 'relative',
@@ -141,8 +157,9 @@ export function DeployButton({
           borderRadius: 8,
           color: inSync ? SYNC_FG : '#fff',
           padding: '12px 8px',
-          cursor: inSync ? 'default' : 'pointer',
+          cursor: inSync || isDeploying ? 'default' : 'pointer',
           boxShadow: inSync ? 'none' : ARMED_GLOW,
+          opacity: isDeploying ? 0.6 : 1,
         }}
       >
         <span className={fillClassName} aria-hidden />
@@ -165,7 +182,7 @@ export function DeployButton({
             opacity: inSync ? 1 : 0.85,
           }}
         >
-          {inSync ? 'dials match the deployed state' : subline(diffCount)}
+          {inSync ? 'dials match the deployed state' : isDeploying ? 'deploying…' : subline(diffCount)}
         </span>
       </button>
       <button

--- a/app/studio/DeployButton.tsx
+++ b/app/studio/DeployButton.tsx
@@ -1,0 +1,195 @@
+'use client';
+
+import { useHoldToFire, DEPLOY_HOLD_MS } from './useHoldToFire';
+
+export { DEPLOY_HOLD_MS };
+
+const mono = 'ui-monospace, SFMono-Regular, Menlo, monospace';
+
+// Armed (has deviations) face — red gradient family per mockup addendum §3.
+const ARMED_GRADIENT = 'linear-gradient(180deg, #d4444a, #a92e33)';
+const ARMED_GLOW = '0 0 0 1px rgba(212,68,74,.45), 0 4px 16px rgba(212,68,74,.45)';
+
+// In-sync (no deviations) face — dark inert.
+const SYNC_BG = '#141a26';
+const SYNC_BORDER = '#1e2635';
+const SYNC_FG = '#5a6375';
+
+// Compact pill's amber diff chip.
+const CHIP_BG = '#3a2a12';
+const CHIP_FG = '#f5a344';
+const CHIP_BORDER = '#6b4a1a';
+
+const FILL_STYLE = `
+.studio-deploy-fill {
+  position: absolute;
+  inset: 0;
+  width: 0%;
+  background: rgba(255, 255, 255, .22);
+  pointer-events: none;
+  transition: width ${DEPLOY_HOLD_MS}ms linear;
+}
+.studio-deploy-fill--holding {
+  width: 100%;
+}
+@media (prefers-reduced-motion: reduce) {
+  .studio-deploy-fill {
+    transition: none;
+  }
+}
+`;
+
+function subline(diffCount: number): string {
+  const noun = diffCount === 1 ? 'setting' : 'settings';
+  const verb = diffCount === 1 ? 'differs' : 'differ';
+  return `▲ ${diffCount} ${noun} ${verb}`;
+}
+
+export function DeployButton({
+  diffCount,
+  onDeploy,
+  onRevert,
+  compact = false,
+}: {
+  diffCount: number;
+  onDeploy: () => Promise<void>;
+  onRevert: () => Promise<void>;
+  compact?: boolean;
+}) {
+  const inSync = diffCount === 0;
+
+  const { holding, handlers } = useHoldToFire({
+    ms: DEPLOY_HOLD_MS,
+    onFire: () => {
+      void onDeploy();
+    },
+    disabled: inSync,
+  });
+
+  const fillClassName = `studio-deploy-fill${holding ? ' studio-deploy-fill--holding' : ''}`;
+
+  if (compact) {
+    return (
+      <>
+        <style>{FILL_STYLE}</style>
+        <button
+          type="button"
+          {...handlers}
+          disabled={inSync}
+          aria-label={inSync ? 'in sync with glass' : `deploy — ${diffCount} differ`}
+          style={{
+            position: 'relative',
+            display: 'flex',
+            alignItems: 'center',
+            gap: 6,
+            overflow: 'hidden',
+            background: inSync ? SYNC_BG : ARMED_GRADIENT,
+            border: `1px solid ${inSync ? SYNC_BORDER : 'transparent'}`,
+            borderRadius: 999,
+            color: inSync ? SYNC_FG : '#fff',
+            fontFamily: mono,
+            fontSize: 11,
+            fontWeight: 700,
+            letterSpacing: '0.06em',
+            padding: '4px 10px',
+            cursor: inSync ? 'default' : 'pointer',
+            boxShadow: inSync ? 'none' : ARMED_GLOW,
+          }}
+        >
+          <span className={fillClassName} aria-hidden />
+          <span style={{ position: 'relative' }}>DEPLOY</span>
+          {diffCount > 0 && (
+            <span
+              style={{
+                position: 'relative',
+                background: CHIP_BG,
+                color: CHIP_FG,
+                border: `1px solid ${CHIP_BORDER}`,
+                borderRadius: 999,
+                padding: '1px 6px',
+                fontSize: 10,
+                fontWeight: 700,
+              }}
+            >
+              {diffCount} differ
+            </span>
+          )}
+        </button>
+      </>
+    );
+  }
+
+  return (
+    <div>
+      <style>{FILL_STYLE}</style>
+      <button
+        type="button"
+        {...handlers}
+        disabled={inSync}
+        aria-label={inSync ? 'IN SYNC WITH GLASS ✓' : 'HOLD TO DEPLOY'}
+        style={{
+          position: 'relative',
+          overflow: 'hidden',
+          width: '100%',
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+          justifyContent: 'center',
+          gap: 2,
+          background: inSync ? SYNC_BG : ARMED_GRADIENT,
+          border: `1px solid ${inSync ? SYNC_BORDER : 'transparent'}`,
+          borderRadius: 8,
+          color: inSync ? SYNC_FG : '#fff',
+          padding: '12px 8px',
+          cursor: inSync ? 'default' : 'pointer',
+          boxShadow: inSync ? 'none' : ARMED_GLOW,
+        }}
+      >
+        <span className={fillClassName} aria-hidden />
+        <span
+          style={{
+            position: 'relative',
+            fontFamily: mono,
+            fontSize: 13,
+            fontWeight: 700,
+            letterSpacing: '0.08em',
+          }}
+        >
+          {inSync ? 'IN SYNC WITH GLASS ✓' : 'HOLD TO DEPLOY'}
+        </span>
+        <span
+          style={{
+            position: 'relative',
+            fontFamily: mono,
+            fontSize: 11,
+            opacity: inSync ? 1 : 0.85,
+          }}
+        >
+          {inSync ? 'dials match the deployed state' : subline(diffCount)}
+        </span>
+      </button>
+      <button
+        type="button"
+        onClick={() => {
+          void onRevert();
+        }}
+        disabled={inSync}
+        style={{
+          display: 'block',
+          marginTop: 6,
+          width: '100%',
+          background: 'transparent',
+          border: 'none',
+          color: '#8b95a7',
+          fontFamily: mono,
+          fontSize: 11,
+          padding: '4px 0',
+          cursor: inSync ? 'default' : 'pointer',
+          opacity: inSync ? 0.35 : 1,
+        }}
+      >
+        ↩ revert to glass
+      </button>
+    </div>
+  );
+}

--- a/app/studio/PreviewPane.test.tsx
+++ b/app/studio/PreviewPane.test.tsx
@@ -1,0 +1,121 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { useTerminatorStore } from '@/app/store/useTerminatorStore';
+import type { WindyWebcam } from '@/app/lib/types';
+
+/** jsdom has no ResizeObserver; StudioPanelFrame renders for real in these tests. */
+class StubResizeObserver {
+  private callback: ResizeObserverCallback;
+  constructor(callback: ResizeObserverCallback) {
+    this.callback = callback;
+  }
+  observe(target: Element) {
+    this.callback(
+      [
+        {
+          target,
+          contentRect: { width: 700, height: 900 } as DOMRectReadOnly,
+        } as ResizeObserverEntry,
+      ],
+      this as unknown as ResizeObserver
+    );
+  }
+  unobserve() {}
+  disconnect() {}
+}
+global.ResizeObserver = StubResizeObserver;
+
+let capturedFeeds: string[] = [];
+
+vi.mock('@/app/components/mosaic/registry', () => ({
+  resolveMosaic: () => (props: { feed: string }) => {
+    capturedFeeds.push(props.feed);
+    return <div data-testid={`mosaic-${props.feed}`} />;
+  },
+  resolveMosaicName: (v: string | null | undefined) => v ?? 'v1',
+}));
+
+import { PreviewPane } from './PreviewPane';
+
+const PANEL = { width: 1440, height: 2560 };
+
+function fakeWebcams(): WindyWebcam[] {
+  return [
+    { webcamId: 1, title: 'sunrise cam' } as unknown as WindyWebcam,
+  ];
+}
+
+describe('PreviewPane', () => {
+  beforeEach(() => {
+    capturedFeeds = [];
+    useTerminatorStore.setState({
+      sunrise: fakeWebcams(),
+      sunset: fakeWebcams(),
+      combined: [],
+      loading: false,
+      error: undefined,
+    });
+  });
+
+  it("renders both stages for view='both'", () => {
+    render(
+      <PreviewPane
+        view="both"
+        onViewChange={() => {}}
+        panel={PANEL}
+        panelPresetLabel="ktc · 1440×2560"
+        versionName="v1"
+      />
+    );
+
+    expect(screen.getAllByTestId('studio-panel-stage')).toHaveLength(2);
+    expect(capturedFeeds.sort()).toEqual(['sunrise', 'sunset']);
+  });
+
+  it("renders one stage for view='sunset'", () => {
+    render(
+      <PreviewPane
+        view="sunset"
+        onViewChange={() => {}}
+        panel={PANEL}
+        panelPresetLabel="ktc · 1440×2560"
+        versionName="v1"
+      />
+    );
+
+    expect(screen.getAllByTestId('studio-panel-stage')).toHaveLength(1);
+    expect(capturedFeeds).toEqual(['sunset']);
+  });
+
+  it("calls onViewChange('sunrise') when the sunrise segment is clicked", () => {
+    let seen: string | null = null;
+    render(
+      <PreviewPane
+        view="both"
+        onViewChange={(v) => {
+          seen = v;
+        }}
+        panel={PANEL}
+        panelPresetLabel="ktc · 1440×2560"
+        versionName="v1"
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /^sunrise$/i }));
+    expect(seen).toBe('sunrise');
+  });
+
+  it('renders the geometry chip with panelPresetLabel', () => {
+    render(
+      <PreviewPane
+        view="both"
+        onViewChange={() => {}}
+        panel={PANEL}
+        panelPresetLabel="ktc · 1440×2560"
+        versionName="v1"
+      />
+    );
+
+    expect(screen.getByText('ktc · 1440×2560')).toBeTruthy();
+  });
+});

--- a/app/studio/PreviewPane.tsx
+++ b/app/studio/PreviewPane.tsx
@@ -1,0 +1,157 @@
+'use client';
+
+import { useTerminatorStore } from '@/app/store/useTerminatorStore';
+import { resolveMosaic } from '@/app/components/mosaic/registry';
+import type { PanelSize } from '@/app/kiosk/panelPreview';
+import type { SettingsValues } from '@/app/lib/settings/schema';
+import { StudioPanelFrame } from './StudioPanelFrame';
+
+export type FeedView = 'sunrise' | 'sunset' | 'both';
+
+const SEGMENTS: FeedView[] = ['sunrise', 'sunset', 'both'];
+
+const mono = 'ui-monospace, SFMono-Regular, Menlo, monospace';
+const dim = '#8b95a7';
+const hairline = '#232a38';
+
+function feedsFor(view: FeedView): Array<'sunrise' | 'sunset'> {
+  return view === 'both' ? ['sunrise', 'sunset'] : [view];
+}
+
+export function PreviewPane({
+  view,
+  onViewChange,
+  panel,
+  panelPresetLabel,
+  versionName,
+  settings,
+}: {
+  view: FeedView;
+  onViewChange: (v: FeedView) => void;
+  panel: PanelSize;
+  panelPresetLabel: string;
+  versionName: string;
+  settings?: SettingsValues;
+}) {
+  const sunrise = useTerminatorStore((t) => t.sunrise);
+  const sunset = useTerminatorStore((t) => t.sunset);
+  const Mosaic = resolveMosaic(versionName);
+  const feeds = feedsFor(view);
+
+  const webcamsFor = (feed: 'sunrise' | 'sunset') =>
+    feed === 'sunrise' ? sunrise : sunset;
+
+  return (
+    <div
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        width: '100%',
+        height: '100%',
+        gap: 16,
+        padding: 16,
+        boxSizing: 'border-box',
+      }}
+    >
+      <div style={{ display: 'flex', alignItems: 'center', gap: 12 }}>
+        <div
+          role="group"
+          aria-label="feed view"
+          style={{
+            display: 'flex',
+            border: `1px solid ${hairline}`,
+            borderRadius: 6,
+            overflow: 'hidden',
+          }}
+        >
+          {SEGMENTS.map((seg) => (
+            <button
+              key={seg}
+              type="button"
+              aria-pressed={view === seg}
+              onClick={() => onViewChange(seg)}
+              style={{
+                padding: '4px 14px',
+                fontSize: 12,
+                textTransform: 'capitalize',
+                cursor: 'pointer',
+                border: 'none',
+                background: view === seg ? '#1d2432' : 'transparent',
+                color: view === seg ? '#e5e7eb' : dim,
+              }}
+            >
+              {seg}
+            </button>
+          ))}
+        </div>
+
+        <span
+          data-testid="studio-geometry-chip"
+          style={{
+            fontFamily: mono,
+            fontSize: 11,
+            letterSpacing: '0.05em',
+            color: dim,
+            border: `1px solid ${hairline}`,
+            borderRadius: 999,
+            padding: '3px 12px',
+          }}
+        >
+          {panelPresetLabel}
+        </span>
+      </div>
+
+      <div
+        style={{
+          display: 'flex',
+          flex: 1,
+          minHeight: 0,
+          width: '100%',
+          alignItems: 'center',
+          justifyContent: 'center',
+          gap: 24,
+        }}
+      >
+        {feeds.map((feed) => (
+          <div
+            key={feed}
+            style={{
+              display: 'flex',
+              flexDirection: 'column',
+              alignItems: 'center',
+              gap: 8,
+              height: '100%',
+              minWidth: 0,
+              flex: 1,
+            }}
+          >
+            <span
+              style={{
+                fontSize: 11,
+                fontWeight: 600,
+                letterSpacing: '0.12em',
+                textTransform: 'uppercase',
+                color: dim,
+              }}
+            >
+              {feed}
+            </span>
+            <div style={{ flex: 1, width: '100%', minHeight: 0 }}>
+              <StudioPanelFrame panel={panel}>
+                <Mosaic
+                  webcams={webcamsFor(feed)}
+                  width={panel.width}
+                  height={panel.height}
+                  feed={feed}
+                  search=""
+                  settings={settings}
+                />
+              </StudioPanelFrame>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/app/studio/StatusStrip.test.tsx
+++ b/app/studio/StatusStrip.test.tsx
@@ -1,0 +1,128 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, act } from '@testing-library/react';
+import { StatusStrip } from './StatusStrip';
+
+describe('StatusStrip', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('renders glass version, revision, poll age, gate counts, and the in-sync state', () => {
+    const now = new Date('2026-08-30T12:00:00Z');
+    vi.setSystemTime(now);
+    const lastPollAt = new Date(now.getTime() - 32_000).toISOString();
+
+    render(
+      <StatusStrip
+        glassVersion="v1"
+        liveRevision={14}
+        lastPollAt={lastPollAt}
+        deployedAtMs={null}
+        diffCount={0}
+        sunrisePass={{ pass: 1, total: 39 }}
+        sunsetPass={{ pass: 3, total: 42 }}
+      />
+    );
+
+    expect(screen.getByText('glass v1')).toBeInTheDocument();
+    expect(screen.getByText('rev 14')).toBeInTheDocument();
+    expect(screen.getByText('polled 32s ago')).toBeInTheDocument();
+    expect(screen.getByText('↑1/39 ↓3/42 pass')).toBeInTheDocument();
+    expect(screen.getByText('in sync')).toBeInTheDocument();
+  });
+
+  it('shows the deploying state with a countdown to the next poll', () => {
+    const deployedAtMs = new Date('2026-08-30T12:00:00Z').getTime();
+    const lastPollAtMs = deployedAtMs - 10_000;
+    vi.setSystemTime(deployedAtMs + 5_000);
+
+    render(
+      <StatusStrip
+        glassVersion="v1"
+        liveRevision={14}
+        lastPollAt={new Date(lastPollAtMs).toISOString()}
+        deployedAtMs={deployedAtMs}
+        diffCount={0}
+        sunrisePass={{ pass: 1, total: 39 }}
+        sunsetPass={{ pass: 3, total: 42 }}
+      />
+    );
+
+    // next poll lands at lastPollAtMs + 60000 = deployedAtMs + 50000;
+    // secondsToGlass = ceil((deployedAtMs+50000 - (deployedAtMs+5000))/1000) = 45
+    expect(screen.getByText('deploying · on glass within 45s')).toBeInTheDocument();
+  });
+
+  it('shows the drift state with the differing count', () => {
+    const now = new Date('2026-08-30T12:00:00Z');
+    vi.setSystemTime(now);
+
+    render(
+      <StatusStrip
+        glassVersion="v1"
+        liveRevision={14}
+        lastPollAt={new Date(now.getTime() - 5_000).toISOString()}
+        deployedAtMs={null}
+        diffCount={7}
+        sunrisePass={{ pass: 1, total: 39 }}
+        sunsetPass={{ pass: 3, total: 42 }}
+      />
+    );
+
+    expect(screen.getByText('7 differ')).toBeInTheDocument();
+  });
+
+  it('shows the stale state with a red kiosk-unreachable poll label when there has been no poll', () => {
+    vi.setSystemTime(new Date('2026-08-30T12:00:00Z'));
+
+    render(
+      <StatusStrip
+        glassVersion="v1"
+        liveRevision={14}
+        lastPollAt={null}
+        deployedAtMs={null}
+        diffCount={0}
+        sunrisePass={{ pass: 1, total: 39 }}
+        sunsetPass={{ pass: 3, total: 42 }}
+      />
+    );
+
+    expect(screen.getByText('polled never — kiosk unreachable?')).toBeInTheDocument();
+    expect(screen.getByText('stale')).toBeInTheDocument();
+  });
+
+  it('ticks the poll age forward once a second, and stops after unmount', () => {
+    const now = new Date('2026-08-30T12:00:00Z');
+    vi.setSystemTime(now);
+    const lastPollAt = new Date(now.getTime() - 1_000).toISOString();
+
+    const { unmount } = render(
+      <StatusStrip
+        glassVersion="v1"
+        liveRevision={14}
+        lastPollAt={lastPollAt}
+        deployedAtMs={null}
+        diffCount={0}
+        sunrisePass={{ pass: 1, total: 39 }}
+        sunsetPass={{ pass: 3, total: 42 }}
+      />
+    );
+
+    expect(screen.getByText('polled 1s ago')).toBeInTheDocument();
+
+    act(() => {
+      vi.advanceTimersByTime(5_000);
+    });
+
+    expect(screen.getByText('polled 6s ago')).toBeInTheDocument();
+
+    const clearIntervalSpy = vi.spyOn(global, 'clearInterval');
+    unmount();
+    expect(clearIntervalSpy).toHaveBeenCalled();
+    clearIntervalSpy.mockRestore();
+  });
+});

--- a/app/studio/StatusStrip.tsx
+++ b/app/studio/StatusStrip.tsx
@@ -1,0 +1,120 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { stripState, formatPollAge, type StripKind } from './stripState';
+import { KIOSK_TICK_INTERVAL_MS } from '@/app/lib/masterConfig';
+
+const mono = 'ui-monospace, SFMono-Regular, Menlo, monospace';
+const dim = '#8b95a7';
+const green = '#4cc38a';
+const amber = '#f5a344';
+const red = '#e5484d';
+
+const DOT_COLOR: Record<StripKind, string> = {
+  insync: green,
+  drift: green,
+  deploying: amber,
+  stale: red,
+};
+
+export interface GatePassCount {
+  pass: number;
+  total: number;
+}
+
+/**
+ * The studio's telemetry line (Task 13, mockup §5): liveness dot, glass
+ * version + revision the kiosk last confirmed, poll freshness, per-feed
+ * detection-gate pass counts, and a right-aligned state word. `nowMs` ticks
+ * every second so the poll age and deploy countdown move without a page
+ * refresh.
+ */
+export function StatusStrip({
+  glassVersion,
+  liveRevision,
+  lastPollAt,
+  deployedAtMs,
+  diffCount,
+  sunrisePass,
+  sunsetPass,
+}: {
+  glassVersion: string;
+  liveRevision: number;
+  lastPollAt: string | null;
+  deployedAtMs: number | null;
+  diffCount: number;
+  sunrisePass: GatePassCount;
+  sunsetPass: GatePassCount;
+}) {
+  const [nowMs, setNowMs] = useState(() => Date.now());
+
+  useEffect(() => {
+    const id = setInterval(() => setNowMs(Date.now()), 1000);
+    return () => clearInterval(id);
+  }, []);
+
+  const lastPollAtMs = lastPollAt ? Date.parse(lastPollAt) : null;
+  const state = stripState({
+    diffCount,
+    lastPollAtMs,
+    deployedAtMs,
+    nowMs,
+    pollIntervalMs: KIOSK_TICK_INTERVAL_MS,
+  });
+
+  const pollAge = formatPollAge(lastPollAtMs, nowMs);
+  const pollLabel =
+    state.kind === 'stale' ? `polled ${pollAge} — kiosk unreachable?` : `polled ${pollAge}`;
+
+  let stateWord: React.ReactNode;
+  switch (state.kind) {
+    case 'insync':
+      stateWord = <span style={{ color: dim }}>in sync</span>;
+      break;
+    case 'deploying':
+      stateWord = (
+        <span style={{ color: amber }}>
+          deploying · on glass within {state.secondsToGlass}s
+        </span>
+      );
+      break;
+    case 'drift':
+      stateWord = <span style={{ color: amber }}>{diffCount} differ</span>;
+      break;
+    case 'stale':
+      stateWord = <span style={{ color: red }}>stale</span>;
+      break;
+  }
+
+  return (
+    <div
+      data-testid="status-strip"
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        width: '100%',
+        gap: 16,
+        fontFamily: mono,
+        fontSize: 11,
+      }}
+    >
+      <span
+        aria-label={`status: ${state.kind}`}
+        style={{
+          width: 8,
+          height: 8,
+          borderRadius: '50%',
+          background: DOT_COLOR[state.kind],
+          flexShrink: 0,
+        }}
+      />
+      <span style={{ color: dim }}>glass {glassVersion}</span>
+      <span style={{ color: dim }}>rev {liveRevision}</span>
+      <span style={{ color: state.kind === 'stale' ? red : dim }}>{pollLabel}</span>
+      <span style={{ color: amber }}>
+        ↑{sunrisePass.pass}/{sunrisePass.total} ↓{sunsetPass.pass}/{sunsetPass.total} pass
+      </span>
+      <span style={{ marginLeft: 'auto' }}>{stateWord}</span>
+    </div>
+  );
+}

--- a/app/studio/StudioClient.tsx
+++ b/app/studio/StudioClient.tsx
@@ -1,0 +1,166 @@
+'use client';
+
+import { useState } from 'react';
+import { useLoadTerminatorWebcams } from '@/app/store/useLoadTerminatorWebcams';
+import { PreviewPane, type FeedView } from './PreviewPane';
+import type { PanelSize } from '@/app/kiosk/panelPreview';
+
+/**
+ * `/studio` chrome: left rail (dial controls, Task 11) + preview + a bottom
+ * status strip (Task 13). This task lays out the grid, keeps `railCollapsed`
+ * state and the collapse pill, and wires the preview to the live terminator
+ * store — the rail's `<aside>` is a placeholder a later task fills in.
+ */
+
+// Hard-coded until Task 10 wires the real studio profile + settings.
+const PANEL: PanelSize = { width: 1440, height: 2560 };
+const PANEL_PRESET_LABEL = 'ktc · 1440×2560';
+const VERSION_NAME = 'v1';
+
+const bg = '#0b0e14';
+const railBg = '#10141d';
+const railBorder = '#1d2432';
+const stripBg = '#0e1119';
+const stripBorder = '#1d2432';
+const dim = '#8b95a7';
+const pillBg = 'rgba(16,20,29,.85)';
+const pillBorder = '#232a38';
+const mono = 'ui-monospace, SFMono-Regular, Menlo, monospace';
+
+export function StudioClient() {
+  useLoadTerminatorWebcams();
+
+  const [railCollapsed, setRailCollapsed] = useState(false);
+  const [view, setView] = useState<FeedView>('both');
+
+  return (
+    <div
+      style={{
+        display: 'grid',
+        gridTemplateColumns: railCollapsed ? '1fr' : '320px 1fr',
+        gridTemplateRows: '1fr 28px',
+        height: '100vh',
+        width: '100%',
+        background: bg,
+        color: '#e5e7eb',
+        overflow: 'hidden',
+      }}
+    >
+      {!railCollapsed && (
+        <aside
+          style={{
+            gridColumn: '1 / 2',
+            gridRow: '1 / 2',
+            background: railBg,
+            borderRight: `1px solid ${railBorder}`,
+            overflow: 'auto',
+            padding: 16,
+            boxSizing: 'border-box',
+          }}
+        >
+          <div
+            style={{
+              display: 'flex',
+              justifyContent: 'space-between',
+              alignItems: 'center',
+              marginBottom: 16,
+            }}
+          >
+            <span style={{ fontSize: 13, fontWeight: 600, color: dim }}>
+              dials
+            </span>
+            <button
+              type="button"
+              onClick={() => setRailCollapsed(true)}
+              aria-label="collapse dials"
+              style={{
+                background: 'transparent',
+                border: `1px solid ${railBorder}`,
+                borderRadius: 4,
+                color: dim,
+                fontSize: 12,
+                padding: '2px 8px',
+                cursor: 'pointer',
+              }}
+            >
+              «
+            </button>
+          </div>
+          <p style={{ fontSize: 12, color: dim, fontFamily: mono, margin: 0 }}>
+            dial controls arrive in a later task
+          </p>
+        </aside>
+      )}
+
+      <main
+        style={{
+          gridColumn: railCollapsed ? '1 / 2' : '2 / 3',
+          gridRow: '1 / 2',
+          position: 'relative',
+          minWidth: 0,
+          minHeight: 0,
+          overflow: 'hidden',
+        }}
+      >
+        <PreviewPane
+          view={view}
+          onViewChange={setView}
+          panel={PANEL}
+          panelPresetLabel={PANEL_PRESET_LABEL}
+          versionName={VERSION_NAME}
+          settings={undefined}
+        />
+
+        {railCollapsed && (
+          <div
+            style={{
+              position: 'absolute',
+              left: 12,
+              bottom: 12,
+              display: 'flex',
+              alignItems: 'center',
+              gap: 8,
+              background: pillBg,
+              border: `1px solid ${pillBorder}`,
+              borderRadius: 999,
+              padding: '6px 8px',
+              backdropFilter: 'blur(4px)',
+            }}
+          >
+            <button
+              type="button"
+              onClick={() => setRailCollapsed(false)}
+              style={{
+                background: 'transparent',
+                border: 'none',
+                color: '#e5e7eb',
+                fontSize: 12,
+                padding: '4px 10px',
+                cursor: 'pointer',
+              }}
+            >
+              » dials
+            </button>
+          </div>
+        )}
+      </main>
+
+      <div
+        style={{
+          gridColumn: '1 / -1',
+          gridRow: '2 / 3',
+          background: stripBg,
+          borderTop: `1px solid ${stripBorder}`,
+          display: 'flex',
+          alignItems: 'center',
+          padding: '0 12px',
+          boxSizing: 'border-box',
+        }}
+      >
+        <span style={{ fontFamily: mono, fontSize: 11, color: dim }}>
+          status strip — coming in a later task
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/app/studio/StudioClient.tsx
+++ b/app/studio/StudioClient.tsx
@@ -3,19 +3,23 @@
 import { useState } from 'react';
 import { useLoadTerminatorWebcams } from '@/app/store/useLoadTerminatorWebcams';
 import { PreviewPane, type FeedView } from './PreviewPane';
+import { StudioRail } from './StudioRail';
+import { useStudioSettings } from './useStudioSettings';
+import { resolveMosaicName } from '@/app/components/mosaic/registry';
 import type { PanelSize } from '@/app/kiosk/panelPreview';
 
 /**
  * `/studio` chrome: left rail (dial controls, Task 11) + preview + a bottom
  * status strip (Task 13). This task lays out the grid, keeps `railCollapsed`
  * state and the collapse pill, and wires the preview to the live terminator
- * store — the rail's `<aside>` is a placeholder a later task fills in.
+ * store. The rail (Task 11) and its settings wiring are now real: panel
+ * size, version, and preview settings all flow from `useStudioSettings`.
  */
 
-// Hard-coded until Task 10 wires the real studio profile + settings.
-const PANEL: PanelSize = { width: 1440, height: 2560 };
-const PANEL_PRESET_LABEL = 'ktc · 1440×2560';
-const VERSION_NAME = 'v1';
+const PANEL_PRESETS: Record<string, PanelSize> = {
+  dell: { width: 1080, height: 1920 },
+  ktc: { width: 1440, height: 2560 },
+};
 
 const bg = '#0b0e14';
 const railBg = '#10141d';
@@ -29,9 +33,17 @@ const mono = 'ui-monospace, SFMono-Regular, Menlo, monospace';
 
 export function StudioClient() {
   useLoadTerminatorWebcams();
+  const settingsApi = useStudioSettings();
 
   const [railCollapsed, setRailCollapsed] = useState(false);
   const [view, setView] = useState<FeedView>('both');
+
+  const sharedSettings = settingsApi.effective('shared');
+  const panelPreset = (sharedSettings.panelPreset as string) ?? 'dell';
+  const panel = PANEL_PRESETS[panelPreset] ?? PANEL_PRESETS.dell;
+  const panelPresetLabel = `${panelPreset} · ${panel.width}×${panel.height}`;
+  const versionName = resolveMosaicName(sharedSettings.activeVersion as string | undefined);
+  const previewSettings = settingsApi.effective(versionName);
 
   return (
     <div
@@ -53,42 +65,12 @@ export function StudioClient() {
             gridRow: '1 / 2',
             background: railBg,
             borderRight: `1px solid ${railBorder}`,
-            overflow: 'auto',
+            overflow: 'hidden',
             padding: 16,
             boxSizing: 'border-box',
           }}
         >
-          <div
-            style={{
-              display: 'flex',
-              justifyContent: 'space-between',
-              alignItems: 'center',
-              marginBottom: 16,
-            }}
-          >
-            <span style={{ fontSize: 13, fontWeight: 600, color: dim }}>
-              dials
-            </span>
-            <button
-              type="button"
-              onClick={() => setRailCollapsed(true)}
-              aria-label="collapse dials"
-              style={{
-                background: 'transparent',
-                border: `1px solid ${railBorder}`,
-                borderRadius: 4,
-                color: dim,
-                fontSize: 12,
-                padding: '2px 8px',
-                cursor: 'pointer',
-              }}
-            >
-              «
-            </button>
-          </div>
-          <p style={{ fontSize: 12, color: dim, fontFamily: mono, margin: 0 }}>
-            dial controls arrive in a later task
-          </p>
+          <StudioRail api={settingsApi} onCollapse={() => setRailCollapsed(true)} />
         </aside>
       )}
 
@@ -105,10 +87,10 @@ export function StudioClient() {
         <PreviewPane
           view={view}
           onViewChange={setView}
-          panel={PANEL}
-          panelPresetLabel={PANEL_PRESET_LABEL}
-          versionName={VERSION_NAME}
-          settings={undefined}
+          panel={panel}
+          panelPresetLabel={panelPresetLabel}
+          versionName={versionName}
+          settings={previewSettings}
         />
 
         {railCollapsed && (

--- a/app/studio/StudioClient.tsx
+++ b/app/studio/StudioClient.tsx
@@ -1,12 +1,17 @@
 'use client';
 
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import { useLoadTerminatorWebcams } from '@/app/store/useLoadTerminatorWebcams';
+import { useTerminatorStore } from '@/app/store/useTerminatorStore';
 import { PreviewPane, type FeedView } from './PreviewPane';
 import { StudioRail } from './StudioRail';
 import { useStudioSettings } from './useStudioSettings';
 import { DeployButton } from './DeployButton';
+import { StatusStrip } from './StatusStrip';
 import { resolveMosaicName } from '@/app/components/mosaic/registry';
+import { mergeSettings } from '@/app/lib/settings/schema';
+import { SHARED_NAMESPACE, SHARED_SCHEMA } from '@/app/lib/settings/sharedSchema';
+import { passesGate } from '@/app/components/mosaic/v1/qualitySignal';
 import type { PanelSize } from '@/app/kiosk/panelPreview';
 
 /**
@@ -27,14 +32,14 @@ const railBg = '#10141d';
 const railBorder = '#1d2432';
 const stripBg = '#0e1119';
 const stripBorder = '#1d2432';
-const dim = '#8b95a7';
 const pillBg = 'rgba(16,20,29,.85)';
 const pillBorder = '#232a38';
-const mono = 'ui-monospace, SFMono-Regular, Menlo, monospace';
 
 export function StudioClient() {
   useLoadTerminatorWebcams();
   const settingsApi = useStudioSettings();
+  const sunriseWebcams = useTerminatorStore((t) => t.sunrise);
+  const sunsetWebcams = useTerminatorStore((t) => t.sunset);
 
   const [railCollapsed, setRailCollapsed] = useState(false);
   const [view, setView] = useState<FeedView>('both');
@@ -45,6 +50,30 @@ export function StudioClient() {
   const panelPresetLabel = `${panelPreset} · ${panel.width}×${panel.height}`;
   const versionName = resolveMosaicName(sharedSettings.activeVersion as string | undefined);
   const previewSettings = settingsApi.effective(versionName);
+
+  // What's actually on glass right now, NOT the studio dial position — the
+  // strip reports the deployed state, so this reads the live profile's
+  // deviations merged over SHARED_SCHEMA rather than settingsApi.effective
+  // (which merges over the studio profile).
+  const glassVersion = resolveMosaicName(
+    mergeSettings(SHARED_SCHEMA, settingsApi.live?.namespaces?.[SHARED_NAMESPACE])
+      .activeVersion as string | undefined
+  );
+
+  const sunrisePass = useMemo(
+    () => ({
+      pass: sunriseWebcams.filter(passesGate).length,
+      total: sunriseWebcams.length,
+    }),
+    [sunriseWebcams]
+  );
+  const sunsetPass = useMemo(
+    () => ({
+      pass: sunsetWebcams.filter(passesGate).length,
+      total: sunsetWebcams.length,
+    }),
+    [sunsetWebcams]
+  );
 
   return (
     <div
@@ -156,9 +185,15 @@ export function StudioClient() {
           boxSizing: 'border-box',
         }}
       >
-        <span style={{ fontFamily: mono, fontSize: 11, color: dim }}>
-          status strip — coming in a later task
-        </span>
+        <StatusStrip
+          glassVersion={glassVersion}
+          liveRevision={settingsApi.liveRevision}
+          lastPollAt={settingsApi.lastPollAt}
+          deployedAtMs={settingsApi.deployedAtMs}
+          diffCount={settingsApi.diffCount}
+          sunrisePass={sunrisePass}
+          sunsetPass={sunsetPass}
+        />
       </div>
     </div>
   );

--- a/app/studio/StudioClient.tsx
+++ b/app/studio/StudioClient.tsx
@@ -5,6 +5,7 @@ import { useLoadTerminatorWebcams } from '@/app/store/useLoadTerminatorWebcams';
 import { PreviewPane, type FeedView } from './PreviewPane';
 import { StudioRail } from './StudioRail';
 import { useStudioSettings } from './useStudioSettings';
+import { DeployButton } from './DeployButton';
 import { resolveMosaicName } from '@/app/components/mosaic/registry';
 import type { PanelSize } from '@/app/kiosk/panelPreview';
 
@@ -70,7 +71,17 @@ export function StudioClient() {
             boxSizing: 'border-box',
           }}
         >
-          <StudioRail api={settingsApi} onCollapse={() => setRailCollapsed(true)} />
+          <StudioRail
+            api={settingsApi}
+            onCollapse={() => setRailCollapsed(true)}
+            deploySlot={
+              <DeployButton
+                diffCount={settingsApi.diffCount}
+                onDeploy={settingsApi.deploy}
+                onRevert={settingsApi.revert}
+              />
+            }
+          />
         </aside>
       )}
 
@@ -123,6 +134,12 @@ export function StudioClient() {
             >
               » dials
             </button>
+            <DeployButton
+              compact
+              diffCount={settingsApi.diffCount}
+              onDeploy={settingsApi.deploy}
+              onRevert={settingsApi.revert}
+            />
           </div>
         )}
       </main>

--- a/app/studio/StudioPanelFrame.test.tsx
+++ b/app/studio/StudioPanelFrame.test.tsx
@@ -1,0 +1,71 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { StudioPanelFrame } from './StudioPanelFrame';
+
+/**
+ * jsdom has no ResizeObserver. Stub one that reports a fixed content box the
+ * instant `observe` is called, so the component's effect resolves
+ * synchronously within the test's render.
+ */
+function stubResizeObserver(size: { width: number; height: number }) {
+  class StubResizeObserver {
+    private callback: ResizeObserverCallback;
+
+    constructor(callback: ResizeObserverCallback) {
+      this.callback = callback;
+    }
+
+    observe(target: Element) {
+      this.callback(
+        [
+          {
+            target,
+            contentRect: {
+              width: size.width,
+              height: size.height,
+            } as DOMRectReadOnly,
+          } as ResizeObserverEntry,
+        ],
+        this as unknown as ResizeObserver
+      );
+    }
+
+    unobserve() {}
+    disconnect() {}
+  }
+
+  global.ResizeObserver = StubResizeObserver;
+}
+
+describe('StudioPanelFrame', () => {
+  it('scales a 1440x2560 panel to fit a 700x900 box by the narrower ratio', () => {
+    stubResizeObserver({ width: 700, height: 900 });
+
+    render(
+      <StudioPanelFrame panel={{ width: 1440, height: 2560 }}>
+        <div>content</div>
+      </StudioPanelFrame>
+    );
+
+    const stage = screen.getByTestId('studio-panel-stage');
+    // 700/1440 = 0.4861..., 900/2560 = 0.3515625 — the narrower ratio wins.
+    expect(stage.style.transform).toBe('scale(0.3515625)');
+    expect(stage.style.width).toBe('1440px');
+    expect(stage.style.height).toBe('2560px');
+    expect(stage.style.transformOrigin).toBe('top left');
+    expect(stage.style.background).toBe('rgb(0, 0, 0)');
+  });
+
+  it('caps the scale at 1 when the measured box is larger than the panel', () => {
+    stubResizeObserver({ width: 5000, height: 8000 });
+
+    render(
+      <StudioPanelFrame panel={{ width: 1440, height: 2560 }}>
+        <div>content</div>
+      </StudioPanelFrame>
+    );
+
+    const stage = screen.getByTestId('studio-panel-stage');
+    expect(stage.style.transform).toBe('scale(1)');
+  });
+});

--- a/app/studio/StudioPanelFrame.tsx
+++ b/app/studio/StudioPanelFrame.tsx
@@ -1,0 +1,74 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+import { fitScale, type PanelSize } from '@/app/kiosk/panelPreview';
+
+/**
+ * PanelFrame's container-measured sibling: PanelFrame fits a panel to the
+ * *window*, this fits it to whatever box its parent lays out for it (the
+ * studio's preview column, sized by the rest of the grid). Same stage
+ * markup — true panel px, scaled down, `top left` origin — just measured
+ * with a ResizeObserver on the wrapping element instead of `window.innerWidth`.
+ */
+export function StudioPanelFrame({
+  panel,
+  children,
+}: {
+  panel: PanelSize;
+  children: React.ReactNode;
+}) {
+  const measureRef = useRef<HTMLDivElement | null>(null);
+  const [box, setBox] = useState({ width: 0, height: 0 });
+
+  useEffect(() => {
+    const el = measureRef.current;
+    if (!el) return;
+
+    const observer = new ResizeObserver((entries) => {
+      const entry = entries[0];
+      if (!entry) return;
+      const { width, height } = entry.contentRect;
+      setBox({ width, height });
+    });
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, []);
+
+  const scale = fitScale(panel.width, panel.height, box.width, box.height);
+
+  return (
+    <div
+      ref={measureRef}
+      style={{
+        width: '100%',
+        height: '100%',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        overflow: 'hidden',
+      }}
+    >
+      <div
+        data-testid="studio-panel-box"
+        style={{
+          width: panel.width * scale,
+          height: panel.height * scale,
+          overflow: 'hidden',
+        }}
+      >
+        <div
+          data-testid="studio-panel-stage"
+          style={{
+            width: panel.width,
+            height: panel.height,
+            transform: `scale(${scale})`,
+            transformOrigin: 'top left',
+            background: '#000',
+          }}
+        >
+          {children}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/studio/StudioRail.tsx
+++ b/app/studio/StudioRail.tsx
@@ -151,8 +151,18 @@ export function StudioRail({
   }, [activeVersion, sharedValuesKey, versionValuesKey, sharedDiffKey, versionDiffKey]);
 
   // Deps array leva uses to re-sync control values from `effective()` when
-  // they change from outside this panel (e.g. a revert()).
-  useControls(schema, { store }, [activeVersion, sharedValuesKey, versionValuesKey]);
+  // they change from outside this panel (e.g. a revert()). Must match the
+  // `schema` useMemo's deps exactly — sharedDiffKey/versionDiffKey are
+  // included too, since a label-only change (a knob's differing-from-live
+  // state flipping, with its value unchanged) still needs leva to pick up
+  // the freshly rebuilt `schema` object with the new ● prefix.
+  useControls(schema, { store }, [
+    activeVersion,
+    sharedValuesKey,
+    versionValuesKey,
+    sharedDiffKey,
+    versionDiffKey,
+  ]);
 
   return (
     <div

--- a/app/studio/StudioRail.tsx
+++ b/app/studio/StudioRail.tsx
@@ -1,0 +1,255 @@
+'use client';
+
+import { useMemo, type ReactNode } from 'react';
+import { LevaPanel, useCreateStore, useControls, folder, button } from 'leva';
+import { SHARED_NAMESPACE, SHARED_SCHEMA } from '@/app/lib/settings/sharedSchema';
+import { MOSAIC_SETTINGS_SCHEMAS } from '@/app/components/mosaic/registry';
+import { buildFolderSpecs, type LevaFolderSpec } from './levaConfig';
+import type { KnobValue, SettingsSchema } from '@/app/lib/settings/schema';
+import type { StudioSettingsApi } from './useStudioSettings';
+
+const dim = '#8b95a7';
+const mono = 'ui-monospace, SFMono-Regular, Menlo, monospace';
+const railBorder = '#1d2432';
+
+const CHIP_BG = '#17351f';
+const CHIP_FG = '#4cc38a';
+
+/**
+ * Dusk-palette leva theme: dark elevations, blue-family accents, a bright
+ * highlight for readable labels/values against the near-black panel.
+ * Typed structurally against leva's `theme` prop at the JSX call site below
+ * (leva doesn't publicly export its `LevaCustomTheme` type).
+ */
+const DUSK_THEME = {
+  colors: {
+    elevation1: '#10141d',
+    elevation2: '#141a26',
+    elevation3: '#1a2130',
+    accent1: '#4a90d9',
+    accent2: '#3f7cc0',
+    accent3: '#5aa3ec',
+    highlight1: '#8b95a7',
+    highlight2: '#b7c0d1',
+    highlight3: '#d7dce6',
+    vivid1: '#5aa3ec',
+    folderTextColor: '#b7c0d1',
+    folderWidgetColor: '#8b95a7',
+    toolTipBackground: '#1a2130',
+    toolTipText: '#d7dce6',
+  },
+  radii: { xs: '2px', sm: '3px', lg: '6px' },
+};
+
+function prettify(section: string): string {
+  return section.charAt(0).toUpperCase() + section.slice(1);
+}
+
+/** Plain leva control descriptor built from a LevaFolderSpec entry. */
+type LevaControl = {
+  value: KnobValue;
+  label: string;
+  min?: number;
+  max?: number;
+  step?: number;
+  options?: string[];
+  onChange: (value: KnobValue) => void;
+};
+
+function controlsForSpec(
+  ns: string,
+  spec: LevaFolderSpec,
+  setKnob: StudioSettingsApi['setKnob']
+): Record<string, LevaControl> {
+  const controls: Record<string, LevaControl> = {};
+  for (const [key, ctrl] of Object.entries(spec.controls)) {
+    controls[key] = {
+      value: ctrl.value,
+      label: ctrl.label,
+      ...(ctrl.min !== undefined ? { min: ctrl.min } : {}),
+      ...(ctrl.max !== undefined ? { max: ctrl.max } : {}),
+      ...(ctrl.step !== undefined ? { step: ctrl.step } : {}),
+      ...(ctrl.options !== undefined ? { options: [...ctrl.options] } : {}),
+      onChange: (value: KnobValue) => setKnob(ns, key, value),
+    };
+  }
+  return controls;
+}
+
+export function StudioRail({
+  api,
+  onCollapse,
+  deploySlot,
+}: {
+  api: StudioSettingsApi;
+  onCollapse: () => void;
+  deploySlot?: ReactNode;
+}) {
+  const store = useCreateStore();
+
+  const sharedValues = api.effective(SHARED_NAMESPACE);
+  const activeVersionKnob = SHARED_SCHEMA.find((k) => k.key === 'activeVersion');
+  const versionOptions = activeVersionKnob?.kind === 'enum' ? activeVersionKnob.options : [];
+  const activeVersion = (sharedValues.activeVersion as string) ?? versionOptions[0] ?? 'v1';
+
+  // The top <select> owns activeVersion — everything else in SHARED_SCHEMA
+  // (currently just panelPreset, both in section 'glass') is dial-controlled.
+  const sharedSchema = useMemo(
+    () => SHARED_SCHEMA.filter((k) => k.key !== 'activeVersion'),
+    []
+  );
+  const versionSchema: SettingsSchema = MOSAIC_SETTINGS_SCHEMAS[activeVersion] ?? [];
+
+  const versionValues = api.effective(activeVersion);
+  const sharedDiff = api.diffByNamespace[SHARED_NAMESPACE] ?? [];
+  const versionDiff = api.diffByNamespace[activeVersion] ?? [];
+
+  const sharedSpecs = buildFolderSpecs(sharedSchema, sharedValues, sharedDiff);
+  const versionSpecs = buildFolderSpecs(versionSchema, versionValues, versionDiff);
+
+  // Precomputed so useMemo/useControls deps arrays below stay simple
+  // expressions leva-eslint's exhaustive-deps check can verify statically.
+  const sharedValuesKey = JSON.stringify(sharedValues);
+  const versionValuesKey = JSON.stringify(versionValues);
+  const sharedDiffKey = sharedDiff.join(',');
+  const versionDiffKey = versionDiff.join(',');
+
+  // resetSection('shared', 'glass') would also clear activeVersion, since
+  // both knobs share that section in SHARED_SCHEMA — but the top <select>
+  // owns activeVersion, so the shared folder's reset button must not touch
+  // it. resetSection has no per-key exclusion, so instead we reset each
+  // non-activeVersion knob in that section directly via setKnob back to its
+  // schema default (currently just panelPreset).
+  const resetSharedFolder = () => {
+    for (const knob of sharedSchema) {
+      api.setKnob(SHARED_NAMESPACE, knob.key, knob.default);
+    }
+  };
+
+  const schema = useMemo(() => {
+    // Dynamically assembled from the schema, so its shape can't be known
+    // statically — cast each folder's entries to leva's own (privately
+    // typed) Schema at the folder() call site, matching the shape folder()
+    // itself declares its parameter as.
+    const out: Record<string, ReturnType<typeof folder>> = {};
+    for (const spec of sharedSpecs) {
+      const controls: Record<string, LevaControl | ReturnType<typeof button>> =
+        controlsForSpec(SHARED_NAMESPACE, spec, api.setKnob);
+      controls[`reset ${spec.section}`] = button(resetSharedFolder);
+      out[spec.section] = folder(controls as Parameters<typeof folder>[0]);
+    }
+    for (const spec of versionSpecs) {
+      const controls: Record<string, LevaControl | ReturnType<typeof button>> =
+        controlsForSpec(activeVersion, spec, api.setKnob);
+      controls[`reset ${spec.section}`] = button(() =>
+        api.resetSection(activeVersion, spec.section)
+      );
+      out[prettify(spec.section)] = folder(controls as Parameters<typeof folder>[0]);
+    }
+    return out;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [activeVersion, sharedValuesKey, versionValuesKey, sharedDiffKey, versionDiffKey]);
+
+  // Deps array leva uses to re-sync control values from `effective()` when
+  // they change from outside this panel (e.g. a revert()).
+  useControls(schema, { store }, [activeVersion, sharedValuesKey, versionValuesKey]);
+
+  return (
+    <div
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        height: '100%',
+        minHeight: 0,
+      }}
+    >
+      <div
+        style={{
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItems: 'center',
+          marginBottom: 12,
+          gap: 8,
+        }}
+      >
+        <span
+          style={{
+            fontSize: 11,
+            fontWeight: 700,
+            letterSpacing: '0.1em',
+            color: CHIP_FG,
+            background: CHIP_BG,
+            borderRadius: 999,
+            padding: '3px 10px',
+          }}
+        >
+          STUDIO
+        </span>
+        <button
+          type="button"
+          onClick={onCollapse}
+          aria-label="collapse dials"
+          style={{
+            background: 'transparent',
+            border: `1px solid ${railBorder}`,
+            borderRadius: 4,
+            color: dim,
+            fontSize: 12,
+            padding: '2px 8px',
+            cursor: 'pointer',
+          }}
+        >
+          «
+        </button>
+      </div>
+
+      <div style={{ marginBottom: 12 }}>
+        <label
+          htmlFor="studio-version-select"
+          style={{
+            display: 'block',
+            fontSize: 11,
+            color: dim,
+            fontFamily: mono,
+            marginBottom: 4,
+          }}
+        >
+          version
+        </label>
+        <select
+          id="studio-version-select"
+          value={activeVersion}
+          onChange={(e) => api.setKnob(SHARED_NAMESPACE, 'activeVersion', e.target.value)}
+          style={{
+            width: '100%',
+            background: '#1a2130',
+            color: '#d7dce6',
+            border: `1px solid ${railBorder}`,
+            borderRadius: 4,
+            padding: '6px 8px',
+            fontSize: 13,
+            fontFamily: mono,
+          }}
+        >
+          {versionOptions.map((v) => (
+            <option key={v} value={v}>
+              {v}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      <div style={{ marginBottom: 12 }}>
+        {deploySlot ?? (
+          <p style={{ fontSize: 11, color: dim, fontFamily: mono, margin: 0 }}>
+            · deploy controls land in Task 12 ·
+          </p>
+        )}
+      </div>
+
+      <div style={{ flex: 1, minHeight: 0, position: 'relative' }}>
+        <LevaPanel store={store} theme={DUSK_THEME} fill flat titleBar={false} />
+      </div>
+    </div>
+  );
+}

--- a/app/studio/levaConfig.test.ts
+++ b/app/studio/levaConfig.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect } from 'vitest';
+import { buildFolderSpecs } from './levaConfig';
+import type { SettingsSchema } from '@/app/lib/settings/schema';
+
+// 3-knob schema spanning 2 sections, deliberately out of alphabetical order
+// so we can assert schema order (not sorted order) is preserved.
+const SCHEMA: SettingsSchema = [
+  {
+    key: 'floorPx',
+    kind: 'number',
+    min: 20,
+    max: 800,
+    step: 10,
+    default: 100,
+    label: 'floor (px)',
+    description: 'Minimum tile size',
+    section: 'sizing',
+  },
+  {
+    key: 'cullOverflow',
+    kind: 'boolean',
+    default: true,
+    label: 'cull overflow',
+    description: 'Remove tiles that overflow the viewport',
+    section: 'arrangement',
+  },
+  {
+    key: 'panelPreset',
+    kind: 'enum',
+    options: ['dell', 'ktc'] as const,
+    default: 'dell',
+    label: 'panel',
+    description: 'Panel size',
+    section: 'sizing',
+  },
+];
+
+describe('buildFolderSpecs', () => {
+  it('groups knobs by section in schema order, one folder per distinct section', () => {
+    const specs = buildFolderSpecs(SCHEMA, { floorPx: 100, cullOverflow: true, panelPreset: 'dell' }, []);
+
+    expect(specs.map((s) => s.section)).toEqual(['sizing', 'arrangement']);
+    expect(Object.keys(specs[0].controls)).toEqual(['floorPx', 'panelPreset']);
+    expect(Object.keys(specs[1].controls)).toEqual(['cullOverflow']);
+  });
+
+  it('prefixes the label with "● " only for keys present in differingKeys', () => {
+    const specs = buildFolderSpecs(
+      SCHEMA,
+      { floorPx: 200, cullOverflow: true, panelPreset: 'dell' },
+      ['floorPx']
+    );
+
+    const sizing = specs.find((s) => s.section === 'sizing')!;
+    expect(sizing.controls.floorPx.label).toBe('● floor (px)');
+    expect(sizing.controls.panelPreset.label).toBe('panel');
+
+    const arrangement = specs.find((s) => s.section === 'arrangement')!;
+    expect(arrangement.controls.cullOverflow.label).toBe('cull overflow');
+  });
+
+  it('includes min/max/step for number knobs and omits them for enum/boolean', () => {
+    const specs = buildFolderSpecs(SCHEMA, { floorPx: 100, cullOverflow: true, panelPreset: 'dell' }, []);
+    const sizing = specs.find((s) => s.section === 'sizing')!;
+
+    expect(sizing.controls.floorPx).toMatchObject({ min: 20, max: 800, step: 10 });
+    expect(sizing.controls.panelPreset.min).toBeUndefined();
+    expect(sizing.controls.panelPreset.max).toBeUndefined();
+    expect(sizing.controls.panelPreset.step).toBeUndefined();
+
+    const arrangement = specs.find((s) => s.section === 'arrangement')!;
+    expect(arrangement.controls.cullOverflow.min).toBeUndefined();
+    expect(arrangement.controls.cullOverflow.step).toBeUndefined();
+  });
+
+  it('includes options for enum knobs and omits them for number/boolean', () => {
+    const specs = buildFolderSpecs(SCHEMA, { floorPx: 100, cullOverflow: true, panelPreset: 'dell' }, []);
+    const sizing = specs.find((s) => s.section === 'sizing')!;
+
+    expect(sizing.controls.panelPreset.options).toEqual(['dell', 'ktc']);
+    expect(sizing.controls.floorPx.options).toBeUndefined();
+
+    const arrangement = specs.find((s) => s.section === 'arrangement')!;
+    expect(arrangement.controls.cullOverflow.options).toBeUndefined();
+  });
+
+  it('takes control values from effective, not from schema defaults', () => {
+    const specs = buildFolderSpecs(
+      SCHEMA,
+      { floorPx: 333, cullOverflow: false, panelPreset: 'ktc' },
+      []
+    );
+    const sizing = specs.find((s) => s.section === 'sizing')!;
+    const arrangement = specs.find((s) => s.section === 'arrangement')!;
+
+    expect(sizing.controls.floorPx.value).toBe(333);
+    expect(sizing.controls.panelPreset.value).toBe('ktc');
+    expect(arrangement.controls.cullOverflow.value).toBe(false);
+  });
+
+  it('returns an empty array for an empty schema', () => {
+    expect(buildFolderSpecs([], {}, [])).toEqual([]);
+  });
+});

--- a/app/studio/levaConfig.ts
+++ b/app/studio/levaConfig.ts
@@ -1,0 +1,63 @@
+import type { KnobValue, SettingsSchema, SettingsValues } from '@/app/lib/settings/schema';
+
+/**
+ * Pure, leva-agnostic builder: turns a settings schema + the current
+ * effective values + the set of keys that currently deviate from live into
+ * the plain-object shape leva's `useControls` accepts, grouped into one
+ * folder per distinct `section`. No leva imports here — this file is fully
+ * unit-testable and StudioRail.tsx is the only leva-aware consumer.
+ */
+export interface LevaFolderSpec {
+  section: string;
+  controls: Record<
+    string,
+    {
+      value: KnobValue;
+      label: string; // '● floorPx' when the knob differs from live, else 'floorPx'
+      min?: number;
+      max?: number;
+      step?: number; // number knobs
+      options?: readonly string[]; // enum knobs
+    }
+  >;
+}
+
+export function buildFolderSpecs(
+  schema: SettingsSchema,
+  effective: SettingsValues,
+  differingKeys: string[]
+): LevaFolderSpec[] {
+  const differing = new Set(differingKeys);
+  const specsBySection = new Map<string, LevaFolderSpec>();
+
+  for (const knob of schema) {
+    let spec = specsBySection.get(knob.section);
+    if (!spec) {
+      spec = { section: knob.section, controls: {} };
+      specsBySection.set(knob.section, spec);
+    }
+
+    const label = differing.has(knob.key) ? `● ${knob.label}` : knob.label;
+    const value = effective[knob.key] ?? knob.default;
+
+    if (knob.kind === 'number') {
+      spec.controls[knob.key] = {
+        value,
+        label,
+        min: knob.min,
+        max: knob.max,
+        step: knob.step,
+      };
+    } else if (knob.kind === 'enum') {
+      spec.controls[knob.key] = {
+        value,
+        label,
+        options: knob.options,
+      };
+    } else {
+      spec.controls[knob.key] = { value, label };
+    }
+  }
+
+  return Array.from(specsBySection.values());
+}

--- a/app/studio/page.tsx
+++ b/app/studio/page.tsx
@@ -14,7 +14,10 @@ import { StudioClient } from './StudioClient';
 function StudioGate() {
   const { isOperator, loading } = useIsOperator();
 
-  if (!loading && !isOperator) {
+  // Treat "loading" as not-yet-operator: render the dark shell (not the
+  // studio chrome) until auth resolves, so an anonymous visitor never sees
+  // /studio's controls flash before the sign-in gate kicks in.
+  if (loading || !isOperator) {
     return (
       <div
         style={{
@@ -29,8 +32,12 @@ function StudioGate() {
           color: '#8b95a7',
         }}
       >
-        <p style={{ fontSize: 14 }}>Owner sign-in required.</p>
-        <AuthControl />
+        {!loading && (
+          <>
+            <p style={{ fontSize: 14 }}>Owner sign-in required.</p>
+            <AuthControl />
+          </>
+        )}
       </div>
     );
   }

--- a/app/studio/page.tsx
+++ b/app/studio/page.tsx
@@ -1,0 +1,47 @@
+'use client';
+
+import { Suspense } from 'react';
+import { useIsOperator } from '@/app/components/auth/useIsOperator';
+import { AuthControl } from '@/app/components/auth/AuthControl';
+import { StudioClient } from './StudioClient';
+
+/**
+ * Client-side gate: not-operator renders a plain dark "sign in" page rather
+ * than the studio chrome. Presentational only — the real authorization is
+ * the server-side `requireOwner` check on every mutating route, same trust
+ * model as the Ops tab.
+ */
+function StudioGate() {
+  const { isOperator, loading } = useIsOperator();
+
+  if (!loading && !isOperator) {
+    return (
+      <div
+        style={{
+          minHeight: '100vh',
+          width: '100%',
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+          justifyContent: 'center',
+          gap: 16,
+          background: '#0b0e14',
+          color: '#8b95a7',
+        }}
+      >
+        <p style={{ fontSize: 14 }}>Owner sign-in required.</p>
+        <AuthControl />
+      </div>
+    );
+  }
+
+  return <StudioClient />;
+}
+
+export default function StudioPage() {
+  return (
+    <Suspense fallback={null}>
+      <StudioGate />
+    </Suspense>
+  );
+}

--- a/app/studio/stripState.test.ts
+++ b/app/studio/stripState.test.ts
@@ -1,0 +1,181 @@
+import { describe, it, expect } from 'vitest';
+import { stripState, formatPollAge } from './stripState';
+
+const POLL_MS = 60_000;
+
+describe('stripState', () => {
+  it('is insync when there is no diff, no deploy in flight, and the last poll is fresh', () => {
+    const nowMs = 1_000_000;
+    expect(
+      stripState({
+        diffCount: 0,
+        lastPollAtMs: nowMs - 5_000,
+        deployedAtMs: null,
+        nowMs,
+        pollIntervalMs: POLL_MS,
+      })
+    ).toEqual({ kind: 'insync' });
+  });
+
+  it('is drift when diffCount > 0 and nothing else overrides it', () => {
+    const nowMs = 1_000_000;
+    expect(
+      stripState({
+        diffCount: 3,
+        lastPollAtMs: nowMs - 5_000,
+        deployedAtMs: null,
+        nowMs,
+        pollIntervalMs: POLL_MS,
+      })
+    ).toEqual({ kind: 'drift' });
+  });
+
+  it('is deploying when deployedAtMs is set and the last poll predates it, with a countdown to the next poll', () => {
+    const deployedAtMs = 1_000_000;
+    const lastPollAtMs = deployedAtMs - 10_000; // stale poll, predates the deploy
+    const nowMs = deployedAtMs + 5_000;
+    // next poll lands at lastPollAtMs + pollIntervalMs = 990000 + 60000 = 1050000
+    // secondsToGlass = ceil((1050000 - 1005000)/1000) = ceil(45) = 45
+    expect(
+      stripState({
+        diffCount: 0,
+        lastPollAtMs,
+        deployedAtMs,
+        nowMs,
+        pollIntervalMs: POLL_MS,
+      })
+    ).toEqual({ kind: 'deploying', secondsToGlass: 45 });
+  });
+
+  it('clamps secondsToGlass to 0 once the countdown has passed', () => {
+    const deployedAtMs = 1_000_000;
+    const lastPollAtMs = deployedAtMs - 10_000;
+    const nowMs = lastPollAtMs + POLL_MS + 30_000; // well past the next poll
+    expect(
+      stripState({
+        diffCount: 0,
+        lastPollAtMs,
+        deployedAtMs,
+        nowMs,
+        pollIntervalMs: POLL_MS,
+      })
+    ).toEqual({ kind: 'deploying', secondsToGlass: 0 });
+  });
+
+  it('is stale when lastPollAtMs is null, regardless of other fields', () => {
+    expect(
+      stripState({
+        diffCount: 0,
+        lastPollAtMs: null,
+        deployedAtMs: null,
+        nowMs: 1_000_000,
+        pollIntervalMs: POLL_MS,
+      })
+    ).toEqual({ kind: 'stale' });
+  });
+
+  it('is stale when the last poll is more than 3 poll intervals old', () => {
+    const nowMs = 1_000_000;
+    expect(
+      stripState({
+        diffCount: 0,
+        lastPollAtMs: nowMs - 3 * POLL_MS - 1,
+        deployedAtMs: null,
+        nowMs,
+        pollIntervalMs: POLL_MS,
+      })
+    ).toEqual({ kind: 'stale' });
+  });
+
+  it('is not yet stale at exactly 3 poll intervals old', () => {
+    const nowMs = 1_000_000;
+    expect(
+      stripState({
+        diffCount: 0,
+        lastPollAtMs: nowMs - 3 * POLL_MS,
+        deployedAtMs: null,
+        nowMs,
+        pollIntervalMs: POLL_MS,
+      })
+    ).toEqual({ kind: 'insync' });
+  });
+
+  it('stale beats deploying when both conditions hold', () => {
+    const deployedAtMs = 1_000_000;
+    // lastPollAtMs predates the deploy AND is stale relative to nowMs.
+    const lastPollAtMs = deployedAtMs - 10_000;
+    const nowMs = lastPollAtMs + 3 * POLL_MS + 1;
+    expect(
+      stripState({
+        diffCount: 0,
+        lastPollAtMs,
+        deployedAtMs,
+        nowMs,
+        pollIntervalMs: POLL_MS,
+      })
+    ).toEqual({ kind: 'stale' });
+  });
+
+  it('stale beats drift', () => {
+    expect(
+      stripState({
+        diffCount: 5,
+        lastPollAtMs: null,
+        deployedAtMs: null,
+        nowMs: 1_000_000,
+        pollIntervalMs: POLL_MS,
+      })
+    ).toEqual({ kind: 'stale' });
+  });
+
+  it('deploying beats drift', () => {
+    const deployedAtMs = 1_000_000;
+    const lastPollAtMs = deployedAtMs - 10_000;
+    const nowMs = deployedAtMs + 5_000;
+    expect(
+      stripState({
+        diffCount: 7,
+        lastPollAtMs,
+        deployedAtMs,
+        nowMs,
+        pollIntervalMs: POLL_MS,
+      })
+    ).toEqual({ kind: 'deploying', secondsToGlass: 45 });
+  });
+
+  it('is not deploying once a fresh poll lands after the deploy', () => {
+    const deployedAtMs = 1_000_000;
+    const lastPollAtMs = deployedAtMs + 1_000; // poll landed after the deploy
+    const nowMs = deployedAtMs + 5_000;
+    expect(
+      stripState({
+        diffCount: 0,
+        lastPollAtMs,
+        deployedAtMs,
+        nowMs,
+        pollIntervalMs: POLL_MS,
+      })
+    ).toEqual({ kind: 'insync' });
+  });
+});
+
+describe('formatPollAge', () => {
+  it('formats sub-minute ages in seconds', () => {
+    const nowMs = 1_000_000;
+    expect(formatPollAge(nowMs - 32_000, nowMs)).toBe('32s ago');
+  });
+
+  it('formats zero age as 0s ago', () => {
+    const nowMs = 1_000_000;
+    expect(formatPollAge(nowMs, nowMs)).toBe('0s ago');
+  });
+
+  it('formats minute-scale ages in minutes', () => {
+    const nowMs = 1_000_000;
+    expect(formatPollAge(nowMs - 6 * 60_000, nowMs)).toBe('6m ago');
+  });
+
+  it('formats a null lastPollAtMs as never', () => {
+    expect(formatPollAge(null, 1_000_000)).toBe('never');
+  });
+});

--- a/app/studio/stripState.ts
+++ b/app/studio/stripState.ts
@@ -1,0 +1,62 @@
+/**
+ * Pure computation behind the studio status strip (Task 13). Kept
+ * dependency-free from React so the priority rules and formatting are
+ * covered directly, without a render.
+ */
+
+export type StripKind = 'insync' | 'drift' | 'deploying' | 'stale';
+
+export interface StripStateArgs {
+  diffCount: number;
+  lastPollAtMs: number | null;
+  deployedAtMs: number | null;
+  nowMs: number;
+  pollIntervalMs: number; // pass KIOSK_TICK_INTERVAL_MS
+}
+
+export interface StripStateResult {
+  kind: StripKind;
+  secondsToGlass?: number;
+}
+
+/**
+ * Priority order (first match wins):
+ *   stale     — lastPollAtMs null OR nowMs - lastPollAtMs > 3 * pollIntervalMs
+ *   deploying — deployedAtMs set AND lastPollAtMs < deployedAtMs
+ *   drift     — diffCount > 0
+ *   insync    — otherwise
+ */
+export function stripState({
+  diffCount,
+  lastPollAtMs,
+  deployedAtMs,
+  nowMs,
+  pollIntervalMs,
+}: StripStateArgs): StripStateResult {
+  const isStale =
+    lastPollAtMs === null || nowMs - lastPollAtMs > 3 * pollIntervalMs;
+  if (isStale) return { kind: 'stale' };
+
+  const isDeploying = deployedAtMs !== null && lastPollAtMs < deployedAtMs;
+  if (isDeploying) {
+    const secondsToGlass = Math.max(
+      0,
+      Math.ceil((lastPollAtMs + pollIntervalMs - nowMs) / 1000)
+    );
+    return { kind: 'deploying', secondsToGlass };
+  }
+
+  if (diffCount > 0) return { kind: 'drift' };
+
+  return { kind: 'insync' };
+}
+
+/** '32s ago' | '6m ago' | 'never' */
+export function formatPollAge(lastPollAtMs: number | null, nowMs: number): string {
+  if (lastPollAtMs === null) return 'never';
+  const ageMs = Math.max(0, nowMs - lastPollAtMs);
+  const ageSeconds = Math.floor(ageMs / 1000);
+  if (ageSeconds < 60) return `${ageSeconds}s ago`;
+  const ageMinutes = Math.floor(ageSeconds / 60);
+  return `${ageMinutes}m ago`;
+}

--- a/app/studio/useHoldToFire.test.tsx
+++ b/app/studio/useHoldToFire.test.tsx
@@ -92,6 +92,23 @@ describe('useHoldToFire', () => {
     expect(onFire).not.toHaveBeenCalled();
   });
 
+  it('unmounting mid-hold cancels the timer so onFire never fires', () => {
+    const onFire = vi.fn();
+    const { result, unmount } = renderHook(() => useHoldToFire({ ms: DEPLOY_HOLD_MS, onFire }));
+
+    act(() => {
+      result.current.handlers.onPointerDown();
+    });
+    expect(result.current.holding).toBe(true);
+
+    unmount();
+
+    act(() => {
+      vi.advanceTimersByTime(DEPLOY_HOLD_MS);
+    });
+    expect(onFire).not.toHaveBeenCalled();
+  });
+
   it('a second hold after firing works', () => {
     const onFire = vi.fn();
     const { result } = renderHook(() => useHoldToFire({ ms: DEPLOY_HOLD_MS, onFire }));

--- a/app/studio/useHoldToFire.test.tsx
+++ b/app/studio/useHoldToFire.test.tsx
@@ -1,0 +1,115 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useHoldToFire, DEPLOY_HOLD_MS } from './useHoldToFire';
+
+describe('useHoldToFire', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('fires exactly once after ms elapses following pointerdown', () => {
+    const onFire = vi.fn();
+    const { result } = renderHook(() => useHoldToFire({ ms: DEPLOY_HOLD_MS, onFire }));
+
+    act(() => {
+      result.current.handlers.onPointerDown();
+    });
+    expect(result.current.holding).toBe(true);
+
+    act(() => {
+      vi.advanceTimersByTime(DEPLOY_HOLD_MS);
+    });
+
+    expect(onFire).toHaveBeenCalledTimes(1);
+    expect(result.current.holding).toBe(false);
+
+    // Advancing further does not fire again.
+    act(() => {
+      vi.advanceTimersByTime(DEPLOY_HOLD_MS);
+    });
+    expect(onFire).toHaveBeenCalledTimes(1);
+  });
+
+  it('releasing at ms - 1 never fires', () => {
+    const onFire = vi.fn();
+    const { result } = renderHook(() => useHoldToFire({ ms: DEPLOY_HOLD_MS, onFire }));
+
+    act(() => {
+      result.current.handlers.onPointerDown();
+    });
+    act(() => {
+      vi.advanceTimersByTime(DEPLOY_HOLD_MS - 1);
+    });
+    act(() => {
+      result.current.handlers.onPointerUp();
+    });
+    expect(result.current.holding).toBe(false);
+
+    act(() => {
+      vi.advanceTimersByTime(10_000);
+    });
+    expect(onFire).not.toHaveBeenCalled();
+  });
+
+  it('pointerleave before firing cancels the hold as a no-op', () => {
+    const onFire = vi.fn();
+    const { result } = renderHook(() => useHoldToFire({ ms: DEPLOY_HOLD_MS, onFire }));
+
+    act(() => {
+      result.current.handlers.onPointerDown();
+    });
+    act(() => {
+      vi.advanceTimersByTime(DEPLOY_HOLD_MS - 1);
+    });
+    act(() => {
+      result.current.handlers.onPointerLeave();
+    });
+
+    act(() => {
+      vi.advanceTimersByTime(10_000);
+    });
+    expect(onFire).not.toHaveBeenCalled();
+  });
+
+  it('disabled ignores pointerdown entirely', () => {
+    const onFire = vi.fn();
+    const { result } = renderHook(() =>
+      useHoldToFire({ ms: DEPLOY_HOLD_MS, onFire, disabled: true })
+    );
+
+    act(() => {
+      result.current.handlers.onPointerDown();
+    });
+    expect(result.current.holding).toBe(false);
+
+    act(() => {
+      vi.advanceTimersByTime(DEPLOY_HOLD_MS);
+    });
+    expect(onFire).not.toHaveBeenCalled();
+  });
+
+  it('a second hold after firing works', () => {
+    const onFire = vi.fn();
+    const { result } = renderHook(() => useHoldToFire({ ms: DEPLOY_HOLD_MS, onFire }));
+
+    act(() => {
+      result.current.handlers.onPointerDown();
+    });
+    act(() => {
+      vi.advanceTimersByTime(DEPLOY_HOLD_MS);
+    });
+    expect(onFire).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      result.current.handlers.onPointerDown();
+    });
+    act(() => {
+      vi.advanceTimersByTime(DEPLOY_HOLD_MS);
+    });
+    expect(onFire).toHaveBeenCalledTimes(2);
+  });
+});

--- a/app/studio/useHoldToFire.ts
+++ b/app/studio/useHoldToFire.ts
@@ -1,0 +1,70 @@
+'use client';
+
+import { useCallback, useRef, useState } from 'react';
+
+/** Hold duration for the Take/Deploy button (ms). Shared with DeployButton's
+ * CSS sweep animation so the visual fill and the fire timer stay in lockstep. */
+export const DEPLOY_HOLD_MS = 600;
+
+export interface UseHoldToFireOptions {
+  ms: number;
+  onFire: () => void;
+  disabled?: boolean;
+}
+
+export interface UseHoldToFireResult {
+  holding: boolean;
+  handlers: {
+    onPointerDown: () => void;
+    onPointerUp: () => void;
+    onPointerLeave: () => void;
+  };
+}
+
+/**
+ * Press-and-hold-to-fire gesture: pointerdown starts a `ms` timer; releasing
+ * or leaving before it elapses cancels it as a no-op; letting it run out
+ * calls `onFire` exactly once and ends the hold. `disabled` ignores all
+ * input (including a hold already in flight would be cleared by the caller
+ * unmounting/re-rendering — disabled itself simply refuses to start one).
+ */
+export function useHoldToFire({
+  ms,
+  onFire,
+  disabled = false,
+}: UseHoldToFireOptions): UseHoldToFireResult {
+  const [holding, setHolding] = useState(false);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const clear = useCallback(() => {
+    if (timerRef.current !== null) {
+      clearTimeout(timerRef.current);
+      timerRef.current = null;
+    }
+  }, []);
+
+  const onPointerDown = useCallback(() => {
+    if (disabled || timerRef.current !== null) return;
+    setHolding(true);
+    timerRef.current = setTimeout(() => {
+      timerRef.current = null;
+      setHolding(false);
+      onFire();
+    }, ms);
+  }, [disabled, ms, onFire]);
+
+  const cancel = useCallback(() => {
+    if (timerRef.current === null) return;
+    clear();
+    setHolding(false);
+  }, [clear]);
+
+  return {
+    holding,
+    handlers: {
+      onPointerDown,
+      onPointerUp: cancel,
+      onPointerLeave: cancel,
+    },
+  };
+}

--- a/app/studio/useHoldToFire.ts
+++ b/app/studio/useHoldToFire.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 
 /** Hold duration for the Take/Deploy button (ms). Shared with DeployButton's
  * CSS sweep animation so the visual fill and the fire timer stay in lockstep. */
@@ -58,6 +58,19 @@ export function useHoldToFire({
     clear();
     setHolding(false);
   }, [clear]);
+
+  // Unmount cleanup: a hold in progress when the owning component unmounts
+  // (e.g. the rail collapses mid-hold, tearing down the full DeployButton)
+  // must not fire onFire from a stale closure after teardown — same pattern
+  // as useStudioSettings.ts's debounce-timer cleanup.
+  useEffect(() => {
+    return () => {
+      if (timerRef.current !== null) {
+        clearTimeout(timerRef.current);
+        timerRef.current = null;
+      }
+    };
+  }, []);
 
   return {
     holding,

--- a/app/studio/useStudioSettings.test.tsx
+++ b/app/studio/useStudioSettings.test.tsx
@@ -98,6 +98,57 @@ describe('useStudioSettings', () => {
     expect(body).toEqual({ namespace: 'v1', values: { floorPx: 200 } });
   });
 
+  it('setKnob no-ops (no PATCH) when called with the current effective value, but a genuinely different value still PATCHes', async () => {
+    // Guards against leva's echo: it re-fires onChange on every
+    // deps-driven resync (e.g. after revert()), calling setKnob with the
+    // value each control already has. That must not schedule a PATCH.
+    const getResponse = settingsResponse({ floorPx: 140 }, {});
+    fetchMock = vi.fn(async (url: string, init?: RequestInit) => {
+      if (!init || (!init.method && url === '/api/kiosk/settings')) {
+        return { ok: true, json: async () => getResponse };
+      }
+      if (init.method === 'PATCH') {
+        return { ok: true, json: async () => ({ revision: 2 }) };
+      }
+      return { ok: true, json: async () => ({}) };
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { result } = renderHook(() => useStudioSettings(), { wrapper });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+
+    expect(result.current.effective('v1').floorPx).toBe(140);
+
+    act(() => {
+      result.current.setKnob('v1', 'floorPx', 140);
+    });
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(400);
+    });
+
+    const noopPatchCalls = fetchMock.mock.calls.filter((c) => c[1]?.method === 'PATCH');
+    expect(noopPatchCalls.length).toBe(0);
+
+    // A genuinely different value still schedules and sends a real PATCH —
+    // the no-op guard must not block real edits.
+    act(() => {
+      result.current.setKnob('v1', 'floorPx', 200);
+    });
+    expect(result.current.effective('v1').floorPx).toBe(200);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(400);
+    });
+
+    const patchCalls = fetchMock.mock.calls.filter((c) => c[1]?.method === 'PATCH');
+    expect(patchCalls.length).toBe(1);
+    const body = JSON.parse(patchCalls[0][1].body as string);
+    expect(body).toEqual({ namespace: 'v1', values: { floorPx: 200 } });
+  });
+
   it('setting a knob back to its default omits that key from the PATCH', async () => {
     const getResponse = settingsResponse({ floorPx: 140 }, {});
     fetchMock = vi.fn(async (url: string, init?: RequestInit) => {

--- a/app/studio/useStudioSettings.test.tsx
+++ b/app/studio/useStudioSettings.test.tsx
@@ -275,4 +275,42 @@ describe('useStudioSettings', () => {
     );
     expect(revertCalls.length).toBe(1);
   });
+
+  it('two synchronous setKnob calls to the same namespace in one batch both survive', async () => {
+    const getResponse = settingsResponse({}, {});
+    fetchMock = vi.fn(async (url: string, init?: RequestInit) => {
+      if (!init || (!init.method && url === '/api/kiosk/settings')) {
+        return { ok: true, json: async () => getResponse };
+      }
+      if (init.method === 'PATCH') {
+        return { ok: true, json: async () => ({ revision: 2 }) };
+      }
+      return { ok: true, json: async () => ({}) };
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { result } = renderHook(() => useStudioSettings(), { wrapper });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+
+    act(() => {
+      result.current.setKnob('v1', 'floorPx', 200);
+      result.current.setKnob('v1', 'padding', 5);
+    });
+
+    // Both edits must be reflected — the second call must not have
+    // clobbered the first via a stale render-time overlay snapshot.
+    expect(result.current.effective('v1').floorPx).toBe(200);
+    expect(result.current.effective('v1').padding).toBe(5);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(400);
+    });
+
+    const patchCalls = fetchMock.mock.calls.filter((c) => c[1]?.method === 'PATCH');
+    expect(patchCalls.length).toBe(1);
+    const body = JSON.parse(patchCalls[0][1].body as string);
+    expect(body).toEqual({ namespace: 'v1', values: { floorPx: 200, padding: 5 } });
+  });
 });

--- a/app/studio/useStudioSettings.test.tsx
+++ b/app/studio/useStudioSettings.test.tsx
@@ -1,0 +1,172 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { SWRConfig } from 'swr';
+import type { ReactNode } from 'react';
+import { useStudioSettings } from './useStudioSettings';
+
+// v1's floorPx default is 100 (COMPOSITION_TILE_FLOOR_PX) — see
+// app/components/mosaic/v1/config.ts.
+const V1_FLOOR_DEFAULT = 100;
+
+function wrapper({ children }: { children: ReactNode }) {
+  return (
+    <SWRConfig value={{ provider: () => new Map(), dedupingInterval: 0 }}>
+      {children}
+    </SWRConfig>
+  );
+}
+
+function settingsResponse(
+  studioV1: Record<string, unknown> = {},
+  liveV1: Record<string, unknown> = {}
+) {
+  return {
+    studio: { namespaces: { v1: studioV1 }, revision: 1 },
+    live: { namespaces: { v1: liveV1 }, revision: 0 },
+    lastPollAt: null,
+  };
+}
+
+describe('useStudioSettings', () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.useRealTimers();
+  });
+
+  it('diffCount is 1 when studio has a deviation and live does not', async () => {
+    fetchMock = vi.fn(async () => ({
+      ok: true,
+      json: async () => settingsResponse({ floorPx: 140 }, {}),
+    }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { result } = renderHook(() => useStudioSettings(), { wrapper });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+
+    expect(result.current.diffCount).toBe(1);
+    expect(result.current.diffByNamespace.v1).toEqual(['floorPx']);
+  });
+
+  it('setKnob updates effective() synchronously and PATCHes the full deviation set after the debounce window', async () => {
+    const getResponse = settingsResponse({}, {});
+    fetchMock = vi.fn(async (url: string, init?: RequestInit) => {
+      if (!init || (!init.method && url === '/api/kiosk/settings')) {
+        return { ok: true, json: async () => getResponse };
+      }
+      if (init.method === 'PATCH') {
+        return { ok: true, json: async () => ({ revision: 2 }) };
+      }
+      return { ok: true, json: async () => ({}) };
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { result } = renderHook(() => useStudioSettings(), { wrapper });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+
+    act(() => {
+      result.current.setKnob('v1', 'floorPx', 200);
+    });
+    // synchronous optimistic update
+    expect(result.current.effective('v1').floorPx).toBe(200);
+
+    const patchCallsBefore = fetchMock.mock.calls.filter(
+      (c) => c[1]?.method === 'PATCH'
+    );
+    expect(patchCallsBefore.length).toBe(0);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(400);
+    });
+
+    const patchCalls = fetchMock.mock.calls.filter(
+      (c) => c[1]?.method === 'PATCH'
+    );
+    expect(patchCalls.length).toBe(1);
+    const [url, init] = patchCalls[0];
+    expect(url).toBe('/api/kiosk/settings');
+    const body = JSON.parse(init.body as string);
+    expect(body).toEqual({ namespace: 'v1', values: { floorPx: 200 } });
+  });
+
+  it('setting a knob back to its default omits that key from the PATCH', async () => {
+    const getResponse = settingsResponse({ floorPx: 140 }, {});
+    fetchMock = vi.fn(async (url: string, init?: RequestInit) => {
+      if (!init || (!init.method && url === '/api/kiosk/settings')) {
+        return { ok: true, json: async () => getResponse };
+      }
+      if (init.method === 'PATCH') {
+        return { ok: true, json: async () => ({ revision: 2 }) };
+      }
+      return { ok: true, json: async () => ({}) };
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { result } = renderHook(() => useStudioSettings(), { wrapper });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+
+    act(() => {
+      result.current.setKnob('v1', 'floorPx', V1_FLOOR_DEFAULT);
+    });
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(400);
+    });
+
+    const patchCalls = fetchMock.mock.calls.filter(
+      (c) => c[1]?.method === 'PATCH'
+    );
+    expect(patchCalls.length).toBe(1);
+    const [, init] = patchCalls[0];
+    const body = JSON.parse(init.body as string);
+    expect(body).toEqual({ namespace: 'v1', values: {} });
+  });
+
+  it('deploy() posts to the deploy route and zeroes diffCount from the mutated response', async () => {
+    fetchMock = vi.fn(async (url: string, init?: RequestInit) => {
+      if (!init || (!init.method && url === '/api/kiosk/settings')) {
+        return { ok: true, json: async () => settingsResponse({ floorPx: 140 }, {}) };
+      }
+      if (init.method === 'POST' && url === '/api/kiosk/settings/deploy') {
+        return {
+          ok: true,
+          json: async () => ({
+            live: { namespaces: { v1: { floorPx: 140 } }, revision: 1 },
+          }),
+        };
+      }
+      return { ok: true, json: async () => ({}) };
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { result } = renderHook(() => useStudioSettings(), { wrapper });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+
+    expect(result.current.diffCount).toBe(1);
+
+    await act(async () => {
+      await result.current.deploy();
+    });
+
+    expect(result.current.diffCount).toBe(0);
+    expect(result.current.deployedAtMs).not.toBeNull();
+    const deployCalls = fetchMock.mock.calls.filter(
+      (c) => c[0] === '/api/kiosk/settings/deploy'
+    );
+    expect(deployCalls.length).toBe(1);
+    expect(deployCalls[0][1]?.method).toBe('POST');
+  });
+});

--- a/app/studio/useStudioSettings.test.tsx
+++ b/app/studio/useStudioSettings.test.tsx
@@ -327,6 +327,105 @@ describe('useStudioSettings', () => {
     expect(revertCalls.length).toBe(1);
   });
 
+  it('deploy() throws and leaves diffCount/deployedAtMs untouched when the deploy route 500s', async () => {
+    fetchMock = vi.fn(async (url: string, init?: RequestInit) => {
+      if (!init || (!init.method && url === '/api/kiosk/settings')) {
+        return { ok: true, json: async () => settingsResponse({ floorPx: 140 }, {}) };
+      }
+      if (init.method === 'POST' && url === '/api/kiosk/settings/deploy') {
+        return { ok: false, status: 500, json: async () => ({ error: 'boom' }) };
+      }
+      return { ok: true, json: async () => ({}) };
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { result } = renderHook(() => useStudioSettings(), { wrapper });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+
+    expect(result.current.diffCount).toBe(1);
+
+    await expect(
+      act(async () => {
+        await result.current.deploy();
+      })
+    ).rejects.toThrow();
+
+    expect(result.current.diffCount).toBe(1);
+    expect(result.current.deployedAtMs).toBeNull();
+  });
+
+  it('revert() throws and does NOT clear the optimistic overlay when the revert route 500s', async () => {
+    const getResponse = settingsResponse({}, {});
+    fetchMock = vi.fn(async (url: string, init?: RequestInit) => {
+      if (!init || (!init.method && url === '/api/kiosk/settings')) {
+        return { ok: true, json: async () => getResponse };
+      }
+      if (init.method === 'PATCH') {
+        return { ok: true, json: async () => ({ revision: 2 }) };
+      }
+      if (init.method === 'POST' && url === '/api/kiosk/settings/revert') {
+        return { ok: false, status: 500, json: async () => ({ error: 'boom' }) };
+      }
+      return { ok: true, json: async () => ({}) };
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { result } = renderHook(() => useStudioSettings(), { wrapper });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+
+    act(() => {
+      result.current.setKnob('v1', 'floorPx', 200);
+    });
+    expect(result.current.effective('v1').floorPx).toBe(200);
+
+    await expect(
+      act(async () => {
+        await result.current.revert();
+      })
+    ).rejects.toThrow();
+
+    // Overlay must survive the failed revert — local edits are not
+    // silently discarded on a 500.
+    expect(result.current.effective('v1').floorPx).toBe(200);
+  });
+
+  it('a failed debounced PATCH keeps the optimistic overlay (edits are not lost)', async () => {
+    const getResponse = settingsResponse({}, {});
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    fetchMock = vi.fn(async (url: string, init?: RequestInit) => {
+      if (!init || (!init.method && url === '/api/kiosk/settings')) {
+        return { ok: true, json: async () => getResponse };
+      }
+      if (init.method === 'PATCH') {
+        return { ok: false, status: 500, json: async () => ({ error: 'boom' }) };
+      }
+      return { ok: true, json: async () => ({}) };
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { result } = renderHook(() => useStudioSettings(), { wrapper });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+
+    act(() => {
+      result.current.setKnob('v1', 'floorPx', 200);
+    });
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(400);
+    });
+
+    // The overlay (and therefore the local edit) survives a flush failure.
+    expect(result.current.effective('v1').floorPx).toBe(200);
+    expect(warnSpy).toHaveBeenCalled();
+    warnSpy.mockRestore();
+  });
+
   it('two synchronous setKnob calls to the same namespace in one batch both survive', async () => {
     const getResponse = settingsResponse({}, {});
     fetchMock = vi.fn(async (url: string, init?: RequestInit) => {

--- a/app/studio/useStudioSettings.test.tsx
+++ b/app/studio/useStudioSettings.test.tsx
@@ -220,4 +220,59 @@ describe('useStudioSettings', () => {
 
     expect(result.current.diffCount).toBe(0);
   });
+
+  it('revert() cancels a pending debounced PATCH (never sent) and clears the optimistic overlay', async () => {
+    const getResponse = settingsResponse({}, {});
+    fetchMock = vi.fn(async (url: string, init?: RequestInit) => {
+      if (!init || (!init.method && url === '/api/kiosk/settings')) {
+        return { ok: true, json: async () => getResponse };
+      }
+      if (init.method === 'PATCH') {
+        return { ok: true, json: async () => ({ revision: 2 }) };
+      }
+      if (init.method === 'POST' && url === '/api/kiosk/settings/revert') {
+        return {
+          ok: true,
+          json: async () => ({
+            studio: { namespaces: { v1: { floorPx: 140 } }, revision: 5 },
+          }),
+        };
+      }
+      return { ok: true, json: async () => ({}) };
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { result } = renderHook(() => useStudioSettings(), { wrapper });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+
+    act(() => {
+      result.current.setKnob('v1', 'floorPx', 200);
+    });
+    expect(result.current.effective('v1').floorPx).toBe(200);
+
+    // Revert immediately — no timer advance — so the debounce timer is
+    // still pending when revert cancels it.
+    await act(async () => {
+      await result.current.revert();
+    });
+
+    // Overlay cleared: effective() now reflects the reverted studio from
+    // the server, not the discarded local edit.
+    expect(result.current.effective('v1').floorPx).toBe(140);
+
+    // Advance well past the debounce window: the cancelled timer must
+    // never fire a PATCH.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1000);
+    });
+
+    const patchCalls = fetchMock.mock.calls.filter((c) => c[1]?.method === 'PATCH');
+    expect(patchCalls.length).toBe(0);
+    const revertCalls = fetchMock.mock.calls.filter(
+      (c) => c[0] === '/api/kiosk/settings/revert'
+    );
+    expect(revertCalls.length).toBe(1);
+  });
 });

--- a/app/studio/useStudioSettings.test.tsx
+++ b/app/studio/useStudioSettings.test.tsx
@@ -169,4 +169,55 @@ describe('useStudioSettings', () => {
     expect(deployCalls.length).toBe(1);
     expect(deployCalls[0][1]?.method).toBe('POST');
   });
+
+  it('deploy() flushes a pending debounced PATCH before posting, so an edit inside the debounce window is not lost', async () => {
+    const getResponse = settingsResponse({}, {});
+    fetchMock = vi.fn(async (url: string, init?: RequestInit) => {
+      if (!init || (!init.method && url === '/api/kiosk/settings')) {
+        return { ok: true, json: async () => getResponse };
+      }
+      if (init.method === 'PATCH') {
+        return { ok: true, json: async () => ({ revision: 2 }) };
+      }
+      if (init.method === 'POST' && url === '/api/kiosk/settings/deploy') {
+        return {
+          ok: true,
+          json: async () => ({
+            live: { namespaces: { v1: { floorPx: 200 } }, revision: 1 },
+          }),
+        };
+      }
+      return { ok: true, json: async () => ({}) };
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { result } = renderHook(() => useStudioSettings(), { wrapper });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+
+    act(() => {
+      result.current.setKnob('v1', 'floorPx', 200);
+    });
+
+    // Deploy immediately — no timer advance — so the debounce window has
+    // not fired yet and the edit is still only in the optimistic overlay.
+    await act(async () => {
+      await result.current.deploy();
+    });
+
+    const patchOrDeployCalls = fetchMock.mock.calls.filter(
+      (c) =>
+        c[1]?.method === 'PATCH' ||
+        (c[1]?.method === 'POST' && c[0] === '/api/kiosk/settings/deploy')
+    );
+    expect(patchOrDeployCalls.length).toBe(2);
+    expect(patchOrDeployCalls[0][1]?.method).toBe('PATCH');
+    expect(patchOrDeployCalls[1][0]).toBe('/api/kiosk/settings/deploy');
+
+    const patchBody = JSON.parse(patchOrDeployCalls[0][1].body as string);
+    expect(patchBody).toEqual({ namespace: 'v1', values: { floorPx: 200 } });
+
+    expect(result.current.diffCount).toBe(0);
+  });
 });

--- a/app/studio/useStudioSettings.ts
+++ b/app/studio/useStudioSettings.ts
@@ -82,6 +82,15 @@ export function useStudioSettings(): StudioSettingsApi {
       method: 'PATCH',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(body),
+    }).then((res) => {
+      if (!res.ok) {
+        // Leave the optimistic overlay in place — the local edit isn't
+        // lost, it just hasn't reached the server. Next successful flush
+        // (this namespace's next edit, or a future retry) resends the full
+        // deviation set from overlayRef, so nothing needs replaying here.
+        console.warn('[studio] settings PATCH failed:', res.status);
+      }
+      return res;
     });
   }, []);
 
@@ -213,6 +222,9 @@ export function useStudioSettings(): StudioSettingsApi {
   const deploy = useCallback(async () => {
     await flushPending();
     const res = await fetch('/api/kiosk/settings/deploy', { method: 'POST' });
+    if (!res.ok) {
+      throw new Error(`deploy failed: ${res.status}`);
+    }
     const json = (await res.json()) as { live: ProfileSettings };
     await mutate(
       (current) => (current ? { ...current, live: json.live } : current),
@@ -224,6 +236,9 @@ export function useStudioSettings(): StudioSettingsApi {
   const revert = useCallback(async () => {
     cancelPending();
     const res = await fetch('/api/kiosk/settings/revert', { method: 'POST' });
+    if (!res.ok) {
+      throw new Error(`revert failed: ${res.status}`);
+    }
     const json = (await res.json()) as { studio: ProfileSettings };
     await mutate(
       (current) => (current ? { ...current, studio: json.studio } : current),

--- a/app/studio/useStudioSettings.ts
+++ b/app/studio/useStudioSettings.ts
@@ -62,11 +62,18 @@ export function useStudioSettings(): StudioSettingsApi {
 
   // Per-namespace optimistic overlay: full local deviation set for a
   // namespace once it has been touched this session, keyed by namespace.
+  // `overlay` (state) drives re-renders; `overlayRef` is the synchronous
+  // source of truth setKnob/resetSection/flush read and write from — React
+  // batches state updates, so reading the `overlay` *state* value back
+  // inside the same synchronous event (e.g. two setKnob calls in one
+  // act()/handler) would see a stale snapshot and drop the earlier edit.
   const [overlay, setOverlay] = useState<Record<string, SettingsValues>>({});
+  const overlayRef = useRef<Record<string, SettingsValues>>({});
   const timers = useRef<Record<string, ReturnType<typeof setTimeout>>>({});
   const [deployedAtMs, setDeployedAtMs] = useState<number | null>(null);
 
-  const flush = useCallback((namespace: string, schema: SettingsSchema, values: SettingsValues) => {
+  const flush = useCallback((namespace: string, schema: SettingsSchema) => {
+    const values = overlayRef.current[namespace] ?? {};
     const body = {
       namespace,
       values: stripDefaults(schema, sanitizeValues(schema, values)),
@@ -79,11 +86,11 @@ export function useStudioSettings(): StudioSettingsApi {
   }, []);
 
   const scheduleFlush = useCallback(
-    (namespace: string, schema: SettingsSchema, values: SettingsValues) => {
+    (namespace: string, schema: SettingsSchema) => {
       if (timers.current[namespace]) clearTimeout(timers.current[namespace]);
       timers.current[namespace] = setTimeout(() => {
         delete timers.current[namespace];
-        void flush(namespace, schema, values);
+        void flush(namespace, schema);
       }, DEBOUNCE_MS);
     },
     [flush]
@@ -121,38 +128,39 @@ export function useStudioSettings(): StudioSettingsApi {
       clearTimeout(timers.current[namespace]);
       delete timers.current[namespace];
       const schema = schemaFor(namespace);
-      const values = overlay[namespace];
-      if (!schema || !values) return Promise.resolve();
-      return flush(namespace, schema, values);
+      if (!schema) return Promise.resolve();
+      return flush(namespace, schema);
     });
     await Promise.all(patches);
-  }, [flush, overlay]);
+  }, [flush]);
 
   const setKnob = useCallback(
     (namespace: string, key: string, value: KnobValue) => {
       const schema = schemaFor(namespace);
       if (!schema) return;
-      const base = overlay[namespace] ?? data?.studio?.namespaces?.[namespace] ?? {};
+      const base = overlayRef.current[namespace] ?? data?.studio?.namespaces?.[namespace] ?? {};
       const next = sanitizeValues(schema, { ...base, [key]: value });
-      setOverlay((prev) => ({ ...prev, [namespace]: next }));
-      scheduleFlush(namespace, schema, next);
+      overlayRef.current = { ...overlayRef.current, [namespace]: next };
+      setOverlay(overlayRef.current);
+      scheduleFlush(namespace, schema);
     },
-    [data, overlay, scheduleFlush]
+    [data, scheduleFlush]
   );
 
   const resetSection = useCallback(
     (namespace: string, section: string) => {
       const schema = schemaFor(namespace);
       if (!schema) return;
-      const base = overlay[namespace] ?? data?.studio?.namespaces?.[namespace] ?? {};
+      const base = overlayRef.current[namespace] ?? data?.studio?.namespaces?.[namespace] ?? {};
       const next: SettingsValues = { ...base };
       for (const knob of schema) {
         if (knob.section === section) delete next[knob.key];
       }
-      setOverlay((prev) => ({ ...prev, [namespace]: next }));
-      scheduleFlush(namespace, schema, next);
+      overlayRef.current = { ...overlayRef.current, [namespace]: next };
+      setOverlay(overlayRef.current);
+      scheduleFlush(namespace, schema);
     },
-    [data, overlay, scheduleFlush]
+    [data, scheduleFlush]
   );
 
   const studio = useMemo<ProfileSettings | undefined>(() => {
@@ -213,6 +221,7 @@ export function useStudioSettings(): StudioSettingsApi {
       (current) => (current ? { ...current, studio: json.studio } : current),
       { revalidate: false }
     );
+    overlayRef.current = {};
     setOverlay({});
   }, [cancelPending, mutate]);
 

--- a/app/studio/useStudioSettings.ts
+++ b/app/studio/useStudioSettings.ts
@@ -1,0 +1,196 @@
+'use client';
+
+import { useCallback, useMemo, useRef, useState } from 'react';
+import useSWR from 'swr';
+import {
+  mergeSettings,
+  diffKeys,
+  sanitizeValues,
+  stripDefaults,
+  type KnobValue,
+  type SettingsSchema,
+  type SettingsValues,
+} from '@/app/lib/settings/schema';
+import { SHARED_NAMESPACE, SHARED_SCHEMA } from '@/app/lib/settings/sharedSchema';
+import { MOSAIC_SETTINGS_SCHEMAS } from '@/app/components/mosaic/registry';
+import type { ProfileSettings } from '@/app/lib/settings/store';
+
+const DEBOUNCE_MS = 400;
+const SETTINGS_URL = '/api/kiosk/settings';
+
+interface SettingsResponse {
+  studio: ProfileSettings;
+  live: ProfileSettings;
+  lastPollAt: string | null;
+}
+
+export interface StudioSettingsApi {
+  loading: boolean;
+  studio: ProfileSettings | undefined; // server truth incl. optimistic local edits
+  live: ProfileSettings | undefined;
+  lastPollAt: string | null;
+  liveRevision: number; // 0 while loading
+  effective: (namespace: string) => SettingsValues; // mergeSettings over studio deviations
+  setKnob: (namespace: string, key: string, value: KnobValue) => void;
+  resetSection: (namespace: string, section: string) => void; // clears that section's deviations
+  diffByNamespace: Record<string, string[]>; // diffKeys(schema, studio[ns], live[ns]) per known ns
+  diffCount: number; // total across namespaces — the badge number
+  deploy: () => Promise<void>;
+  revert: () => Promise<void>;
+  deployedAtMs: number | null; // Date.now() at last successful deploy this session
+}
+
+function schemaFor(namespace: string): SettingsSchema | null {
+  if (namespace === SHARED_NAMESPACE) return SHARED_SCHEMA;
+  return MOSAIC_SETTINGS_SCHEMAS[namespace] ?? null;
+}
+
+const KNOWN_NAMESPACES = [SHARED_NAMESPACE, ...Object.keys(MOSAIC_SETTINGS_SCHEMAS)];
+
+const fetcher = (url: string) => fetch(url).then((r) => r.json());
+
+/**
+ * Owns all studio settings state for /studio: polls the studio+live profiles,
+ * layers an optimistic local overlay on top of the studio profile so dials
+ * feel live, debounce-PATCHes each namespace's full deviation set 400ms
+ * after the last edit, and exposes deploy/revert against the live profile.
+ */
+export function useStudioSettings(): StudioSettingsApi {
+  const { data, isLoading, mutate } = useSWR<SettingsResponse>(SETTINGS_URL, fetcher, {
+    refreshInterval: 30_000,
+  });
+
+  // Per-namespace optimistic overlay: full local deviation set for a
+  // namespace once it has been touched this session, keyed by namespace.
+  const [overlay, setOverlay] = useState<Record<string, SettingsValues>>({});
+  const timers = useRef<Record<string, ReturnType<typeof setTimeout>>>({});
+  const [deployedAtMs, setDeployedAtMs] = useState<number | null>(null);
+
+  const flush = useCallback((namespace: string, schema: SettingsSchema, values: SettingsValues) => {
+    const body = {
+      namespace,
+      values: stripDefaults(schema, sanitizeValues(schema, values)),
+    };
+    void fetch(SETTINGS_URL, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+  }, []);
+
+  const scheduleFlush = useCallback(
+    (namespace: string, schema: SettingsSchema, values: SettingsValues) => {
+      if (timers.current[namespace]) clearTimeout(timers.current[namespace]);
+      timers.current[namespace] = setTimeout(() => {
+        flush(namespace, schema, values);
+      }, DEBOUNCE_MS);
+    },
+    [flush]
+  );
+
+  const setKnob = useCallback(
+    (namespace: string, key: string, value: KnobValue) => {
+      const schema = schemaFor(namespace);
+      if (!schema) return;
+      setOverlay((prev) => {
+        const base = prev[namespace] ?? data?.studio?.namespaces?.[namespace] ?? {};
+        const next = sanitizeValues(schema, { ...base, [key]: value });
+        scheduleFlush(namespace, schema, next);
+        return { ...prev, [namespace]: next };
+      });
+    },
+    [data, scheduleFlush]
+  );
+
+  const resetSection = useCallback(
+    (namespace: string, section: string) => {
+      const schema = schemaFor(namespace);
+      if (!schema) return;
+      setOverlay((prev) => {
+        const base = prev[namespace] ?? data?.studio?.namespaces?.[namespace] ?? {};
+        const next: SettingsValues = { ...base };
+        for (const knob of schema) {
+          if (knob.section === section) delete next[knob.key];
+        }
+        scheduleFlush(namespace, schema, next);
+        return { ...prev, [namespace]: next };
+      });
+    },
+    [data, scheduleFlush]
+  );
+
+  const studio = useMemo<ProfileSettings | undefined>(() => {
+    if (!data?.studio) return undefined;
+    if (Object.keys(overlay).length === 0) return data.studio;
+    return {
+      ...data.studio,
+      namespaces: { ...data.studio.namespaces, ...overlay },
+    };
+  }, [data, overlay]);
+
+  const live = data?.live;
+
+  const effective = useCallback(
+    (namespace: string) => {
+      const schema = schemaFor(namespace);
+      if (!schema) return {};
+      return mergeSettings(schema, studio?.namespaces?.[namespace]);
+    },
+    [studio]
+  );
+
+  const diffByNamespace = useMemo(() => {
+    const out: Record<string, string[]> = {};
+    for (const namespace of KNOWN_NAMESPACES) {
+      const schema = schemaFor(namespace);
+      if (!schema) continue;
+      out[namespace] = diffKeys(
+        schema,
+        studio?.namespaces?.[namespace],
+        live?.namespaces?.[namespace]
+      );
+    }
+    return out;
+  }, [studio, live]);
+
+  const diffCount = useMemo(
+    () => Object.values(diffByNamespace).reduce((sum, keys) => sum + keys.length, 0),
+    [diffByNamespace]
+  );
+
+  const deploy = useCallback(async () => {
+    const res = await fetch('/api/kiosk/settings/deploy', { method: 'POST' });
+    const json = (await res.json()) as { live: ProfileSettings };
+    await mutate(
+      (current) => (current ? { ...current, live: json.live } : current),
+      { revalidate: false }
+    );
+    setDeployedAtMs(Date.now());
+  }, [mutate]);
+
+  const revert = useCallback(async () => {
+    const res = await fetch('/api/kiosk/settings/revert', { method: 'POST' });
+    const json = (await res.json()) as { studio: ProfileSettings };
+    await mutate(
+      (current) => (current ? { ...current, studio: json.studio } : current),
+      { revalidate: false }
+    );
+    setOverlay({});
+  }, [mutate]);
+
+  return {
+    loading: isLoading,
+    studio,
+    live,
+    lastPollAt: data?.lastPollAt ?? null,
+    liveRevision: data?.live?.revision ?? 0,
+    effective,
+    setKnob,
+    resetSection,
+    diffByNamespace,
+    diffCount,
+    deploy,
+    revert,
+    deployedAtMs,
+  };
+}

--- a/app/studio/useStudioSettings.ts
+++ b/app/studio/useStudioSettings.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import useSWR from 'swr';
 import {
   mergeSettings,
@@ -98,6 +98,17 @@ export function useStudioSettings(): StudioSettingsApi {
     }
   }, []);
 
+  // Unmount cleanup: a pending debounce timer must not fire a PATCH from a
+  // stale closure after the component that owns this hook has torn down.
+  useEffect(() => {
+    return () => {
+      for (const namespace of Object.keys(timers.current)) {
+        clearTimeout(timers.current[namespace]);
+      }
+      timers.current = {};
+    };
+  }, []);
+
   // Cancel every pending per-namespace debounce timer and PATCH its
   // namespace's full deviation set immediately — used by deploy() so a dial
   // moved less than DEBOUNCE_MS before Deploy is still in the studio row
@@ -121,31 +132,27 @@ export function useStudioSettings(): StudioSettingsApi {
     (namespace: string, key: string, value: KnobValue) => {
       const schema = schemaFor(namespace);
       if (!schema) return;
-      setOverlay((prev) => {
-        const base = prev[namespace] ?? data?.studio?.namespaces?.[namespace] ?? {};
-        const next = sanitizeValues(schema, { ...base, [key]: value });
-        scheduleFlush(namespace, schema, next);
-        return { ...prev, [namespace]: next };
-      });
+      const base = overlay[namespace] ?? data?.studio?.namespaces?.[namespace] ?? {};
+      const next = sanitizeValues(schema, { ...base, [key]: value });
+      setOverlay((prev) => ({ ...prev, [namespace]: next }));
+      scheduleFlush(namespace, schema, next);
     },
-    [data, scheduleFlush]
+    [data, overlay, scheduleFlush]
   );
 
   const resetSection = useCallback(
     (namespace: string, section: string) => {
       const schema = schemaFor(namespace);
       if (!schema) return;
-      setOverlay((prev) => {
-        const base = prev[namespace] ?? data?.studio?.namespaces?.[namespace] ?? {};
-        const next: SettingsValues = { ...base };
-        for (const knob of schema) {
-          if (knob.section === section) delete next[knob.key];
-        }
-        scheduleFlush(namespace, schema, next);
-        return { ...prev, [namespace]: next };
-      });
+      const base = overlay[namespace] ?? data?.studio?.namespaces?.[namespace] ?? {};
+      const next: SettingsValues = { ...base };
+      for (const knob of schema) {
+        if (knob.section === section) delete next[knob.key];
+      }
+      setOverlay((prev) => ({ ...prev, [namespace]: next }));
+      scheduleFlush(namespace, schema, next);
     },
-    [data, scheduleFlush]
+    [data, overlay, scheduleFlush]
   );
 
   const studio = useMemo<ProfileSettings | undefined>(() => {

--- a/app/studio/useStudioSettings.ts
+++ b/app/studio/useStudioSettings.ts
@@ -139,6 +139,14 @@ export function useStudioSettings(): StudioSettingsApi {
       const schema = schemaFor(namespace);
       if (!schema) return;
       const base = overlayRef.current[namespace] ?? data?.studio?.namespaces?.[namespace] ?? {};
+      // No-op guard: leva re-fires onChange on a programmatic resync (its
+      // deps-driven store.addData), so every control that gets re-synced
+      // from outside (e.g. after revert()) calls setKnob with the value it
+      // already has. Without this check that schedules a spurious PATCH
+      // per control on every resync. mirrors effective()'s merge so "the
+      // current value" here means the same thing it means everywhere else.
+      const current = mergeSettings(schema, base)[key];
+      if (current === value) return;
       const next = sanitizeValues(schema, { ...base, [key]: value });
       overlayRef.current = { ...overlayRef.current, [namespace]: next };
       setOverlay(overlayRef.current);

--- a/app/studio/useStudioSettings.ts
+++ b/app/studio/useStudioSettings.ts
@@ -71,7 +71,7 @@ export function useStudioSettings(): StudioSettingsApi {
       namespace,
       values: stripDefaults(schema, sanitizeValues(schema, values)),
     };
-    void fetch(SETTINGS_URL, {
+    return fetch(SETTINGS_URL, {
       method: 'PATCH',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(body),
@@ -82,11 +82,40 @@ export function useStudioSettings(): StudioSettingsApi {
     (namespace: string, schema: SettingsSchema, values: SettingsValues) => {
       if (timers.current[namespace]) clearTimeout(timers.current[namespace]);
       timers.current[namespace] = setTimeout(() => {
-        flush(namespace, schema, values);
+        delete timers.current[namespace];
+        void flush(namespace, schema, values);
       }, DEBOUNCE_MS);
     },
     [flush]
   );
+
+  // Cancel every pending per-namespace debounce timer without sending its
+  // PATCH — used by revert(), whose whole point is discarding those edits.
+  const cancelPending = useCallback(() => {
+    for (const namespace of Object.keys(timers.current)) {
+      clearTimeout(timers.current[namespace]);
+      delete timers.current[namespace];
+    }
+  }, []);
+
+  // Cancel every pending per-namespace debounce timer and PATCH its
+  // namespace's full deviation set immediately — used by deploy() so a dial
+  // moved less than DEBOUNCE_MS before Deploy is still in the studio row
+  // that gets copied to live (copyProfile reads whatever exists at POST
+  // time; an un-flushed edit would otherwise be silently dropped from the
+  // take).
+  const flushPending = useCallback(async () => {
+    const namespaces = Object.keys(timers.current);
+    const patches = namespaces.map((namespace) => {
+      clearTimeout(timers.current[namespace]);
+      delete timers.current[namespace];
+      const schema = schemaFor(namespace);
+      const values = overlay[namespace];
+      if (!schema || !values) return Promise.resolve();
+      return flush(namespace, schema, values);
+    });
+    await Promise.all(patches);
+  }, [flush, overlay]);
 
   const setKnob = useCallback(
     (namespace: string, key: string, value: KnobValue) => {
@@ -159,6 +188,7 @@ export function useStudioSettings(): StudioSettingsApi {
   );
 
   const deploy = useCallback(async () => {
+    await flushPending();
     const res = await fetch('/api/kiosk/settings/deploy', { method: 'POST' });
     const json = (await res.json()) as { live: ProfileSettings };
     await mutate(
@@ -166,9 +196,10 @@ export function useStudioSettings(): StudioSettingsApi {
       { revalidate: false }
     );
     setDeployedAtMs(Date.now());
-  }, [mutate]);
+  }, [flushPending, mutate]);
 
   const revert = useCallback(async () => {
+    cancelPending();
     const res = await fetch('/api/kiosk/settings/revert', { method: 'POST' });
     const json = (await res.json()) as { studio: ProfileSettings };
     await mutate(
@@ -176,7 +207,7 @@ export function useStudioSettings(): StudioSettingsApi {
       { revalidate: false }
     );
     setOverlay({});
-  }, [mutate]);
+  }, [cancelPending, mutate]);
 
   return {
     loading: isLoading,

--- a/database/migrations/20260830_kiosk_settings.sql
+++ b/database/migrations/20260830_kiosk_settings.sql
@@ -1,0 +1,17 @@
+-- kiosk_settings: dial values for the kiosk studio (spec:
+-- docs/superpowers/specs/2026-08-30-kiosk-studio-control-and-mosaic-v2-design.md).
+-- One row per (profile, namespace). 'studio' is the editing surface, 'live' is
+-- what the glass reads; "Deploy to glass" copies studio -> live. The JSONB blob
+-- stores ONLY values that deviate from the code-default in the version's
+-- settingsSchema, so adding/renaming/removing knobs never needs a migration.
+-- Forward-only, idempotent. Apply manually via:
+--   psql "$DATABASE_URL" -f database/migrations/20260830_kiosk_settings.sql
+
+CREATE TABLE IF NOT EXISTS kiosk_settings (
+  profile     TEXT NOT NULL CHECK (profile IN ('studio', 'live')),
+  namespace   TEXT NOT NULL,
+  data        JSONB NOT NULL DEFAULT '{}'::jsonb,
+  revision    INT NOT NULL DEFAULT 1,
+  updated_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+  PRIMARY KEY (profile, namespace)
+);

--- a/docs/ops/kiosk-composition-tuning.md
+++ b/docs/ops/kiosk-composition-tuning.md
@@ -97,10 +97,12 @@ The URL params in the table above still work, and still win: precedence is
 That's what makes `?floor=60` useful for a one-off check without disturbing
 what's deployed for everyone else.
 
-Under the hood, `/kiosk/*` and `/studio` both read live settings via
-`/api/kiosk/state`, which is Redis-first (`getLiveSettingsCached`) and only
-falls back to Neon on a cache miss — so deploys show up on the glass within a
-poll cycle, not a redeploy.
+Under the hood, `/kiosk/*` reads live settings via `/api/kiosk/state`, which
+is Redis-first (`getLiveSettingsCached`) and only falls back to Neon on a
+cache miss — so deploys show up on the glass within a poll cycle, not a
+redeploy. `/studio` reads through the owner-gated `/api/kiosk/settings`
+(Neon) instead, since it needs both the studio and live profiles, not just
+the mirrored live one.
 
 ## On the Pi
 

--- a/docs/ops/kiosk-composition-tuning.md
+++ b/docs/ops/kiosk-composition-tuning.md
@@ -73,6 +73,35 @@ The kiosk dims itself to near-black between 1am and 8am local, and `d` toggles
 that dim by hand. If a preview goes dark mid-session, that is what happened —
 add `quiet=off`.
 
+## The dials moved to `/studio`
+
+`/studio` (owner-only — client-side gate shows "Owner sign-in required" if
+you're not signed in, but the real authorization is `requireOwner` on every
+mutating route) is now the primary way to tune composition. It's a leva rail
+next to a live sunrise/sunset preview pair, backed by the same settings
+schema as the URL params above, with two profiles:
+
+- **studio** — your scratch pad. Moving a dial previews instantly and
+  persists to the studio profile (survives a reload), but the kiosk glass
+  never sees it until you deploy.
+- **live** — what `/kiosk/sunrise` and `/kiosk/sunset` actually read. Only
+  changes when you push studio to it.
+
+Hold the **HOLD TO DEPLOY** button to push the studio profile to live (the
+badge showing `N differ` zeroes out); **↩ revert to glass** snaps the studio
+dials back to whatever's currently deployed. Both are explicit actions —
+turning a dial alone never touches the glass.
+
+The URL params in the table above still work, and still win: precedence is
+**URL param → deployed (live) profile → code default in `masterConfig.ts`**.
+That's what makes `?floor=60` useful for a one-off check without disturbing
+what's deployed for everyone else.
+
+Under the hood, `/kiosk/*` and `/studio` both read live settings via
+`/api/kiosk/state`, which is Redis-first (`getLiveSettingsCached`) and only
+falls back to Neon on a cache miss — so deploys show up on the glass within a
+poll cycle, not a redeploy.
+
 ## On the Pi
 
 `~/kiosk-launch.sh` lives only on the Pi and is not yet in this repo. Getting

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
         "firebase-admin": "^13.5.0",
         "framer-motion": "^12.23.24",
         "geomagnetism": "^0.2.0",
+        "leva": "^0.10.1",
         "mapbox-gl": "^3.14.0",
         "next": "^15.5.19",
         "next-auth": "^5.0.0-beta.31",
@@ -2393,32 +2394,42 @@
       "license": "Apache-2.0"
     },
     "node_modules/@floating-ui/core": {
-      "version": "1.7.3",
-      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.3.tgz",
-      "integrity": "sha512-sGnvb5dmrJaKEZ+LDIpguvdX3bDlEllmv4/ClQ9awcmCZrlx5jQyyMWFM5kBI+EyNOCDDiKk8il0zeuX3Zlg/w==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.8.0.tgz",
+      "integrity": "sha512-0CIZ5itps/8x7BG8dEIhs53BvCUH2PCoogtakwRTut+Arm58sJooJ0AuZhLw2HJYIR5cMLNPBSS728sPho2khQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
-        "@floating-ui/utils": "^0.2.10"
+        "@floating-ui/utils": "^0.2.12"
       }
     },
     "node_modules/@floating-ui/dom": {
-      "version": "1.7.4",
-      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.4.tgz",
-      "integrity": "sha512-OOchDgh4F2CchOX94cRVqhvy7b3AFb+/rQXyswmzmGakRfkMgoWVjfnLWkRirfLEfuD4ysVW16eXzwt3jHIzKA==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.8.0.tgz",
+      "integrity": "sha512-yXSrzeHZBTZadLOlfyhCkJHNeLJnHRnRInwdZ40L7ZiaAtrBwoYlsDrX3v5zB1Utk7CLfzcOVnVVWoXEky7Ceg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
-        "@floating-ui/core": "^1.7.3",
-        "@floating-ui/utils": "^0.2.10"
+        "@floating-ui/core": "^1.8.0",
+        "@floating-ui/utils": "^0.2.12"
+      }
+    },
+    "node_modules/@floating-ui/react-dom": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.9.tgz",
+      "integrity": "sha512-JDjEFGCpImxDCA7JJKviA0M9+RtmJdj0m/NVU5IMgBK+AmZouAQQ7/+2GLH0GXXY0YMw9oXPB8hKdbPYg5QLYg==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/dom": "^1.8.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
       }
     },
     "node_modules/@floating-ui/utils": {
-      "version": "0.2.10",
-      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.10.tgz",
-      "integrity": "sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==",
-      "license": "MIT",
-      "peer": true
+      "version": "0.2.12",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.12.tgz",
+      "integrity": "sha512-HpCo8tmWzLVad5s2d19EhAz5zqrrQ6s69qd6moPMQvkOuSwDT1YgRfWSVuc4ennqrgv3OHppiOGMQ7oC13yIww==",
+      "license": "MIT"
     },
     "node_modules/@google-cloud/firestore": {
       "version": "7.11.6",
@@ -4535,6 +4546,398 @@
       "integrity": "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==",
       "license": "BSD-3-Clause"
     },
+    "node_modules/@radix-ui/primitive": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.7.tgz",
+      "integrity": "sha512-rqWnm76nYT8HoNNqEjpgJ7Pw/DrBj5iBTrmEPo6HTX5+VJyBNOqTdv4g89G63HuR5g0AaENoAcH7Is5fF2kZ8Q==",
+      "license": "MIT"
+    },
+    "node_modules/@radix-ui/react-arrow": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-arrow/-/react-arrow-1.1.15.tgz",
+      "integrity": "sha512-v4zggRcjadnI+ClKDuijlQEW4tw3NoaeHc/PwpKnLoLLKNUG4InLegkstooLcRIUWCs+8L22dGURCVuFfOKfnA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-compose-refs": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.5.tgz",
+      "integrity": "sha512-+48PbAAbq3didjJxa+OaWY2ZwgAKsNiRGyeHKszblZMQ+kcpd9pAaT11cMkGEie0vsOi3QdeTE6d5Fe3Gn61kA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-context": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.2.2.tgz",
+      "integrity": "sha512-RHCUGwKHDr0hDGg4X7ma4JG4/+12qxw8rkh5QKdDldlCvtja6nUx1Ef/8HVrJze81lEsgLQlqjzjGNHantgnQA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dismissable-layer": {
+      "version": "1.1.19",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.1.19.tgz",
+      "integrity": "sha512-8g4pfOL9HoKKLWGiypT+dphVqjFfmcXO5GBnhsG6zI+lxAx/8feQpr+1LSN8Re3hiZ+XkLNS4O9ztK11/LzQ6w==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.10",
+        "@radix-ui/react-use-callback-ref": "1.1.4",
+        "@radix-ui/react-use-effect-event": "0.0.5"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-id": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-1.1.4.tgz",
+      "integrity": "sha512-TMQp2llA+RYn7JcjnrMnz7wN4pcVttPZnRZo52PLQsoLVKzNlVwUeHmfePgTgRluXFvlD3GD5g5MOVVTJCO0qA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.4"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-popper": {
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-popper/-/react-popper-1.3.7.tgz",
+      "integrity": "sha512-UsJrrd7w4wuKKTdvd/DNERVlwSlUcyXzjhyDwBk+3aPOsCjOY6ZSbxuw8E6lZTjjfP8Cpd0J8VVkrYUWyGYXyg==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/react-dom": "^2.0.0",
+        "@radix-ui/react-arrow": "1.1.15",
+        "@radix-ui/react-compose-refs": "1.1.5",
+        "@radix-ui/react-context": "1.2.2",
+        "@radix-ui/react-primitive": "2.1.10",
+        "@radix-ui/react-use-callback-ref": "1.1.4",
+        "@radix-ui/react-use-layout-effect": "1.1.4",
+        "@radix-ui/react-use-rect": "1.1.4",
+        "@radix-ui/react-use-size": "1.1.4",
+        "@radix-ui/rect": "1.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-portal": {
+      "version": "1.1.17",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-1.1.17.tgz",
+      "integrity": "sha512-vKQLcWypUnwZVvfV7UkGahH2g6ySe8M8R+zYBwPrv5byZ9QAW6cQVvNKo7GgmD+p8aYb6D9JBuvy8/WhOno2wQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.10",
+        "@radix-ui/react-use-layout-effect": "1.1.4"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-presence": {
+      "version": "1.1.10",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.1.10.tgz",
+      "integrity": "sha512-3wyzCQ6+ubRA+D4uv9m95JYLXxmOHp05qjrkjeA7uKHHtjpPggQzc6DAb0URl7j67oR0K2foO4ip27TiX037Bw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.4"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.10",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.10.tgz",
+      "integrity": "sha512-MucOnzh6hR5mid6VpkbglRAMYMjKLqRnGBbjXkzjK52fuQDd1qbkx78a5P40mkcnVXJdEVxm26E9OPAiUq7nBg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.3.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-slot": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.3.3.tgz",
+      "integrity": "sha512-qx7oqnYbxnK9kYI9m317qmFmEgo6ywqWvbTogdj7cL9p3/yx4M48p7Rnw5z3H890cL/ow/EeWJsuTykeZVXP5Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.5"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tooltip": {
+      "version": "1.2.16",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-tooltip/-/react-tooltip-1.2.16.tgz",
+      "integrity": "sha512-6EamKFRRnlpdadndbZ6LMwycfwkwPte1B42hs6QA0gYhjaOKqW4PZ4pjaW9UrlDX5eVt/OjncE7BFTPL5nmZhg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.5",
+        "@radix-ui/react-context": "1.2.2",
+        "@radix-ui/react-dismissable-layer": "1.1.19",
+        "@radix-ui/react-id": "1.1.4",
+        "@radix-ui/react-popper": "1.3.7",
+        "@radix-ui/react-portal": "1.1.17",
+        "@radix-ui/react-presence": "1.1.10",
+        "@radix-ui/react-primitive": "2.1.10",
+        "@radix-ui/react-slot": "1.3.3",
+        "@radix-ui/react-use-controllable-state": "1.2.6",
+        "@radix-ui/react-use-layout-effect": "1.1.4",
+        "@radix-ui/react-visually-hidden": "1.2.11"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-callback-ref": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.4.tgz",
+      "integrity": "sha512-R6OUY2e2fA6Yn6s+VSx5KBV6Nx8LQEhu+cz7LCej18rQ1HLyg9PSC9jP/ZNx0o6FAIK9c0F1kHylzSxKsdlkrQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-controllable-state": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.2.6.tgz",
+      "integrity": "sha512-uEQJGT97ZA/TgP/Hydw47lHu+/vQj6z/0jA+WeTbK1o9Rx45GImjpD0tc3W5ad3D6XTSR6e1yEO0FvGq6WQfVQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.7",
+        "@radix-ui/react-use-effect-event": "0.0.5",
+        "@radix-ui/react-use-layout-effect": "1.1.4"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-effect-event": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-effect-event/-/react-use-effect-event-0.0.5.tgz",
+      "integrity": "sha512-7cshFL8HGS/7HEiHH+9kL9HBwp2sa9yX18Knwek6KYWmXwM7pegMgta2AXMQKI+rq3JnfSj9x8wYqFMTdG1Jgg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.4"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-layout-effect": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.4.tgz",
+      "integrity": "sha512-K20DkRkUwDnxEYMBPcg3Y6voLkEy5p5QQmszZgLngKKiC7dzBR/aEuK3w1qlx2JWDUNH6FluahYdgR3BP+QbYw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-rect": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-rect/-/react-use-rect-1.1.4.tgz",
+      "integrity": "sha512-cSOCh6JlkmfjLyNcLiu2nB4v+nm+dkZ+Q5KHWk/soo4U7ZLiEQFKHK9/YmtBHjfCEaU43IBKQOc4/uJmCaiCTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/rect": "1.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-size": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-size/-/react-use-size-1.1.4.tgz",
+      "integrity": "sha512-D3anSY15EJoxrihpsXI6SMrmmonnQtR2ni7arO+Lfdg3O95b9hNXxONk8jA5C8ANdF/h5HMAxejgs8PWJ6rlhw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.4"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-visually-hidden": {
+      "version": "1.2.11",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-visually-hidden/-/react-visually-hidden-1.2.11.tgz",
+      "integrity": "sha512-NFS86RYYZb4/exihaESBGOpMJFz8MGLAfu3mOBSGByVnVPC9JPASfYubxd/8KbkQK0sYAv8lVQDEQukDX/qXvQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/rect": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/rect/-/rect-1.1.3.tgz",
+      "integrity": "sha512-JtyZR+mqgBibTo8xea3B6ZRmzZiM/YeVBtUkas6zMuXjAlfIFIW2FgqeM9eLyvEaYX66vr6DJMK+4U6LV0KhNw==",
+      "license": "MIT"
+    },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-beta.27",
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.27.tgz",
@@ -4905,6 +5308,15 @@
       "integrity": "sha512-5EwMtOqvJMMa3HbmxLlF74e+3/HhwBTMcvt3nqVJgGCozO6hzIPOBlwm8mGVNR9SN2IJpxSnlxczyDjcn7qIyw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@stitches/react": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@stitches/react/-/react-1.2.8.tgz",
+      "integrity": "sha512-9g9dWI4gsSVe8bNLlb+lMkBYsnIKCZTmvqvDG+Avnn69XfmHZKiaMrx7cgTaddq7aTPPmXiTsbFcUy0xgI4+wA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">= 16.3.0"
+      }
     },
     "node_modules/@swc/helpers": {
       "version": "0.5.15",
@@ -5992,7 +6404,7 @@
       "version": "19.1.7",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.1.7.tgz",
       "integrity": "sha512-i5ZzwYpqjmrKenzkoLM2Ibzt6mAsM7pxB6BCIouEVVmgiqaMj1TjaK7hnA36hbW5aZv20kx7Lw6hWzPWg0Rurw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.0.0"
@@ -6664,6 +7076,24 @@
       "license": "MIT",
       "dependencies": {
         "uncrypto": "^0.1.3"
+      }
+    },
+    "node_modules/@use-gesture/core": {
+      "version": "10.3.1",
+      "resolved": "https://registry.npmjs.org/@use-gesture/core/-/core-10.3.1.tgz",
+      "integrity": "sha512-WcINiDt8WjqBdUXye25anHiNxPc0VOrlT8F6LLkU6cycrOGUDyY/yyFmsg3k8i5OLvv25llc0QC45GhR/C8llw==",
+      "license": "MIT"
+    },
+    "node_modules/@use-gesture/react": {
+      "version": "10.3.1",
+      "resolved": "https://registry.npmjs.org/@use-gesture/react/-/react-10.3.1.tgz",
+      "integrity": "sha512-Yy19y6O2GJq8f7CHf7L0nxL8bf4PZCPaVOCgJrusOeFHY1LvHgYXnmnXg6N5iwAnbgbZCDjo60SiM6IPJi9C5g==",
+      "license": "MIT",
+      "dependencies": {
+        "@use-gesture/core": "10.3.1"
+      },
+      "peerDependencies": {
+        "react": ">= 16.8.0"
       }
     },
     "node_modules/@vaadin/a11y-base": {
@@ -7427,6 +7857,15 @@
         "node": ">=12"
       }
     },
+    "node_modules/assign-symbols": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
+      "integrity": "sha512-Q+JC7Whu8HhmTdBph/Tq59IoRtoy6KAm5zzPv00WdujX82lbAL8K7WVjne7vdCsAmbF4AYaDOPyO3k0kl8qIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/ast-types-flow": {
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.8.tgz",
@@ -7460,6 +7899,15 @@
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
       "license": "MIT",
       "optional": true
+    },
+    "node_modules/attr-accept": {
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/attr-accept/-/attr-accept-2.2.5.tgz",
+      "integrity": "sha512-0bDNnY/u6pPwHDMoF0FieU354oBi0a8rD9FcsLwzcGWbc8KS8KPIi7y+s13OlVY+gMWc/9xEMUgNE6Qm8ZllYQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
     },
     "node_modules/available-typed-arrays": {
       "version": "1.0.7",
@@ -7997,6 +8445,12 @@
           "url": "https://github.com/saikocat/colorbrewer/blob/master/LICENSE.txt"
         }
       ]
+    },
+    "node_modules/colord": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/colord/-/colord-2.10.0.tgz",
+      "integrity": "sha512-AidJptpBJmjTclAp9BkLwJi0T93fo5epJnbaZslpg6QVzpHjAiveF55mE9AcUJiGMqRHgMDY8soMsQtuNYMHfw==",
+      "license": "MIT"
     },
     "node_modules/combined-stream": {
       "version": "1.0.8",
@@ -9602,6 +10056,27 @@
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
       "license": "MIT"
     },
+    "node_modules/extend-shallow": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+      "integrity": "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==",
+      "license": "MIT",
+      "dependencies": {
+        "is-extendable": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/extend-shallow/node_modules/is-extendable": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+      "integrity": "sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/farmhash-modern": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/farmhash-modern/-/farmhash-modern-1.1.0.tgz",
@@ -9759,6 +10234,18 @@
       },
       "engines": {
         "node": ">=16.0.0"
+      }
+    },
+    "node_modules/file-selector": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/file-selector/-/file-selector-0.5.0.tgz",
+      "integrity": "sha512-s8KNnmIDTBoD0p9uJ9uD0XY38SCeBOtj0UMXyQSLg1Ypfrfj8+dAvwsLjYQkQ2GjhVtp2HrnF5cJzMhBjfD8HA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 10"
       }
     },
     "node_modules/fill-range": {
@@ -10026,6 +10513,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/for-in": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
+      "integrity": "sha512-7EwmXrOjyL+ChxMhmG5lnW9MPt1aIeZEwKhQzoBUdTV0N3zuwWDZYVJatDvZ2OyzPUvdIAZDsCetk3coyMfcnQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/foreachasync": {
@@ -10396,6 +10892,15 @@
       },
       "funding": {
         "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
+    "node_modules/get-value": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
+      "integrity": "sha512-Ln0UQDlxH1BapMu3GPtf7CuYNwRZf2gwCuPqbyG6pB8WfmFpzqcy4xtAaAMUhnNqjMKTiCPZG2oMT3YSx8U2NA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/gl-matrix": {
@@ -11230,6 +11735,18 @@
       "integrity": "sha512-IOQqts/aHWbiisY5DuPJQ0gcbvaLFCa7fBa9xoLfxBZvQ+ZI/Zh9xoI7Gk+G64N0FdK4AbibytHht2tWgpJWLg==",
       "license": "MIT"
     },
+    "node_modules/is-extendable": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+      "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+      "license": "MIT",
+      "dependencies": {
+        "is-plain-object": "^2.0.4"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -11348,6 +11865,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-plain-object": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
+      "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+      "license": "MIT",
+      "dependencies": {
+        "isobject": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/is-potential-custom-element-name": {
@@ -11528,6 +12057,15 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/isobject": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+      "integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/iterator.prototype": {
       "version": "1.1.5",
@@ -11870,6 +12408,46 @@
       },
       "engines": {
         "node": ">=0.10"
+      }
+    },
+    "node_modules/leva": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/leva/-/leva-0.10.1.tgz",
+      "integrity": "sha512-BcjnfUX8jpmwZUz2L7AfBtF9vn4ggTH33hmeufDULbP3YgNZ/C+ss/oO3stbrqRQyaOmRwy70y7BGTGO81S3rA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-portal": "^1.1.4",
+        "@radix-ui/react-tooltip": "^1.1.8",
+        "@stitches/react": "^1.2.8",
+        "@use-gesture/react": "^10.2.5",
+        "colord": "^2.9.2",
+        "dequal": "^2.0.2",
+        "merge-value": "^1.0.0",
+        "react-colorful": "^5.5.1",
+        "react-dropzone": "^12.0.0",
+        "v8n": "^1.3.3",
+        "zustand": "^3.6.9"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/leva/node_modules/zustand": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-3.7.2.tgz",
+      "integrity": "sha512-PIJDIZKtokhof+9+60cpockVOq05sJzHCriyvaLBmEJixseQ1a5Kdov6fWZfWOu5SK9c+FhH1jU0tntLxRJYMA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.7.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        }
       }
     },
     "node_modules/levn": {
@@ -12501,6 +13079,21 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/merge-value": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/merge-value/-/merge-value-1.0.0.tgz",
+      "integrity": "sha512-fJMmvat4NeKz63Uv9iHWcPDjCWcCkoiRoajRTEO8hlhUC6rwaHg0QCF9hBOTjZmm4JuglPckPSTtcuJL5kp0TQ==",
+      "license": "MIT",
+      "dependencies": {
+        "get-value": "^2.0.6",
+        "is-extendable": "^1.0.0",
+        "mixin-deep": "^1.2.0",
+        "set-value": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/merge2": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -12620,6 +13213,19 @@
       },
       "engines": {
         "node": ">= 18"
+      }
+    },
+    "node_modules/mixin-deep": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.2.tgz",
+      "integrity": "sha512-WRoDn//mXBiJ1H40rqa3vH0toePwSsGb45iInWlTySa+Uu4k3tYUSxa2v1KqAiLtvlrSzaExqS1gtk96A9zvEA==",
+      "license": "MIT",
+      "dependencies": {
+        "for-in": "^1.0.2",
+        "is-extendable": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/mjolnir.js": {
@@ -13896,6 +14502,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-colorful": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/react-colorful/-/react-colorful-5.8.0.tgz",
+      "integrity": "sha512-Wy9OzPfjSN9bF12OB8N7UQvlsZ0I+7wHxpN+bV5BjNQGxOj6IiwkRjevJK9yOBjJWGQvAaf1OXtn8rUeEatAng==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
     "node_modules/react-dom": {
       "version": "19.1.0",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.1.0.tgz",
@@ -13906,6 +14522,23 @@
       },
       "peerDependencies": {
         "react": "^19.1.0"
+      }
+    },
+    "node_modules/react-dropzone": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/react-dropzone/-/react-dropzone-12.1.0.tgz",
+      "integrity": "sha512-iBYHA1rbopIvtzokEX4QubO6qk5IF/x3BtKGu74rF2JkQDXnwC4uO/lHKpaw4PJIV6iIAYOlwLv2FpiGyqHNog==",
+      "license": "MIT",
+      "dependencies": {
+        "attr-accept": "^2.2.2",
+        "file-selector": "^0.5.0",
+        "prop-types": "^15.8.1"
+      },
+      "engines": {
+        "node": ">= 10.13"
+      },
+      "peerDependencies": {
+        "react": ">= 16.8"
       }
     },
     "node_modules/react-is": {
@@ -14458,6 +15091,30 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/set-value": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.1.tgz",
+      "integrity": "sha512-JxHc1weCN68wRY0fhCoXpyK55m/XPHafOmK4UWD7m2CI14GMcFypt4w/0+NV5f/ZMby2F6S2wwA7fgynh9gWSw==",
+      "license": "MIT",
+      "dependencies": {
+        "extend-shallow": "^2.0.1",
+        "is-extendable": "^0.1.1",
+        "is-plain-object": "^2.0.3",
+        "split-string": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/set-value/node_modules/is-extendable": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+      "integrity": "sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/setimmediate": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
@@ -14676,6 +15333,31 @@
       "resolved": "https://registry.npmjs.org/splaytree-ts/-/splaytree-ts-1.0.2.tgz",
       "integrity": "sha512-0kGecIZNIReCSiznK3uheYB8sbstLjCZLiwcQwbmLhgHJj2gz6OnSPkVzJQCMnmEz1BQ4gPK59ylhBoEWOhGNA==",
       "license": "BDS-3-Clause"
+    },
+    "node_modules/split-string": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
+      "integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
+      "license": "MIT",
+      "dependencies": {
+        "extend-shallow": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/split-string/node_modules/extend-shallow": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
+      "integrity": "sha512-BwY5b5Ql4+qZoefgMj2NUmx+tehVTH/Kf4k1ZEtOHNFcm2wSxMRo992l6X3TIgni2eZVTZ85xMOjF31fwZAj6Q==",
+      "license": "MIT",
+      "dependencies": {
+        "assign-symbols": "^1.0.0",
+        "is-extendable": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/sprintf-js": {
       "version": "1.0.3",
@@ -15806,6 +16488,12 @@
       "bin": {
         "uuid": "dist-node/bin/uuid"
       }
+    },
+    "node_modules/v8n": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/v8n/-/v8n-1.5.1.tgz",
+      "integrity": "sha512-LdabyT4OffkyXFCe9UT+uMkxNBs5rcTVuZClvxQr08D5TUgo1OFKkoT65qYRCsiKBl/usHjpXvP4hHMzzDRj3A==",
+      "license": "MIT"
     },
     "node_modules/vary": {
       "version": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "firebase-admin": "^13.5.0",
     "framer-motion": "^12.23.24",
     "geomagnetism": "^0.2.0",
+    "leva": "^0.10.1",
     "mapbox-gl": "^3.14.0",
     "next": "^15.5.19",
     "next-auth": "^5.0.0-beta.31",


### PR DESCRIPTION
Phase 1 of the kiosk studio (spec + mockup decisions: `docs/superpowers/specs/2026-08-30-kiosk-studio-control-and-mosaic-v2-design.md` on `docs/kiosk-studio-v2-spec`): the settings pipeline end-to-end, plus the owner-gated `/studio` control page — proven against v1's existing knobs before any v2 mosaic exists.

## What shipped

- **Settings schema core** (`app/lib/settings/`): typed knob descriptors, sanitize/merge/diff primitives; `shared` namespace (activeVersion, panelPreset) + v1 schema mirroring the frozen `COMPOSITION_CONFIG`.
- **Storage**: `kiosk_settings` table (one row per `(profile, namespace)`, JSONB **deviations-only** — values equal to code defaults are never stored; unknown keys inert on read). Migration `database/migrations/20260830_kiosk_settings.sql` — **already applied to Neon and verified** (round-trip tested against the live table).
- **API**: owner-gated `GET/PATCH /api/kiosk/settings` (PATCH writes studio only), `POST .../deploy` (the sole live write path; copies studio→live + refreshes the Redis mirror), `POST .../revert`.
- **Kiosk delivery**: merged live settings ride the existing 60s `/api/kiosk/state` poll via a Redis mirror (300s TTL, self-healing) — **the hot path never touches Neon** (cold-miss fill only). Poll freshness is marked only for real kiosk pollers (`?kiosk=1`).
- **Precedence everywhere**: URL param → server profile → code default (`?floor=`, `?models=`, `?v=` all still win on-glass).
- **`/studio`**: dark full-page operator tool — leva dial rail rendered from the schema (folders per section, `●` on knobs that differ from glass, per-section reset), dual-feed preview at true panel size with a sunrise|sunset|both toggle, hold-to-deploy (600ms) "Deploy to glass" with the diff count in the button face + failure states, "Revert to glass", status strip (glass version · settings rev · poll freshness · `↑a/b ↓c/d pass` gate counts · in-sync/deploying-countdown/stale states).

## Recorded deviations from the spec

1. **Kiosk pages don't self-apply panel geometry** — the Pi's fullscreen window physically *is* the panel; the shared geometry setting drives the studio preview, and `?panel=` remains the explicit override.
2. **Per-knob reset deferred** (leva has no native per-row reset): per-section reset buttons + `●` differs-markers instead; revisit in the polish phase.

## Verification

- 934 tests green (full suite), lint clean, `next build` passes (35/35 pages incl. `/studio`).
- Final whole-branch review (most capable model) + one fix wave: deploy/revert now fail loudly (res.ok guards + red failure lines), mirror self-heals via TTL, poll-marking gated to kiosk traffic.
- Live DB round-trip verified (upsert/read/delete on the real table; live profile untouched — zero rows, i.e. pure code defaults, so merging this changes nothing on the glass until the first Deploy).

## Still owed before full merge confidence (needs Jesse's signed-in session)

1. `/studio` visual pass (rail, both feeds, collapse pill, strip).
2. Move a dial → badge counts → reload → dial value survives (studio profile persistence).
3. Hold Deploy → badge zeroes → `/kiosk/sunset` picks it up within 60s (this is also the only live exercise of `copyProfile`'s transaction).
4. Revert pulls a dead-end experiment back; `?floor=60` still beats the deployed value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FhSrLmoaqHe2miFjCYGUYa
