### PR TITLE
Per-camera error audit: false-shows are concentrated and characterizable

### DIFF
--- a/docs/ml/2026-08-31-camera-error-audit.md
+++ b/docs/ml/2026-08-31-camera-error-audit.md
@@ -1,0 +1,64 @@
+---
+title: "Per-camera error audit v1 — false-shows are concentrated and characterizable"
+date: 2026-08-31
+status: findings recorded; mitigation decision pending
+---
+
+# Per-camera error audit (2026-08-31)
+
+First item on the failure-mode track after the retest ceiling verdict closed
+the global-metrics chapter (see the quality-ceiling roadmap). Question: are
+the composed system's errors spread thin, or do a few cameras systematically
+fool the shipping pair?
+
+**Method.** All 9,118 operator-labeled webcam frames rescored locally through
+the shipping ONNX pair (`20260829_062437_v5_binary_gold` +
+`20260830_190519_v5_quality_llm_backbone_finetune`, gate 0.55) via the
+parity-verified `score_manifest` preprocessing — archived
+`ai_regression_score` is ~92% v4-era and says nothing about the current
+heads. Offender bar: ≥3 error events across ≥2 distinct capture days (one
+bad frame is noise — the same standard that caught three non-replicating
+detection "wins"). Tooling: `ml/audit_camera_errors.py`; full report
+`ml/artifacts/reports/camera_error_audit_v1.json`.
+
+## Findings
+
+- **Errors are concentrated.** 5,538 operator-N frames → 169 false-shows
+  (3.1%), of which only 27 (0.5%) at big-tile size (tile ≥ 0.5). **17
+  cameras account for 42% of all false-shows**; the top four account for a
+  third of the big-tile ones.
+- **The failure class is coherent: warm light or warm terrain near the
+  horizon that isn't sunset sky.** Eyeballed offenders:
+  - `4057187` Broome Intl Airport (AU) — **11/11 N frames shown across 9
+    days, mean tile 0.46**: sodium floodlight rows along the horizon under
+    dusk skies. The single worst camera in the fleet.
+  - `2947112` Coober Pedy opal mine (AU) — 4/5 shown, mean tile 0.44:
+    red-orange spoil heaps; the whole frame is sunset-colored terrain.
+  - `29095214` Mount Gambier Airport, `29275205` Wagga Wagga Airport —
+    same airport-floodlight signature. Four of the top offenders are
+    airports.
+  - The remaining 13 offenders false-show only at *small* tile
+    (meanTileN ≤ 0.32) — low product harm.
+- **Misses of ≥4 frames barely recur**: only three cameras with 2 misses
+  each (Cartago CR, Cochrane CA, Arica CL) — silhouette-candidate leads,
+  nothing systematic yet.
+- **Camera 3656741 (the v2-confirmation double-fooler) did NOT clear the
+  recurrence bar** — its two famous frames never repeated. The
+  repeated-days discipline is doing its job.
+- Caveat: the labeled population is hard-example-biased, so 3.1% is not a
+  production rate; rankings are within-population comparisons.
+
+## Recommended mitigation (pending Jesse's call)
+
+Training-side fixes are unpromising — these frames are already IN the gold
+training set and the model still misreads them; that is what "at the label
+ceiling" looks like. The pragmatic fix is display-side:
+
+**A per-camera showcase cap for the four big-tile offenders** (4057187,
+2947112, 29095214, 29275205): cap their tile signal below the showcase tier
+(or exclude them from top-N placement) in the mosaic's qualitySignal path.
+Small list, evidence-backed, reversible, and it removes ~a third of the
+big-tile embarrassments before the 2026-09-13 showing. Owned by the display
+lane (`app/components/mosaic/v1/qualitySignal.ts` + `passesGate`); this doc
+is the handoff evidence. Re-run the audit as labels accumulate
+(`.venv/bin/python ml/audit_camera_errors.py`) before growing the list.

--- a/ml/artifacts/reports/camera_error_audit_v1.json
+++ b/ml/artifacts/reports/camera_error_audit_v1.json
@@ -1,0 +1,518 @@
+{
+  "gate": 0.55,
+  "big_tile": 0.5,
+  "min_events": 3,
+  "min_days": 2,
+  "binary_onnx": "ml/artifacts/models/binary_resnet18/20260829_062437_v5_binary_gold/model.onnx",
+  "quality_onnx": "ml/artifacts/models/regression_resnet18/20260830_190519_v5_quality_llm_backbone_finetune/model.onnx",
+  "frames_scored": 9118,
+  "skipped": 0,
+  "cameras": 1382,
+  "operator_N": 5538,
+  "false_shows": 169,
+  "big_false_shows": 27,
+  "offenders": [
+    {
+      "webcam_id": 4057187,
+      "meta": "Broome \u203a West: Broome International Airp \u00b7 Broome \u00b7 Australia",
+      "labeled": 34,
+      "n_N": 11,
+      "false_shows": 11,
+      "big_false_shows": 3,
+      "distinct_days": 9,
+      "fs_rate": 1.0,
+      "mean_tile_on_N": 0.463,
+      "sample_frames": [
+        {
+          "tile": 0.641,
+          "snapshot_id": 120199,
+          "url": "https://storage.googleapis.com/sunrisesunset-32a25.firebasestorage.app/snapshots/4057187/1785708070319.jpg"
+        },
+        {
+          "tile": 0.536,
+          "snapshot_id": 119837,
+          "url": "https://storage.googleapis.com/sunrisesunset-32a25.firebasestorage.app/snapshots/4057187/1785617121961.jpg"
+        },
+        {
+          "tile": 0.532,
+          "snapshot_id": 120800,
+          "url": "https://storage.googleapis.com/sunrisesunset-32a25.firebasestorage.app/snapshots/4057187/1785880863885.jpg"
+        }
+      ]
+    },
+    {
+      "webcam_id": 2947112,
+      "meta": "Coober Pedy: Umoona Opal Mine & Museum \u00b7 Coober Pedy \u00b7 Australia",
+      "labeled": 5,
+      "n_N": 5,
+      "false_shows": 4,
+      "big_false_shows": 3,
+      "distinct_days": 4,
+      "fs_rate": 0.8,
+      "mean_tile_on_N": 0.442,
+      "sample_frames": [
+        {
+          "tile": 0.613,
+          "snapshot_id": 119738,
+          "url": "https://storage.googleapis.com/sunrisesunset-32a25.firebasestorage.app/snapshots/2947112/1785574996700.jpg"
+        },
+        {
+          "tile": 0.594,
+          "snapshot_id": 122267,
+          "url": "https://storage.googleapis.com/sunrisesunset-32a25.firebasestorage.app/snapshots/2947112/1786352507736.jpg"
+        },
+        {
+          "tile": 0.506,
+          "snapshot_id": 120048,
+          "url": "https://storage.googleapis.com/sunrisesunset-32a25.firebasestorage.app/snapshots/2947112/1785661276045.jpg"
+        }
+      ]
+    },
+    {
+      "webcam_id": 29095214,
+      "meta": "Wandilo \u203a North-west: Mount Gambier Airp \u00b7 unknown \u00b7 Australia",
+      "labeled": 22,
+      "n_N": 15,
+      "false_shows": 4,
+      "big_false_shows": 2,
+      "distinct_days": 4,
+      "fs_rate": 0.27,
+      "mean_tile_on_N": 0.117,
+      "sample_frames": [
+        {
+          "tile": 0.598,
+          "snapshot_id": 119843,
+          "url": "https://storage.googleapis.com/sunrisesunset-32a25.firebasestorage.app/snapshots/29095214/1785618070669.jpg"
+        },
+        {
+          "tile": 0.554,
+          "snapshot_id": 120449,
+          "url": "https://storage.googleapis.com/sunrisesunset-32a25.firebasestorage.app/snapshots/29095214/1785787319659.jpg"
+        },
+        {
+          "tile": 0.397,
+          "snapshot_id": 123919,
+          "url": "https://storage.googleapis.com/sunrisesunset-32a25.firebasestorage.app/snapshots/29095214/1786913193710.jpg"
+        }
+      ]
+    },
+    {
+      "webcam_id": 29275205,
+      "meta": "Wagga Wagga \u203a North-east: Waga Wagga Air \u00b7 Wagga Wagga \u00b7 Australia",
+      "labeled": 15,
+      "n_N": 7,
+      "false_shows": 3,
+      "big_false_shows": 1,
+      "distinct_days": 2,
+      "fs_rate": 0.43,
+      "mean_tile_on_N": 0.169,
+      "sample_frames": [
+        {
+          "tile": 0.548,
+          "snapshot_id": 124794,
+          "url": "https://storage.googleapis.com/sunrisesunset-32a25.firebasestorage.app/snapshots/29275205/1787256942975.jpg"
+        },
+        {
+          "tile": 0.447,
+          "snapshot_id": 124025,
+          "url": "https://storage.googleapis.com/sunrisesunset-32a25.firebasestorage.app/snapshots/29275205/1786953803299.jpg"
+        },
+        {
+          "tile": 0.185,
+          "snapshot_id": 124700,
+          "url": "https://storage.googleapis.com/sunrisesunset-32a25.firebasestorage.app/snapshots/29275205/1787213749339.jpg"
+        }
+      ]
+    },
+    {
+      "webcam_id": 97,
+      "meta": "North Slope: Toolik Lake \u00b7 unknown \u00b7 United States",
+      "labeled": 87,
+      "n_N": 39,
+      "false_shows": 6,
+      "big_false_shows": 0,
+      "distinct_days": 4,
+      "fs_rate": 0.15,
+      "mean_tile_on_N": 0.028,
+      "sample_frames": [
+        {
+          "tile": 0.368,
+          "snapshot_id": 121517,
+          "url": "https://storage.googleapis.com/sunrisesunset-32a25.firebasestorage.app/snapshots/97/1786095945424.jpg"
+        },
+        {
+          "tile": 0.226,
+          "snapshot_id": 121238,
+          "url": "https://storage.googleapis.com/sunrisesunset-32a25.firebasestorage.app/snapshots/97/1786012300139.jpg"
+        },
+        {
+          "tile": 0.191,
+          "snapshot_id": 123299,
+          "url": "https://storage.googleapis.com/sunrisesunset-32a25.firebasestorage.app/snapshots/97/1786700755887.jpg"
+        }
+      ]
+    },
+    {
+      "webcam_id": 3914190,
+      "meta": "Tondo \u00b7 Tondo \u00b7 Philippines",
+      "labeled": 32,
+      "n_N": 8,
+      "false_shows": 5,
+      "big_false_shows": 0,
+      "distinct_days": 5,
+      "fs_rate": 0.62,
+      "mean_tile_on_N": 0.198,
+      "sample_frames": [
+        {
+          "tile": 0.399,
+          "snapshot_id": 77156,
+          "url": "https://storage.googleapis.com/sunrisesunset-32a25.firebasestorage.app/snapshots/3914190/1772705809427.jpg"
+        },
+        {
+          "tile": 0.345,
+          "snapshot_id": 73210,
+          "url": "https://storage.googleapis.com/sunrisesunset-32a25.firebasestorage.app/snapshots/3914190/1771753429360.jpg"
+        },
+        {
+          "tile": 0.327,
+          "snapshot_id": 72859,
+          "url": "https://storage.googleapis.com/sunrisesunset-32a25.firebasestorage.app/snapshots/3914190/1771666969226.jpg"
+        }
+      ]
+    },
+    {
+      "webcam_id": 5961510,
+      "meta": "Gamsha \u203a North-east \u00b7 Gamsha \u00b7 Egypt",
+      "labeled": 48,
+      "n_N": 13,
+      "false_shows": 5,
+      "big_false_shows": 0,
+      "distinct_days": 4,
+      "fs_rate": 0.38,
+      "mean_tile_on_N": 0.038,
+      "sample_frames": [
+        {
+          "tile": 0.299,
+          "snapshot_id": 122715,
+          "url": "https://storage.googleapis.com/sunrisesunset-32a25.firebasestorage.app/snapshots/5961510/1786501841956.jpg"
+        },
+        {
+          "tile": 0.105,
+          "snapshot_id": 121030,
+          "url": "https://storage.googleapis.com/sunrisesunset-32a25.firebasestorage.app/snapshots/5961510/1785951079917.jpg"
+        },
+        {
+          "tile": 0.071,
+          "snapshot_id": 123121,
+          "url": "https://storage.googleapis.com/sunrisesunset-32a25.firebasestorage.app/snapshots/5961510/1786641352219.jpg"
+        }
+      ]
+    },
+    {
+      "webcam_id": 160,
+      "meta": "Utqia\u0121vik \u203a North: Arctic Slope Telephon \u00b7 Utqia\u0121vik \u00b7 United States",
+      "labeled": 43,
+      "n_N": 37,
+      "false_shows": 4,
+      "big_false_shows": 0,
+      "distinct_days": 3,
+      "fs_rate": 0.11,
+      "mean_tile_on_N": 0.02,
+      "sample_frames": [
+        {
+          "tile": 0.349,
+          "snapshot_id": 74811,
+          "url": "https://storage.googleapis.com/sunrisesunset-32a25.firebasestorage.app/snapshots/160/1772146849544.jpg"
+        },
+        {
+          "tile": 0.313,
+          "snapshot_id": 74819,
+          "url": "https://storage.googleapis.com/sunrisesunset-32a25.firebasestorage.app/snapshots/160/1772148709614.jpg"
+        },
+        {
+          "tile": 0.17,
+          "snapshot_id": 72709,
+          "url": "https://storage.googleapis.com/sunrisesunset-32a25.firebasestorage.app/snapshots/160/1771631689539.jpg"
+        }
+      ]
+    },
+    {
+      "webcam_id": 28894257,
+      "meta": "Simkot-05 \u203a South-east: Simikot Airport  \u00b7 unknown \u00b7 Nepal",
+      "labeled": 16,
+      "n_N": 14,
+      "false_shows": 4,
+      "big_false_shows": 0,
+      "distinct_days": 3,
+      "fs_rate": 0.29,
+      "mean_tile_on_N": 0.06,
+      "sample_frames": [
+        {
+          "tile": 0.346,
+          "snapshot_id": 126684,
+          "url": "https://storage.googleapis.com/sunrisesunset-32a25.firebasestorage.app/snapshots/28894257/1788010265072.jpg"
+        },
+        {
+          "tile": 0.332,
+          "snapshot_id": 121559,
+          "url": "https://storage.googleapis.com/sunrisesunset-32a25.firebasestorage.app/snapshots/28894257/1786110336906.jpg"
+        },
+        {
+          "tile": 0.095,
+          "snapshot_id": 121650,
+          "url": "https://storage.googleapis.com/sunrisesunset-32a25.firebasestorage.app/snapshots/28894257/1786146336314.jpg"
+        }
+      ]
+    },
+    {
+      "webcam_id": 2051,
+      "meta": "ingeyri \u203a North-west: H\u00f6f\u00f0i Westfjords \u00b7 ingeyri \u00b7 Iceland",
+      "labeled": 13,
+      "n_N": 5,
+      "false_shows": 4,
+      "big_false_shows": 0,
+      "distinct_days": 2,
+      "fs_rate": 0.8,
+      "mean_tile_on_N": 0.284,
+      "sample_frames": [
+        {
+          "tile": 0.446,
+          "snapshot_id": 126547,
+          "url": "https://storage.googleapis.com/sunrisesunset-32a25.firebasestorage.app/snapshots/2051/1787962556238.jpg"
+        },
+        {
+          "tile": 0.416,
+          "snapshot_id": 126562,
+          "url": "https://storage.googleapis.com/sunrisesunset-32a25.firebasestorage.app/snapshots/2051/1787966209671.jpg"
+        },
+        {
+          "tile": 0.335,
+          "snapshot_id": 124847,
+          "url": "https://storage.googleapis.com/sunrisesunset-32a25.firebasestorage.app/snapshots/2051/1787269553229.jpg"
+        }
+      ]
+    },
+    {
+      "webcam_id": 3236,
+      "meta": "Tasiilaq \u203a North-east: The Red House \u00b7 Tasiilaq \u00b7 Greenland",
+      "labeled": 75,
+      "n_N": 61,
+      "false_shows": 3,
+      "big_false_shows": 0,
+      "distinct_days": 3,
+      "fs_rate": 0.05,
+      "mean_tile_on_N": -0.001,
+      "sample_frames": [
+        {
+          "tile": 0.052,
+          "snapshot_id": 124396,
+          "url": "https://storage.googleapis.com/sunrisesunset-32a25.firebasestorage.app/snapshots/3236/1787099509095.jpg"
+        },
+        {
+          "tile": -0.032,
+          "snapshot_id": 121919,
+          "url": "https://storage.googleapis.com/sunrisesunset-32a25.firebasestorage.app/snapshots/3236/1786236356790.jpg"
+        },
+        {
+          "tile": -0.085,
+          "snapshot_id": 126100,
+          "url": "https://storage.googleapis.com/sunrisesunset-32a25.firebasestorage.app/snapshots/3236/1787785258776.jpg"
+        }
+      ]
+    },
+    {
+      "webcam_id": 404,
+      "meta": "Storuman \u203a North-west: Square \u00b7 Storuman \u00b7 Sweden",
+      "labeled": 90,
+      "n_N": 20,
+      "false_shows": 3,
+      "big_false_shows": 0,
+      "distinct_days": 2,
+      "fs_rate": 0.15,
+      "mean_tile_on_N": 0.019,
+      "sample_frames": [
+        {
+          "tile": 0.283,
+          "snapshot_id": 120178,
+          "url": "https://storage.googleapis.com/sunrisesunset-32a25.firebasestorage.app/snapshots/404/1785705369008.jpg"
+        },
+        {
+          "tile": 0.085,
+          "snapshot_id": 120201,
+          "url": "https://storage.googleapis.com/sunrisesunset-32a25.firebasestorage.app/snapshots/404/1785708082347.jpg"
+        },
+        {
+          "tile": 0.015,
+          "snapshot_id": 123426,
+          "url": "https://storage.googleapis.com/sunrisesunset-32a25.firebasestorage.app/snapshots/404/1786742150060.jpg"
+        }
+      ]
+    },
+    {
+      "webcam_id": 3309592,
+      "meta": "York \u203a South-east: White Gum Air Park \u00b7 York \u00b7 Australia",
+      "labeled": 8,
+      "n_N": 7,
+      "false_shows": 3,
+      "big_false_shows": 0,
+      "distinct_days": 3,
+      "fs_rate": 0.43,
+      "mean_tile_on_N": 0.075,
+      "sample_frames": [
+        {
+          "tile": 0.347,
+          "snapshot_id": 121527,
+          "url": "https://storage.googleapis.com/sunrisesunset-32a25.firebasestorage.app/snapshots/3309592/1786097749544.jpg"
+        },
+        {
+          "tile": 0.11,
+          "snapshot_id": 120971,
+          "url": "https://storage.googleapis.com/sunrisesunset-32a25.firebasestorage.app/snapshots/3309592/1785924945766.jpg"
+        },
+        {
+          "tile": 0.065,
+          "snapshot_id": 119751,
+          "url": "https://storage.googleapis.com/sunrisesunset-32a25.firebasestorage.app/snapshots/3309592/1785579336309.jpg"
+        }
+      ]
+    },
+    {
+      "webcam_id": 2972357,
+      "meta": "Valleyview: Hwy 43: South of Twp Rd 700  \u00b7 unknown \u00b7 Canada",
+      "labeled": 28,
+      "n_N": 17,
+      "false_shows": 3,
+      "big_false_shows": 0,
+      "distinct_days": 3,
+      "fs_rate": 0.18,
+      "mean_tile_on_N": -0.021,
+      "sample_frames": [
+        {
+          "tile": -0.052,
+          "snapshot_id": 125962,
+          "url": "https://storage.googleapis.com/sunrisesunset-32a25.firebasestorage.app/snapshots/2972357/1787715125621.jpg"
+        },
+        {
+          "tile": -0.129,
+          "snapshot_id": 121469,
+          "url": "https://storage.googleapis.com/sunrisesunset-32a25.firebasestorage.app/snapshots/2972357/1786077939157.jpg"
+        },
+        {
+          "tile": -0.168,
+          "snapshot_id": 125108,
+          "url": "https://storage.googleapis.com/sunrisesunset-32a25.firebasestorage.app/snapshots/2972357/1787370353196.jpg"
+        }
+      ]
+    },
+    {
+      "webcam_id": 29048102,
+      "meta": "Albany \u203a West: I 80 Cooper Cove - West \u00b7 unknown \u00b7 United States",
+      "labeled": 20,
+      "n_N": 8,
+      "false_shows": 3,
+      "big_false_shows": 0,
+      "distinct_days": 2,
+      "fs_rate": 0.38,
+      "mean_tile_on_N": 0.042,
+      "sample_frames": [
+        {
+          "tile": 0.198,
+          "snapshot_id": 119767,
+          "url": "https://storage.googleapis.com/sunrisesunset-32a25.firebasestorage.app/snapshots/29048102/1785583882018.jpg"
+        },
+        {
+          "tile": 0.108,
+          "snapshot_id": 121541,
+          "url": "https://storage.googleapis.com/sunrisesunset-32a25.firebasestorage.app/snapshots/29048102/1786103136143.jpg"
+        },
+        {
+          "tile": 0.028,
+          "snapshot_id": 121539,
+          "url": "https://storage.googleapis.com/sunrisesunset-32a25.firebasestorage.app/snapshots/29048102/1786102293243.jpg"
+        }
+      ]
+    },
+    {
+      "webcam_id": 27660488,
+      "meta": "South Slave Region: Taltson River Airstr \u00b7 unknown \u00b7 Canada",
+      "labeled": 50,
+      "n_N": 6,
+      "false_shows": 3,
+      "big_false_shows": 0,
+      "distinct_days": 2,
+      "fs_rate": 0.5,
+      "mean_tile_on_N": 0.129,
+      "sample_frames": [
+        {
+          "tile": 0.319,
+          "snapshot_id": 120897,
+          "url": "https://storage.googleapis.com/sunrisesunset-32a25.firebasestorage.app/snapshots/27660488/1785904528717.jpg"
+        },
+        {
+          "tile": 0.293,
+          "snapshot_id": 121967,
+          "url": "https://storage.googleapis.com/sunrisesunset-32a25.firebasestorage.app/snapshots/27660488/1786250750639.jpg"
+        },
+        {
+          "tile": 0.16,
+          "snapshot_id": 121964,
+          "url": "https://storage.googleapis.com/sunrisesunset-32a25.firebasestorage.app/snapshots/27660488/1786249847119.jpg"
+        }
+      ]
+    },
+    {
+      "webcam_id": 29182812,
+      "meta": "Mullaquana \u203a South-west: Ceduna -> Facin \u00b7 unknown \u00b7 Australia",
+      "labeled": 6,
+      "n_N": 4,
+      "false_shows": 3,
+      "big_false_shows": 0,
+      "distinct_days": 3,
+      "fs_rate": 0.75,
+      "mean_tile_on_N": 0.295,
+      "sample_frames": [
+        {
+          "tile": 0.488,
+          "snapshot_id": 122797,
+          "url": "https://storage.googleapis.com/sunrisesunset-32a25.firebasestorage.app/snapshots/29182812/1786525307492.jpg"
+        },
+        {
+          "tile": 0.476,
+          "snapshot_id": 123289,
+          "url": "https://storage.googleapis.com/sunrisesunset-32a25.firebasestorage.app/snapshots/29182812/1786698115719.jpg"
+        },
+        {
+          "tile": 0.217,
+          "snapshot_id": 123809,
+          "url": "https://storage.googleapis.com/sunrisesunset-32a25.firebasestorage.app/snapshots/29182812/1786871755525.jpg"
+        }
+      ]
+    }
+  ],
+  "miss_offenders": [
+    {
+      "webcam_id": 28588659,
+      "meta": "Oriental \u203a North: Cartago \u00b7 Oriental \u00b7 Costa Rica",
+      "labeled": 67,
+      "n_ge4": 2,
+      "miss4": 2,
+      "distinct_days": 2
+    },
+    {
+      "webcam_id": 5358806,
+      "meta": "Cochrane \u00b7 Cochrane \u00b7 Canada",
+      "labeled": 131,
+      "n_ge4": 2,
+      "miss4": 2,
+      "distinct_days": 2
+    },
+    {
+      "webcam_id": 27046337,
+      "meta": "Arica \u203a North: Aeropuerto Internacional  \u00b7 Arica \u00b7 Chile",
+      "labeled": 40,
+      "n_ge4": 6,
+      "miss4": 2,
+      "distinct_days": 2
+    }
+  ]
+}

--- a/ml/audit_camera_errors.py
+++ b/ml/audit_camera_errors.py
@@ -1,0 +1,204 @@
+#!/usr/bin/env python3
+"""Per-camera error audit: which cameras systematically fool the shipping pair?
+
+Scores EVERY operator-labeled webcam frame through the shipping ONNX pair
+(the verified score_manifest preprocessing — archived ai_regression_score is
+mostly v4-era and says nothing about the current heads) and aggregates errors
+by camera. Motivated by webcam 3656741 putting two N frames in the v2
+confirmation's top-8 tiles an hour apart.
+
+Error classes, composed exactly as production composes (gate x quality):
+  false_show      operator N, p_sunset >= gate            (shown at all)
+  big_false_show  operator N, tile >= --big-tile          (shown LARGE)
+  miss4           operator rating >= 4, p_sunset < gate   (a showcase frame hidden)
+
+A camera is an OFFENDER only with repeated evidence: >= --min-events errors
+across >= --min-days distinct capture days. One bad frame is noise — the
+same standard that caught three non-replicating detection "wins."
+
+Population caveat: manual_labels is dominated by hard-example draws (the
+v4-era disagreement queue), so rates are NOT production rates; the audit
+ranks cameras against each other on the same biased population.
+
+Usage:
+  .venv/bin/python ml/audit_camera_errors.py
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from collections import defaultdict
+from pathlib import Path
+
+import numpy as np
+import onnxruntime as ort
+import psycopg2
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from score_manifest import load_image, softmax_positive  # noqa: E402
+
+BINARY_DEFAULT = "ml/artifacts/models/binary_resnet18/20260829_062437_v5_binary_gold/model.onnx"
+QUALITY_DEFAULT = (
+    "ml/artifacts/models/regression_resnet18/"
+    "20260830_190519_v5_quality_llm_backbone_finetune/model.onnx"
+)
+
+
+def load_env_local() -> None:
+    env = Path(__file__).resolve().parent.parent / ".env.local"
+    if not env.exists():
+        return
+    for line in env.read_text().splitlines():
+        line = line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, _, val = line.partition("=")
+        os.environ.setdefault(key.strip(), val.strip().strip('"').strip("'"))
+
+
+def main() -> None:
+    p = argparse.ArgumentParser(description="Per-camera error audit vs operator truth")
+    p.add_argument("--gate", type=float, default=0.55)
+    p.add_argument("--big-tile", type=float, default=0.5)
+    p.add_argument("--min-events", type=int, default=3)
+    p.add_argument("--min-days", type=int, default=2)
+    p.add_argument("--binary-onnx", default=BINARY_DEFAULT)
+    p.add_argument("--quality-onnx", default=QUALITY_DEFAULT)
+    p.add_argument("--cache-dir", default="ml/artifacts/image_cache")
+    p.add_argument("--limit", type=int, default=None, help="frame cap, for smoke runs")
+    args = p.parse_args()
+
+    load_env_local()
+    conn = psycopg2.connect(os.environ["DATABASE_URL"])
+    cur = conn.cursor()
+    cur.execute(
+        """
+        SELECT s.id, s.webcam_id, m.is_sunset, m.rating,
+               s.captured_at::date, s.firebase_url,
+               COALESCE(w.title,''), COALESCE(w.city,''), COALESCE(w.country,'')
+        FROM manual_labels m
+        JOIN webcam_snapshots s ON s.id = m.image_id
+        LEFT JOIN webcams w ON w.id = s.webcam_id
+        WHERE m.source = 'webcam' AND s.firebase_url IS NOT NULL
+        ORDER BY s.id
+        """
+    )
+    frames = cur.fetchall()
+    conn.close()
+    if args.limit:
+        frames = frames[: args.limit]
+    print(f"  scoring {len(frames)} labeled frames through the shipping pair…")
+
+    bsess = ort.InferenceSession(args.binary_onnx)
+    qsess = ort.InferenceSession(args.quality_onnx)
+    bin_name = bsess.get_inputs()[0].name
+    q_name = qsess.get_inputs()[0].name
+    cache = Path(args.cache_dir)
+    cache.mkdir(parents=True, exist_ok=True)
+
+    cams: dict[int, dict] = defaultdict(lambda: dict(
+        n=0, n_N=0, n_ge4=0, false_shows=0, big_false_shows=0, miss4=0,
+        fs_days=set(), miss_days=set(), tile_sum_N=0.0,
+        meta="", worst=[],  # (tile, snapshot_id, url) for op-N frames shown
+    ))
+    skipped = 0
+    for i, (sid, wid, is_sunset, rating, day, url, title, city, country) in enumerate(frames):
+        if i and i % 1000 == 0:
+            print(f"  …{i}/{len(frames)} (skipped {skipped})")
+        arr = load_image(str(url), cache)
+        if arr is None:
+            skipped += 1
+            continue
+        p_sun = softmax_positive(
+            np.asarray(bsess.run(None, {bin_name: arr})[0][0], dtype=np.float32))
+        q = float(np.asarray(qsess.run(None, {q_name: arr})[0]).squeeze())
+        shown = p_sun >= args.gate
+        tile = q if shown else 0.0
+
+        c = cams[wid]
+        c["n"] += 1
+        c["meta"] = " · ".join(x for x in (title[:40], city, country) if x)
+        if not is_sunset:
+            c["n_N"] += 1
+            c["tile_sum_N"] += tile
+            if shown:
+                c["false_shows"] += 1
+                c["fs_days"].add(str(day))
+                c["worst"].append((round(tile, 3), sid, url))
+            if tile >= args.big_tile:
+                c["big_false_shows"] += 1
+        elif rating is not None and rating >= 4:
+            c["n_ge4"] += 1
+            if not shown:
+                c["miss4"] += 1
+                c["miss_days"].add(str(day))
+
+    def offender_rows(kind: str):
+        rows = []
+        for wid, c in cams.items():
+            if kind == "false_show":
+                events, days = c["false_shows"], len(c["fs_days"])
+                if events >= args.min_events and days >= args.min_days:
+                    rows.append(dict(
+                        webcam_id=wid, meta=c["meta"], labeled=c["n"], n_N=c["n_N"],
+                        false_shows=events, big_false_shows=c["big_false_shows"],
+                        distinct_days=days,
+                        fs_rate=round(events / max(c["n_N"], 1), 2),
+                        mean_tile_on_N=round(c["tile_sum_N"] / max(c["n_N"], 1), 3),
+                        sample_frames=[dict(tile=t, snapshot_id=s, url=u)
+                                       for t, s, u in sorted(c["worst"], reverse=True)[:3]],
+                    ))
+            else:
+                events, days = c["miss4"], len(c["miss_days"])
+                if events >= 2 and days >= args.min_days:
+                    rows.append(dict(
+                        webcam_id=wid, meta=c["meta"], labeled=c["n"],
+                        n_ge4=c["n_ge4"], miss4=events, distinct_days=days,
+                    ))
+        key = "big_false_shows" if kind == "false_show" else "miss4"
+        return sorted(rows, key=lambda r: (r.get(key, 0), r.get("false_shows", 0)),
+                      reverse=True)
+
+    show_offenders = offender_rows("false_show")
+    miss_offenders = offender_rows("miss")
+
+    total_N = sum(c["n_N"] for c in cams.values())
+    total_fs = sum(c["false_shows"] for c in cams.values())
+    total_big = sum(c["big_false_shows"] for c in cams.values())
+    print(f"\n  frames scored: {len(frames) - skipped} (skipped {skipped}), "
+          f"cameras: {len(cams)}")
+    print(f"  operator-N frames: {total_N}; shown {total_fs} "
+          f"({total_fs / max(total_N,1):.1%}), shown BIG {total_big} "
+          f"({total_big / max(total_N,1):.1%})")
+    conc = sum(r["false_shows"] for r in show_offenders)
+    print(f"  false-shows concentrated in {len(show_offenders)} offender cameras: "
+          f"{conc}/{total_fs} ({conc / max(total_fs,1):.0%})")
+    print(f"\n  top false-show offenders (>= {args.min_events} events, "
+          f">= {args.min_days} days):")
+    for r in show_offenders[:15]:
+        print(f"    cam {r['webcam_id']:>8}  fs {r['false_shows']:>3} "
+              f"(big {r['big_false_shows']:>3}) over {r['distinct_days']:>2}d  "
+              f"rate {r['fs_rate']:>5}  meanTileN {r['mean_tile_on_N']:>5}  {r['meta']}")
+    print(f"\n  top >=4-miss cameras (silhouette candidates):")
+    for r in miss_offenders[:10]:
+        print(f"    cam {r['webcam_id']:>8}  miss4 {r['miss4']} / {r['n_ge4']} "
+              f"over {r['distinct_days']}d  {r['meta']}")
+
+    out = Path("ml/artifacts/reports/camera_error_audit_v1.json")
+    out.write_text(json.dumps(dict(
+        gate=args.gate, big_tile=args.big_tile,
+        min_events=args.min_events, min_days=args.min_days,
+        binary_onnx=args.binary_onnx, quality_onnx=args.quality_onnx,
+        frames_scored=len(frames) - skipped, skipped=skipped,
+        cameras=len(cams), operator_N=total_N,
+        false_shows=total_fs, big_false_shows=total_big,
+        offenders=show_offenders, miss_offenders=miss_offenders,
+    ), indent=2))
+    print(f"\n  report: {out}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
First failure-mode-track item after the retest ceiling verdict. Rescores all 9,118 operator-labeled frames through the shipping ONNX pair (verified preprocessing; archived scores are ~92% v4-era junk) and aggregates errors per camera with a repeated-evidence bar (≥3 events, ≥2 distinct days).

**Findings** (full write-up in `docs/ml/2026-08-31-camera-error-audit.md`):
- 169/5,538 operator-N frames false-show (3.1%); only 27 at big-tile size
- 17 cameras account for 42% of false-shows; top 4 (Broome Airport 11/11 over 9 days, Coober Pedy opal mine, two more airports) account for a third of the big ones
- Failure class: warm floodlights / red terrain near the horizon — not sky
- Camera 3656741 did NOT recur — the repeated-days bar filtered the earlier anecdote out
- ≥4 misses barely recur (3 cameras × 2 events) — no systematic silhouette camera yet

**Proposed mitigation** (not in this PR): display-side showcase cap for the 4 big-tile offenders in qualitySignal — small, evidence-backed, reversible, lands before the Sept 13 showing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PFEBJDpDderUkdc5GsrgEt