### PR TITLE
feat(scenes): capture/replay harness — frozen kiosk states, reconstructed from history, replayable in /studio

### DIFF
--- a/app/api/kiosk/scenes/[id]/route.test.ts
+++ b/app/api/kiosk/scenes/[id]/route.test.ts
@@ -1,0 +1,70 @@
+import { it, expect, vi, beforeEach } from 'vitest';
+import { NextResponse } from 'next/server';
+
+const requireOwner = vi.fn();
+const getScene = vi.fn();
+const updateSceneMeta = vi.fn();
+const deleteScene = vi.fn();
+vi.mock('@/app/lib/owner', () => ({ requireOwner: () => requireOwner() }));
+vi.mock('@/app/lib/scenes/store', () => ({
+  getScene: (id: number) => getScene(id),
+  updateSceneMeta: (id: number, p: unknown) => updateSceneMeta(id, p),
+  deleteScene: (id: number) => deleteScene(id),
+}));
+
+import { GET, PATCH, DELETE } from './route';
+
+const params = (id: string) => ({ params: Promise.resolve({ id }) });
+const req = (body?: unknown) =>
+  new Request('http://t/api/kiosk/scenes/2', { method: 'PATCH', body: JSON.stringify(body ?? {}) });
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  requireOwner.mockResolvedValue(null);
+});
+
+it('GET denies non-owners without touching the store', async () => {
+  requireOwner.mockResolvedValue(NextResponse.json({ error: 'nope' }, { status: 403 }));
+  const res = await GET(req(), params('2'));
+  expect(res.status).toBe(403);
+  expect(getScene).not.toHaveBeenCalled();
+});
+
+it('GET returns 404 for missing and the scene when found', async () => {
+  getScene.mockResolvedValueOnce(null);
+  expect((await GET(req(), params('9'))).status).toBe(404);
+  getScene.mockResolvedValueOnce({ id: 2, label: 'b' });
+  const res = await GET(req(), params('2'));
+  expect((await res.json()).label).toBe('b');
+});
+
+it('GET rejects a non-numeric id', async () => {
+  expect((await GET(req(), params('abc'))).status).toBe(400);
+  expect(getScene).not.toHaveBeenCalled();
+});
+
+it('PATCH updates metadata only', async () => {
+  updateSceneMeta.mockResolvedValue(true);
+  const res = await PATCH(req({ label: 'renamed', tags: ['grant'] }), params('2'));
+  expect(res.status).toBe(200);
+  expect(updateSceneMeta).toHaveBeenCalledWith(2, { label: 'renamed', tags: ['grant'] });
+});
+
+it('PATCH rejects attempts to modify state', async () => {
+  const res = await PATCH(req({ state: { sunrise: [] } }), params('2'));
+  expect(res.status).toBe(400);
+  expect(updateSceneMeta).not.toHaveBeenCalled();
+});
+
+it('PATCH and DELETE 404 on a missing id', async () => {
+  updateSceneMeta.mockResolvedValue(false);
+  expect((await PATCH(req({ label: 'x' }), params('9'))).status).toBe(404);
+  deleteScene.mockResolvedValue(false);
+  expect((await DELETE(req(), params('9'))).status).toBe(404);
+});
+
+it('DELETE removes a scene', async () => {
+  deleteScene.mockResolvedValue(true);
+  const res = await DELETE(req(), params('3'));
+  expect(await res.json()).toEqual({ ok: true });
+});

--- a/app/api/kiosk/scenes/[id]/route.test.ts
+++ b/app/api/kiosk/scenes/[id]/route.test.ts
@@ -43,6 +43,13 @@ it('GET rejects a non-numeric id', async () => {
   expect(getScene).not.toHaveBeenCalled();
 });
 
+it('PATCH denies non-owners without touching the store', async () => {
+  requireOwner.mockResolvedValue(NextResponse.json({ error: 'nope' }, { status: 403 }));
+  const res = await PATCH(req({ label: 'x' }), params('2'));
+  expect(res.status).toBe(403);
+  expect(updateSceneMeta).not.toHaveBeenCalled();
+});
+
 it('PATCH updates metadata only', async () => {
   updateSceneMeta.mockResolvedValue(true);
   const res = await PATCH(req({ label: 'renamed', tags: ['grant'] }), params('2'));
@@ -61,6 +68,13 @@ it('PATCH and DELETE 404 on a missing id', async () => {
   expect((await PATCH(req({ label: 'x' }), params('9'))).status).toBe(404);
   deleteScene.mockResolvedValue(false);
   expect((await DELETE(req(), params('9'))).status).toBe(404);
+});
+
+it('DELETE denies non-owners without touching the store', async () => {
+  requireOwner.mockResolvedValue(NextResponse.json({ error: 'nope' }, { status: 403 }));
+  const res = await DELETE(req(), params('2'));
+  expect(res.status).toBe(403);
+  expect(deleteScene).not.toHaveBeenCalled();
 });
 
 it('DELETE removes a scene', async () => {

--- a/app/api/kiosk/scenes/[id]/route.ts
+++ b/app/api/kiosk/scenes/[id]/route.ts
@@ -1,0 +1,62 @@
+import { NextResponse } from 'next/server';
+import { requireOwner } from '@/app/lib/owner';
+import { deleteScene, getScene, updateSceneMeta } from '@/app/lib/scenes/store';
+
+export const dynamic = 'force-dynamic';
+
+type Ctx = { params: Promise<{ id: string }> };
+
+function parseId(raw: string): number | null {
+  const id = Number(raw);
+  return Number.isInteger(id) && id > 0 ? id : null;
+}
+
+export async function GET(_request: Request, { params }: Ctx) {
+  const denied = await requireOwner();
+  if (denied) return denied;
+  const id = parseId((await params).id);
+  if (id === null) return NextResponse.json({ error: 'bad id' }, { status: 400 });
+  const scene = await getScene(id);
+  if (!scene) return NextResponse.json({ error: 'not found' }, { status: 404 });
+  return NextResponse.json(scene);
+}
+
+export async function PATCH(request: Request, { params }: Ctx) {
+  const denied = await requireOwner();
+  if (denied) return denied;
+  const id = parseId((await params).id);
+  if (id === null) return NextResponse.json({ error: 'bad id' }, { status: 400 });
+
+  let body: Record<string, unknown>;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: 'invalid JSON body' }, { status: 400 });
+  }
+  const allowed = ['label', 'tags', 'notes'];
+  const extra = Object.keys(body).filter((k) => !allowed.includes(k));
+  if (extra.length > 0) {
+    return NextResponse.json(
+      { error: `immutable or unknown fields: ${extra.join(', ')}` },
+      { status: 400 }
+    );
+  }
+  const patch: { label?: string; tags?: string[]; notes?: string } = {};
+  if (typeof body.label === 'string') patch.label = body.label.trim();
+  if (Array.isArray(body.tags)) patch.tags = body.tags.map(String);
+  if (typeof body.notes === 'string') patch.notes = body.notes;
+
+  const found = await updateSceneMeta(id, patch);
+  if (!found) return NextResponse.json({ error: 'not found' }, { status: 404 });
+  return NextResponse.json({ ok: true });
+}
+
+export async function DELETE(_request: Request, { params }: Ctx) {
+  const denied = await requireOwner();
+  if (denied) return denied;
+  const id = parseId((await params).id);
+  if (id === null) return NextResponse.json({ error: 'bad id' }, { status: 400 });
+  const found = await deleteScene(id);
+  if (!found) return NextResponse.json({ error: 'not found' }, { status: 404 });
+  return NextResponse.json({ ok: true });
+}

--- a/app/api/kiosk/scenes/route.test.ts
+++ b/app/api/kiosk/scenes/route.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NextResponse } from 'next/server';
+
+const requireOwner = vi.fn();
+const listScenes = vi.fn();
+const createScene = vi.fn();
+const reconstructScene = vi.fn();
+const captureLiveScene = vi.fn();
+vi.mock('@/app/lib/owner', () => ({ requireOwner: () => requireOwner() }));
+vi.mock('@/app/lib/scenes/store', () => ({
+  listScenes: () => listScenes(), createScene: (i: unknown) => createScene(i),
+}));
+vi.mock('@/app/lib/scenes/reconstruct', () => ({
+  reconstructScene: (...a: unknown[]) => reconstructScene(...a),
+}));
+vi.mock('@/app/lib/scenes/captureLive', () => ({
+  captureLiveScene: () => captureLiveScene(),
+}));
+
+import { GET, POST } from './route';
+
+const emptyState = { sunrise: [], sunset: [] };
+const post = (body: unknown) =>
+  POST(new Request('http://t/api/kiosk/scenes', { method: 'POST', body: JSON.stringify(body) }));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  requireOwner.mockResolvedValue(null);
+});
+
+describe('GET /api/kiosk/scenes', () => {
+  it('denies non-owners without touching the store', async () => {
+    requireOwner.mockResolvedValue(NextResponse.json({ error: 'nope' }, { status: 403 }));
+    const res = await GET();
+    expect(res.status).toBe(403);
+    expect(listScenes).not.toHaveBeenCalled();
+  });
+  it('lists scenes', async () => {
+    listScenes.mockResolvedValue([{ id: 1 }]);
+    const res = await GET();
+    expect((await res.json()).scenes).toEqual([{ id: 1 }]);
+  });
+});
+
+describe('POST /api/kiosk/scenes', () => {
+  it('rejects a missing label', async () => {
+    expect((await post({ at: '2026-06-21T11:45:00Z' })).status).toBe(400);
+  });
+  it('rejects an unparseable at', async () => {
+    expect((await post({ label: 'x', at: 'not-a-date' })).status).toBe(400);
+  });
+  it('reconstructs when at is given', async () => {
+    reconstructScene.mockResolvedValue({ state: { sunrise: [{}], sunset: [] }, reconstructed: 1, skipped: 2 });
+    createScene.mockResolvedValue(5);
+    const res = await post({ label: 'solstice', at: '2026-06-21T11:45:00Z', windowMinutes: 30 });
+    expect(res.status).toBe(201);
+    expect(await res.json()).toEqual({ id: 5, source: 'historical', reconstructed: 1, skipped: 2 });
+    expect(reconstructScene).toHaveBeenCalledWith(new Date('2026-06-21T11:45:00Z'), 30);
+    expect(createScene).toHaveBeenCalledWith(expect.objectContaining({ source: 'historical', provenance: null }));
+    expect(captureLiveScene).not.toHaveBeenCalled();
+  });
+  it('returns 422 when reconstruction finds nothing', async () => {
+    reconstructScene.mockResolvedValue({ state: emptyState, reconstructed: 0, skipped: 0 });
+    expect((await post({ label: 'x', at: '2001-01-01T00:00:00Z' })).status).toBe(422);
+    expect(createScene).not.toHaveBeenCalled();
+  });
+  it('captures live when at is omitted', async () => {
+    captureLiveScene.mockResolvedValue({
+      state: { sunrise: [], sunset: [{}] },
+      provenance: { activeVersion: 'v1', settings: {} }, pinned: 2, pinFailures: 1,
+    });
+    createScene.mockResolvedValue(6);
+    const res = await post({ label: 'tonight' });
+    expect(res.status).toBe(201);
+    expect(await res.json()).toEqual({ id: 6, source: 'live', pinned: 2, pinFailures: 1 });
+    expect(createScene).toHaveBeenCalledWith(expect.objectContaining({
+      source: 'live',
+      provenance: { activeVersion: 'v1', settings: {} },
+    }));
+  });
+});

--- a/app/api/kiosk/scenes/route.test.ts
+++ b/app/api/kiosk/scenes/route.test.ts
@@ -43,6 +43,14 @@ describe('GET /api/kiosk/scenes', () => {
 });
 
 describe('POST /api/kiosk/scenes', () => {
+  it('denies non-owners without touching the store or capture', async () => {
+    requireOwner.mockResolvedValue(NextResponse.json({ error: 'nope' }, { status: 403 }));
+    const res = await post({ label: 'x', at: '2026-06-21T11:45:00Z' });
+    expect(res.status).toBe(403);
+    expect(createScene).not.toHaveBeenCalled();
+    expect(reconstructScene).not.toHaveBeenCalled();
+    expect(captureLiveScene).not.toHaveBeenCalled();
+  });
   it('rejects a missing label', async () => {
     expect((await post({ at: '2026-06-21T11:45:00Z' })).status).toBe(400);
   });

--- a/app/api/kiosk/scenes/route.ts
+++ b/app/api/kiosk/scenes/route.ts
@@ -1,0 +1,56 @@
+import { NextResponse } from 'next/server';
+import { requireOwner } from '@/app/lib/owner';
+import { createScene, listScenes } from '@/app/lib/scenes/store';
+import { reconstructScene } from '@/app/lib/scenes/reconstruct';
+import { captureLiveScene } from '@/app/lib/scenes/captureLive';
+
+export const dynamic = 'force-dynamic';
+export const maxDuration = 60; // live capture may pin several frames
+
+export async function GET() {
+  const denied = await requireOwner();
+  if (denied) return denied;
+  return NextResponse.json({ scenes: await listScenes() });
+}
+
+export async function POST(request: Request) {
+  const denied = await requireOwner();
+  if (denied) return denied;
+
+  let body: Record<string, unknown>;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: 'invalid JSON body' }, { status: 400 });
+  }
+
+  const label = typeof body.label === 'string' ? body.label.trim() : '';
+  if (!label) return NextResponse.json({ error: 'label is required' }, { status: 400 });
+  const tags = Array.isArray(body.tags) ? body.tags.map(String) : [];
+  const notes = typeof body.notes === 'string' ? body.notes : '';
+
+  if (body.at !== undefined) {
+    const at = new Date(String(body.at));
+    if (Number.isNaN(at.getTime())) {
+      return NextResponse.json({ error: 'unparseable at timestamp' }, { status: 400 });
+    }
+    const windowMinutes = Math.min(180, Math.max(5, Number(body.windowMinutes) || 45));
+    const { state, reconstructed, skipped } = await reconstructScene(at, windowMinutes);
+    if (reconstructed === 0) {
+      return NextResponse.json(
+        { error: 'no snapshots found in the window', skipped },
+        { status: 422 }
+      );
+    }
+    const id = await createScene({
+      label, tags, notes, representsAt: at, source: 'historical', state, provenance: null,
+    });
+    return NextResponse.json({ id, source: 'historical', reconstructed, skipped }, { status: 201 });
+  }
+
+  const { state, provenance, pinned, pinFailures } = await captureLiveScene();
+  const id = await createScene({
+    label, tags, notes, representsAt: new Date(), source: 'live', state, provenance,
+  });
+  return NextResponse.json({ id, source: 'live', pinned, pinFailures }, { status: 201 });
+}

--- a/app/lib/scenes/captureLive.test.ts
+++ b/app/lib/scenes/captureLive.test.ts
@@ -79,4 +79,45 @@ describe('captureLiveScene', () => {
     const result = await captureLiveScene();
     expect(result.provenance.activeVersion).toBe('v1');
   });
+
+  it('preserves sibling image fields when pinning volatile frames', async () => {
+    const volatile = cam({
+      webcamId: 9,
+      images: {
+        sizes: {
+          icon: { width: 48, height: 48 },
+          preview: { width: 400, height: 224 },
+          thumbnail: { width: 200, height: 112 },
+        },
+        current: {
+          preview: 'https://images-webcams.windy.com/9.jpg',
+          icon: 'i.jpg',
+          thumbnail: 't.jpg',
+        },
+        daylight: {
+          icon: 'di.jpg',
+          preview: 'dp.jpg',
+          thumbnail: 'dt.jpg',
+        },
+      },
+    });
+    fetchTerminatorWebcams.mockResolvedValue([volatile]);
+    captureWebcamSnapshot.mockResolvedValue({ url: 'https://firebasestorage.googleapis.com/pinned-9.jpg', path: 'p' });
+    const result = await captureLiveScene();
+    expect(result.pinned).toBe(1);
+    expect(result.state.sunset[0].images?.current.preview)
+      .toBe('https://firebasestorage.googleapis.com/pinned-9.jpg');
+    expect(result.state.sunset[0].images?.current.icon).toBe('i.jpg');
+    expect(result.state.sunset[0].images?.current.thumbnail).toBe('t.jpg');
+    expect(result.state.sunset[0].images?.sizes).toEqual({
+      icon: { width: 48, height: 48 },
+      preview: { width: 400, height: 224 },
+      thumbnail: { width: 200, height: 112 },
+    });
+    expect(result.state.sunset[0].images?.daylight).toEqual({
+      icon: 'di.jpg',
+      preview: 'dp.jpg',
+      thumbnail: 'dt.jpg',
+    });
+  });
 });

--- a/app/lib/scenes/captureLive.test.ts
+++ b/app/lib/scenes/captureLive.test.ts
@@ -12,7 +12,7 @@ import { captureLiveScene, isDurableFrameUrl } from './captureLive';
 
 const cam = (over: Partial<WindyWebcam>): WindyWebcam => ({
   webcamId: 1, title: 'c', viewCount: 0, status: 'active',
-  images: { current: { preview: 'https://firebasestorage.googleapis.com/f.jpg' } },
+  images: { current: { preview: 'https://storage.googleapis.com/sunset-webcam-map.appspot.com/snapshots/1/1700000000000.jpg' } },
   location: { latitude: 1, longitude: 2 }, categories: [],
   phase: 'sunset', rank: 1,
   ...over,
@@ -26,10 +26,22 @@ beforeEach(() => {
 });
 
 describe('isDurableFrameUrl', () => {
-  it('accepts firebase storage URLs and rejects windy CDN URLs', () => {
+  it('accepts real storage.googleapis.com upload URLs (see uploadToFirebase)', () => {
+    expect(
+      isDurableFrameUrl(
+        'https://storage.googleapis.com/sunset-webcam-map.appspot.com/snapshots/1/1700000000000.jpg'
+      )
+    ).toBe(true);
+  });
+
+  it('also accepts firebasestorage.googleapis.com as a compatibility bonus', () => {
     expect(isDurableFrameUrl('https://firebasestorage.googleapis.com/f.jpg')).toBe(true);
+  });
+
+  it('rejects windy CDN URLs, undefined, and malformed URLs', () => {
     expect(isDurableFrameUrl('https://images-webcams.windy.com/x/preview.jpg')).toBe(false);
     expect(isDurableFrameUrl(undefined)).toBe(false);
+    expect(isDurableFrameUrl('not a url')).toBe(false);
   });
 });
 

--- a/app/lib/scenes/captureLive.test.ts
+++ b/app/lib/scenes/captureLive.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { WindyWebcam } from '@/app/lib/types';
+
+const fetchTerminatorWebcams = vi.fn();
+const captureWebcamSnapshot = vi.fn();
+const getProfileSettings = vi.fn();
+vi.mock('@/app/lib/terminatorPayload', () => ({ fetchTerminatorWebcams: (...a: unknown[]) => fetchTerminatorWebcams(...a) }));
+vi.mock('@/app/lib/webcamSnapshot', () => ({ captureWebcamSnapshot: (...a: unknown[]) => captureWebcamSnapshot(...a) }));
+vi.mock('@/app/lib/settings/store', () => ({ getProfileSettings: (...a: unknown[]) => getProfileSettings(...a) }));
+
+import { captureLiveScene, isDurableFrameUrl } from './captureLive';
+
+const cam = (over: Partial<WindyWebcam>): WindyWebcam => ({
+  webcamId: 1, title: 'c', viewCount: 0, status: 'active',
+  images: { current: { preview: 'https://firebasestorage.googleapis.com/f.jpg' } },
+  location: { latitude: 1, longitude: 2 }, categories: [],
+  phase: 'sunset', rank: 1,
+  ...over,
+});
+
+beforeEach(() => {
+  fetchTerminatorWebcams.mockReset();
+  captureWebcamSnapshot.mockReset();
+  getProfileSettings.mockReset();
+  getProfileSettings.mockResolvedValue({ namespaces: { shared: { activeVersion: 'v1' } }, revision: 3 });
+});
+
+describe('isDurableFrameUrl', () => {
+  it('accepts firebase storage URLs and rejects windy CDN URLs', () => {
+    expect(isDurableFrameUrl('https://firebasestorage.googleapis.com/f.jpg')).toBe(true);
+    expect(isDurableFrameUrl('https://images-webcams.windy.com/x/preview.jpg')).toBe(false);
+    expect(isDurableFrameUrl(undefined)).toBe(false);
+  });
+});
+
+describe('captureLiveScene', () => {
+  it('keeps durable frames untouched and splits feeds by phase', async () => {
+    fetchTerminatorWebcams.mockResolvedValue([
+      cam({ webcamId: 1, phase: 'sunrise' }), cam({ webcamId: 2, phase: 'sunset' }),
+    ]);
+    const result = await captureLiveScene();
+    expect(captureWebcamSnapshot).not.toHaveBeenCalled();
+    expect(result.state.sunrise).toHaveLength(1);
+    expect(result.state.sunset).toHaveLength(1);
+    expect(result.pinned).toBe(0);
+  });
+
+  it('pins volatile frames and swaps in the uploaded URL', async () => {
+    const volatile = cam({ webcamId: 3, images: { current: { preview: 'https://images-webcams.windy.com/3.jpg' } } });
+    fetchTerminatorWebcams.mockResolvedValue([volatile]);
+    captureWebcamSnapshot.mockResolvedValue({ url: 'https://firebasestorage.googleapis.com/pinned.jpg', path: 'p' });
+    const result = await captureLiveScene();
+    expect(result.pinned).toBe(1);
+    expect(result.state.sunset[0].images?.current.preview)
+      .toBe('https://firebasestorage.googleapis.com/pinned.jpg');
+  });
+
+  it('counts a failed pin and keeps the original URL', async () => {
+    const volatile = cam({ webcamId: 3, images: { current: { preview: 'https://images-webcams.windy.com/3.jpg' } } });
+    fetchTerminatorWebcams.mockResolvedValue([volatile]);
+    captureWebcamSnapshot.mockResolvedValue(null);
+    const result = await captureLiveScene();
+    expect(result.pinFailures).toBe(1);
+    expect(result.state.sunset[0].images?.current.preview)
+      .toBe('https://images-webcams.windy.com/3.jpg');
+  });
+
+  it('records provenance from the live profile', async () => {
+    fetchTerminatorWebcams.mockResolvedValue([cam({})]);
+    const result = await captureLiveScene();
+    expect(getProfileSettings).toHaveBeenCalledWith('live');
+    expect(result.provenance.activeVersion).toBe('v1');
+    expect(result.provenance.settings.shared).toEqual({ activeVersion: 'v1' });
+  });
+
+  it('falls back to DEFAULT_MOSAIC_VERSION when live profile has no activeVersion', async () => {
+    fetchTerminatorWebcams.mockResolvedValue([cam({})]);
+    getProfileSettings.mockResolvedValue({ namespaces: {}, revision: 1 });
+    const result = await captureLiveScene();
+    expect(result.provenance.activeVersion).toBe('v1');
+  });
+});

--- a/app/lib/scenes/captureLive.test.ts
+++ b/app/lib/scenes/captureLive.test.ts
@@ -92,6 +92,46 @@ describe('captureLiveScene', () => {
     expect(result.provenance.activeVersion).toBe('v1');
   });
 
+  it('pins >5 volatile frames in bounded chunks, preserving pool order and accounting for null and rejected pins', async () => {
+    const cams = Array.from({ length: 8 }, (_, i) =>
+      cam({
+        webcamId: i + 1,
+        images: { current: { preview: `https://images-webcams.windy.com/${i + 1}.jpg` } },
+      })
+    );
+    fetchTerminatorWebcams.mockResolvedValue(cams);
+
+    captureWebcamSnapshot.mockImplementation((c: WindyWebcam) => {
+      if (c.webcamId === 3) return Promise.resolve(null); // null result -> pinFailure
+      if (c.webcamId === 6) return Promise.reject(new Error('boom')); // rejection -> pinFailure
+      return Promise.resolve({
+        url: `https://storage.googleapis.com/bucket/pinned-${c.webcamId}.jpg`,
+        path: 'p',
+      });
+    });
+
+    const result = await captureLiveScene();
+
+    expect(result.pinned).toBe(6);
+    expect(result.pinFailures).toBe(2);
+    // Original pool order (webcamId 1..8) must be preserved in the output.
+    expect(result.state.sunset.map((c) => c.webcamId)).toEqual([1, 2, 3, 4, 5, 6, 7, 8]);
+    // Failed pins (null and rejected) keep the original, unmutated cam/URL.
+    expect(result.state.sunset[2].images?.current.preview).toBe(
+      'https://images-webcams.windy.com/3.jpg'
+    );
+    expect(result.state.sunset[5].images?.current.preview).toBe(
+      'https://images-webcams.windy.com/6.jpg'
+    );
+    // Successful pins swap in the uploaded URL, including one from the second chunk.
+    expect(result.state.sunset[0].images?.current.preview).toBe(
+      'https://storage.googleapis.com/bucket/pinned-1.jpg'
+    );
+    expect(result.state.sunset[7].images?.current.preview).toBe(
+      'https://storage.googleapis.com/bucket/pinned-8.jpg'
+    );
+  });
+
   it('preserves sibling image fields when pinning volatile frames', async () => {
     const volatile = cam({
       webcamId: 9,

--- a/app/lib/scenes/captureLive.ts
+++ b/app/lib/scenes/captureLive.ts
@@ -6,10 +6,18 @@ import { DEFAULT_MOSAIC_VERSION } from '@/app/components/mosaic/registry';
 import type { WindyWebcam } from '@/app/lib/types';
 import type { SceneProvenance, SceneState } from './types';
 
+const DURABLE_HOSTNAMES = new Set([
+  // Real host produced by uploadToFirebase (app/lib/webcamSnapshot.ts):
+  // `https://storage.googleapis.com/${bucket.name}/${path}`.
+  'storage.googleapis.com',
+  // Kept for compatibility with any legacy/alternate Firebase SDK URL shape.
+  'firebasestorage.googleapis.com',
+]);
+
 export function isDurableFrameUrl(url: string | undefined): boolean {
   if (!url) return false;
   try {
-    return new URL(url).hostname === 'firebasestorage.googleapis.com';
+    return DURABLE_HOSTNAMES.has(new URL(url).hostname);
   } catch {
     return false;
   }

--- a/app/lib/scenes/captureLive.ts
+++ b/app/lib/scenes/captureLive.ts
@@ -1,0 +1,61 @@
+import 'server-only';
+import { fetchTerminatorWebcams } from '@/app/lib/terminatorPayload';
+import { captureWebcamSnapshot } from '@/app/lib/webcamSnapshot';
+import { getProfileSettings } from '@/app/lib/settings/store';
+import { DEFAULT_MOSAIC_VERSION } from '@/app/components/mosaic/registry';
+import type { WindyWebcam } from '@/app/lib/types';
+import type { SceneProvenance, SceneState } from './types';
+
+export function isDurableFrameUrl(url: string | undefined): boolean {
+  if (!url) return false;
+  try {
+    return new URL(url).hostname === 'firebasestorage.googleapis.com';
+  } catch {
+    return false;
+  }
+}
+
+export interface LiveCaptureResult {
+  state: SceneState;
+  provenance: SceneProvenance;
+  pinned: number;
+  pinFailures: number;
+}
+
+export async function captureLiveScene(): Promise<LiveCaptureResult> {
+  const webcams = await fetchTerminatorWebcams();
+  let pinned = 0;
+  let pinFailures = 0;
+
+  const frozen: WindyWebcam[] = [];
+  for (const cam of webcams) {
+    const preview = cam.images?.current?.preview;
+    if (isDurableFrameUrl(preview)) {
+      frozen.push(cam);
+      continue;
+    }
+    const uploaded = await captureWebcamSnapshot(cam);
+    if (uploaded) {
+      pinned += 1;
+      frozen.push({
+        ...cam,
+        images: { ...cam.images, current: { ...cam.images?.current, preview: uploaded.url } },
+      });
+    } else {
+      pinFailures += 1;
+      frozen.push(cam);
+    }
+  }
+
+  const state: SceneState = {
+    sunrise: frozen.filter((c) => c.phase === 'sunrise'),
+    sunset: frozen.filter((c) => c.phase === 'sunset'),
+  };
+
+  const profile = await getProfileSettings('live');
+  const settings: SceneProvenance['settings'] = profile.namespaces;
+  const activeVersion =
+    (profile.namespaces.shared?.activeVersion as string | undefined) ?? DEFAULT_MOSAIC_VERSION;
+
+  return { state, provenance: { activeVersion, settings }, pinned, pinFailures };
+}

--- a/app/lib/scenes/captureLive.ts
+++ b/app/lib/scenes/captureLive.ts
@@ -30,29 +30,47 @@ export interface LiveCaptureResult {
   pinFailures: number;
 }
 
+// Bound how many pins run at once so a ~30-cam pool at 1-2s each doesn't
+// push against the POST route's maxDuration=60s by running fully serially.
+const PIN_CONCURRENCY = 5;
+
 export async function captureLiveScene(): Promise<LiveCaptureResult> {
   const webcams = await fetchTerminatorWebcams();
   let pinned = 0;
   let pinFailures = 0;
 
-  const frozen: WindyWebcam[] = [];
-  for (const cam of webcams) {
+  // Preallocate by index so pool order survives out-of-order chunk settling.
+  const frozen: WindyWebcam[] = new Array(webcams.length);
+  const volatileIndices: number[] = [];
+
+  webcams.forEach((cam, index) => {
     const preview = cam.images?.current?.preview;
     if (isDurableFrameUrl(preview)) {
-      frozen.push(cam);
-      continue;
-    }
-    const uploaded = await captureWebcamSnapshot(cam);
-    if (uploaded) {
-      pinned += 1;
-      frozen.push({
-        ...cam,
-        images: { ...cam.images, current: { ...cam.images?.current, preview: uploaded.url } },
-      });
+      frozen[index] = cam;
     } else {
-      pinFailures += 1;
-      frozen.push(cam);
+      volatileIndices.push(index);
     }
+  });
+
+  for (let start = 0; start < volatileIndices.length; start += PIN_CONCURRENCY) {
+    const chunkIndices = volatileIndices.slice(start, start + PIN_CONCURRENCY);
+    const settled = await Promise.allSettled(
+      chunkIndices.map((index) => captureWebcamSnapshot(webcams[index]))
+    );
+    settled.forEach((outcome, i) => {
+      const index = chunkIndices[i];
+      const cam = webcams[index];
+      if (outcome.status === 'fulfilled' && outcome.value) {
+        pinned += 1;
+        frozen[index] = {
+          ...cam,
+          images: { ...cam.images, current: { ...cam.images?.current, preview: outcome.value.url } },
+        };
+      } else {
+        pinFailures += 1;
+        frozen[index] = cam;
+      }
+    });
   }
 
   const state: SceneState = {

--- a/app/lib/scenes/reconstruct.test.ts
+++ b/app/lib/scenes/reconstruct.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const sqlMock = vi.fn();
+vi.mock('@/app/lib/db', () => ({ sql: (...args: unknown[]) => sqlMock(...args) }));
+
+import { rowsToSceneState, reconstructScene, type HistoricalSnapshotRow } from './reconstruct';
+
+const row = (over: Partial<HistoricalSnapshotRow>): HistoricalSnapshotRow => ({
+  webcam_id: 1, phase: 'sunset', rank: 3,
+  firebase_url: 'https://firebasestorage.googleapis.com/x.jpg',
+  snapshot_captured_at: '2026-06-21T11:40:00Z',
+  llm_quality: '0.8125', llm_is_sunset: true, llm_model: 'claude-sonnet-4-5',
+  title: 'Cam', status: 'active', view_count: 10,
+  lat: '47.606200', lng: '-122.332100',
+  city: 'Seattle', region: 'WA', country: 'US', continent: 'NA',
+  categories: [], urls: null, player: null,
+  rating: 4, orientation: 'W', webcam_source: 'windy', external_id: 'w1',
+  ...over,
+});
+
+describe('rowsToSceneState', () => {
+  it('builds WindyWebcam entries with the durable frame and numeric coords', () => {
+    const { state, reconstructed, skipped } = rowsToSceneState([row({})]);
+    expect(reconstructed).toBe(1);
+    expect(skipped).toBe(0);
+    const cam = state.sunset[0];
+    expect(cam.images?.current.preview).toBe('https://firebasestorage.googleapis.com/x.jpg');
+    expect(cam.location.latitude).toBe(47.6062);   // Neon NUMERIC string → number
+    expect(cam.location.longitude).toBe(-122.3321);
+    expect(cam.llmQuality).toBe(0.8125);
+    expect(cam.phase).toBe('sunset');
+    expect(cam.rank).toBe(3);
+  });
+
+  it('splits by recorded phase', () => {
+    const { state } = rowsToSceneState([
+      row({ webcam_id: 1, phase: 'sunrise' }),
+      row({ webcam_id: 2, phase: 'sunset' }),
+    ]);
+    expect(state.sunrise).toHaveLength(1);
+    expect(state.sunset).toHaveLength(1);
+  });
+
+  it('skips rows with null phase or empty firebase_url and counts them', () => {
+    const { reconstructed, skipped } = rowsToSceneState([
+      row({}), row({ webcam_id: 2, phase: null }), row({ webcam_id: 3, firebase_url: '' }),
+    ]);
+    expect(reconstructed).toBe(1);
+    expect(skipped).toBe(2);
+  });
+
+  it('orders each feed by rank ascending', () => {
+    const { state } = rowsToSceneState([
+      row({ webcam_id: 1, rank: 9 }), row({ webcam_id: 2, rank: 2 }),
+    ]);
+    expect(state.sunset.map((c) => c.rank)).toEqual([2, 9]);
+  });
+});
+
+describe('reconstructScene', () => {
+  beforeEach(() => sqlMock.mockReset());
+  it('queries a window around the timestamp with a nearest-row pick per webcam', async () => {
+    sqlMock.mockResolvedValueOnce([row({})]);
+    const result = await reconstructScene(new Date('2026-06-21T11:45:00Z'), 45);
+    expect(result.reconstructed).toBe(1);
+    const query = (sqlMock.mock.calls[0][0] as string[]).join('?');
+    expect(query).toContain('DISTINCT ON (s.webcam_id)');
+    expect(query).toContain('FROM webcam_snapshots s');
+  });
+});

--- a/app/lib/scenes/reconstruct.test.ts
+++ b/app/lib/scenes/reconstruct.test.ts
@@ -55,6 +55,31 @@ describe('rowsToSceneState', () => {
     ]);
     expect(state.sunset.map((c) => c.rank)).toEqual([2, 9]);
   });
+
+  it('handles null rank and sorts nulls last', () => {
+    const { state } = rowsToSceneState([
+      row({ webcam_id: 1, rank: 1 }), row({ webcam_id: 2, rank: null }),
+    ]);
+    expect(state.sunset.map((c) => c.rank)).toEqual([1, undefined]);
+  });
+
+  it('preserves null llm fields (quality, is_sunset, model)', () => {
+    const { state } = rowsToSceneState([
+      row({ llm_quality: null, llm_is_sunset: null, llm_model: null }),
+    ]);
+    const cam = state.sunset[0];
+    expect(cam.llmQuality).toBeNull();
+    expect(cam.llmIsSunset).toBeNull();
+    expect(cam.llmModel).toBeNull();
+  });
+
+  it('returns empty state when given no rows', () => {
+    const { state, reconstructed, skipped } = rowsToSceneState([]);
+    expect(state.sunrise).toHaveLength(0);
+    expect(state.sunset).toHaveLength(0);
+    expect(reconstructed).toBe(0);
+    expect(skipped).toBe(0);
+  });
 });
 
 describe('reconstructScene', () => {

--- a/app/lib/scenes/reconstruct.ts
+++ b/app/lib/scenes/reconstruct.ts
@@ -1,0 +1,104 @@
+import 'server-only';
+import { sql } from '@/app/lib/db';
+import type { WindyWebcam } from '@/app/lib/types';
+import type { SceneState } from './types';
+
+export interface HistoricalSnapshotRow {
+  webcam_id: number;
+  phase: 'sunrise' | 'sunset' | null;
+  rank: number | null;
+  firebase_url: string;
+  snapshot_captured_at: string;
+  llm_quality: string | number | null;
+  llm_is_sunset: boolean | null;
+  llm_model: string | null;
+  title: string | null;
+  status: string | null;
+  view_count: number | null;
+  lat: string | number | null;
+  lng: string | number | null;
+  city: string | null;
+  region: string | null;
+  country: string | null;
+  continent: string | null;
+  categories: unknown;
+  urls: unknown;
+  player: unknown;
+  rating: number | null;
+  orientation: string | null;
+  webcam_source: string | null;
+  external_id: string | null;
+}
+
+export interface ReconstructResult {
+  state: SceneState;
+  reconstructed: number;
+  skipped: number;
+}
+
+const toMaybeNumber = (v: string | number | null): number | null =>
+  v === null || v === undefined ? null : Number(v);
+
+export function rowsToSceneState(rows: HistoricalSnapshotRow[]): ReconstructResult {
+  const state: SceneState = { sunrise: [], sunset: [] };
+  let skipped = 0;
+  for (const r of rows) {
+    if (!r.phase || !r.firebase_url) { skipped += 1; continue; }
+    const cam: WindyWebcam = {
+      webcamId: r.webcam_id,
+      title: r.title ?? 'Unknown',
+      viewCount: r.view_count ?? 0,
+      status: r.status ?? 'unknown',
+      images: { current: { preview: r.firebase_url } },
+      location: {
+        city: r.city ?? '', region: r.region ?? '',
+        latitude: Number(r.lat), longitude: Number(r.lng),
+        country: r.country ?? '', continent: r.continent ?? '',
+      },
+      categories: (r.categories as WindyWebcam['categories']) ?? [],
+      urls: (r.urls as WindyWebcam['urls']) ?? undefined,
+      player: (r.player as WindyWebcam['player']) ?? undefined,
+      phase: r.phase,
+      rank: r.rank ?? undefined,
+      source: r.webcam_source ?? undefined,
+      externalId: r.external_id ?? undefined,
+      rating: r.rating ?? undefined,
+      orientation: (r.orientation as WindyWebcam['orientation']) ?? undefined,
+      llmQuality: toMaybeNumber(r.llm_quality),
+      llmIsSunset: r.llm_is_sunset,
+      llmModel: r.llm_model,
+      lastUpdatedOn: r.snapshot_captured_at,
+    };
+    state[r.phase].push(cam);
+  }
+  const byRank = (a: WindyWebcam, b: WindyWebcam) =>
+    (a.rank ?? Number.MAX_SAFE_INTEGER) - (b.rank ?? Number.MAX_SAFE_INTEGER);
+  state.sunrise.sort(byRank);
+  state.sunset.sort(byRank);
+  return { state, reconstructed: state.sunrise.length + state.sunset.length, skipped };
+}
+
+export async function reconstructScene(
+  at: Date,
+  windowMinutes: number
+): Promise<ReconstructResult> {
+  const windowMs = windowMinutes * 60 * 1000;
+  const from = new Date(at.getTime() - windowMs);
+  const to = new Date(at.getTime() + windowMs);
+  const rows = (await sql`
+    SELECT DISTINCT ON (s.webcam_id)
+      s.webcam_id, s.phase, s.rank, s.firebase_url,
+      s.captured_at AS snapshot_captured_at,
+      s.llm_quality, s.llm_is_sunset, s.llm_model,
+      w.title, w.status, w.view_count, w.lat, w.lng,
+      w.city, w.region, w.country, w.continent,
+      w.categories, w.urls, w.player, w.rating, w.orientation,
+      w.source AS webcam_source, w.external_id
+    FROM webcam_snapshots s
+    JOIN webcams w ON w.id = s.webcam_id
+    WHERE s.captured_at BETWEEN ${from} AND ${to}
+    ORDER BY s.webcam_id,
+      ABS(EXTRACT(EPOCH FROM (s.captured_at - ${at})))
+  `) as HistoricalSnapshotRow[];
+  return rowsToSceneState(rows);
+}

--- a/app/lib/scenes/store.test.ts
+++ b/app/lib/scenes/store.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const sqlMock = vi.fn();
+vi.mock('@/app/lib/db', () => ({ sql: (...args: unknown[]) => sqlMock(...args) }));
+
+import { createScene, listScenes, getScene, updateSceneMeta, deleteScene } from './store';
+
+const state = { sunrise: [], sunset: [] };
+
+beforeEach(() => sqlMock.mockReset());
+
+describe('createScene', () => {
+  it('inserts and returns the new id', async () => {
+    sqlMock.mockResolvedValueOnce([{ id: 7 }]);
+    const id = await createScene({
+      label: 'solstice 4:45am', tags: ['edge-case'], notes: '',
+      representsAt: new Date('2026-06-21T11:45:00Z'),
+      source: 'historical', state, provenance: null,
+    });
+    expect(id).toBe(7);
+    const query = (sqlMock.mock.calls[0][0] as string[]).join('?');
+    expect(query).toContain('INSERT INTO kiosk_scenes');
+  });
+});
+
+describe('listScenes', () => {
+  it('maps rows to summaries, newest represents_at first', async () => {
+    sqlMock.mockResolvedValueOnce([{
+      id: 1, label: 'a', tags: ['x'], represents_at: '2026-08-30T02:00:00Z',
+      source: 'live', created_at: '2026-08-30T02:01:00Z',
+    }]);
+    const scenes = await listScenes();
+    expect(scenes[0]).toEqual({
+      id: 1, label: 'a', tags: ['x'], representsAt: '2026-08-30T02:00:00Z',
+      source: 'live', createdAt: '2026-08-30T02:01:00Z',
+    });
+    expect((sqlMock.mock.calls[0][0] as string[]).join('?')).toContain('ORDER BY represents_at DESC');
+  });
+});
+
+describe('getScene', () => {
+  it('returns null for a missing id', async () => {
+    sqlMock.mockResolvedValueOnce([]);
+    expect(await getScene(99)).toBeNull();
+  });
+  it('returns the full scene', async () => {
+    sqlMock.mockResolvedValueOnce([{
+      id: 2, label: 'b', tags: [], notes: 'n', represents_at: 't1',
+      source: 'historical', created_at: 't2', state, provenance: null,
+    }]);
+    const scene = await getScene(2);
+    expect(scene?.state).toEqual(state);
+    expect(scene?.notes).toBe('n');
+  });
+});
+
+describe('updateSceneMeta', () => {
+  it('updates only provided fields and reports found', async () => {
+    sqlMock.mockResolvedValueOnce([{ id: 2 }]);
+    expect(await updateSceneMeta(2, { label: 'renamed' })).toBe(true);
+    const query = (sqlMock.mock.calls[0][0] as string[]).join('?');
+    expect(query).toContain('UPDATE kiosk_scenes');
+    expect(query).not.toContain('state');
+  });
+  it('returns false when nothing matched', async () => {
+    sqlMock.mockResolvedValueOnce([]);
+    expect(await updateSceneMeta(99, { notes: 'x' })).toBe(false);
+  });
+});
+
+describe('deleteScene', () => {
+  it('returns true when a row was deleted', async () => {
+    sqlMock.mockResolvedValueOnce([{ id: 3 }]);
+    expect(await deleteScene(3)).toBe(true);
+  });
+});

--- a/app/lib/scenes/store.ts
+++ b/app/lib/scenes/store.ts
@@ -1,0 +1,64 @@
+import 'server-only';
+import { sql } from '@/app/lib/db';
+import type { Scene, SceneCreateInput, SceneSummary } from './types';
+
+export async function createScene(input: SceneCreateInput): Promise<number> {
+  const rows = await sql`
+    INSERT INTO kiosk_scenes (label, tags, notes, represents_at, source, state, provenance)
+    VALUES (${input.label}, ${input.tags}, ${input.notes}, ${input.representsAt},
+            ${input.source}, ${JSON.stringify(input.state)},
+            ${input.provenance ? JSON.stringify(input.provenance) : null})
+    RETURNING id`;
+  return rows[0].id as number;
+}
+
+export async function listScenes(): Promise<SceneSummary[]> {
+  const rows = await sql`
+    SELECT id, label, tags, represents_at, source, created_at
+    FROM kiosk_scenes ORDER BY represents_at DESC`;
+  return rows.map((r) => ({
+    id: r.id as number,
+    label: r.label as string,
+    tags: r.tags as string[],
+    representsAt: String(r.represents_at),
+    source: r.source as 'live' | 'historical',
+    createdAt: String(r.created_at),
+  }));
+}
+
+export async function getScene(id: number): Promise<Scene | null> {
+  const rows = await sql`
+    SELECT id, label, tags, notes, represents_at, source, state, provenance, created_at
+    FROM kiosk_scenes WHERE id = ${id}`;
+  if (rows.length === 0) return null;
+  const r = rows[0];
+  return {
+    id: r.id as number,
+    label: r.label as string,
+    tags: r.tags as string[],
+    notes: r.notes as string,
+    representsAt: String(r.represents_at),
+    source: r.source as 'live' | 'historical',
+    createdAt: String(r.created_at),
+    state: r.state as Scene['state'],
+    provenance: (r.provenance ?? null) as Scene['provenance'],
+  };
+}
+
+export async function updateSceneMeta(
+  id: number,
+  patch: { label?: string; tags?: string[]; notes?: string }
+): Promise<boolean> {
+  const rows = await sql`
+    UPDATE kiosk_scenes SET
+      label = COALESCE(${patch.label ?? null}, label),
+      tags  = COALESCE(${patch.tags ?? null}, tags),
+      notes = COALESCE(${patch.notes ?? null}, notes)
+    WHERE id = ${id} RETURNING id`;
+  return rows.length > 0;
+}
+
+export async function deleteScene(id: number): Promise<boolean> {
+  const rows = await sql`DELETE FROM kiosk_scenes WHERE id = ${id} RETURNING id`;
+  return rows.length > 0;
+}

--- a/app/lib/scenes/types.ts
+++ b/app/lib/scenes/types.ts
@@ -1,0 +1,36 @@
+import type { WindyWebcam } from '@/app/lib/types';
+
+export interface SceneState {
+  sunrise: WindyWebcam[];
+  sunset: WindyWebcam[];
+}
+
+export interface SceneProvenance {
+  activeVersion: string;
+  settings: Record<string, Record<string, unknown>>; // namespace -> deviations
+}
+
+export interface SceneSummary {
+  id: number;
+  label: string;
+  tags: string[];
+  representsAt: string;
+  source: 'live' | 'historical';
+  createdAt: string;
+}
+
+export interface Scene extends SceneSummary {
+  notes: string;
+  state: SceneState;
+  provenance: SceneProvenance | null;
+}
+
+export interface SceneCreateInput {
+  label: string;
+  tags: string[];
+  notes: string;
+  representsAt: Date;
+  source: 'live' | 'historical';
+  state: SceneState;
+  provenance: SceneProvenance | null;
+}

--- a/app/studio/PreviewPane.test.tsx
+++ b/app/studio/PreviewPane.test.tsx
@@ -155,4 +155,62 @@ describe('PreviewPane', () => {
     expect(screen.getByTestId('tile-42')).toBeTruthy();
     expect(screen.queryByTestId('tile-1')).toBeNull();
   });
+
+  it('renders no live tiles and a loading status when a scene is selected but not yet loaded', () => {
+    render(
+      <PreviewPane
+        view="sunset"
+        onViewChange={() => {}}
+        panel={PANEL}
+        panelPresetLabel="ktc · 1440×2560"
+        versionName="v1"
+        scenes={[
+          {
+            id: 1,
+            label: 'solstice',
+            tags: [],
+            representsAt: '2026-06-21T11:45:00Z',
+            source: 'historical',
+            createdAt: '2026-06-21T11:45:00Z',
+          },
+        ]}
+        sceneSource={{ kind: 'scene', id: 1 }}
+        onSceneSourceChange={() => {}}
+        sceneState={null}
+      />
+    );
+
+    // Live store has webcamId 1 in both feeds (see beforeEach) — it must not leak through.
+    expect(screen.queryByTestId('tile-1')).toBeNull();
+    expect(screen.getByText('loading scene…')).toBeTruthy();
+  });
+
+  it('renders no live tiles and the hook error when a scene fails to load', () => {
+    render(
+      <PreviewPane
+        view="sunset"
+        onViewChange={() => {}}
+        panel={PANEL}
+        panelPresetLabel="ktc · 1440×2560"
+        versionName="v1"
+        scenes={[
+          {
+            id: 1,
+            label: 'solstice',
+            tags: [],
+            representsAt: '2026-06-21T11:45:00Z',
+            source: 'historical',
+            createdAt: '2026-06-21T11:45:00Z',
+          },
+        ]}
+        sceneSource={{ kind: 'scene', id: 1 }}
+        onSceneSourceChange={() => {}}
+        sceneState={null}
+        error="/api/kiosk/scenes/1: 404"
+      />
+    );
+
+    expect(screen.queryByTestId('tile-1')).toBeNull();
+    expect(screen.getByText('/api/kiosk/scenes/1: 404')).toBeTruthy();
+  });
 });

--- a/app/studio/PreviewPane.test.tsx
+++ b/app/studio/PreviewPane.test.tsx
@@ -28,9 +28,15 @@ global.ResizeObserver = StubResizeObserver;
 let capturedFeeds: string[] = [];
 
 vi.mock('@/app/components/mosaic/registry', () => ({
-  resolveMosaic: () => (props: { feed: string }) => {
+  resolveMosaic: () => (props: { feed: string; webcams: Array<{ webcamId: number }> }) => {
     capturedFeeds.push(props.feed);
-    return <div data-testid={`mosaic-${props.feed}`} />;
+    return (
+      <div data-testid={`mosaic-${props.feed}`}>
+        {props.webcams.map((w) => (
+          <div key={w.webcamId} data-testid={`tile-${w.webcamId}`} />
+        ))}
+      </div>
+    );
   },
   resolveMosaicName: (v: string | null | undefined) => v ?? 'v1',
 }));
@@ -117,5 +123,36 @@ describe('PreviewPane', () => {
     );
 
     expect(screen.getByText('ktc · 1440×2560')).toBeTruthy();
+  });
+
+  it('renders scene state webcams instead of the live store when a scene is selected', () => {
+    render(
+      <PreviewPane
+        view="sunset"
+        onViewChange={() => {}}
+        panel={PANEL}
+        panelPresetLabel="ktc · 1440×2560"
+        versionName="v1"
+        scenes={[
+          {
+            id: 1,
+            label: 'solstice',
+            tags: [],
+            representsAt: '2026-06-21T11:45:00Z',
+            source: 'historical',
+            createdAt: '2026-06-21T11:45:00Z',
+          },
+        ]}
+        sceneSource={{ kind: 'scene', id: 1 }}
+        onSceneSourceChange={() => {}}
+        sceneState={{
+          sunrise: [],
+          sunset: [{ webcamId: 42, title: 'scene sunset cam' } as unknown as WindyWebcam],
+        }}
+      />
+    );
+
+    expect(screen.getByTestId('tile-42')).toBeTruthy();
+    expect(screen.queryByTestId('tile-1')).toBeNull();
   });
 });

--- a/app/studio/PreviewPane.tsx
+++ b/app/studio/PreviewPane.tsx
@@ -35,6 +35,7 @@ export function PreviewPane({
   sceneSource = { kind: 'live' },
   onSceneSourceChange,
   sceneState = null,
+  error = null,
 }: {
   view: FeedView;
   onViewChange: (v: FeedView) => void;
@@ -46,14 +47,20 @@ export function PreviewPane({
   sceneSource?: SceneSource;
   onSceneSourceChange?: (source: SceneSource) => void;
   sceneState?: SceneState | null;
+  error?: string | null;
 }) {
   const liveSunrise = useTerminatorStore((t) => t.sunrise);
   const liveSunset = useTerminatorStore((t) => t.sunset);
   const Mosaic = resolveMosaic(versionName);
   const feeds = feedsFor(view);
 
+  // A scene is selected but hasn't resolved yet (still loading, 404, or a
+  // fetch error) — don't fall through to the live pool and silently show
+  // it under the scene's header, and don't render live tiles at all.
+  const sceneUnresolved = sceneSource.kind === 'scene' && !sceneState;
+
   const webcamsFor = (feed: 'sunrise' | 'sunset') => {
-    if (sceneState) return sceneState[feed];
+    if (sceneSource.kind === 'scene') return sceneState ? sceneState[feed] : [];
     return feed === 'sunrise' ? liveSunrise : liveSunset;
   };
 
@@ -143,6 +150,19 @@ export function PreviewPane({
             </option>
           ))}
         </select>
+
+        {sceneUnresolved && (
+          <span
+            data-testid="studio-scene-status"
+            style={{
+              fontFamily: mono,
+              fontSize: 11,
+              color: error ? '#f0a04b' : dim,
+            }}
+          >
+            {error ?? 'loading scene…'}
+          </span>
+        )}
       </div>
 
       <div

--- a/app/studio/PreviewPane.tsx
+++ b/app/studio/PreviewPane.tsx
@@ -4,6 +4,8 @@ import { useTerminatorStore } from '@/app/store/useTerminatorStore';
 import { resolveMosaic } from '@/app/components/mosaic/registry';
 import type { PanelSize } from '@/app/kiosk/panelPreview';
 import type { SettingsValues } from '@/app/lib/settings/schema';
+import type { SceneSource } from './useSceneWebcams';
+import type { SceneState, SceneSummary } from '@/app/lib/scenes/types';
 import { StudioPanelFrame } from './StudioPanelFrame';
 
 export type FeedView = 'sunrise' | 'sunset' | 'both';
@@ -18,6 +20,10 @@ function feedsFor(view: FeedView): Array<'sunrise' | 'sunset'> {
   return view === 'both' ? ['sunrise', 'sunset'] : [view];
 }
 
+function sceneOptionLabel(scene: SceneSummary): string {
+  return `${scene.label} — ${new Date(scene.representsAt).toLocaleString()}`;
+}
+
 export function PreviewPane({
   view,
   onViewChange,
@@ -25,6 +31,10 @@ export function PreviewPane({
   panelPresetLabel,
   versionName,
   settings,
+  scenes = [],
+  sceneSource = { kind: 'live' },
+  onSceneSourceChange,
+  sceneState = null,
 }: {
   view: FeedView;
   onViewChange: (v: FeedView) => void;
@@ -32,14 +42,20 @@ export function PreviewPane({
   panelPresetLabel: string;
   versionName: string;
   settings?: SettingsValues;
+  scenes?: SceneSummary[];
+  sceneSource?: SceneSource;
+  onSceneSourceChange?: (source: SceneSource) => void;
+  sceneState?: SceneState | null;
 }) {
-  const sunrise = useTerminatorStore((t) => t.sunrise);
-  const sunset = useTerminatorStore((t) => t.sunset);
+  const liveSunrise = useTerminatorStore((t) => t.sunrise);
+  const liveSunset = useTerminatorStore((t) => t.sunset);
   const Mosaic = resolveMosaic(versionName);
   const feeds = feedsFor(view);
 
-  const webcamsFor = (feed: 'sunrise' | 'sunset') =>
-    feed === 'sunrise' ? sunrise : sunset;
+  const webcamsFor = (feed: 'sunrise' | 'sunset') => {
+    if (sceneState) return sceneState[feed];
+    return feed === 'sunrise' ? liveSunrise : liveSunset;
+  };
 
   return (
     <div
@@ -100,6 +116,33 @@ export function PreviewPane({
         >
           {panelPresetLabel}
         </span>
+
+        <select
+          aria-label="data source"
+          data-testid="studio-scene-select"
+          value={sceneSource.kind === 'live' ? 'live' : String(sceneSource.id)}
+          onChange={(e) => {
+            const raw = e.target.value;
+            onSceneSourceChange?.(
+              raw === 'live' ? { kind: 'live' } : { kind: 'scene', id: Number(raw) }
+            );
+          }}
+          style={{
+            fontSize: 12,
+            background: '#0e1119',
+            color: '#e5e7eb',
+            border: `1px solid ${hairline}`,
+            borderRadius: 6,
+            padding: '4px 8px',
+          }}
+        >
+          <option value="live">live</option>
+          {scenes.map((scene) => (
+            <option key={scene.id} value={scene.id}>
+              {sceneOptionLabel(scene)}
+            </option>
+          ))}
+        </select>
       </div>
 
       <div

--- a/app/studio/StudioClient.tsx
+++ b/app/studio/StudioClient.tsx
@@ -6,6 +6,7 @@ import { useTerminatorStore } from '@/app/store/useTerminatorStore';
 import { PreviewPane, type FeedView } from './PreviewPane';
 import { StudioRail } from './StudioRail';
 import { useStudioSettings } from './useStudioSettings';
+import { useSceneWebcams, type SceneSource } from './useSceneWebcams';
 import { DeployButton } from './DeployButton';
 import { StatusStrip } from './StatusStrip';
 import { resolveMosaicName } from '@/app/components/mosaic/registry';
@@ -36,7 +37,9 @@ const pillBg = 'rgba(16,20,29,.85)';
 const pillBorder = '#232a38';
 
 export function StudioClient() {
-  useLoadTerminatorWebcams();
+  const [sceneSource, setSceneSource] = useState<SceneSource>({ kind: 'live' });
+  useLoadTerminatorWebcams({ paused: sceneSource.kind === 'scene' });
+  const { scenes, sceneState } = useSceneWebcams(sceneSource);
   const settingsApi = useStudioSettings();
   const sunriseWebcams = useTerminatorStore((t) => t.sunrise);
   const sunsetWebcams = useTerminatorStore((t) => t.sunset);
@@ -131,6 +134,10 @@ export function StudioClient() {
           panelPresetLabel={panelPresetLabel}
           versionName={versionName}
           settings={previewSettings}
+          scenes={scenes}
+          sceneSource={sceneSource}
+          onSceneSourceChange={setSceneSource}
+          sceneState={sceneState}
         />
 
         {railCollapsed && (

--- a/app/studio/StudioClient.tsx
+++ b/app/studio/StudioClient.tsx
@@ -39,7 +39,7 @@ const pillBorder = '#232a38';
 export function StudioClient() {
   const [sceneSource, setSceneSource] = useState<SceneSource>({ kind: 'live' });
   useLoadTerminatorWebcams({ paused: sceneSource.kind === 'scene' });
-  const { scenes, sceneState } = useSceneWebcams(sceneSource);
+  const { scenes, sceneState, error: sceneError } = useSceneWebcams(sceneSource);
   const settingsApi = useStudioSettings();
   const sunriseWebcams = useTerminatorStore((t) => t.sunrise);
   const sunsetWebcams = useTerminatorStore((t) => t.sunset);
@@ -138,6 +138,7 @@ export function StudioClient() {
           sceneSource={sceneSource}
           onSceneSourceChange={setSceneSource}
           sceneState={sceneState}
+          error={sceneError}
         />
 
         {railCollapsed && (

--- a/app/studio/useSceneWebcams.test.ts
+++ b/app/studio/useSceneWebcams.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+
+const fetchMock = vi.fn();
+vi.stubGlobal('fetch', fetchMock);
+
+import { useSceneWebcams } from './useSceneWebcams';
+
+const listPayload = {
+  scenes: [{ id: 1, label: 'solstice', tags: [], representsAt: 't', source: 'historical', createdAt: 't' }],
+};
+const scenePayload = {
+  id: 1, label: 'solstice', tags: [], notes: '', representsAt: 't', source: 'historical',
+  createdAt: 't', provenance: null,
+  state: { sunrise: [{ webcamId: 9 }], sunset: [] },
+};
+
+beforeEach(() => {
+  fetchMock.mockReset();
+  fetchMock.mockImplementation((url: string) =>
+    Promise.resolve({
+      ok: true,
+      json: () =>
+        Promise.resolve(String(url).endsWith('/1') ? scenePayload : listPayload),
+    })
+  );
+});
+
+describe('useSceneWebcams', () => {
+  it('serves the scene list and null state for live', async () => {
+    const { result } = renderHook(() => useSceneWebcams({ kind: 'live' }));
+    await waitFor(() => expect(result.current.scenes).toHaveLength(1));
+    expect(result.current.sceneState).toBeNull();
+  });
+
+  it('serves the selected scene state', async () => {
+    const { result } = renderHook(() => useSceneWebcams({ kind: 'scene', id: 1 }));
+    await waitFor(() => expect(result.current.sceneState).not.toBeNull());
+    expect(result.current.sceneState?.sunrise[0].webcamId).toBe(9);
+    expect(result.current.sceneLabel).toBe('solstice');
+  });
+});

--- a/app/studio/useSceneWebcams.ts
+++ b/app/studio/useSceneWebcams.ts
@@ -1,0 +1,32 @@
+'use client';
+
+import useSWR from 'swr';
+import type { Scene, SceneState, SceneSummary } from '@/app/lib/scenes/types';
+
+export type SceneSource = { kind: 'live' } | { kind: 'scene'; id: number };
+
+const fetcher = (url: string) =>
+  fetch(url).then((r) => {
+    if (!r.ok) throw new Error(`${url}: ${r.status}`);
+    return r.json();
+  });
+
+export function useSceneWebcams(source: SceneSource): {
+  scenes: SceneSummary[];
+  sceneState: SceneState | null;
+  sceneLabel: string | null;
+  error: string | null;
+} {
+  const list = useSWR<{ scenes: SceneSummary[] }>('/api/kiosk/scenes', fetcher);
+  const sceneId = source.kind === 'scene' ? source.id : null;
+  const scene = useSWR<Scene>(
+    sceneId === null ? null : `/api/kiosk/scenes/${sceneId}`,
+    fetcher
+  );
+  return {
+    scenes: list.data?.scenes ?? [],
+    sceneState: scene.data?.state ?? null,
+    sceneLabel: scene.data?.label ?? null,
+    error: (list.error ?? scene.error)?.message ?? null,
+  };
+}

--- a/database/migrations/20260830_kiosk_scenes.sql
+++ b/database/migrations/20260830_kiosk_scenes.sql
@@ -1,0 +1,17 @@
+-- kiosk_scenes: frozen kiosk input states for /studio replay + the grant
+-- archive (spec: docs/superpowers/specs/2026-08-30-kiosk-scenes-design.md).
+-- state is the MosaicProps-shaped pool; provenance records what was live at
+-- capture (null for reconstructed scenes). state is immutable after insert.
+-- Apply with:
+--   psql "$DATABASE_URL" -f database/migrations/20260830_kiosk_scenes.sql
+CREATE TABLE IF NOT EXISTS kiosk_scenes (
+  id SERIAL PRIMARY KEY,
+  label TEXT NOT NULL,
+  tags TEXT[] NOT NULL DEFAULT '{}',
+  notes TEXT NOT NULL DEFAULT '',
+  represents_at TIMESTAMPTZ NOT NULL,
+  source TEXT NOT NULL CHECK (source IN ('live', 'historical')),
+  state JSONB NOT NULL,
+  provenance JSONB,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);

--- a/scripts/scene-history-report.mjs
+++ b/scripts/scene-history-report.mjs
@@ -1,0 +1,39 @@
+// scripts/scene-history-report.mjs
+// Read-only report: how deep and how evenly webcam_snapshots history covers
+// the clock/calendar. Run: node scripts/scene-history-report.mjs
+import { neon } from '@neondatabase/serverless';
+import { readFileSync } from 'node:fs';
+
+function loadDatabaseUrl() {
+  if (process.env.DATABASE_URL) return process.env.DATABASE_URL;
+  const env = readFileSync('.env.local', 'utf8');
+  const line = env.split('\n').find((l) => l.startsWith('DATABASE_URL='));
+  if (!line) throw new Error('DATABASE_URL not found in env or .env.local');
+  return line.slice('DATABASE_URL='.length).replace(/^"|"$/g, '');
+}
+
+const sql = neon(loadDatabaseUrl());
+
+const [range] = await sql`
+  SELECT MIN(captured_at) AS oldest, MAX(captured_at) AS newest,
+         COUNT(*)::int AS total,
+         COUNT(DISTINCT webcam_id)::int AS webcams
+  FROM webcam_snapshots`;
+console.log('range:', range);
+
+const byMonth = await sql`
+  SELECT to_char(date_trunc('month', captured_at), 'YYYY-MM') AS month,
+         COUNT(*)::int AS rows, COUNT(DISTINCT webcam_id)::int AS webcams
+  FROM webcam_snapshots GROUP BY 1 ORDER BY 1`;
+console.table(byMonth);
+
+const byHourUtc = await sql`
+  SELECT EXTRACT(HOUR FROM captured_at)::int AS hour_utc, COUNT(*)::int AS rows
+  FROM webcam_snapshots GROUP BY 1 ORDER BY 1`;
+console.table(byHourUtc);
+
+const phaseCoverage = await sql`
+  SELECT phase, COUNT(*)::int AS rows,
+         COUNT(llm_quality)::int AS with_llm
+  FROM webcam_snapshots GROUP BY 1 ORDER BY 1`;
+console.table(phaseCoverage);


### PR DESCRIPTION
Scenes: frozen kiosk input states — reconstructable from nine months of snapshot history, capturable live with frame pinning, stored behind an owner-gated CRUD API, and replayable through the /studio preview via a `live | scene` selector. This is the aesthetic-design-tool harness for dialing in mosaic v2 against recorded edge cases before the showing; the grant-material archive stacks on the same store later.

Spec: `docs/superpowers/specs/2026-08-30-kiosk-scenes-design.md` · Plan: `docs/superpowers/plans/2026-08-30-kiosk-scenes.md` (both on `docs/kiosk-scenes-spec`)

**Stacked on #96** (kiosk-studio phase 1) — merge that first; GitHub will retarget this PR to `main` automatically.

## What's here

- `kiosk_scenes` table (migration applied + verified) + CRUD store; scene `state` is immutable, PATCH touches only label/tags/notes.
- `reconstructScene(at, windowMinutes)`: nearest-snapshot-per-webcam within ±window, using recorded `phase`/`rank` and durable Firebase frame URLs. Verified against production: June-solstice 12:00 UTC reconstructs 9 sunset cams, 0 skipped, and round-trips through the store intact.
- `captureLiveScene()`: freezes `fetchTerminatorWebcams()`, pins volatile (Windy) frames to Firebase with bounded concurrency (5 at a time), records provenance (`activeVersion` + live-profile settings). A failed pin keeps the original URL and increments `pinFailures` — the counter never lies.
- Owner-gated `GET/POST /api/kiosk/scenes`, `GET/PATCH/DELETE /api/kiosk/scenes/:id` — denied-path tests on all five handlers.
- /studio preview header gains `live | scene ▾`; a selected scene feeds both panes and pauses live polling; an unloaded/failed scene shows "loading scene…"/the error instead of silently rendering the live pool.
- Two seed library scenes already saved via the smoke run.

Tests: 982 passing, lint clean. Every task went through implementer → reviewer → (fix round → scoped re-review) gates; final whole-branch review's findings (wrong durable hostname, sequential pinning, silent scene fallback) fixed and re-verified.

## Snapshot-history coverage (bounds the scene library)

`scripts/scene-history-report.mjs` (full tables in the script's output):

- Range: 2025-11-26 → 2026-08-31, 59,030 rows, 2,569 webcams; phase populated on 100%, `llm_quality` on ~78%.
- By month: 2025-11/12 nearly empty (16/83 rows), 2026-02→08 dense (7.6k–19.5k rows/month; May is a 6-row gap).
- By hour (UTC): continuous coverage, roughly 1.3k–3.8k rows/hour — every hour of the clock is reconstructable in the dense months.

## Recorded spec deviations

1. Reconstruction result field is `skipped` (rows dropped for null phase / empty frame URL), not the spec's `missing`.
2. `provenance` is `{ activeVersion, settings }` — no `gateStats` in v0 (the live payload lacks `llm_*` and the version-true gate helper belongs to the studio status strip; add later if wanted).

## Known limitations (flagged by the final review; accepted for v0)

- Historical scenes join the **current** `webcams` row — titles/coords/ratings drift by design; the frozen part is frames + recorded phase/rank/llm ratings.
- `state` JSONB is raw `WindyWebcam[]` (~30–60KB/scene) with no shape-version stamp; old scenes replay through future mosaic versions as-is.
- `deleteScene` doesn't clean up pinned Firebase files; pinned frames share the `snapshots/<id>/` prefix without a `webcam_snapshots` row.
- `represents_at`/`created_at` serialize via `String(Date)` (locale string, not ISO) in API responses; clients parse it fine.
- `getProfileSettings` throw inside a live capture 500s after uploads complete (orphan files, no scene row) — acceptable for owner tooling.
- `windowMinutes: 0` falls to the default 45 rather than clamping to 5.
- Preview status line has no aria-live; a scenes-list fetch error is not surfaced once a scene is already loaded.

## Still open (not in this PR)

- On-glass /studio pass by Jesse: pick a scene, dial against it (Task 7 step 3).
- One real live capture during an active window to verify pin counts + `maxDuration` headroom.
- Deferred stack per spec: auto-capture cron, scene-gallery grid, invariant vitest fixtures, print-res export.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018JrABqpTyAXRJnj7LySaSD
