### PR TITLE
Retest draw: measure the operator's test-retest ceiling (quality-ceiling Phase 0)

### DIFF
--- a/app/api/manual-labels/route.test.ts
+++ b/app/api/manual-labels/route.test.ts
@@ -4,6 +4,8 @@ import { NextResponse } from 'next/server';
 
 const requireOwnerMock = vi.fn();
 const upsertMock = vi.fn();
+const upsertRetestMock = vi.fn();
+const resolveDestMock = vi.fn();
 const deleteMock = vi.fn();
 const countMock = vi.fn();
 
@@ -12,6 +14,8 @@ vi.mock('@/app/lib/owner', () => ({
 }));
 vi.mock('@/app/lib/manualLabels', () => ({
   upsertManualLabel: (...a: unknown[]) => upsertMock(...a),
+  upsertRetestLabel: (...a: unknown[]) => upsertRetestMock(...a),
+  resolveLabelDestination: (...a: unknown[]) => resolveDestMock(...a),
   deleteManualLabel: (...a: unknown[]) => deleteMock(...a),
   countManualLabels: (...a: unknown[]) => countMock(...a),
 }));
@@ -29,6 +33,8 @@ const post = (body: unknown) =>
 beforeEach(() => {
   requireOwnerMock.mockReset().mockResolvedValue(null);
   upsertMock.mockReset().mockResolvedValue(SAVED);
+  upsertRetestMock.mockReset().mockResolvedValue(SAVED);
+  resolveDestMock.mockReset().mockResolvedValue('gold');
   deleteMock.mockReset().mockResolvedValue(1);
   countMock.mockReset().mockResolvedValue(113);
 });
@@ -90,6 +96,42 @@ describe('POST /api/manual-labels', () => {
     expect(upsertMock).toHaveBeenCalledWith({
       source: 'flickr', imageId: 5709, isSunset: true, rating: 3, origin: null,
     });
+  });
+});
+
+describe('POST /api/manual-labels — retest routing', () => {
+  // A retest label written through upsertManualLabel would ON CONFLICT
+  // OVERWRITE the operator's gold label; these pin the fork in the road.
+  it('routes a retest-sample label into manual_label_retests, never manual_labels', async () => {
+    resolveDestMock.mockResolvedValue('retest');
+    const res = await POST(
+      post({ source: 'webcam', imageId: 7, isSunset: true, rating: 3, origin: 'retest_v1' }),
+    );
+    expect(res.status).toBe(200);
+    expect(resolveDestMock).toHaveBeenCalledWith('retest_v1', 'webcam', 7);
+    expect(upsertRetestMock).toHaveBeenCalledWith({
+      source: 'webcam', imageId: 7, isSunset: true, rating: 3, origin: 'retest_v1',
+    });
+    expect(upsertMock).not.toHaveBeenCalled();
+  });
+  it('rejects a retest origin for a frame outside the sample (400, nothing written)', async () => {
+    // Without this, a stray retest origin would fall through to the gold
+    // upsert and overwrite the original label.
+    resolveDestMock.mockResolvedValue('reject');
+    const res = await POST(
+      post({ source: 'webcam', imageId: 999, isSunset: false, origin: 'retest_v1' }),
+    );
+    expect(res.status).toBe(400);
+    expect(upsertMock).not.toHaveBeenCalled();
+    expect(upsertRetestMock).not.toHaveBeenCalled();
+  });
+  it('leaves hard_example and draw-sample origins on the gold path', async () => {
+    const res = await POST(
+      post({ source: 'webcam', imageId: 7, isSunset: true, rating: 4, origin: 'random_ordinary_v1' }),
+    );
+    expect(res.status).toBe(200);
+    expect(upsertMock).toHaveBeenCalled();
+    expect(upsertRetestMock).not.toHaveBeenCalled();
   });
 });
 

--- a/app/api/manual-labels/route.ts
+++ b/app/api/manual-labels/route.ts
@@ -2,6 +2,8 @@ import { NextResponse } from 'next/server';
 import { requireOwner } from '@/app/lib/owner';
 import {
   upsertManualLabel,
+  upsertRetestLabel,
+  resolveLabelDestination,
   deleteManualLabel,
   countManualLabels,
   type LabelSource,
@@ -37,13 +39,30 @@ export async function POST(request: Request) {
     if (origin != null && (typeof origin !== 'string' || !/^[a-z0-9_]{1,64}$/.test(origin))) {
       return NextResponse.json({ error: 'bad origin' }, { status: 400 });
     }
-    const saved = await upsertManualLabel({
-      source,
-      imageId: imageIdNum,
-      isSunset,
-      rating: rating ?? null,
-      origin: origin ?? null,
-    });
+    // Retest labels go to their own table: written through the gold upsert
+    // they would ON CONFLICT overwrite the operator's original label. The
+    // destination is resolved from label_samples (kind + membership), never
+    // from what the client asserts.
+    const destination = await resolveLabelDestination(origin ?? null, source, imageIdNum);
+    if (destination === 'reject') {
+      return NextResponse.json({ error: 'not in retest sample' }, { status: 400 });
+    }
+    const saved =
+      destination === 'retest'
+        ? await upsertRetestLabel({
+            source,
+            imageId: imageIdNum,
+            isSunset,
+            rating: rating ?? null,
+            origin,
+          })
+        : await upsertManualLabel({
+            source,
+            imageId: imageIdNum,
+            isSunset,
+            rating: rating ?? null,
+            origin: origin ?? null,
+          });
     if (!saved) {
       // The insert returned no row, so nothing was stored. Say so rather than
       // letting the queue count this as a save.

--- a/app/api/snapshots/route.test.ts
+++ b/app/api/snapshots/route.test.ts
@@ -186,3 +186,78 @@ describe('GET /api/snapshots?mode=verification', () => {
     expect(body.snapshots[0]).toHaveProperty('provenance');
   });
 });
+
+describe('GET /api/snapshots?mode=verification — retest samples', () => {
+  const allText = () =>
+    sqlMock.mock.calls.map(([s]) => (s as TemplateStringsArray).join('?'));
+
+  // A retest sample (label_samples.kind = 'retest') re-serves frames that BY
+  // CONSTRUCTION already have manual_labels rows; drop-out and progress must
+  // therefore read manual_label_retests instead.
+  const mockRetestKind = () => {
+    sqlMock.mockImplementation((strings: TemplateStringsArray) => {
+      const q = strings.join('?');
+      if (/select\s+kind\s+from\s+label_samples/i.test(q)) {
+        return Promise.resolve([{ kind: 'retest' }]);
+      }
+      if (/count\(\*\)::int as size/i.test(q)) {
+        return Promise.resolve([{ size: 150, labeled: 12 }]);
+      }
+      return Promise.resolve([]);
+    });
+  };
+
+  it('serves retest frames despite their manual_labels rows (no gold exclusion)', async () => {
+    mockRetestKind();
+    await GET(req('?mode=verification&sample=retest_v1'));
+    const text = allText();
+    // Membership filter still applies…
+    expect(text.some((q) => /s\.id in\s*\(\s*select image_id from label_samples/i.test(q))).toBe(true);
+    // …but nothing excludes on manual_labels — every retest frame has a row there.
+    expect(text.some((q) => /not in\s*\(\s*select image_id from manual_labels/i.test(q))).toBe(false);
+  });
+
+  it('drops a frame from the queue once manual_label_retests has its re-rating', async () => {
+    mockRetestKind();
+    await GET(req('?mode=verification&sample=retest_v1'));
+    const text = allText();
+    expect(
+      text.some((q) =>
+        /not in\s*\(\s*select image_id from manual_label_retests\s+where source\s*=\s*'webcam'\s+and origin\s*=\s*\?/i.test(q),
+      ),
+    ).toBe(true);
+  });
+
+  it('reports retest progress from manual_label_retests, not manual_labels', async () => {
+    mockRetestKind();
+    const res = await GET(req('?mode=verification&sample=retest_v1'));
+    const body = await res.json();
+    expect(body.sample).toEqual({ name: 'retest_v1', size: 150, labeled: 12 });
+    const progressCall = allText().find((q) => /count\(\*\)::int as size/i.test(q));
+    expect(progressCall).toMatch(/manual_label_retests/i);
+    expect(progressCall).not.toMatch(/join manual_labels\b/i);
+  });
+
+  it('stays blind: no query joins manual_labels, so the first-pass label is never fetched', async () => {
+    mockRetestKind();
+    await GET(req('?mode=verification&sample=retest_v1'));
+    const text = allText();
+    expect(text.some((q) => /join\s+manual_labels\b/i.test(q))).toBe(false);
+  });
+
+  it('draw samples keep the manual_labels drop-out exactly as before', async () => {
+    // Kind lookup returns 'draw' — behavior must be indistinguishable from
+    // the pre-retest code path.
+    sqlMock.mockImplementation((strings: TemplateStringsArray) => {
+      const q = strings.join('?');
+      if (/select\s+kind\s+from\s+label_samples/i.test(q)) {
+        return Promise.resolve([{ kind: 'draw' }]);
+      }
+      return Promise.resolve([]);
+    });
+    await GET(req('?mode=verification&sample=random_ordinary_v1'));
+    const text = allText();
+    expect(text.some((q) => /not in\s*\(\s*select image_id from manual_labels where source\s*=\s*'webcam'/i.test(q))).toBe(true);
+    expect(text.some((q) => /manual_label_retests/i.test(q) && /not in/i.test(q))).toBe(false);
+  });
+});

--- a/app/api/snapshots/route.ts
+++ b/app/api/snapshots/route.ts
@@ -207,6 +207,17 @@ export async function GET(request: Request) {
       // per request would drift while it was being rated. Overrides
       // disagreements_only — the whole point is the frames that queue skips.
       const sampleName = searchParams.get('sample');
+      // A retest sample (kind='retest') re-serves frames that BY CONSTRUCTION
+      // already have manual_labels rows — the operator is rating them a second
+      // time, blind, to measure test–retest reliability. Drop-out and progress
+      // for those read manual_label_retests instead; the manual_labels
+      // exclusion below would otherwise hide the entire sample.
+      const sampleKindRows = sampleName
+        ? ((await sql`
+            SELECT kind FROM label_samples WHERE sample_name = ${sampleName} LIMIT 1
+          `) as { kind: string }[])
+        : [];
+      const isRetest = sampleKindRows[0]?.kind === 'retest';
       // Over-fetch so the merged result can be paged in JS.
       const fetchN = limit + offset;
 
@@ -240,7 +251,12 @@ export async function GET(request: Request) {
                + ABS(COALESCE(e.ai_regression_score, 0) - COALESCE(e.llm_quality, 0)))`
         : sql`EXTRACT(EPOCH FROM e.scraped_at)`;
 
-      const webcamFilter = sampleName
+      const webcamFilter = sampleName && isRetest
+        ? sql`AND s.id IN (SELECT image_id FROM label_samples
+                            WHERE sample_name = ${sampleName} AND source = 'webcam')
+              AND s.id NOT IN (SELECT image_id FROM manual_label_retests
+                                WHERE source = 'webcam' AND origin = ${sampleName})`
+        : sampleName
         ? sql`AND s.id IN (SELECT image_id FROM label_samples
                             WHERE sample_name = ${sampleName} AND source = 'webcam')
               AND s.id NOT IN (SELECT image_id FROM manual_labels WHERE source = 'webcam')`
@@ -248,7 +264,12 @@ export async function GET(request: Request) {
         ? sql`AND s.model_disagreement_kind IS NOT NULL
               AND s.id NOT IN (SELECT image_id FROM manual_labels WHERE source = 'webcam')`
         : sql`AND s.id NOT IN (SELECT image_id FROM manual_labels WHERE source = 'webcam')`;
-      const externalFilter = sampleName
+      const externalFilter = sampleName && isRetest
+        ? sql`AND e.id IN (SELECT image_id FROM label_samples
+                            WHERE sample_name = ${sampleName} AND source = 'flickr')
+              AND e.id NOT IN (SELECT image_id FROM manual_label_retests
+                                WHERE source = 'flickr' AND origin = ${sampleName})`
+        : sampleName
         ? sql`AND e.id IN (SELECT image_id FROM label_samples
                             WHERE sample_name = ${sampleName} AND source = 'flickr')
               AND e.id NOT IN (SELECT image_id FROM manual_labels WHERE source = 'flickr')`
@@ -369,7 +390,18 @@ export async function GET(request: Request) {
       // reports what is still unrated.
       let sample: { name: string; size: number; labeled: number } | null = null;
       if (sampleName) {
-        const sampleRows = (await sql`
+        const sampleRows = isRetest
+          ? ((await sql`
+              SELECT
+                count(*)::int AS size,
+                count(r.id)::int AS labeled
+              FROM label_samples ls
+              LEFT JOIN manual_label_retests r
+                ON r.source = ls.source AND r.image_id = ls.image_id
+               AND r.origin = ls.sample_name
+              WHERE ls.sample_name = ${sampleName}
+            `) as { size: number; labeled: number }[])
+          : ((await sql`
           SELECT
             count(*)::int AS size,
             count(m.id)::int AS labeled
@@ -377,7 +409,7 @@ export async function GET(request: Request) {
           LEFT JOIN manual_labels m
             ON m.source = ls.source AND m.image_id = ls.image_id
           WHERE ls.sample_name = ${sampleName}
-        `) as { size: number; labeled: number }[];
+        `) as { size: number; labeled: number }[]);
         sample = {
           name: sampleName,
           size: sampleRows[0]?.size ?? 0,

--- a/app/components/HardExamples/HardExamplesQueue.test.tsx
+++ b/app/components/HardExamples/HardExamplesQueue.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import HardExamplesQueue, { SAMPLE_NAME } from './HardExamplesQueue';
+import HardExamplesQueue, { SAMPLE_NAME, RETEST_SAMPLE_NAME } from './HardExamplesQueue';
 
 // Two frames with different provenance so we can assert the right bucket moves.
 const FRAMES = [
@@ -609,5 +609,72 @@ describe('HardExamplesQueue population integrity (regression, 2026-08-29)', () =
     // 120 of 200 rated must never read as finished.
     await waitFor(() => expect(screen.getByText(/still unrated/)).toBeTruthy());
     expect(screen.queryByText(/Sample complete/)).toBeNull();
+  });
+});
+
+describe('HardExamplesQueue retest queue', () => {
+  // Third queue: already-rated frames served back BLIND so the operator's
+  // test–retest agreement (the ceiling for any model) can be measured. Same
+  // fetch-time origin stamping as the random sample — the server routes
+  // retest origins into manual_label_retests, so a wrong origin here would
+  // overwrite gold labels.
+  const RETEST = { name: RETEST_SAMPLE_NAME, size: 150, labeled: 3 };
+
+  const urls: string[] = [];
+  beforeEach(() => {
+    urls.length = 0;
+    labelSeq = 0;
+    vi.stubGlobal('fetch', vi.fn(async (url: string) => {
+      urls.push(String(url));
+      if (String(url).startsWith('/api/snapshots')) {
+        const isRetest = String(url).includes(`sample=${RETEST_SAMPLE_NAME}`);
+        return {
+          ok: true,
+          json: async () => ({
+            snapshots: isRetest
+              ? FRAMES.map((f) => ({ ...f, modelDisagreementKind: null }))
+              : FRAMES,
+            total: 2,
+            counts: COUNTS,
+            sample: isRetest ? RETEST : null,
+          }),
+        } as Response;
+      }
+      return labelResponse();
+    }));
+  });
+
+  const switchToRetest = async () => {
+    render(<HardExamplesQueue />);
+    await screen.findByText('Frame one');
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Retest' }));
+    });
+  };
+
+  it('asks for the retest sample instead of the disagreement ranking', async () => {
+    await switchToRetest();
+    const last = urls.filter((u) => u.startsWith('/api/snapshots')).at(-1) ?? '';
+    expect(last).toContain(`sample=${RETEST_SAMPLE_NAME}`);
+    expect(last).not.toContain('disagreements_only=true');
+  });
+
+  it('stamps the retest sample name as origin on saves', async () => {
+    await switchToRetest();
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Not a sunset (N)' }));
+    });
+    const post = (fetch as unknown as ReturnType<typeof vi.fn>).mock.calls.find(
+      (c) => String(c[0]).startsWith('/api/manual-labels'),
+    );
+    expect(JSON.parse(String((post?.[1] as RequestInit)?.body)).origin).toBe(
+      RETEST_SAMPLE_NAME,
+    );
+  });
+
+  it('shows progress through the retest draw', async () => {
+    await switchToRetest();
+    expect(await screen.findByTestId('sample-progress')).toHaveTextContent('3 / 150');
+    expect(screen.queryByText('left to rate:')).toBeNull();
   });
 });

--- a/app/components/HardExamples/HardExamplesQueue.tsx
+++ b/app/components/HardExamples/HardExamplesQueue.tsx
@@ -44,6 +44,15 @@ type SampleProgress = { name: string; size: number; labeled: number };
 // to v3 while two test expectations still hardcoded v2, and main went red.
 export const SAMPLE_NAME = 'random_ordinary_v3';
 
+// The ACTIVE retest sample — already-rated frames served back BLIND so the
+// operator's test–retest agreement (the ceiling for any model trained on
+// these labels) can be measured. Loaded by `ml/load_retest_sample.py`; the
+// server routes this origin into manual_label_retests, so the re-ratings can
+// never overwrite the gold rows in manual_labels. Analysis:
+// `ml/analyze_retest.py --sample-name retest_v1` (quality-ceiling roadmap,
+// Phase 0).
+export const RETEST_SAMPLE_NAME = 'retest_v1';
+
 const BATCH = 120;
 const SIDE = 2; // thumbs each side (symmetric)
 const THUMB_W = 104;
@@ -157,7 +166,7 @@ export function HardExamplesQueue({
   const [blind, setBlind] = useState(true);
   const [view, setView] = useState<'queue' | 'grid'>('queue');
   const [source, setSource] = useState<'all' | 'webcam' | 'flickr'>('all');
-  const [queue, setQueue] = useState<'disagreements' | 'sample'>('disagreements');
+  const [queue, setQueue] = useState<'disagreements' | 'sample' | 'retest'>('disagreements');
 
   const [snapshots, setSnapshots] = useState<QueuedSnapshot[]>([]);
   const [counts, setCounts] = useState<Counts>({ archiveTrained: 0, archiveNew: 0, flickr: 0 });
@@ -209,15 +218,17 @@ export function HardExamplesQueue({
       // Read the mode ONCE, here, and carry it through this whole request. The
       // request, the frames it returns and the origin they are labeled with all
       // come from this single value, so they cannot disagree with each other.
-      const fetchOrigin = queue === 'sample' ? SAMPLE_NAME : 'hard_example';
+      const activeSample =
+        queue === 'sample' ? SAMPLE_NAME : queue === 'retest' ? RETEST_SAMPLE_NAME : null;
+      const fetchOrigin = activeSample ?? 'hard_example';
       try {
         const srcParam = source === 'all' ? '' : `&source=${source}`;
-        // The sample is a fixed set served in its own frozen order, so it takes
-        // the place of the disagreement ranking rather than layering on top.
-        const queueParam =
-          queue === 'sample'
-            ? `&sample=${encodeURIComponent(SAMPLE_NAME)}`
-            : '&disagreements_only=true';
+        // A sample (random or retest) is a fixed set served in its own frozen
+        // order, so it takes the place of the disagreement ranking rather than
+        // layering on top.
+        const queueParam = activeSample
+          ? `&sample=${encodeURIComponent(activeSample)}`
+          : '&disagreements_only=true';
         const r = await fetch(
           `/api/snapshots?mode=verification${queueParam}&limit=${batchSize}&offset=${offset}${srcParam}`,
         );
@@ -461,6 +472,7 @@ export function HardExamplesQueue({
       >
         <ToggleButton value="disagreements">Disagreements</ToggleButton>
         <ToggleButton value="sample">Random sample</ToggleButton>
+        <ToggleButton value="retest">Retest</ToggleButton>
       </ToggleButtonGroup>
       <Box sx={{ flex: 1 }} />
       {saved.total != null && (
@@ -475,12 +487,12 @@ export function HardExamplesQueue({
           </span>
         </Box>
       )}
-      {queue === 'sample' ? (
+      {queue !== 'disagreements' ? (
         <Box
           data-testid="sample-progress"
           sx={{ display: 'flex', gap: 0.75, fontSize: 12, alignItems: 'center' }}
         >
-          <span style={{ color: '#94a3b8' }}>sample:</span>
+          <span style={{ color: '#94a3b8' }}>{queue === 'retest' ? 'retest:' : 'sample:'}</span>
           <span style={{ color: '#cbd5e1' }}>
             <b>{sample?.labeled ?? 0}</b> / {sample?.size ?? 0} rated
           </span>
@@ -531,9 +543,11 @@ export function HardExamplesQueue({
       ) : !current ? (
         <Box sx={{ flex: 1, display: 'grid', placeItems: 'center', minHeight: '36vh' }}>
           <Typography sx={{ color: '#9ca3af' }}>
-            {queue === 'sample'
+            {queue !== 'disagreements'
               ? !sample || sample.size === 0
-                ? `No frames in sample "${SAMPLE_NAME}" — load it with ml/load_label_sample.py.`
+                ? queue === 'retest'
+                  ? `No frames in sample "${RETEST_SAMPLE_NAME}" — load it with ml/load_retest_sample.py.`
+                  : `No frames in sample "${SAMPLE_NAME}" — load it with ml/load_label_sample.py.`
                 : sample.labeled >= sample.size
                 ? `Sample complete — all ${sample.size} frames rated.`
                 : // Running out of LOADED frames is not the same as finishing
@@ -607,7 +621,9 @@ export function HardExamplesQueue({
                 color: current.queueOrigin === SAMPLE_NAME ? '#6ee7b7' : '#94a3b8',
               }}
             >
-              {current.queueOrigin === SAMPLE_NAME
+              {current.queueOrigin === RETEST_SAMPLE_NAME
+                ? `Retest${sample ? ` · ${sample.labeled} of ${sample.size}` : ''}`
+                : current.queueOrigin === SAMPLE_NAME
                 ? `Random sample${sample ? ` · ${sample.labeled} of ${sample.size}` : ''}`
                 : 'Disagreement queue'}
             </Typography>
@@ -619,7 +635,11 @@ export function HardExamplesQueue({
               {/* Sample frames carry no disagreement — and saying one exists
                   would prime the rating, which is the one thing this set has
                   to avoid. */}
-              {current.queueOrigin === SAMPLE_NAME
+              {current.queueOrigin === RETEST_SAMPLE_NAME
+                ? // Never hint that this frame was rated before, let alone what
+                  // it got — a remembered or primed rating defeats the retest.
+                  'Rate it on its own terms.'
+                : current.queueOrigin === SAMPLE_NAME
                 ? 'Random ordinary frame — rate it on its own terms.'
                 : current.modelDisagreementKind
                 ? WHY[current.modelDisagreementKind] ?? 'Judges disagree on this frame.'

--- a/app/lib/manualLabels.ts
+++ b/app/lib/manualLabels.ts
@@ -35,6 +35,54 @@ export async function upsertManualLabel(opts: {
   return { id: Number(row.id), labeledAt: new Date(row.labeled_at).toISOString() };
 }
 
+/** Where a label write belongs, resolved from the DATABASE's record of the
+ *  sample — not from anything the client asserts. A retest label routed into
+ *  manual_labels would ON CONFLICT overwrite the operator's gold label, so
+ *  'retest' is only returned when the sample is kind='retest' AND the frame
+ *  is actually a member; a retest origin on a non-member is 'reject', never
+ *  a silent fall-through to the gold path. */
+export async function resolveLabelDestination(
+  origin: string | null | undefined,
+  source: LabelSource,
+  imageId: number,
+): Promise<'gold' | 'retest' | 'reject'> {
+  if (!origin) return 'gold';
+  const rows = (await sql`
+    SELECT kind,
+           bool_or(source = ${source} AND image_id = ${imageId}) AS member
+    FROM label_samples WHERE sample_name = ${origin} GROUP BY kind
+  `) as { kind: string; member: boolean }[];
+  const row = rows[0];
+  if (!row) return 'gold'; // 'hard_example' etc. — an origin, not a sample name
+  if (row.kind !== 'retest') return 'gold'; // eval draws keep the gold path
+  return row.member ? 'retest' : 'reject';
+}
+
+/** Second-pass (retest) label. Same shape as upsertManualLabel but writes to
+ *  manual_label_retests, conflicting per (source, image_id, origin) so the
+ *  operator can self-correct within a sitting without ever touching gold. */
+export async function upsertRetestLabel(opts: {
+  source: LabelSource;
+  imageId: number;
+  isSunset: boolean;
+  rating?: number | null;
+  origin: string;
+}): Promise<SavedLabel | null> {
+  const rows = (await sql`
+    INSERT INTO manual_label_retests (source, image_id, is_sunset, rating, origin)
+    VALUES (${opts.source}, ${opts.imageId}, ${opts.isSunset}, ${opts.rating ?? null},
+            ${opts.origin})
+    ON CONFLICT (source, image_id, origin) DO UPDATE
+      SET is_sunset = EXCLUDED.is_sunset,
+          rating = EXCLUDED.rating,
+          labeled_at = now()
+    RETURNING id, labeled_at
+  `) as { id: number | string; labeled_at: string | Date }[];
+  const row = rows[0];
+  if (!row) return null;
+  return { id: Number(row.id), labeledAt: new Date(row.labeled_at).toISOString() };
+}
+
 export async function deleteManualLabel(
   source: LabelSource,
   imageId: number,

--- a/database/migrations/20260830_manual_label_retests.sql
+++ b/database/migrations/20260830_manual_label_retests.sql
@@ -1,0 +1,29 @@
+-- Retest labels: the operator re-rating frames they already rated, to measure
+-- test–retest reliability (the ceiling for any model — see
+-- docs/superpowers/plans/2026-08-30-quality-ceiling-and-labeling-roadmap.md).
+--
+-- A separate table, NOT rows in manual_labels: that table is
+-- UNIQUE (source, image_id) and its write path is ON CONFLICT DO UPDATE, so a
+-- retest through it would OVERWRITE the gold label. Physical separation also
+-- keeps retests out of every training export by construction —
+-- export_dataset.py reads manual_labels.
+--   psql "$DATABASE_URL" -f database/migrations/20260830_manual_label_retests.sql
+
+CREATE TABLE IF NOT EXISTS manual_label_retests (
+  id          BIGSERIAL PRIMARY KEY,
+  source      TEXT NOT NULL CHECK (source IN ('webcam', 'flickr')),
+  image_id    BIGINT NOT NULL,
+  is_sunset   BOOLEAN NOT NULL,
+  rating      INT CHECK (rating BETWEEN 1 AND 5),
+  origin      TEXT NOT NULL,          -- retest sample name, e.g. 'retest_v1'
+  labeled_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+  UNIQUE (source, image_id, origin)   -- one re-rating per frame per campaign
+);
+
+-- 'draw' = a normal eval draw (quarantined from training);
+-- 'retest' = already-labeled frames served back blind. Their ORIGINAL labels
+-- must stay IN training, so export_dataset.py's quarantine guards are scoped
+-- to kind = 'draw' — that scoping must land before any retest sample loads.
+ALTER TABLE label_samples
+  ADD COLUMN IF NOT EXISTS kind TEXT NOT NULL DEFAULT 'draw'
+  CHECK (kind IN ('draw', 'retest'));

--- a/docs/superpowers/plans/2026-08-29-two-scale-model-STATE.md
+++ b/docs/superpowers/plans/2026-08-29-two-scale-model-STATE.md
@@ -339,6 +339,29 @@ Reports: `ml/artifacts/reports/v5_binary_on_operator_random200.json` and
 
 ---
 
+## What's next (2026-08-30: Phase 0 BUILT, sitting pending)
+
+`2026-08-30-quality-ceiling-and-labeling-roadmap.md` is the follow-on plan:
+Phase 0 measures the operator's own test–retest ceiling, which gates whether
+a big detection-gated quality labeling push (Phase 1) is worth anything.
+Detection stays frozen; Flickr stays out of fine-tune; images are not the
+constraint, labels are.
+
+**Phase 0 is built** (branch `feat/retest-draw`): the Hard Examples queue has
+a third **Retest** toggle serving `retest_v1` — 150 already-rated frames,
+blind, stratified (15 per rating 1–5, 40 N, 35 rating-1, stale-first, seed
+20260830). Re-ratings go to the new `manual_label_retests` table, physically
+separate from gold (`manual_labels` is UNIQUE(source,image_id) with an
+ON CONFLICT DO UPDATE upsert — a retest through it would overwrite gold).
+`label_samples.kind` distinguishes eval draws from retests, and the export
+quarantine is scoped to `kind='draw'` so the retest frames' original labels
+stay in training (counts verified unchanged). Next action is the operator's:
+one blind sitting, then
+`.venv/bin/python ml/analyze_retest.py --sample-name retest_v1` prints the
+pre-registered ceiling verdict.
+
+---
+
 ## The three workstreams
 
 ### Workstream 1 — Model training (the ML thread)

--- a/docs/superpowers/plans/2026-08-30-quality-ceiling-and-labeling-roadmap.md
+++ b/docs/superpowers/plans/2026-08-30-quality-ceiling-and-labeling-roadmap.md
@@ -1,0 +1,160 @@
+---
+title: "Quality ceiling measurement and labeling roadmap"
+date: 2026-08-30
+status: parked — deliberately not executing yet
+---
+
+# Quality ceiling & labeling roadmap
+
+> **Status: Phase 0 BUILT (2026-08-30) — awaiting the operator sitting.**
+> Implementation plan: `2026-08-30-retest-draw-implementation.md`, executed on
+> branch `feat/retest-draw`. `retest_v1` is loaded (150 frames: 15 per rating
+> 1–5, 40 N, 35 rating-1; seed 20260830) and the Hard Examples queue has a
+> **Retest** toggle showing 0/150. Re-ratings land in `manual_label_retests`
+> (never `manual_labels`); the export quarantine is scoped to `kind='draw'`
+> (row counts verified unchanged: gold 8371+344, llm 58323). After the
+> sitting: `.venv/bin/python ml/analyze_retest.py --sample-name retest_v1`
+> prints the pre-registered verdict. Phases 1–2 remain gated on it.
+>
+> Companion to `2026-08-29-two-scale-model-STATE.md` (read that first — it
+> holds the settled findings this plan builds on).
+
+**Goal:** decide, with a measurement instead of a feeling, whether the rating
+models have real headroom — and only then spend labeling effort where the
+measurement says it pays.
+
+## Decisions settled in the 2026-08-30 conversation (don't re-litigate)
+
+1. **Detection head is frozen.** Three "improvements" (retrain, warm start ×2)
+   failed to replicate on fresh operator draws; the old head is stable at
+   0.776–0.816 F1 across four independent eval sets. The standing rule from
+   STATE holds: any detection win not confirmed on a fresh operator draw is
+   noise. Remaining detection work is failure modes, not the global metric.
+2. **"Closer to 1" is not a coherent target until the ceiling is measured.**
+   Both labels are subjective judgments; no model can agree with the operator
+   more consistently than the operator agrees with himself. Self-correlation
+   (test–retest) is the ceiling. Measuring it is Phase 0 and gates everything
+   else. Intuition check, because it reads backwards: **high** self-consistency
+   means **more** model work is justified (the gap is the model's fault);
+   **low** self-consistency means the model is already near the best possible
+   (the gap is label noise).
+3. **Pearson ~0.68 and F1 ~0.80 are different metrics on different tasks** —
+   the gap between them says nothing about the quality head "lagging."
+4. **Flickr stays out of fine-tune data.** v4's positive class was 97.5%
+   Flickr and it scored F1 0.08 against operator labels — it learned
+   "beautiful composed photo," not "sunset from a fixed webcam." Flickr's
+   5,767 rows stay in the LLM pretrain corpus only. Do not collect more for
+   training; the product scores webcam frames.
+5. **Images are not the constraint; labels are.** ~46k webcam rows banked,
+   high-rated intake (`SAVE_HIGH_RATED_SNAPSHOTS`) adds more every 15 min.
+   Nothing deletes anything (`CLEANUP_ENABLED = false`, no cron). Waiting to
+   accumulate more images buys nothing.
+6. **Same-camera-pool skew:** eval is already immune (splits group by
+   `webcam_id`; eval draws use unseen cameras). The real bias is the
+   **model-gated intake feedback loop** — frames are saved only when the
+   incumbent model likes them or disagrees with Claude, so the archive drifts
+   toward what the incumbent already understands. Mitigation is the
+   trickle-save side item below, plus new custom cams adding unseen scenes.
+7. **Claude re-rating spend stays PARKED** (pre-registered rule in STATE; the
+   last quality win cost zero API spend).
+
+---
+
+## Phase 0 — Retest draw: measure the operator ceiling ⭐ gate for everything
+
+One labeling sitting (~150 frames). Cheapest decisive experiment available.
+
+**Draw.** ~150 frames the operator has already rated, served back **blind**
+through the existing queue. Stratify so both questions get power:
+- ~75 frames originally rated 1–5 (sunsets), oversampling 3/4/5 (they're
+  scarce and they're where quality discrimination matters);
+- ~75 from the N/1 boundary region (originals rated N or 1), where detection
+  "misses" concentrate.
+Original ratings date from 2026-08-07 → 08-30, so the time gap is already
+weeks — acceptable for test–retest.
+
+**Mechanics.** Same `label_samples` machinery as `random_ordinary_v1`: freeze
+the draw with a seed (`ml/load_label_sample.py`), name it `retest_v1`, stamp
+`origin = 'retest_v1'` in `manual_labels`. Blind mode on (no prior rating, no
+judge scores visible). **Retest labels are measurement-only** — they are
+duplicates of training rows and must never enter an export; keep the origin
+separable and extend the export quarantine if needed.
+
+**Measurements.**
+- Quality self-Pearson + MAE on frames rated as a sunset both times.
+- Detection self-agreement: N-vs-(1–5) percent agreement and Cohen's kappa;
+  the F1-equivalent of the operator against his own earlier labels.
+- Confusion matrix by original rating (where does the operator drift — 3↔4?
+  N↔1?).
+
+**Decision rules (pre-registered now, so we can't rationalize later):**
+- Let `gap = self-Pearson − model Pearson` (model = 0.697 pooled / 0.63–0.70
+  fresh-data range).
+- **gap ≤ 0.10** → the global quality metric is near ceiling. Skip Phase 1's
+  big push. Move to the failure-mode track.
+- **gap > 0.10** → real headroom; Phase 1 is justified, with expected gain
+  roughly bounded by the gap.
+- Detection analog: if the operator's self-agreement F1-equivalent lands near
+  0.80–0.85, the frozen detection head at 0.78–0.80 is *finished* and that
+  conversation closes permanently.
+
+## Phase 1 — Detection-gated quality labeling push (CONDITIONAL on Phase 0)
+
+Only if the quality gap says headroom exists.
+
+- Draw **1,000+** frames the live detection head scores **≥ 0.55**, from
+  cameras outside every operator eval draw, excluding all `label_samples`
+  frames (the existing export guard pattern). At the ~75% enrichment the gate
+  provides, nearly every rating becomes a quality label instead of one in
+  four.
+- Name it `gated_quality_v1`; **training-only, forever** — a model-gated draw
+  is biased by construction and must never grade the model that drew it.
+  Never pool with random or hard-case sets.
+- Queue is resumable; chew through it across sittings. 200-per-draw was a
+  sitting size, not a design limit.
+- **Label-volume curve:** retrain the quality head on 25% / 50% / 100% of the
+  new labels. If the curve is still climbing at 100%, draw `gated_quality_v2`;
+  if it's flat by 50%, stop labeling — the answer is architecture or ceiling,
+  not volume.
+
+## Phase 2 — Quality head retrain (CONDITIONAL on Phase 1)
+
+- Proven recipe: backbone warm start from the LLM pretrain
+  (`--init-backbone-checkpoint`), same seed discipline as the shipping head.
+- **Pre-registered bar:** beat the shipping head's Pearson on a *fresh* random
+  confirmation draw (`random_ordinary_v4`, ~200 frames, drawn after training,
+  unseen cameras). Wash band +0.02, per the standing convention. Never pick a
+  winner on the data it was selected on — that mistake has now been caught
+  three times on the detection side.
+
+## Failure-mode track (runs regardless of Phase 0's verdict)
+
+This is where "we want this really good" actually lives once global metrics
+are at ceiling:
+- **Silhouette 4s** — the known quality blind spot; ties into the queued
+  manual-rating-for-custom-cams work.
+- **Per-camera error audit** — webcam 3656741 fooled both heads twice an hour
+  apart; find the other cameras like it and characterize what they share.
+- **Below-gate rendering** — product intent is "show every image, just
+  small"; STATE's design note stands (gate currently *hides* 10–15/25 of the
+  operator's rating-1 frames; they should render minimal instead).
+
+## Side items (cheap, independent, no phase dependency)
+
+1. **Random trickle-save intake.** Add a sampled unconditional save
+   (~1-in-50 frames regardless of score) alongside `SAVE_HIGH_RATED_SNAPSHOTS`
+   in the `update-cameras` save gate, so an unbiased stream keeps entering the
+   archive and the intake feedback loop has a control arm.
+2. **Fix `SNAPSHOT_SYSTEM_README.md`** — still claims a 7-day auto-delete
+   that has never run (`ml/OPERATING_GUIDE.md` has the accurate description).
+3. **Leaderboard instrument drift** — the board ranks
+   `COALESCE(llm_quality, ai_regression_score)`; Claude campaigns stopped
+   mid-July, so new frames compete on ONNX scores against old frames' Claude
+   scores. Not urgent; decide eventually whether to re-rank on one instrument.
+
+## Explicit non-goals
+
+- No detection-head retraining or threshold re-derivation (gate stays 0.55).
+- No Flickr in fine-tune data; no new Flickr collection for training.
+- No Claude re-rating spend (parked, per STATE's pre-registration).
+- No waiting on image accumulation — the archive is already the big pool.

--- a/docs/superpowers/plans/2026-08-30-retest-draw-implementation.md
+++ b/docs/superpowers/plans/2026-08-30-retest-draw-implementation.md
@@ -1,0 +1,450 @@
+# Retest Draw (Phase 0 of quality-ceiling roadmap) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** serve ~150 already-rated frames back to the operator blind, store the
+re-ratings in a separate table, and compute the operator's test–retest ceiling
+(quality self-Pearson, detection self-agreement) with a pre-registered
+decision rule.
+
+**Architecture:** a new `manual_label_retests` table receives retest labels so
+the gold `manual_labels` rows are physically untouchable (the existing write
+path is an `ON CONFLICT DO UPDATE` upsert that would otherwise overwrite
+gold). Retest sample membership reuses `label_samples` with a new
+`kind = 'retest'` column; the training-export quarantine is scoped to
+`kind = 'draw'` so retest membership does not silently remove gold rows from
+training. The queue UI gains a third toggle position.
+
+**Tech Stack:** Next.js route handlers + Neon (`@/app/lib/db` tagged sql),
+vitest, psycopg2 scripts in `ml/` reading `DATABASE_URL` from `.env.local`.
+
+**Spec:** `docs/superpowers/plans/2026-08-30-quality-ceiling-and-labeling-roadmap.md`
+(Phase 0 section — draw shape, blind requirement, decision rules).
+
+## Global Constraints
+
+- Branch: `feat/retest-draw` off current `main`; verify
+  `git rev-parse --abbrev-ref HEAD` before every commit; stage explicit paths
+  only, never `git add -A` (shared checkout).
+- Retest labels must NEVER be able to reach `manual_labels` or any training
+  export — enforced by table separation, not by convention.
+- Blind: no original rating, no judge scores, no disagreement text in any
+  retest-mode response.
+- Origin stamping binds to the fetched record/sample, not client UI state
+  (the 2026-08-29 mislabeling bug class): the server validates sample
+  membership before accepting a retest write.
+- Migrations are forward-only and idempotent
+  (`CREATE TABLE IF NOT EXISTS` / `ADD COLUMN IF NOT EXISTS`), applied with
+  `psql "$DATABASE_URL" -f <file>` (DATABASE_URL from `.env.local`).
+- Draw shape (from the spec): quality arm 15 per rating 1–5 (redistribute to
+  adjacent buckets if short), detection arm 40 N + 35 rating-1; webcam frames
+  only; frame must have a non-null `firebase_url`; prefer originals labeled
+  ≥ 14 days ago inside each bucket, fill with newer only when a bucket is
+  short; seed 20260830.
+- Decision rule (pre-registered, restated from the spec): gap =
+  self-Pearson − 0.697; ≤ 0.10 → ceiling reached, failure-mode track;
+  > 0.10 → Phase 1 justified.
+
+---
+
+### Task 1: Migration — `manual_label_retests` + `label_samples.kind`
+
+**Files:**
+- Create: `database/migrations/20260830_manual_label_retests.sql`
+
+**Interfaces:**
+- Produces: table `manual_label_retests(source, image_id, is_sunset, rating,
+  origin, labeled_at, UNIQUE (source, image_id, origin))`; column
+  `label_samples.kind TEXT NOT NULL DEFAULT 'draw'` with
+  `CHECK (kind IN ('draw','retest'))`.
+
+- [ ] **Step 1: Write the migration**
+
+```sql
+-- Retest labels: the operator re-rating frames they already rated, to measure
+-- test–retest reliability (the ceiling for any model). A separate table, NOT
+-- rows in manual_labels: that table is UNIQUE (source, image_id) and its
+-- write path is ON CONFLICT DO UPDATE, so a retest through it would OVERWRITE
+-- the gold label. Physical separation also keeps retests out of every
+-- training export by construction — export_dataset.py reads manual_labels.
+--   psql "$DATABASE_URL" -f database/migrations/20260830_manual_label_retests.sql
+
+CREATE TABLE IF NOT EXISTS manual_label_retests (
+  id          BIGSERIAL PRIMARY KEY,
+  source      TEXT NOT NULL CHECK (source IN ('webcam', 'flickr')),
+  image_id    BIGINT NOT NULL,
+  is_sunset   BOOLEAN NOT NULL,
+  rating      INT CHECK (rating BETWEEN 1 AND 5),
+  origin      TEXT NOT NULL,          -- retest sample name, e.g. 'retest_v1'
+  labeled_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+  UNIQUE (source, image_id, origin)   -- one re-rating per frame per campaign
+);
+
+-- 'draw' = a normal eval draw (quarantined from training);
+-- 'retest' = already-labeled frames served back blind (their ORIGINAL labels
+-- must stay IN training — the export guard is scoped to kind = 'draw').
+ALTER TABLE label_samples
+  ADD COLUMN IF NOT EXISTS kind TEXT NOT NULL DEFAULT 'draw'
+  CHECK (kind IN ('draw', 'retest'));
+```
+
+- [ ] **Step 2: Apply and verify**
+
+Run (annotation first, command second):
+verify both objects exist; second query returns `kind`
+```bash
+psql "$DATABASE_URL" -f database/migrations/20260830_manual_label_retests.sql
+psql "$DATABASE_URL" -c "\d manual_label_retests" \
+  && psql "$DATABASE_URL" -c "SELECT DISTINCT kind FROM label_samples"
+```
+Expected: table described; single row `draw`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add database/migrations/20260830_manual_label_retests.sql
+git commit -m "feat(labels): manual_label_retests table + label_samples.kind"
+```
+
+### Task 2: Scope the export quarantine to `kind = 'draw'`
+
+Must land BEFORE any retest rows are loaded: today's guard excludes ANY
+`label_samples` member from training, so loading `retest_v1` naively would
+silently drop up to 150 gold rows from the gold legs and their LLM rows from
+the pretrain leg.
+
+**Files:**
+- Modify: `ml/export_dataset.py` — all three `NOT EXISTS (SELECT 1 FROM
+  label_samples ls ...)` guards (≈ lines 309, 394, 411).
+
+**Interfaces:**
+- Consumes: `label_samples.kind` from Task 1.
+- Produces: unchanged export CLI; guards now read
+  `AND NOT EXISTS (SELECT 1 FROM label_samples ls WHERE ... AND ls.kind = 'draw')`.
+
+- [ ] **Step 1: Record the baseline row counts**
+
+Run the export dry-run / count path the repo already uses and save the
+per-leg row counts printed (gold webcam, gold flickr, llm_only). These are
+the regression oracle.
+
+- [ ] **Step 2: Add `AND ls.kind = 'draw'` inside each of the three NOT EXISTS subqueries**
+
+One-line change per site; keep the surrounding comment and extend it:
+"scoped to kind='draw' — retest samples re-serve frames whose ORIGINAL labels
+are training data and must stay in."
+
+- [ ] **Step 3: Re-run the count path; expect byte-identical row counts**
+
+All existing rows default to `kind = 'draw'`, so counts must not move. Any
+drift = bug, stop.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add ml/export_dataset.py
+git commit -m "fix(export): scope label_samples quarantine to kind='draw'"
+```
+
+### Task 3: Stratified retest loader — `ml/load_retest_sample.py`
+
+**Files:**
+- Create: `ml/load_retest_sample.py` (mirror the structure/CLI conventions of
+  `ml/load_label_sample.py`, including `load_env_local()` copied verbatim).
+
+**Interfaces:**
+- Produces: rows in `label_samples` with `kind = 'retest'`,
+  `sample_name = args.sample_name`, shuffled `position` 1..N.
+- CLI: `--sample-name retest_v1 --seed 20260830 --dry-run`.
+
+- [ ] **Step 1: Write the draw**
+
+Buckets, all `source = 'webcam'`, all requiring
+`s.firebase_url IS NOT NULL` via `JOIN webcam_snapshots s ON s.id = m.image_id`:
+
+```python
+QUALITY_PER_RATING = 15          # ratings 1..5
+DETECTION_N = 40                 # is_sunset = false
+DETECTION_R1 = 35                # rating = 1 (drawn separately from quality arm)
+STALE_DAYS = 14                  # prefer originals labeled >= 14 days ago
+
+def draw_bucket(cur, where_sql, params, want, rng):
+    cur.execute(f"""
+        SELECT m.image_id, (m.labeled_at < now() - %s * interval '1 day') AS stale
+        FROM manual_labels m
+        JOIN webcam_snapshots s ON s.id = m.image_id
+        WHERE m.source = 'webcam' AND s.firebase_url IS NOT NULL AND {where_sql}
+    """, (STALE_DAYS, *params))
+    rows = cur.fetchall()
+    stale = [r[0] for r in rows if r[1]]; fresh = [r[0] for r in rows if not r[1]]
+    rng.shuffle(stale); rng.shuffle(fresh)
+    return (stale + fresh)[:want]
+```
+
+Quality arm: loop `rating = 1..5` with `where_sql = "m.is_sunset AND m.rating = %s"`.
+If a bucket returns fewer than 15, redistribute the shortfall to the nearest
+ratings that have surplus (walk outward: 5→4→3...). Detection arm:
+`"NOT m.is_sunset"` for 40, `"m.is_sunset AND m.rating = 1"` for 35 — dedupe
+against the quality arm's rating-1 picks before topping up. Shuffle the
+combined list with `random.Random(seed)` for `position`.
+
+- [ ] **Step 2: Dry-run and eyeball**
+
+```bash
+.venv/bin/python ml/load_retest_sample.py --sample-name retest_v1 --dry-run
+```
+Expected: per-bucket counts summing to ~150, % stale reported, zero inserts.
+
+- [ ] **Step 3: Load for real, verify in SQL**
+
+should return 150 / 'retest' / positions 1..150 gapless
+```bash
+psql "$DATABASE_URL" -c "SELECT count(*), min(position), max(position) \
+  FROM label_samples WHERE sample_name = 'retest_v1' AND kind = 'retest'"
+```
+
+- [ ] **Step 4: Re-run the Task 2 export count check** — counts still at
+baseline (this is the guard actually earning its keep).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add ml/load_retest_sample.py
+git commit -m "feat(ml): stratified retest sample loader"
+```
+
+### Task 4: `upsertRetestLabel` + sample routing helper in `app/lib/manualLabels.ts`
+
+**Files:**
+- Modify: `app/lib/manualLabels.ts`
+- Test: extend the existing manual-labels route tests (Task 5's file) — the
+  lib is exercised through the route, matching current repo convention.
+
+**Interfaces:**
+- Produces:
+  `upsertRetestLabel(opts: {source, imageId, isSunset, rating?, origin}) : Promise<SavedLabel | null>` —
+  INSERT ... ON CONFLICT `(source, image_id, origin)` DO UPDATE into
+  `manual_label_retests` (self-correction within a sitting is allowed; it
+  never touches `manual_labels`).
+  `resolveLabelDestination(origin, source, imageId) : Promise<'gold' | 'retest' | 'reject'>`.
+
+- [ ] **Step 1: Implement**
+
+```ts
+export async function resolveLabelDestination(
+  origin: string | null | undefined,
+  source: LabelSource,
+  imageId: number,
+): Promise<'gold' | 'retest' | 'reject'> {
+  if (!origin) return 'gold';
+  const rows = (await sql`
+    SELECT kind,
+           bool_or(source = ${source} AND image_id = ${imageId}) AS member
+    FROM label_samples WHERE sample_name = ${origin} GROUP BY kind
+  `) as { kind: string; member: boolean }[];
+  const row = rows[0];
+  if (!row) return 'gold';                       // 'hard_example' etc. — not a sample name
+  if (row.kind !== 'retest') return 'gold';      // eval draws keep today's path
+  return row.member ? 'retest' : 'reject';       // retest write MUST bind to the sample
+}
+```
+
+`upsertRetestLabel` mirrors `upsertManualLabel` verbatim except table name,
+conflict target `(source, image_id, origin)`, and `origin` is required.
+
+- [ ] **Step 2: Commit with Task 5** (single reviewable unit — the route is
+the only caller).
+
+### Task 5: Route retest writes in `POST /api/manual-labels`
+
+**Files:**
+- Modify: `app/api/manual-labels/route.ts`
+- Test: the route's existing test file (follow its established `vi.mock`
+  pattern for `@/app/lib/db` and owner auth).
+
+**Interfaces:**
+- Consumes: `resolveLabelDestination`, `upsertRetestLabel` (Task 4).
+- Produces: unchanged response shape `{ saved: SavedLabel }`; new 400
+  `{ error: 'not in retest sample' }` on 'reject'.
+
+- [ ] **Step 1: Write the failing tests**
+
+Three cases, mocking the `label_samples` lookup result:
+```ts
+it('routes a retest-sample label into manual_label_retests, not manual_labels', ...)
+// mock resolve → kind 'retest', member true; assert the INSERT SQL string
+// contains 'manual_label_retests' and NOT a bare 'manual_labels' insert
+it('rejects a retest origin for a frame outside the sample (400)', ...)
+it('leaves hard_example and draw-sample origins on the gold path', ...)
+```
+
+- [ ] **Step 2: Run to verify they fail** — `npm run test -- manual-labels`
+
+- [ ] **Step 3: Implement**
+
+After the existing origin-format validation:
+```ts
+const dest = await resolveLabelDestination(origin ?? null, source, imageId);
+if (dest === 'reject') {
+  return NextResponse.json({ error: 'not in retest sample' }, { status: 400 });
+}
+const saved = dest === 'retest'
+  ? await upsertRetestLabel({ source, imageId, isSunset, rating, origin })
+  : await upsertManualLabel({ source, imageId, isSunset, rating, origin });
+```
+
+- [ ] **Step 4: Run tests to green** — `npm run test -- manual-labels`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/lib/manualLabels.ts app/api/manual-labels/route.ts <test file>
+git commit -m "feat(labels): route retest-sample labels to manual_label_retests"
+```
+
+### Task 6: Retest mode in `GET /api/snapshots?mode=verification`
+
+**Files:**
+- Modify: `app/api/snapshots/route.ts` (sample branch, ≈ lines 204–380)
+- Test: `app/api/snapshots/route.test.ts` (existing
+  `mode=verification` describe block's mock pattern)
+
+**Interfaces:**
+- Consumes: `label_samples.kind`, `manual_label_retests`.
+- Produces: same response shape; for a `kind='retest'` sample the drop-out
+  filter and the `sample.labeled` progress counter read
+  `manual_label_retests` (matched on `origin = sampleName`) instead of
+  `manual_labels`, and the `NOT IN manual_labels` exclusion is dropped
+  (every retest frame is in `manual_labels` by construction).
+
+- [ ] **Step 1: Write the failing tests**
+
+```ts
+it('serves retest-sample frames even though they have manual_labels rows', ...)
+it('drops a frame from the retest queue once manual_label_retests has it', ...)
+it('reports retest progress from manual_label_retests', ...)
+it('retest responses carry no original rating, is_sunset, judge or disagreement fields', ...)
+// the last one is the blind guarantee — assert on Object.keys of a returned item
+```
+
+- [ ] **Step 2: Run to verify they fail.**
+
+- [ ] **Step 3: Implement**
+
+Fetch the kind once when `sampleName` is set:
+```ts
+const kindRows = sampleName
+  ? ((await sql`SELECT kind FROM label_samples WHERE sample_name = ${sampleName} LIMIT 1`) as { kind: string }[])
+  : [];
+const isRetest = kindRows[0]?.kind === 'retest';
+```
+Branch `webcamFilter` (and its external twin, though retest_v1 is
+webcam-only) on `isRetest`:
+```ts
+? sql`AND s.id IN (SELECT image_id FROM label_samples
+                    WHERE sample_name = ${sampleName} AND source = 'webcam')
+      AND s.id NOT IN (SELECT image_id FROM manual_label_retests
+                        WHERE source = 'webcam' AND origin = ${sampleName})`
+```
+Progress block: count labeled from `manual_label_retests` when `isRetest`.
+Do not add any new SELECT columns — blindness falls out of the existing
+field list; the test pins it.
+
+- [ ] **Step 4: Run tests to green** — `npm run test -- snapshots/route`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/api/snapshots/route.ts app/api/snapshots/route.test.ts
+git commit -m "feat(queue): serve retest samples with retest-table drop-out"
+```
+
+### Task 7: Third queue toggle in `HardExamplesQueue.tsx`
+
+**Files:**
+- Modify: `app/components/HardExamples/HardExamplesQueue.tsx`
+- Test: `app/components/HardExamples/HardExamplesQueue.test.tsx`
+
+**Interfaces:**
+- Consumes: GET/POST behavior from Tasks 5–6.
+- Produces: `RETEST_SAMPLE_NAME = 'retest_v1'` constant beside the existing
+  `SAMPLE_NAME`; queue state union gains `'retest'`; when selected,
+  `fetchOrigin = RETEST_SAMPLE_NAME` and the fetch appends
+  `&sample=retest_v1` — reusing the exact origin-binding path the
+  2026-08-29 fix installed (origin travels with the fetched frame, not UI
+  state at save time).
+
+- [ ] **Step 1: Failing test** — toggling to Retest fetches with
+`sample=retest_v1` and saves labels with `origin: 'retest_v1'` (mirror the
+existing sample-toggle test).
+
+- [ ] **Step 2–4: Implement, green, then commit**
+
+```bash
+git add app/components/HardExamples/HardExamplesQueue.tsx \
+        app/components/HardExamples/HardExamplesQueue.test.tsx
+git commit -m "feat(queue): retest toggle"
+```
+
+### Task 8: Analysis — `ml/analyze_retest.py`
+
+**Files:**
+- Create: `ml/analyze_retest.py` (env loading as in Task 3)
+
+**Interfaces:**
+- CLI: `--sample-name retest_v1 --model-pearson 0.697 --gap-threshold 0.10`
+- Output: stdout table + JSON report
+  `ml/artifacts/reports/retest_v1_ceiling.json`.
+
+- [ ] **Step 1: Implement**
+
+Join originals to retests:
+```sql
+SELECT m.is_sunset AS o_sun, m.rating AS o_r, m.origin AS o_origin,
+       m.labeled_at AS o_at,
+       r.is_sunset AS t_sun, r.rating AS t_r, r.labeled_at AS t_at
+FROM manual_label_retests r
+JOIN manual_labels m ON m.source = r.source AND m.image_id = r.image_id
+WHERE r.origin = %s
+```
+Compute (numpy only — no scipy dependency):
+- detection: percent agreement, Cohen's kappa, and the F1 of the retest pass
+  treated as predictions against the original pass;
+- quality: Pearson (`np.corrcoef`) + MAE on rows where both passes say
+  sunset and both have ratings, on the normalized (r−1)/4 scale to match
+  model reporting; n reported alongside;
+- 6×6 confusion matrix over {N,1..5};
+- splits by original-label age (≥/< 14 days) and by `o_origin`;
+- verdict line: `gap = self_pearson - model_pearson` →
+  `CEILING REACHED (failure-mode track)` if `gap <= 0.10` with n≥40 quality
+  pairs, `HEADROOM — Phase 1 justified` if `gap > 0.10`, `UNDERPOWERED —
+  finish the sitting` if n < 40.
+
+- [ ] **Step 2: Smoke on partial data** — runs cleanly at any completion
+level (guard div-by-zero; print n everywhere).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add ml/analyze_retest.py
+git commit -m "feat(ml): retest ceiling analysis with pre-registered verdict"
+```
+
+### Task 9: Wrap-up
+
+- [ ] `npm run test` full suite + `npm run lint` green.
+- [ ] Update `2026-08-30-quality-ceiling-and-labeling-roadmap.md` Phase 0
+  status → "built, awaiting operator sitting"; add the queue-toggle
+  instructions ("Hard Examples → Retest, n / 150 progress").
+- [ ] Update STATE doc "What's next" block: Phase 0 built, sitting pending.
+- [ ] Push `feat/retest-draw`, open PR, return checkout to `main`, announce
+  in the session channel (2b is queued for the checkout).
+
+## Execution notes
+
+- Tasks 1–3 are DB/ml-side and testable without the Next.js suite; Tasks 4–7
+  are one review arc (write path, read path, UI) — do not ship 6/7 without 5,
+  or the queue would serve retest frames whose labels overwrite gold.
+- The operator sitting itself and the Task 8 verdict are NOT part of this
+  branch's definition of done — the code is done when the queue shows
+  `retest_v1 0/150` and the full suite is green.

--- a/ml/analyze_retest.py
+++ b/ml/analyze_retest.py
@@ -1,0 +1,200 @@
+#!/usr/bin/env python3
+"""Compute the operator's test–retest ceiling from a retest sample.
+
+Joins manual_label_retests (second pass) to manual_labels (first pass) and
+reports, with the pre-registered verdict from the quality-ceiling roadmap
+(docs/superpowers/plans/2026-08-30-quality-ceiling-and-labeling-roadmap.md):
+
+  detection — percent agreement, Cohen's kappa, and F1 of pass 2 read as
+              predictions against pass 1
+  quality   — Pearson + MAE on frames BOTH passes call a sunset, on the
+              normalized (rating-1)/4 scale the model reports use
+  6x6 confusion matrix over {N,1..5}, plus splits by original-label age and
+  by the original label's origin
+
+Verdict rule (pre-registered 2026-08-30 — do not re-tune after seeing data):
+  gap = self_pearson - model_pearson (model = shipping quality head, 0.697
+  on the pooled 500). gap <= 0.10 with n >= 40 pairs -> CEILING REACHED;
+  gap > 0.10 -> HEADROOM, Phase 1 justified; n < 40 -> UNDERPOWERED.
+
+Runs cleanly at any completion level of the sitting.
+
+Usage:
+  .venv/bin/python ml/analyze_retest.py --sample-name retest_v1
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+
+import numpy as np
+import psycopg2
+
+
+def load_env_local() -> None:
+    env = Path(__file__).resolve().parent.parent / ".env.local"
+    if not env.exists():
+        return
+    for line in env.read_text().splitlines():
+        line = line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, _, val = line.partition("=")
+        os.environ.setdefault(key.strip(), val.strip().strip('"').strip("'"))
+
+
+def cat(is_sunset: bool, rating) -> str:
+    """Collapse a label to one of N,1..5 (a sunset with no rating -> '?')."""
+    if not is_sunset:
+        return "N"
+    return str(rating) if rating is not None else "?"
+
+
+def cohens_kappa(a: np.ndarray, b: np.ndarray) -> float:
+    """Binary kappa; a, b are bool arrays."""
+    po = float(np.mean(a == b))
+    pe = float(np.mean(a) * np.mean(b) + np.mean(~a) * np.mean(~b))
+    return (po - pe) / (1 - pe) if pe < 1 else 1.0
+
+
+def f1(truth: np.ndarray, pred: np.ndarray) -> float:
+    tp = int(np.sum(truth & pred))
+    fp = int(np.sum(~truth & pred))
+    fn = int(np.sum(truth & ~pred))
+    return 2 * tp / (2 * tp + fp + fn) if (2 * tp + fp + fn) else 0.0
+
+
+def quality_stats(pairs: list[tuple[int, int]]) -> dict:
+    """pairs = (original rating, retest rating), 1..5 each."""
+    if len(pairs) < 2:
+        return {"n": len(pairs), "pearson": None, "mae": None}
+    o = (np.array([p[0] for p in pairs], dtype=float) - 1) / 4
+    t = (np.array([p[1] for p in pairs], dtype=float) - 1) / 4
+    pearson = None
+    if np.std(o) > 0 and np.std(t) > 0:
+        pearson = float(np.corrcoef(o, t)[0, 1])
+    return {"n": len(pairs), "pearson": pearson,
+            "mae": float(np.mean(np.abs(o - t)))}
+
+
+def main() -> None:
+    p = argparse.ArgumentParser(description="Test–retest ceiling analysis")
+    p.add_argument("--sample-name", required=True)
+    p.add_argument("--model-pearson", type=float, default=0.697,
+                   help="shipping quality head on the pooled 500 (the bar)")
+    p.add_argument("--gap-threshold", type=float, default=0.10)
+    p.add_argument("--stale-days", type=int, default=14)
+    p.add_argument("--out", default=None,
+                   help="JSON report path (default: ml/artifacts/reports/<sample>_ceiling.json)")
+    args = p.parse_args()
+
+    load_env_local()
+    database_url = os.getenv("DATABASE_URL")
+    if not database_url:
+        sys.exit("DATABASE_URL not set (looked in the environment and .env.local)")
+
+    with psycopg2.connect(database_url) as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                SELECT m.is_sunset, m.rating, m.origin,
+                       (m.labeled_at < r.labeled_at - %s * interval '1 day') AS stale,
+                       r.is_sunset, r.rating
+                FROM manual_label_retests r
+                JOIN manual_labels m
+                  ON m.source = r.source AND m.image_id = r.image_id
+                WHERE r.origin = %s
+                """,
+                (args.stale_days, args.sample_name),
+            )
+            rows = cur.fetchall()
+            cur.execute(
+                "SELECT count(*) FROM label_samples WHERE sample_name = %s",
+                (args.sample_name,),
+            )
+            sample_size = cur.fetchone()[0]
+
+    n = len(rows)
+    print(f"  {args.sample_name}: {n} / {sample_size} re-rated")
+    if n == 0:
+        sys.exit("  nothing to analyze yet")
+
+    o_sun = np.array([r[0] for r in rows], dtype=bool)
+    t_sun = np.array([r[4] for r in rows], dtype=bool)
+
+    agreement = float(np.mean(o_sun == t_sun))
+    kappa = cohens_kappa(o_sun, t_sun)
+    det_f1 = f1(o_sun, t_sun)
+
+    both_rated = [(r[1], r[5]) for r in rows
+                  if r[0] and r[4] and r[1] is not None and r[5] is not None]
+    q_all = quality_stats(both_rated)
+
+    # Splits: original-label age relative to the retest, and original origin.
+    q_stale = quality_stats([(r[1], r[5]) for r in rows
+                             if r[3] and r[0] and r[4]
+                             and r[1] is not None and r[5] is not None])
+    q_fresh = quality_stats([(r[1], r[5]) for r in rows
+                             if not r[3] and r[0] and r[4]
+                             and r[1] is not None and r[5] is not None])
+    by_origin: dict[str, int] = {}
+    for r in rows:
+        by_origin[r[2]] = by_origin.get(r[2], 0) + 1
+
+    cats = ["N", "1", "2", "3", "4", "5"]
+    confusion = {oc: {tc: 0 for tc in cats} for oc in cats}
+    for r in rows:
+        oc, tc = cat(r[0], r[1]), cat(r[4], r[5])
+        if oc in confusion and tc in confusion[oc]:
+            confusion[oc][tc] += 1
+
+    print(f"  detection: agreement {agreement:.3f}, kappa {kappa:.3f}, "
+          f"self-F1 {det_f1:.3f}  (n={n})")
+    pearson_txt = "n/a" if q_all["pearson"] is None else f"{q_all['pearson']:.3f}"
+    mae_txt = "n/a" if q_all["mae"] is None else f"{q_all['mae']:.3f}"
+    print(f"  quality:   self-Pearson {pearson_txt}, MAE {mae_txt}  (n={q_all['n']})")
+    for name, q in (("stale originals", q_stale), ("fresh originals", q_fresh)):
+        ptxt = "n/a" if q["pearson"] is None else f"{q['pearson']:.3f}"
+        print(f"             {name}: Pearson {ptxt} (n={q['n']})")
+    print(f"  originals by origin: {by_origin}")
+    print("  confusion (rows = pass 1, cols = pass 2):")
+    print("      " + "  ".join(f"{c:>3}" for c in cats))
+    for oc in cats:
+        print(f"   {oc:>2} " + "  ".join(f"{confusion[oc][tc]:>3}" for tc in cats))
+
+    verdict = "UNDERPOWERED — finish the sitting (need n >= 40 quality pairs)"
+    gap = None
+    if q_all["pearson"] is not None and q_all["n"] >= 40:
+        gap = q_all["pearson"] - args.model_pearson
+        verdict = (
+            f"CEILING REACHED (gap {gap:+.3f} <= {args.gap_threshold}) — failure-mode track"
+            if gap <= args.gap_threshold
+            else f"HEADROOM (gap {gap:+.3f} > {args.gap_threshold}) — Phase 1 justified"
+        )
+    print(f"  VERDICT: {verdict}")
+
+    out = Path(args.out) if args.out else (
+        Path(__file__).resolve().parent / "artifacts" / "reports"
+        / f"{args.sample_name}_ceiling.json")
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(json.dumps({
+        "sample": args.sample_name, "rated": n, "sample_size": sample_size,
+        "detection": {"agreement": agreement, "kappa": kappa, "self_f1": det_f1},
+        "quality": q_all,
+        "quality_stale_originals": q_stale,
+        "quality_fresh_originals": q_fresh,
+        "originals_by_origin": by_origin,
+        "confusion": confusion,
+        "model_pearson": args.model_pearson,
+        "gap": gap,
+        "verdict": verdict,
+    }, indent=2))
+    print(f"  report: {out.relative_to(Path.cwd()) if out.is_relative_to(Path.cwd()) else out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/ml/export_dataset.py
+++ b/ml/export_dataset.py
@@ -308,8 +308,11 @@ def fetch_rows(
           -- EVAL QUARANTINE: same rule as the gold leg below. Every
           -- label_samples frame is LLM-rated, so without this the LLM
           -- pretrain trains on all 500 frames of the only unbiased eval set.
+          -- Scoped to kind='draw': retest samples re-serve frames whose
+          -- ORIGINAL labels are training data and must stay in.
           AND NOT EXISTS (SELECT 1 FROM label_samples ls
-                          WHERE ls.source = 'webcam' AND ls.image_id = s.id)
+                          WHERE ls.source = 'webcam' AND ls.image_id = s.id
+                            AND ls.kind = 'draw')
         """
     elif label_source == "public_aggregate":
         query = """
@@ -391,8 +394,12 @@ def fetch_gold_rows(
       -- eval set; training on it would silently destroy the yardstick every
       -- v5 decision is measured against. If a *training* sample is ever
       -- drawn, add an explicit opt-in rather than removing this.
+      -- Scoped to kind='draw': retest samples (kind='retest') re-serve
+      -- already-labeled frames blind; their ORIGINAL labels stay in training
+      -- (the re-ratings live in manual_label_retests, never exported).
       AND NOT EXISTS (SELECT 1 FROM label_samples ls
-                      WHERE ls.source = m.source AND ls.image_id = m.image_id)
+                      WHERE ls.source = m.source AND ls.image_id = m.image_id
+                        AND ls.kind = 'draw')
     UNION ALL
     SELECT
       e.id AS snapshot_id,
@@ -407,9 +414,10 @@ def fetch_gold_rows(
     FROM manual_labels m
     JOIN external_images e ON e.id = m.image_id
     WHERE m.source = 'flickr' AND e.image_url IS NOT NULL
-      -- Same eval quarantine as the webcam leg above.
+      -- Same eval quarantine as the webcam leg above, same kind='draw' scope.
       AND NOT EXISTS (SELECT 1 FROM label_samples ls
-                      WHERE ls.source = m.source AND ls.image_id = m.image_id)
+                      WHERE ls.source = m.source AND ls.image_id = m.image_id
+                        AND ls.kind = 'draw')
     """
     with conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as cur:
         cur.execute(query)

--- a/ml/load_retest_sample.py
+++ b/ml/load_retest_sample.py
@@ -1,0 +1,191 @@
+#!/usr/bin/env python3
+"""Freeze a stratified RETEST sample into `label_samples` (kind='retest').
+
+A retest sample re-serves frames the operator has ALREADY rated, blind, so the
+two passes measure test–retest reliability — the ceiling for any model trained
+on these labels (roadmap: docs/superpowers/plans/
+2026-08-30-quality-ceiling-and-labeling-roadmap.md, Phase 0).
+
+Unlike load_label_sample.py, this draw comes FROM manual_labels rather than
+excluding it, and the re-ratings land in manual_label_retests, never touching
+the gold rows. kind='retest' tells both the queue API (serve despite an
+existing label; drop out on a retest row) and the export quarantine (whose
+NOT EXISTS guard is scoped to kind='draw') what this sample is.
+
+Stratification (webcam frames with a live firebase_url only):
+  quality arm    — 15 frames per rating 1..5; shortfall in a bucket
+                   redistributes to the nearest ratings with surplus
+  detection arm  — 40 N frames (is_sunset = false) + 35 rating-1 frames
+                   (disjoint from the quality arm's rating-1 picks)
+Within every bucket, frames whose original label is >= --stale-days old are
+preferred: a fresher memory of the first pass inflates agreement.
+
+Usage:
+  .venv/bin/python ml/load_retest_sample.py --sample-name retest_v1 --dry-run
+  .venv/bin/python ml/load_retest_sample.py --sample-name retest_v1
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import random
+import sys
+from pathlib import Path
+
+import psycopg2
+import psycopg2.extras
+
+QUALITY_PER_RATING = 15  # ratings 1..5
+DETECTION_N = 40         # is_sunset = false
+DETECTION_R1 = 35        # extra rating-1 frames for the N/1 boundary
+
+
+def load_env_local() -> None:
+    """Match run_training.py: DATABASE_URL lives in .env.local, not the shell."""
+    env = Path(__file__).resolve().parent.parent / ".env.local"
+    if not env.exists():
+        return
+    for line in env.read_text().splitlines():
+        line = line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, _, val = line.partition("=")
+        os.environ.setdefault(key.strip(), val.strip().strip('"').strip("'"))
+
+
+def draw_bucket(cur, where_sql: str, params: tuple, want: int,
+                stale_days: int, rng: random.Random,
+                exclude: set[int]) -> tuple[list[int], int]:
+    """Return (picked image_ids, stale_count_in_pick), stale-first."""
+    cur.execute(
+        f"""
+        SELECT m.image_id,
+               (m.labeled_at < now() - %s * interval '1 day') AS stale
+        FROM manual_labels m
+        JOIN webcam_snapshots s ON s.id = m.image_id
+        WHERE m.source = 'webcam' AND s.firebase_url IS NOT NULL AND {where_sql}
+        """,
+        (stale_days, *params),
+    )
+    rows = [(r[0], r[1]) for r in cur.fetchall() if r[0] not in exclude]
+    stale = [iid for iid, is_stale in rows if is_stale]
+    fresh = [iid for iid, is_stale in rows if not is_stale]
+    rng.shuffle(stale)
+    rng.shuffle(fresh)
+    picked = (stale + fresh)[:want]
+    return picked, sum(1 for iid in picked if iid in set(stale))
+
+
+def main() -> None:
+    p = argparse.ArgumentParser(description="Freeze a stratified retest sample")
+    p.add_argument("--sample-name", required=True)
+    p.add_argument("--seed", type=int, default=20260830)
+    p.add_argument("--stale-days", type=int, default=14)
+    p.add_argument("--dry-run", action="store_true")
+    args = p.parse_args()
+
+    load_env_local()
+    database_url = os.getenv("DATABASE_URL")
+    if not database_url:
+        sys.exit("DATABASE_URL not set (looked in the environment and .env.local)")
+
+    rng = random.Random(args.seed)
+    picked: dict[str, list[int]] = {}
+    stale_counts: dict[str, int] = {}
+    taken: set[int] = set()
+
+    with psycopg2.connect(database_url) as conn:
+        with conn.cursor() as cur:
+            # Quality arm, walking 1..5; collect shortfalls, then redistribute.
+            shortfall = 0
+            for r in range(1, 6):
+                ids, n_stale = draw_bucket(
+                    cur, "m.is_sunset AND m.rating = %s", (r,),
+                    QUALITY_PER_RATING, args.stale_days, rng, taken)
+                picked[f"q{r}"] = ids
+                stale_counts[f"q{r}"] = n_stale
+                taken.update(ids)
+                shortfall += QUALITY_PER_RATING - len(ids)
+            # Redistribute shortfall outward from 5 down (the scarce end is
+            # usually 5; surplus usually lives in 1-3).
+            for r in (4, 3, 2, 1):
+                if shortfall <= 0:
+                    break
+                extra, n_stale = draw_bucket(
+                    cur, "m.is_sunset AND m.rating = %s", (r,),
+                    shortfall, args.stale_days, rng, taken)
+                picked[f"q{r}"].extend(extra)
+                stale_counts[f"q{r}"] += n_stale
+                taken.update(extra)
+                shortfall -= len(extra)
+
+            ids, n_stale = draw_bucket(
+                cur, "NOT m.is_sunset", (), DETECTION_N,
+                args.stale_days, rng, taken)
+            picked["dN"] = ids
+            stale_counts["dN"] = n_stale
+            taken.update(ids)
+
+            ids, n_stale = draw_bucket(
+                cur, "m.is_sunset AND m.rating = %s", (1,), DETECTION_R1,
+                args.stale_days, rng, taken)
+            picked["d1"] = ids
+            stale_counts["d1"] = n_stale
+            taken.update(ids)
+
+            # Informational: overlap with existing draw samples (eval frames).
+            all_ids = [iid for ids in picked.values() for iid in ids]
+            cur.execute(
+                "SELECT count(DISTINCT image_id) FROM label_samples "
+                "WHERE source = 'webcam' AND image_id = ANY(%s)",
+                (all_ids,),
+            )
+            in_draws = cur.fetchone()[0]
+
+    total = len(all_ids)
+    print(f"  Buckets (want q1-5={QUALITY_PER_RATING} each, "
+          f"dN={DETECTION_N}, d1={DETECTION_R1}; seed {args.seed}):")
+    for name in ("q1", "q2", "q3", "q4", "q5", "dN", "d1"):
+        n = len(picked[name])
+        print(f"    {name}: {n:3d}  ({stale_counts[name]} stale >= {args.stale_days}d)")
+    print(f"  Total {total}; {in_draws} also belong to an existing draw sample "
+          f"(fine — their retest rows are separate)")
+
+    if args.dry_run:
+        print("  --dry-run: nothing written")
+        return
+
+    rng.shuffle(all_ids)
+    records = [
+        (args.sample_name, "webcam", iid, i, "retest")
+        for i, iid in enumerate(all_ids)
+    ]
+    with psycopg2.connect(database_url) as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                "SELECT count(*) FROM label_samples WHERE sample_name = %s",
+                (args.sample_name,),
+            )
+            before = cur.fetchone()[0]
+            # Idempotent: re-running with the same name and seed is a no-op, and
+            # never renumbers positions out from under a half-rated sitting.
+            psycopg2.extras.execute_values(
+                cur,
+                """
+                INSERT INTO label_samples (sample_name, source, image_id, position, kind)
+                VALUES %s
+                ON CONFLICT (sample_name, source, image_id) DO NOTHING
+                """,
+                records,
+            )
+            cur.execute(
+                "SELECT count(*) FROM label_samples WHERE sample_name = %s",
+                (args.sample_name,),
+            )
+            after = cur.fetchone()[0]
+    print(f"  Inserted {after - before} new rows; '{args.sample_name}' now holds {after}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What

Phase 0 of the quality-ceiling roadmap (`docs/superpowers/plans/2026-08-30-quality-ceiling-and-labeling-roadmap.md`): serve 150 already-rated frames back to the operator **blind**, store the re-ratings separately, and compute the test-retest ceiling that decides whether a big labeling push is worth anything.

## Why a separate table

`manual_labels` is `UNIQUE (source, image_id)` with an `ON CONFLICT DO UPDATE` write path — a re-rating through the existing queue would silently **overwrite the gold label**. Re-ratings land in the new `manual_label_retests` table instead; the server routes by `label_samples.kind` + membership, never by client-asserted state, and a retest origin on a non-member frame is a 400.

## The export-quarantine trap this defuses

The training exports excluded ANY `label_samples` member. Loading a retest draw naively would have silently pulled ~150 gold rows out of training. The quarantine is now scoped to `kind='draw'`; row counts verified byte-identical before/after the change AND after loading the draw (gold 8371 webcam + 344 flickr, llm 58323).

## Contents

- Migration `20260830_manual_label_retests.sql` (applied to Neon)
- `ml/load_retest_sample.py` — stratified draw: 15 per rating 1-5, 40 N, 35 rating-1, stale-first, seed 20260830; `retest_v1` loaded 150/150
- Write path: `resolveLabelDestination` + `upsertRetestLabel`, wired in `POST /api/manual-labels`
- Queue API: `kind='retest'` samples drop out on `manual_label_retests`, progress reads it too; blindness pinned (no query joins `manual_labels`)
- UI: third **Retest** toggle in the Hard Examples queue (0/150)
- `ml/analyze_retest.py` — prints the pre-registered verdict (gap vs quality-head Pearson 0.697, threshold 0.10)

## Verification

823 tests pass, lint clean, progress SQL returns (150, 0) against Neon.

Not in scope: the sitting itself and the verdict — the queue is ready whenever the operator is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PFEBJDpDderUkdc5GsrgEt