### PR TITLE
Per-camera calibration leg 1: nightly tempering prior with frame retention

### DIFF
--- a/app/api/admin/calibration-frames/route.ts
+++ b/app/api/admin/calibration-frames/route.ts
@@ -1,0 +1,37 @@
+import { NextResponse } from 'next/server';
+import { requireOwner } from '@/app/lib/owner';
+import { sql } from '@/app/lib/db';
+import type { CalibrationFrameRow } from '@/app/lib/opsTypes';
+
+export const dynamic = 'force-dynamic';
+export const runtime = 'nodejs';
+
+// The frames behind one camera's tempering multiplier. Fetched on expand
+// rather than bundled into ops-stats: the evidence table holds ~9k rows today
+// and only grows as labels accumulate.
+export async function GET(request: Request) {
+  const denied = await requireOwner();
+  if (denied) return denied;
+
+  const webcamId = Number(
+    new URL(request.url).searchParams.get('webcamId') ?? '',
+  );
+  if (!Number.isFinite(webcamId)) {
+    return NextResponse.json({ error: 'webcamId required' }, { status: 400 });
+  }
+
+  const frames = (await sql`
+    select snapshot_id, captured_on::text as captured_on,
+           p_sunset::float as p_sunset,
+           tile::float as tile,
+           firebase_url
+    from camera_calibration_evidence
+    where webcam_id = ${webcamId}
+      and is_negative = true
+      and fired = true
+    order by tile desc nulls last
+    limit 50
+  `) as unknown as CalibrationFrameRow[];
+
+  return NextResponse.json({ frames });
+}

--- a/app/api/admin/ops-stats/route.ts
+++ b/app/api/admin/ops-stats/route.ts
@@ -7,6 +7,8 @@ import type {
   OpsStatsResponse,
   ProviderUsageRow,
   CostEventRow,
+  CalibrationCameraRow,
+  CalibrationHistoryRow,
 } from '@/app/lib/opsTypes';
 
 export const dynamic = 'force-dynamic';
@@ -37,6 +39,31 @@ export async function GET() {
     ORDER BY occurred_on ASC
   `) as unknown as CostEventRow[];
 
+  // Per-camera calibration. The ::float casts are deliberate — NUMERIC
+  // otherwise arrives as a string through the Neon driver.
+  const calibrationCameras = (await sql`
+    select w.id as webcam_id, w.title,
+           w.calibration_multiplier::float as multiplier,
+           (w.calibration_evidence->>'falseShows')::float     as false_shows,
+           (w.calibration_evidence->>'negativeFrames')::float as negative_frames,
+           (w.calibration_evidence->>'falseShowDays')::int    as false_show_days,
+           w.calibration_computed_at::text as computed_at
+    from webcams w
+    where w.calibration_multiplier is not null
+      and w.calibration_multiplier < 1
+    order by w.calibration_multiplier asc
+    limit 100
+  `) as unknown as CalibrationCameraRow[];
+
+  const calibrationHistory = (await sql`
+    select webcam_id, computed_at::text as computed_at,
+           multiplier::float as multiplier,
+           previous_multiplier::float as previous_multiplier
+    from camera_calibration_history
+    order by computed_at desc
+    limit 200
+  `) as unknown as CalibrationHistoryRow[];
+
   const body: OpsStatsResponse = {
     dailyStats: rows.reverse(), // oldest → newest for charting
     providerUsage: providerUsage.map((r) => ({
@@ -44,6 +71,8 @@ export async function GET() {
       compute_time_s: Number(r.compute_time_s),
     })),
     costEvents,
+    calibrationCameras,
+    calibrationHistory,
   };
   return NextResponse.json(body);
 }

--- a/app/api/cron/recompute-camera-calibration/route.ts
+++ b/app/api/cron/recompute-camera-calibration/route.ts
@@ -1,0 +1,48 @@
+import { NextResponse } from 'next/server';
+import { verifyCronAuth } from '../update-cameras/lib/auth';
+import { recomputeCameraCalibration } from '../update-cameras/lib/recomputeCameraCalibration';
+import { resolveBinaryModelVersion } from '../update-cameras/lib/aiScoring';
+
+export const dynamic = 'force-dynamic';
+export const maxDuration = 60;
+
+// Per-camera calibration recompute.
+// Spec: docs/superpowers/specs/2026-08-31-per-camera-calibration-design.md
+//
+// Derives a bounded per-camera tempering multiplier from accumulated error
+// evidence and writes it to the webcams row. Pure SQL recompute (no image
+// download, no ONNX), so it does NOT need the ml/artifacts bundle and runs on
+// its own nightly schedule, isolated from the live-scoring tick budget.
+//
+// It NEVER touches the detection verdict — only the tile/quality signal.
+
+async function handle(request: Request) {
+  if (!verifyCronAuth(request) && process.env.NODE_ENV !== 'development') {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+  try {
+    const result = await recomputeCameraCalibration({
+      // The EFFECTIVE version, not the default constant — env can override it,
+      // and the evidence rows are scoped by the version actually in use.
+      modelVersion: resolveBinaryModelVersion(),
+    });
+    return NextResponse.json({ ok: true, ...result });
+  } catch (error) {
+    console.error('[recompute-camera-calibration] failed:', error);
+    return NextResponse.json(
+      {
+        error: 'Internal server error',
+        details: error instanceof Error ? error.message : 'Unknown error',
+      },
+      { status: 500 },
+    );
+  }
+}
+
+export async function GET(request: Request) {
+  return handle(request);
+}
+
+export async function POST(request: Request) {
+  return handle(request);
+}

--- a/app/api/cron/update-cameras/lib/aiScoring.ts
+++ b/app/api/cron/update-cameras/lib/aiScoring.ts
@@ -103,7 +103,7 @@ function resolveBinaryModelPath(): string {
     AI_ONNX_BINARY_MODEL_PATH_DEFAULT;
   return path.isAbsolute(ref) ? ref : path.join(process.cwd(), ref);
 }
-function resolveBinaryModelVersion(): string {
+export function resolveBinaryModelVersion(): string {
   return (
     process.env.AI_BINARY_MODEL_VERSION?.trim() ||
     AI_BINARY_MODEL_VERSION_DEFAULT

--- a/app/api/cron/update-cameras/lib/dailyDigest.test.ts
+++ b/app/api/cron/update-cameras/lib/dailyDigest.test.ts
@@ -7,7 +7,7 @@ vi.mock('@/app/lib/db', () => ({
     sqlMock(strings, ...values),
 }));
 
-import { sendDailyUsageDigest } from './dailyDigest';
+import { sendDailyUsageDigest, formatCalibrationLine } from './dailyDigest';
 
 const NOW = new Date('2026-08-03T00:20:00Z');
 const SUNSET = 'noisy-leaf-96391119';
@@ -82,5 +82,105 @@ describe('sendDailyUsageDigest', () => {
     fetchMock.mockRejectedValueOnce(new Error('resend down'));
     const result = await sendDailyUsageDigest(NOW);
     expect(result).toEqual({ skipped: 'send-failed' });
+  });
+});
+
+describe('calibration section is isolated from the cost email', () => {
+  const fetchMock = vi.fn();
+  beforeEach(() => {
+    sqlMock.mockReset();
+    fetchMock.mockReset();
+    vi.stubGlobal('fetch', fetchMock);
+    process.env.RESEND_API_KEY = 'test-key';
+    process.env.DIGEST_EMAIL_TO = 'jesse@example.com';
+  });
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    delete process.env.RESEND_API_KEY;
+    delete process.env.DIGEST_EMAIL_TO;
+  });
+
+  // The digest's job is the cost email. If the calibration tables are missing
+  // (migration not run on some environment) the email must still go out.
+  it('still sends the cost email when the calibration query throws', async () => {
+    sqlMock
+      .mockResolvedValueOnce(usageRows)
+      .mockResolvedValueOnce(eventRows)
+      .mockRejectedValue(new Error('relation "camera_calibration_history" does not exist'));
+    fetchMock.mockResolvedValueOnce({ ok: true, json: async () => ({ id: 'em_1' }) });
+
+    const result = await sendDailyUsageDigest(NOW);
+
+    expect(result).toEqual({ sent: true });
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+    expect(body.html).toContain('CU-hr');        // cost content survived
+    expect(body.html).not.toContain('Calibration:'); // section degraded to silence
+  });
+
+  it('includes the calibration line when the data is available', async () => {
+    sqlMock
+      .mockResolvedValueOnce(usageRows)
+      .mockResolvedValueOnce(eventRows)
+      .mockResolvedValueOnce([{ tempered: 17 }])
+      .mockResolvedValueOnce([
+        { webcam_id: 4057187, title: 'Broome International Airport', multiplier: 0.59 },
+      ])
+      .mockResolvedValueOnce([{ healed: 1 }]);
+    fetchMock.mockResolvedValueOnce({ ok: true, json: async () => ({ id: 'em_1' }) });
+
+    await sendDailyUsageDigest(NOW);
+
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+    expect(body.html).toContain('17 cameras tempered');
+    expect(body.html).toContain('Broome International Airport 0.59');
+    expect(body.html).toContain('1 healed');
+  });
+});
+
+describe('formatCalibrationLine', () => {
+  it('renders total, newly tempered with names, and healed', () => {
+    const html = formatCalibrationLine({
+      tempered: 17,
+      newlyTempered: [
+        { webcamId: 4057187, title: 'Broome International Airport', multiplier: 0.59 },
+        { webcamId: 29182812, title: 'Ceduna', multiplier: 0.72 },
+      ],
+      healed: 1,
+    });
+    expect(html).toContain('17 cameras tempered');
+    expect(html).toContain('2 newly tempered');
+    expect(html).toContain('Broome International Airport 0.59');
+    expect(html).toContain('Ceduna 0.72');
+    expect(html).toContain('1 healed');
+  });
+
+  it('omits the newly/healed clauses when nothing changed', () => {
+    const html = formatCalibrationLine({ tempered: 17, newlyTempered: [], healed: 0 });
+    expect(html).toContain('17 cameras tempered');
+    expect(html).toContain('no changes');
+    expect(html).not.toContain('newly tempered');
+    expect(html).not.toContain('healed');
+  });
+
+  it('renders nothing at all when calibration data is unavailable', () => {
+    expect(formatCalibrationLine(null)).toBe('');
+  });
+
+  it('falls back to the webcam id when a camera has no title', () => {
+    const html = formatCalibrationLine({
+      tempered: 1,
+      newlyTempered: [{ webcamId: 4057187, title: null, multiplier: 0.59 }],
+      healed: 0,
+    });
+    expect(html).toContain('#4057187 0.59');
+  });
+
+  it('singularises one newly tempered camera', () => {
+    const html = formatCalibrationLine({
+      tempered: 3,
+      newlyTempered: [{ webcamId: 1, title: 'A', multiplier: 0.8 }],
+      healed: 0,
+    });
+    expect(html).toContain('1 newly tempered');
   });
 });

--- a/app/api/cron/update-cameras/lib/dailyDigest.ts
+++ b/app/api/cron/update-cameras/lib/dailyDigest.ts
@@ -1,4 +1,8 @@
 import { sql } from '@/app/lib/db';
+import {
+  getCalibrationDigestSummary,
+  type CalibrationDigestSummary,
+} from './dbOperations';
 import { deriveDailyDeltas } from '@/app/components/Ops/opsMath';
 import type { ProviderUsageRow, CostEventRow } from '@/app/lib/opsTypes';
 import {
@@ -13,6 +17,35 @@ const LABELS: Record<string, string> = {
   [SUNSET_PROJECT]: 'sunrise-sunset (this site)',
   [NWAC_PROJECT]: 'nwac-observations',
 };
+
+/**
+ * One-line per-camera calibration summary for the digest.
+ *
+ * Ambient awareness, not an audit surface: the Ops tab answers "why is this
+ * camera at 0.59"; this answers "did anything change while I wasn't looking".
+ * Steady state is one clause; the events worth knowing are cameras newly
+ * tempered and cameras that healed.
+ *
+ * `null` (calibration unavailable) renders nothing rather than an error line.
+ */
+export function formatCalibrationLine(
+  summary: CalibrationDigestSummary | null,
+): string {
+  if (!summary) return '';
+  const { tempered, newlyTempered, healed } = summary;
+
+  const parts: string[] = [`<b>${tempered} cameras tempered</b>`];
+  if (newlyTempered.length > 0) {
+    const named = newlyTempered
+      .map((c) => `${c.title ?? `#${c.webcamId}`} ${c.multiplier.toFixed(2)}`)
+      .join(', ');
+    parts.push(`${newlyTempered.length} newly tempered (${named})`);
+  }
+  if (healed > 0) parts.push(`${healed} healed`);
+  if (newlyTempered.length === 0 && healed === 0) parts.push('no changes');
+
+  return `<p style="font:12px sans-serif">Calibration: ${parts.join(' · ')}</p>`;
+}
 
 // Daily usage digest email, sent right after the once-per-UTC-day provider
 // snapshot lands (the caller gates on that, which gives once-a-day semantics
@@ -40,6 +73,11 @@ export async function sendDailyUsageDigest(
       WHERE occurred_on > CURRENT_DATE - ${DIGEST_LOOKBACK_DAYS}::int
       ORDER BY occurred_on ASC
     `) as unknown as CostEventRow[];
+
+    // Isolated on purpose: getCalibrationDigestSummary swallows its own
+    // failures and returns null, so a missing calibration table degrades this
+    // section to silence instead of killing the cost email.
+    const calibration = await getCalibrationDigestSummary();
 
     const rows = usage.map((r) => ({ ...r, compute_time_s: Number(r.compute_time_s) }));
     const deltas = deriveDailyDeltas(rows);
@@ -110,6 +148,7 @@ export async function sendDailyUsageDigest(
             : '<p style="font:12px sans-serif">Daily chart appears after two snapshots.</p>'
         }
         ${eventList}
+        ${formatCalibrationLine(calibration)}
         <p style="font:11px sans-serif;color:#6b7280">
           Same data as the Ops tab. Estimate uses $${NEON_COST_PER_CU_HOUR}/CU-hr;
           the invoice of record is Vercel → Settings → Billing.

--- a/app/api/cron/update-cameras/lib/dbOperations.ts
+++ b/app/api/cron/update-cameras/lib/dbOperations.ts
@@ -901,3 +901,61 @@ export async function insertCalibrationHistoryBatch(
     )
   `;
 }
+
+export interface CalibrationDigestSummary {
+  tempered: number;
+  newlyTempered: { webcamId: number; title: string | null; multiplier: number }[];
+  healed: number;
+}
+
+/**
+ * Fleet-level calibration summary for the daily digest.
+ *
+ * Returns null rather than throwing when the calibration tables are absent
+ * (an environment where the migration has not run). The digest's job is the
+ * cost email; a missing calibration surface must degrade to silence, never
+ * take the whole email down with it.
+ */
+export async function getCalibrationDigestSummary(): Promise<CalibrationDigestSummary | null> {
+  try {
+    const totals = (await sql`
+      select count(*)::int as tempered
+      from webcams
+      where calibration_multiplier is not null and calibration_multiplier < 1
+    `) as { tempered: number }[];
+
+    // "Newly tempered" = crossed from neutral into tempered in the last day.
+    const newly = (await sql`
+      select h.webcam_id, w.title, h.multiplier::float as multiplier
+      from camera_calibration_history h
+      join webcams w on w.id = h.webcam_id
+      where h.computed_at > now() - interval '1 day'
+        and h.multiplier < 1
+        and (h.previous_multiplier is null or h.previous_multiplier >= 1)
+      order by h.multiplier asc
+      limit 5
+    `) as { webcam_id: number; title: string | null; multiplier: number }[];
+
+    const healedRows = (await sql`
+      select count(*)::int as healed
+      from camera_calibration_history
+      where computed_at > now() - interval '1 day'
+        and multiplier >= 1
+        and previous_multiplier is not null
+        and previous_multiplier < 1
+    `) as { healed: number }[];
+
+    return {
+      tempered: Number(totals[0]?.tempered ?? 0),
+      newlyTempered: newly.map((r) => ({
+        webcamId: Number(r.webcam_id),
+        title: r.title,
+        multiplier: Number(r.multiplier),
+      })),
+      healed: Number(healedRows[0]?.healed ?? 0),
+    };
+  } catch (error) {
+    console.warn('[calibrationDigest] summary unavailable:', error);
+    return null;
+  }
+}

--- a/app/api/cron/update-cameras/lib/dbOperations.ts
+++ b/app/api/cron/update-cameras/lib/dbOperations.ts
@@ -785,3 +785,119 @@ export async function updateExternalImageDisagreementsBatch(
   `;
 }
 
+
+/* -------------------------------------------------------------------------- */
+/* Per-camera calibration (tempering prior)                                    */
+/* Spec: docs/superpowers/specs/2026-08-31-per-camera-calibration-design.md    */
+/* -------------------------------------------------------------------------- */
+
+export interface CameraCalibrationRow {
+  webcamId: number;
+  falseShows: number;
+  negativeFrames: number;
+  falseShowDays: number;
+  rawFalseShows: number;
+  previousMultiplier: number | null;
+}
+
+/**
+ * Aggregate calibration evidence per camera, scoped to ONE model generation
+ * and a rolling window, with exponential decay applied in SQL.
+ *
+ * The window governs eligibility (so a camera with no recent false-show heals
+ * completely); the decay governs magnitude (so it relaxes smoothly first).
+ */
+export async function findCalibrationEvidenceByCamera(
+  modelVersion: string,
+  windowDays: number,
+  halfLifeDays: number,
+): Promise<CameraCalibrationRow[]> {
+  const rows = (await sql`
+    select e.webcam_id                                             as webcam_id,
+           sum(case when e.is_negative and e.fired
+                    then power(0.5, (current_date - e.captured_on)::numeric
+                                    / ${halfLifeDays}::numeric)
+                    else 0 end)                                    as false_shows,
+           sum(case when e.is_negative
+                    then power(0.5, (current_date - e.captured_on)::numeric
+                                    / ${halfLifeDays}::numeric)
+                    else 0 end)                                    as negative_frames,
+           count(distinct case when e.is_negative and e.fired
+                               then e.captured_on end)             as false_show_days,
+           count(*) filter (where e.is_negative and e.fired)       as raw_false_shows,
+           max(w.calibration_multiplier)                           as previous_multiplier
+    from camera_calibration_evidence e
+    join webcams w on w.id = e.webcam_id
+    where e.model_version = ${modelVersion}
+      and e.captured_on > current_date - ${windowDays}::int
+    group by e.webcam_id
+  `) as {
+    webcam_id: number;
+    false_shows: number | string;
+    negative_frames: number | string;
+    false_show_days: number | string;
+    raw_false_shows: number | string;
+    previous_multiplier: number | string | null;
+  }[];
+
+  // NUMERIC comes back as a STRING through the Neon driver — coerce every one.
+  return rows.map((r) => ({
+    webcamId: Number(r.webcam_id),
+    falseShows: Number(r.false_shows),
+    negativeFrames: Number(r.negative_frames),
+    falseShowDays: Number(r.false_show_days),
+    rawFalseShows: Number(r.raw_false_shows),
+    previousMultiplier:
+      r.previous_multiplier == null ? null : Number(r.previous_multiplier),
+  }));
+}
+
+/** One batched UPDATE for the whole fleet rather than a round-trip per camera. */
+export async function updateCameraCalibrationBatch(
+  updates: { webcamId: number; multiplier: number; evidence: unknown }[],
+): Promise<void> {
+  if (updates.length === 0) return;
+  const ids = updates.map((u) => u.webcamId);
+  const mults = updates.map((u) => u.multiplier);
+  const evidence = updates.map((u) => JSON.stringify(u.evidence));
+  await sql`
+    update webcams w
+    set calibration_multiplier = v.mult,
+        calibration_evidence = v.evidence::jsonb,
+        calibration_computed_at = now()
+    from unnest(${ids}::bigint[], ${mults}::numeric[], ${evidence}::text[])
+      as v(id, mult, evidence)
+    where w.id = v.id
+  `;
+}
+
+/** Append-only. Called only for cameras whose multiplier actually changed. */
+export async function insertCalibrationHistoryBatch(
+  rows: {
+    webcamId: number;
+    multiplier: number;
+    previousMultiplier: number | null;
+    falseShows: number;
+    negativeFrames: number;
+    rawFalseShows: number;
+    falseShowDays: number;
+    modelVersion: string;
+  }[],
+): Promise<void> {
+  if (rows.length === 0) return;
+  await sql`
+    insert into camera_calibration_history
+      (webcam_id, multiplier, previous_multiplier, false_shows,
+       negative_frames, raw_false_shows, false_show_days, model_version)
+    select * from unnest(
+      ${rows.map((r) => r.webcamId)}::bigint[],
+      ${rows.map((r) => r.multiplier)}::numeric[],
+      ${rows.map((r) => r.previousMultiplier)}::numeric[],
+      ${rows.map((r) => r.falseShows)}::numeric[],
+      ${rows.map((r) => r.negativeFrames)}::numeric[],
+      ${rows.map((r) => r.rawFalseShows)}::int[],
+      ${rows.map((r) => r.falseShowDays)}::int[],
+      ${rows.map((r) => r.modelVersion)}::text[]
+    )
+  `;
+}

--- a/app/api/cron/update-cameras/lib/recomputeCameraCalibration.test.ts
+++ b/app/api/cron/update-cameras/lib/recomputeCameraCalibration.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  findCalibrationEvidenceByCamera: vi.fn(),
+  updateCameraCalibrationBatch: vi.fn(),
+  insertCalibrationHistoryBatch: vi.fn(),
+}));
+
+vi.mock('./dbOperations', () => mocks);
+
+import { recomputeCameraCalibration } from './recomputeCameraCalibration';
+
+const MODEL = '20260829_062437_v5_binary_gold';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.updateCameraCalibrationBatch.mockResolvedValue(undefined);
+  mocks.insertCalibrationHistoryBatch.mockResolvedValue(undefined);
+});
+
+describe('recomputeCameraCalibration', () => {
+  it('tempers a camera clearing the recurrence bar and records history', async () => {
+    mocks.findCalibrationEvidenceByCamera.mockResolvedValue([
+      {
+        webcamId: 4057187,
+        falseShows: 11,
+        negativeFrames: 11,
+        falseShowDays: 9,
+        rawFalseShows: 11,
+        previousMultiplier: null,
+      },
+    ]);
+
+    const result = await recomputeCameraCalibration({ modelVersion: MODEL });
+
+    expect(result).toEqual({ camerasEvaluated: 1, tempered: 1, changed: 1 });
+
+    const [updates] = mocks.updateCameraCalibrationBatch.mock.calls[0];
+    expect(updates[0].webcamId).toBe(4057187);
+    expect(updates[0].multiplier).toBeCloseTo(0.577, 3);
+
+    const [history] = mocks.insertCalibrationHistoryBatch.mock.calls[0];
+    expect(history).toHaveLength(1);
+    expect(history[0].previousMultiplier).toBeNull();
+    expect(history[0].modelVersion).toBe(MODEL);
+  });
+
+  it('writes NO history row when the multiplier is unchanged (clause 8)', async () => {
+    mocks.findCalibrationEvidenceByCamera.mockResolvedValue([
+      {
+        webcamId: 4057187,
+        falseShows: 11,
+        negativeFrames: 11,
+        falseShowDays: 9,
+        rawFalseShows: 11,
+        previousMultiplier: 0.577,
+      },
+    ]);
+
+    const result = await recomputeCameraCalibration({ modelVersion: MODEL });
+
+    expect(result.changed).toBe(0);
+    const [history] = mocks.insertCalibrationHistoryBatch.mock.calls[0];
+    expect(history).toHaveLength(0);
+  });
+
+  it('writes a history row carrying the previous value when it changes', async () => {
+    mocks.findCalibrationEvidenceByCamera.mockResolvedValue([
+      {
+        webcamId: 4057187,
+        falseShows: 4,
+        negativeFrames: 15,
+        falseShowDays: 4,
+        rawFalseShows: 4,
+        previousMultiplier: 0.577,
+      },
+    ]);
+
+    await recomputeCameraCalibration({ modelVersion: MODEL });
+
+    const [history] = mocks.insertCalibrationHistoryBatch.mock.calls[0];
+    expect(history).toHaveLength(1);
+    expect(history[0].previousMultiplier).toBe(0.577);
+    expect(history[0].multiplier).toBeCloseTo(0.882, 3);
+  });
+
+  it('heals a camera back to 1.0 and records that as a change', async () => {
+    mocks.findCalibrationEvidenceByCamera.mockResolvedValue([
+      {
+        webcamId: 4057187,
+        falseShows: 0,
+        negativeFrames: 0,
+        falseShowDays: 0,
+        rawFalseShows: 0,
+        previousMultiplier: 0.577,
+      },
+    ]);
+
+    const result = await recomputeCameraCalibration({ modelVersion: MODEL });
+
+    expect(result.tempered).toBe(0);
+    const [updates] = mocks.updateCameraCalibrationBatch.mock.calls[0];
+    expect(updates[0].multiplier).toBe(1);
+    const [history] = mocks.insertCalibrationHistoryBatch.mock.calls[0];
+    expect(history[0].multiplier).toBe(1);
+  });
+
+  it('handles an empty fleet without writing anything', async () => {
+    mocks.findCalibrationEvidenceByCamera.mockResolvedValue([]);
+
+    const result = await recomputeCameraCalibration({ modelVersion: MODEL });
+
+    expect(result).toEqual({ camerasEvaluated: 0, tempered: 0, changed: 0 });
+  });
+});

--- a/app/api/cron/update-cameras/lib/recomputeCameraCalibration.ts
+++ b/app/api/cron/update-cameras/lib/recomputeCameraCalibration.ts
@@ -1,0 +1,88 @@
+import { computeTemperingMultiplier } from '@/app/lib/cameraCalibration';
+import {
+  CALIBRATION_WINDOW_DAYS,
+  CALIBRATION_HALF_LIFE_DAYS,
+} from '@/app/lib/masterConfig';
+import {
+  findCalibrationEvidenceByCamera,
+  updateCameraCalibrationBatch,
+  insertCalibrationHistoryBatch,
+} from './dbOperations';
+
+export interface CalibrationResult {
+  camerasEvaluated: number;
+  tempered: number;
+  changed: number;
+}
+
+/** Multipliers are stored NUMERIC(4,3); anything smaller is not a real change. */
+const CHANGE_EPSILON = 0.001;
+
+/**
+ * Recompute every camera's tempering multiplier from accumulated evidence.
+ *
+ * Pure SQL + arithmetic: no image download, no ONNX. That is why this runs on
+ * its own nightly cron without the ml/artifacts bundle.
+ *
+ * History is written for CHANGES ONLY — writing every camera every night would
+ * add ~1,000 near-identical rows nightly, and webcams.calibration_computed_at
+ * already answers "did the job run".
+ */
+export async function recomputeCameraCalibration(opts: {
+  modelVersion: string;
+}): Promise<CalibrationResult> {
+  const rows = await findCalibrationEvidenceByCamera(
+    opts.modelVersion,
+    CALIBRATION_WINDOW_DAYS,
+    CALIBRATION_HALF_LIFE_DAYS,
+  );
+
+  const updates = rows.map((r) => {
+    const multiplier = computeTemperingMultiplier({
+      falseShows: r.falseShows,
+      negativeFrames: r.negativeFrames,
+      falseShowDays: r.falseShowDays,
+      rawFalseShows: r.rawFalseShows,
+    });
+    return { row: r, multiplier };
+  });
+
+  await updateCameraCalibrationBatch(
+    updates.map(({ row, multiplier }) => ({
+      webcamId: row.webcamId,
+      multiplier,
+      evidence: {
+        falseShows: row.falseShows,
+        negativeFrames: row.negativeFrames,
+        falseShowDays: row.falseShowDays,
+        rawFalseShows: row.rawFalseShows,
+        modelVersion: opts.modelVersion,
+      },
+    })),
+  );
+
+  const changed = updates.filter(
+    ({ row, multiplier }) =>
+      row.previousMultiplier == null ||
+      Math.abs(row.previousMultiplier - multiplier) > CHANGE_EPSILON,
+  );
+
+  await insertCalibrationHistoryBatch(
+    changed.map(({ row, multiplier }) => ({
+      webcamId: row.webcamId,
+      multiplier,
+      previousMultiplier: row.previousMultiplier,
+      falseShows: row.falseShows,
+      negativeFrames: row.negativeFrames,
+      rawFalseShows: row.rawFalseShows,
+      falseShowDays: row.falseShowDays,
+      modelVersion: opts.modelVersion,
+    })),
+  );
+
+  return {
+    camerasEvaluated: rows.length,
+    tempered: updates.filter((u) => u.multiplier < 1).length,
+    changed: changed.length,
+  };
+}

--- a/app/api/db-all-webcams/route.ts
+++ b/app/api/db-all-webcams/route.ts
@@ -18,7 +18,8 @@ export async function GET() {
            w.last_fetched_at, w.created_at, w.updated_at,
            w.rating, w.orientation, w.ai_rating, w.ai_model_version,
            w.ai_rating_binary, w.ai_model_version_binary,
-           w.ai_rating_regression, w.ai_model_version_regression
+           w.ai_rating_regression, w.ai_model_version_regression,
+           w.calibration_multiplier
     from webcams w
     where (w.source <> 'custom'
            or (w.state = 'deployed' and w.ended_at is null and w.paused = false))
@@ -78,6 +79,7 @@ export async function GET() {
     ai_rating: number | string | null;
     ai_model_version: string | null;
     ai_rating_binary: number | string | null;
+    calibration_multiplier: number | string | null;
     ai_model_version_binary: string | null;
     ai_rating_regression: number | string | null;
     ai_model_version_regression: string | null;
@@ -112,6 +114,7 @@ export async function GET() {
     aiRating: toMaybeNumber(row.ai_rating),
     aiModelVersion: row.ai_model_version ?? undefined,
     aiRatingBinary: toMaybeNumber(row.ai_rating_binary),
+    calibrationMultiplier: toMaybeNumber(row.calibration_multiplier),
     aiModelVersionBinary: row.ai_model_version_binary ?? undefined,
     aiRatingRegression: toMaybeNumber(row.ai_rating_regression),
     aiModelVersionRegression:

--- a/app/components/Ops/CalibrationPanel.tsx
+++ b/app/components/Ops/CalibrationPanel.tsx
@@ -1,0 +1,159 @@
+'use client';
+
+import { useState } from 'react';
+import { Box, Typography } from '@mui/material';
+import type {
+  CalibrationCameraRow,
+  CalibrationHistoryRow,
+  CalibrationFrameRow,
+} from '@/app/lib/opsTypes';
+
+/**
+ * Per-camera calibration surface.
+ * Spec: docs/superpowers/specs/2026-08-31-per-camera-calibration-design.md
+ *
+ * Three things, because retained evidence is only useful if it is reachable:
+ * the current tempering, the frames behind it (on expand), and how each
+ * camera's multiplier has moved over time.
+ */
+export function CalibrationPanel({
+  cameras,
+  history,
+}: {
+  cameras: CalibrationCameraRow[];
+  history: CalibrationHistoryRow[];
+}) {
+  const [openId, setOpenId] = useState<number | null>(null);
+  const [frames, setFrames] = useState<Record<number, CalibrationFrameRow[]>>({});
+  const [loading, setLoading] = useState(false);
+
+  async function toggle(webcamId: number) {
+    if (openId === webcamId) {
+      setOpenId(null);
+      return;
+    }
+    setOpenId(webcamId);
+    if (frames[webcamId]) return;
+    setLoading(true);
+    try {
+      const res = await fetch(`/api/admin/calibration-frames?webcamId=${webcamId}`);
+      const json = (await res.json()) as { frames?: CalibrationFrameRow[] };
+      setFrames((f) => ({ ...f, [webcamId]: json.frames ?? [] }));
+    } catch {
+      setFrames((f) => ({ ...f, [webcamId]: [] }));
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <Box sx={{ mt: 3 }}>
+      <Typography variant="h6" sx={{ color: 'white', mb: 1 }}>
+        Camera calibration
+      </Typography>
+
+      {cameras.length === 0 ? (
+        <Typography sx={{ color: '#9ca3af' }}>
+          No cameras tempered. (Neutral until the evidence writer has run and
+          the nightly job has computed.)
+        </Typography>
+      ) : (
+        <>
+          <Typography variant="caption" sx={{ color: '#9ca3af' }}>
+            {cameras.length} tempered — click a row to see the frames behind it
+          </Typography>
+          <Box sx={{ mt: 1 }}>
+            {cameras.map((c) => (
+              <Box key={c.webcam_id} sx={{ mb: 0.5 }}>
+                <Box
+                  onClick={() => toggle(c.webcam_id)}
+                  sx={{
+                    display: 'flex',
+                    gap: 2,
+                    alignItems: 'center',
+                    p: 1,
+                    borderRadius: 1,
+                    cursor: 'pointer',
+                    backgroundColor: '#374151',
+                    '&:hover': { backgroundColor: '#4b5563' },
+                  }}
+                >
+                  <Typography sx={{ color: '#fbbf24', minWidth: 56 }}>
+                    {c.multiplier.toFixed(3)}
+                  </Typography>
+                  <Typography sx={{ color: 'white', flex: 1 }}>
+                    {c.title ?? '(untitled)'}{' '}
+                    <span style={{ color: '#9ca3af' }}>#{c.webcam_id}</span>
+                  </Typography>
+                  <Typography variant="caption" sx={{ color: '#9ca3af' }}>
+                    {c.false_shows?.toFixed(1)} / {c.negative_frames?.toFixed(1)} over{' '}
+                    {c.false_show_days}d
+                  </Typography>
+                </Box>
+
+                {openId === c.webcam_id && (
+                  <Box sx={{ display: 'flex', gap: 1, flexWrap: 'wrap', p: 1 }}>
+                    {loading && !frames[c.webcam_id] ? (
+                      <Typography variant="caption" sx={{ color: '#9ca3af' }}>
+                        loading frames…
+                      </Typography>
+                    ) : (frames[c.webcam_id] ?? []).length === 0 ? (
+                      <Typography variant="caption" sx={{ color: '#9ca3af' }}>
+                        No retained frames for this camera.
+                      </Typography>
+                    ) : (
+                      (frames[c.webcam_id] ?? []).map((f) => (
+                        <Box key={f.snapshot_id} sx={{ width: 120 }}>
+                          {/* eslint-disable-next-line @next/next/no-img-element */}
+                          <img
+                            src={f.firebase_url}
+                            alt={`snapshot ${f.snapshot_id}`}
+                            style={{ width: '100%', borderRadius: 4 }}
+                          />
+                          <Typography
+                            variant="caption"
+                            sx={{ color: '#9ca3af', display: 'block' }}
+                          >
+                            p {f.p_sunset.toFixed(2)} · tile{' '}
+                            {f.tile == null ? '—' : f.tile.toFixed(2)}
+                          </Typography>
+                          <Typography
+                            variant="caption"
+                            sx={{ color: '#6b7280', display: 'block' }}
+                          >
+                            {f.captured_on}
+                          </Typography>
+                        </Box>
+                      ))
+                    )}
+                  </Box>
+                )}
+              </Box>
+            ))}
+          </Box>
+        </>
+      )}
+
+      <Typography variant="subtitle2" sx={{ color: 'white', mt: 2 }}>
+        Recent changes
+      </Typography>
+      {history.length === 0 ? (
+        <Typography variant="caption" sx={{ color: '#9ca3af' }}>
+          No multiplier changes recorded yet.
+        </Typography>
+      ) : (
+        history.slice(0, 20).map((h, i) => (
+          <Typography
+            key={`${h.webcam_id}-${h.computed_at}-${i}`}
+            variant="caption"
+            sx={{ color: '#9ca3af', display: 'block' }}
+          >
+            #{h.webcam_id}:{' '}
+            {h.previous_multiplier == null ? '—' : h.previous_multiplier.toFixed(3)} →{' '}
+            {h.multiplier.toFixed(3)} ({h.computed_at})
+          </Typography>
+        ))
+      )}
+    </Box>
+  );
+}

--- a/app/components/Ops/OpsPanels.tsx
+++ b/app/components/Ops/OpsPanels.tsx
@@ -4,6 +4,7 @@ import { pct } from './opsMath';
 import { Sparkline } from './Sparkline';
 import { UsageChart } from './UsageChart';
 import { DozeControl } from './DozeControl';
+import { CalibrationPanel } from './CalibrationPanel';
 
 function Stat({
   label,
@@ -71,6 +72,10 @@ export function OpsPanels({ data }: { data: OpsStatsResponse }) {
           })()}
         </>
       )}
+      <CalibrationPanel
+        cameras={data.calibrationCameras ?? []}
+        history={data.calibrationHistory ?? []}
+      />
     </>
   );
 }

--- a/app/components/mosaic/v1/qualitySignal.test.ts
+++ b/app/components/mosaic/v1/qualitySignal.test.ts
@@ -67,3 +67,49 @@ describe('passesGate', () => {
     expect(passesGate({ ...base, aiRatingBinary: SHOWN })).toBe(true);
   });
 });
+
+describe('per-camera tempering', () => {
+  it('shrinks the tile score for a tempered camera', () => {
+    const score = getQualityScore({
+      ...base,
+      aiRatingBinary: SHOWN,
+      aiRatingRegression: 5,
+      calibrationMultiplier: 0.5,
+    } as WindyWebcam);
+    expect(score).toBe(3);
+  });
+
+  it('is a no-op for an untempered camera', () => {
+    expect(
+      getQualityScore({
+        ...base,
+        aiRatingBinary: SHOWN,
+        aiRatingRegression: 3.7,
+      })
+    ).toBe(3.7);
+  });
+
+  it('keeps the floor at 1 for a rejected frame regardless of multiplier', () => {
+    expect(
+      getQualityScore({
+        ...base,
+        aiRatingBinary: REJECTED,
+        aiRatingRegression: 4.2,
+        calibrationMultiplier: 0.5,
+      } as WindyWebcam)
+    ).toBe(1);
+  });
+
+  it('leaves passesGate bit-identical with and without a multiplier (clause 4)', () => {
+    const atGate = 1 + 0.55 * 4; // 3.2
+    for (const binary of [REJECTED, atGate, SHOWN]) {
+      const without = passesGate({ ...base, aiRatingBinary: binary });
+      const with05 = passesGate({
+        ...base,
+        aiRatingBinary: binary,
+        calibrationMultiplier: 0.5,
+      } as WindyWebcam);
+      expect(with05).toBe(without);
+    }
+  });
+});

--- a/app/components/mosaic/v1/qualitySignal.ts
+++ b/app/components/mosaic/v1/qualitySignal.ts
@@ -1,4 +1,5 @@
 import { AI_BINARY_DECISION_THRESHOLD } from '@/app/lib/masterConfig';
+import { applyTempering } from '@/app/lib/cameraCalibration';
 import type { WindyWebcam } from '@/app/lib/types';
 
 // The detection gate expressed on the 1-5 rating scale that
@@ -25,7 +26,12 @@ export function getQualityScore(webcam: WindyWebcam): number | null {
   if (typeof detection === 'number' && detection < GATE_AS_RATING) {
     return 1;
   }
-  return webcam.aiRatingRegression ?? null;
+  const raw = webcam.aiRatingRegression ?? null;
+  if (raw == null) return null;
+  // Per-camera tempering scales only the part ABOVE the floor, so a tempered
+  // frame gets smaller but is never hidden. passesGate is deliberately NOT
+  // tempered — the detection verdict is frozen.
+  return applyTempering(raw, webcam.calibrationMultiplier);
 }
 
 /**

--- a/app/lib/cameraCalibration.test.ts
+++ b/app/lib/cameraCalibration.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect } from 'vitest';
+import {
+  computeTemperingMultiplier,
+  decayWeight,
+  applyTempering,
+  type CalibrationEvidence,
+} from './cameraCalibration';
+
+const neutral: CalibrationEvidence = {
+  falseShows: 0,
+  negativeFrames: 0,
+  falseShowDays: 0,
+  rawFalseShows: 0,
+};
+
+describe('computeTemperingMultiplier', () => {
+  it('returns exactly 1.0 for a camera with no evidence (clause 6)', () => {
+    expect(computeTemperingMultiplier(neutral)).toBe(1);
+  });
+
+  it('returns 1.0 below the event bar even with many negative frames', () => {
+    expect(
+      computeTemperingMultiplier({
+        falseShows: 2,
+        negativeFrames: 40,
+        falseShowDays: 2,
+        rawFalseShows: 2,
+      })
+    ).toBe(1);
+  });
+
+  it('returns 1.0 when false-shows do not recur across days', () => {
+    expect(
+      computeTemperingMultiplier({
+        falseShows: 5,
+        negativeFrames: 5,
+        falseShowDays: 1,
+        rawFalseShows: 5,
+      })
+    ).toBe(1);
+  });
+
+  it('reproduces the Broome baseline: 11/11 over 9 days -> 0.577', () => {
+    const m = computeTemperingMultiplier({
+      falseShows: 11,
+      negativeFrames: 11,
+      falseShowDays: 9,
+      rawFalseShows: 11,
+    });
+    expect(m).toBeCloseTo(0.577, 3);
+  });
+
+  it('reproduces Mount Gambier: 4/15 over 4 days -> 0.882', () => {
+    const m = computeTemperingMultiplier({
+      falseShows: 4,
+      negativeFrames: 15,
+      falseShowDays: 4,
+      rawFalseShows: 4,
+    });
+    expect(m).toBeCloseTo(0.882, 3);
+  });
+
+  it('never returns below MIN_MULTIPLIER even at a 100% false-show rate (clause 5)', () => {
+    const m = computeTemperingMultiplier({
+      falseShows: 1000,
+      negativeFrames: 1000,
+      falseShowDays: 50,
+      rawFalseShows: 1000,
+    });
+    expect(m).toBeGreaterThanOrEqual(0.5);
+  });
+
+  it('never returns above 1.0 (clause 5)', () => {
+    const m = computeTemperingMultiplier({
+      falseShows: 0,
+      negativeFrames: 100,
+      falseShowDays: 5,
+      rawFalseShows: 3,
+    });
+    expect(m).toBeLessThanOrEqual(1);
+  });
+
+  it('is bounded for adversarial input (negative, NaN, missing) (clause 5)', () => {
+    for (const e of [
+      { falseShows: -5, negativeFrames: -5, falseShowDays: 9, rawFalseShows: 9 },
+      { falseShows: NaN, negativeFrames: NaN, falseShowDays: 9, rawFalseShows: 9 },
+      { falseShows: 5, negativeFrames: 0, falseShowDays: 9, rawFalseShows: 5 },
+    ] as CalibrationEvidence[]) {
+      const m = computeTemperingMultiplier(e);
+      expect(Number.isFinite(m)).toBe(true);
+      expect(m).toBeGreaterThanOrEqual(0.5);
+      expect(m).toBeLessThanOrEqual(1);
+    }
+  });
+});
+
+describe('decayWeight', () => {
+  it('is 1 for a frame captured today', () => {
+    expect(decayWeight(0, 90)).toBe(1);
+  });
+
+  it('is 0.5 at exactly one half-life', () => {
+    expect(decayWeight(90, 90)).toBeCloseTo(0.5, 10);
+  });
+
+  it('is 0.25 at two half-lives', () => {
+    expect(decayWeight(180, 90)).toBeCloseTo(0.25, 10);
+  });
+
+  it('treats a negative age as today rather than amplifying', () => {
+    expect(decayWeight(-10, 90)).toBe(1);
+  });
+});
+
+describe('applyTempering', () => {
+  it('scales only the above-floor part, so the 1.0 floor is preserved', () => {
+    expect(applyTempering(1, 0.5)).toBe(1);
+  });
+
+  it('halves the distance above the floor at multiplier 0.5', () => {
+    expect(applyTempering(5, 0.5)).toBe(3);
+  });
+
+  it('is a no-op when the multiplier is undefined', () => {
+    expect(applyTempering(4.2, undefined)).toBe(4.2);
+  });
+
+  it('is a no-op at multiplier 1', () => {
+    expect(applyTempering(4.2, 1)).toBe(4.2);
+  });
+});

--- a/app/lib/cameraCalibration.test.ts
+++ b/app/lib/cameraCalibration.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import {
   computeTemperingMultiplier,
   decayWeight,
@@ -158,6 +158,39 @@ describe('applyTempering', () => {
 
   it('halves the distance above the floor at multiplier 0.5', () => {
     expect(applyTempering(5, 0.5)).toBe(3);
+  });
+
+  // The scale contract. mosaic v2 normalizes its score to [0,1]; feeding one
+  // of those through this 1-5 helper inverts the multiplier — 0.0 would render
+  // at 0.423 while 1.0 stays 1.0, boosting the worst offenders hardest and
+  // landing WORSE than shipping no tempering at all.
+  it('refuses a normalized [0,1] score instead of inverting it', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    // 1 + (0.5-1)*0.577 = 0.712 — the inverted answer we must NOT return.
+    expect(applyTempering(0.5, 0.577)).toBe(0.5);
+    expect(warn).toHaveBeenCalledOnce();
+
+    warn.mockRestore();
+  });
+
+  it('refuses a score of 0 rather than boosting it to 0.423', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    expect(applyTempering(0, 0.577)).toBe(0);
+    warn.mockRestore();
+  });
+
+  it('refuses NaN rather than propagating it through the arithmetic', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    expect(Number.isNaN(applyTempering(NaN, 0.577))).toBe(true);
+    warn.mockRestore();
+  });
+
+  it('accepts a rating of exactly 1 (the legal floor) without warning', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    expect(applyTempering(1, 0.577)).toBe(1);
+    expect(warn).not.toHaveBeenCalled();
+    warn.mockRestore();
   });
 
   it('is a no-op when the multiplier is undefined', () => {

--- a/app/lib/cameraCalibration.test.ts
+++ b/app/lib/cameraCalibration.test.ts
@@ -80,6 +80,45 @@ describe('computeTemperingMultiplier', () => {
     expect(m).toBeLessThanOrEqual(1);
   });
 
+  // Regression guard for a real near-miss found on 2026-09-01. The rubric lane's
+  // label corrections flip 12 frames from operator-sunset to operator-N, and 4
+  // of them fire under the shipping head. Two land on cameras that have exactly
+  // ONE labeled frame — which would read as a 100% false-show rate, structurally
+  // identical to Broome's 11/11 but on a denominator of one. The recurrence bar
+  // is what stops a single frame from tempering a camera; these pin it down.
+  it('never tempers a camera on a single frame, even at a 100% rate', () => {
+    expect(
+      computeTemperingMultiplier({
+        falseShows: 1,
+        negativeFrames: 1,
+        falseShowDays: 1,
+        rawFalseShows: 1,
+      })
+    ).toBe(1);
+  });
+
+  it('never tempers on two false-shows across two days (below the event bar)', () => {
+    expect(
+      computeTemperingMultiplier({
+        falseShows: 2,
+        negativeFrames: 2,
+        falseShowDays: 2,
+        rawFalseShows: 2,
+      })
+    ).toBe(1);
+  });
+
+  it('tempers at exactly the bar: 3 false-shows across 2 days', () => {
+    const m = computeTemperingMultiplier({
+      falseShows: 3,
+      negativeFrames: 3,
+      falseShowDays: 2,
+      rawFalseShows: 3,
+    });
+    expect(m).toBeLessThan(1);
+    expect(m).toBeGreaterThanOrEqual(0.5);
+  });
+
   it('is bounded for adversarial input (negative, NaN, missing) (clause 5)', () => {
     for (const e of [
       { falseShows: -5, negativeFrames: -5, falseShowDays: 9, rawFalseShows: 9 },

--- a/app/lib/cameraCalibration.ts
+++ b/app/lib/cameraCalibration.ts
@@ -1,0 +1,74 @@
+import {
+  CALIBRATION_MIN_EVENTS,
+  CALIBRATION_MIN_DAYS,
+  CALIBRATION_PRIOR_K,
+  CALIBRATION_MAX_TEMPER,
+  CALIBRATION_MIN_MULTIPLIER,
+} from './masterConfig';
+
+/**
+ * Per-camera tempering evidence, already windowed and decayed by the caller.
+ *
+ * The rate is conditioned on the camera's NEGATIVE frames only — "given a
+ * boring frame, does this camera fool the model?". That conditioning is
+ * load-bearing: whole-population rates rank Broome 8th-9th because its 21
+ * genuinely correct fires dilute the error rate. See the spec.
+ */
+export interface CalibrationEvidence {
+  /** Decayed weight of false-shows inside the window. */
+  falseShows: number;
+  /** Decayed weight of operator-negative frames inside the window. */
+  negativeFrames: number;
+  /** Distinct capture days with a false-show, inside the window. */
+  falseShowDays: number;
+  /** Undecayed false-show count inside the window — the recurrence bar. */
+  rawFalseShows: number;
+}
+
+const finiteOrZero = (n: number): number =>
+  Number.isFinite(n) ? Math.max(0, n) : 0;
+
+/**
+ * Exponential decay weight for a frame captured `ageDays` ago.
+ * A future-dated frame (clock skew) weighs the same as today's, never more.
+ */
+export function decayWeight(ageDays: number, halfLifeDays: number): number {
+  const age = Math.max(0, finiteOrZero(ageDays));
+  if (!(halfLifeDays > 0)) return 1;
+  return Math.pow(0.5, age / halfLifeDays);
+}
+
+/**
+ * The tempering multiplier. Bounded to [MIN_MULTIPLIER, 1] by construction.
+ *
+ * Returns exactly 1 (neutral) unless the recurrence bar is cleared, so new
+ * cameras and one-off mistakes are never tempered.
+ */
+export function computeTemperingMultiplier(e: CalibrationEvidence): number {
+  const rawFalseShows = finiteOrZero(e.rawFalseShows);
+  const falseShowDays = finiteOrZero(e.falseShowDays);
+
+  if (rawFalseShows < CALIBRATION_MIN_EVENTS) return 1;
+  if (falseShowDays < CALIBRATION_MIN_DAYS) return 1;
+
+  const falseShows = finiteOrZero(e.falseShows);
+  const negativeFrames = finiteOrZero(e.negativeFrames);
+
+  const rate = falseShows / (negativeFrames + CALIBRATION_PRIOR_K);
+  const raw = 1 - CALIBRATION_MAX_TEMPER * rate;
+
+  return Math.min(1, Math.max(CALIBRATION_MIN_MULTIPLIER, raw));
+}
+
+/**
+ * Apply a multiplier to a 1-5 tile score, scaling only the part ABOVE the
+ * floor of 1. Product intent is "show every image, just small" — a tempered
+ * frame gets smaller, never hidden, and 1 stays 1.
+ */
+export function applyTempering(
+  score: number,
+  multiplier: number | undefined
+): number {
+  if (multiplier == null || !Number.isFinite(multiplier)) return score;
+  return 1 + (score - 1) * multiplier;
+}

--- a/app/lib/cameraCalibration.ts
+++ b/app/lib/cameraCalibration.ts
@@ -70,5 +70,27 @@ export function applyTempering(
   multiplier: number | undefined
 ): number {
   if (multiplier == null || !Number.isFinite(multiplier)) return score;
+
+  // SCALE CONTRACT. `score` is a 1-5 RATING with a floor of 1 — not a
+  // normalized [0,1] signal. The distinction is load-bearing, because on a
+  // [0,1] scale this formula INVERTS: at multiplier 0.577 a score of 0.0
+  // becomes 0.423 while 1.0 is untouched, so the frames the evidence flagged
+  // as worst get boosted hardest and a tempered camera renders LARGER than
+  // with no tempering at all. Refuse rather than invert.
+  //
+  // Fail-visible, not fail-hard: this runs in the kiosk render path, and the
+  // quality head can emit negatives (769 of 9,118 evidence rows do), so a
+  // throw could blank the display if the write-path clamp ever changed.
+  // Warn loudly and return untempered — wrong-but-visible beats inverted.
+  if (!(score >= 1)) {
+    console.warn(
+      `[cameraCalibration] applyTempering received score=${score}, below the ` +
+        `1-5 rating floor. Expected a rating, not a normalized [0,1] signal ` +
+        `(mosaic v2 normalizes — use score * multiplier there). Returning ` +
+        `untempered to avoid inverting the multiplier.`
+    );
+    return score;
+  }
+
   return 1 + (score - 1) * multiplier;
 }

--- a/app/lib/masterConfig.ts
+++ b/app/lib/masterConfig.ts
@@ -261,3 +261,31 @@ export const KIOSK_TICK_INTERVAL_MS = 60_000;
 // app/components/mosaic/<version>/config.ts. Each mosaic version owns its
 // own constants so tuning one never disturbs another.
 // ---------------------------------------------------------------------------
+
+// ---------------------------------------------------------------------------
+// Per-camera calibration (tempering prior)
+// Spec: docs/superpowers/specs/2026-08-31-per-camera-calibration-design.md
+//
+// A bounded multiplier on the TILE/QUALITY signal only. It must never move the
+// detection verdict — passesGate does not read any of these.
+// ---------------------------------------------------------------------------
+
+// Recurrence bar: one bad frame is noise. Same standard that caught three
+// non-replicating detection "wins".
+export const CALIBRATION_MIN_EVENTS = 3;
+export const CALIBRATION_MIN_DAYS = 2;
+
+// Smoothing prior, so a camera with 3 false-shows out of 3 N frames does not
+// slam straight to the floor.
+export const CALIBRATION_PRIOR_K = 2;
+
+// MAX_TEMPER 0.5 was chosen because it DOMINATES 0.65: identical benefit
+// (8 big false-shows fixed) at 60% less harm (10 genuine >=4 frames demoted
+// vs 25). Lower to 0.35 to back off; that needs no other change.
+export const CALIBRATION_MAX_TEMPER = 0.5;
+export const CALIBRATION_MIN_MULTIPLIER = 0.5;
+
+// Decay shapes MAGNITUDE; the window governs ELIGIBILITY. Both are needed:
+// with an undecayed recurrence bar a camera could never fully heal.
+export const CALIBRATION_HALF_LIFE_DAYS = 90;
+export const CALIBRATION_WINDOW_DAYS = 365;

--- a/app/lib/opsTypes.ts
+++ b/app/lib/opsTypes.ts
@@ -30,4 +30,38 @@ export interface OpsStatsResponse {
   dailyStats: DailyStatsRow[];
   providerUsage: ProviderUsageRow[];
   costEvents: CostEventRow[];
+  calibrationCameras: CalibrationCameraRow[];
+  calibrationHistory: CalibrationHistoryRow[];
+}
+
+/** A tempered camera and the evidence behind it. */
+export interface CalibrationCameraRow {
+  webcam_id: number;
+  title: string | null;
+  multiplier: number;
+  false_shows: number;
+  negative_frames: number;
+  false_show_days: number;
+  computed_at: string | null;
+}
+
+/** One multiplier change, for the over-time view. */
+export interface CalibrationHistoryRow {
+  webcam_id: number;
+  computed_at: string;
+  multiplier: number;
+  previous_multiplier: number | null;
+}
+
+/**
+ * One false-show frame behind a camera's tempering — the "was this camera
+ * fairly tempered?" check. Fetched per-camera on expand, never bulk-loaded:
+ * the evidence table holds ~9k rows and grows.
+ */
+export interface CalibrationFrameRow {
+  snapshot_id: number;
+  captured_on: string;
+  p_sunset: number;
+  tile: number | null;
+  firebase_url: string;
 }

--- a/app/lib/terminatorPayload.test.ts
+++ b/app/lib/terminatorPayload.test.ts
@@ -28,6 +28,18 @@ describe('fetchTerminatorWebcams query shape', () => {
     expect(fullQuery).toMatch(/limit 1/);
   });
 
+  // The kiosk reads THIS payload, not db-all-webcams. A column added to only
+  // one of the two queries disables the feature on the surface that matters
+  // while everything still renders — which is exactly how per-camera
+  // tempering shipped dead to the kiosk once already.
+  it('selects calibration_multiplier so tempering reaches the kiosk', async () => {
+    await fetchTerminatorWebcams();
+
+    const [strings] = sqlMock.mock.calls[0];
+    const fullQuery = strings.join('?').toLowerCase();
+    expect(fullQuery).toMatch(/w\.calibration_multiplier/);
+  });
+
   it('joins the cameras table for device traceability', async () => {
     await fetchTerminatorWebcams();
 
@@ -65,6 +77,7 @@ describe('fetchTerminatorWebcams row mapping', () => {
     ai_rating: null, ai_model_version: null,
     ai_rating_binary: null, ai_model_version_binary: null,
     ai_rating_regression: null, ai_model_version_regression: null,
+    calibration_multiplier: null,
     latest_snapshot_url: null,
     latest_snapshot_captured_at: null,
     device_class: null, firmware_version: null, hardware_id: null,
@@ -136,6 +149,47 @@ describe('fetchTerminatorWebcams row mapping', () => {
 
     expect(result[0].images).toBeUndefined();
     expect(result[0].liveAssetKind).toBe('windy_bundle');
+  });
+});
+
+describe('calibration multiplier survives the terminator payload', () => {
+  const baseRow = {
+    webcam_id: 100, phase: 'sunset', rank: 1,
+    id: 100, source: 'windy', external_id: 'ext-100', title: 'A cam',
+    status: 'active', view_count: 10,
+    lat: 10, lng: 20,
+    city: 'X', region: 'Y', country: 'Z', continent: 'NA',
+    images: null, urls: null, player: null, categories: null,
+    last_fetched_at: null, created_at: null, updated_at: null,
+    rating: null, orientation: null,
+    ai_rating: null, ai_model_version: null,
+    ai_rating_binary: null, ai_model_version_binary: null,
+    ai_rating_regression: null, ai_model_version_regression: null,
+    calibration_multiplier: null,
+    latest_snapshot_url: null, latest_snapshot_captured_at: null,
+    device_class: null, firmware_version: null, hardware_id: null,
+  };
+
+  beforeEach(() => sqlMock.mockReset());
+
+  // NUMERIC(4,3) arrives as a STRING through the Neon driver, so this asserts
+  // the type as well as the value — a string would silently break the
+  // arithmetic in applyTempering.
+  it('coerces a tempered camera to a number', async () => {
+    sqlMock.mockResolvedValue([{ ...baseRow, calibration_multiplier: '0.590' }]);
+
+    const [cam] = await fetchTerminatorWebcams();
+
+    expect(cam.calibrationMultiplier).toBe(0.59);
+    expect(typeof cam.calibrationMultiplier).toBe('number');
+  });
+
+  it('leaves an untempered camera undefined so tempering is a no-op', async () => {
+    sqlMock.mockResolvedValue([{ ...baseRow, calibration_multiplier: null }]);
+
+    const [cam] = await fetchTerminatorWebcams();
+
+    expect(cam.calibrationMultiplier).toBeUndefined();
   });
 });
 

--- a/app/lib/terminatorPayload.ts
+++ b/app/lib/terminatorPayload.ts
@@ -31,6 +31,7 @@ type TerminatorRow = {
   ai_rating_binary: number | string | null;
   ai_model_version_binary: string | null;
   ai_rating_regression: number | string | null;
+  calibration_multiplier: number | string | null;
   ai_model_version_regression: string | null;
   // From LEFT JOIN LATERAL on webcam_snapshots (only populated for source='custom')
   latest_snapshot_url: string | null;
@@ -72,6 +73,7 @@ export async function fetchTerminatorWebcams(): Promise<WindyWebcam[]> {
            w.rating, w.orientation, w.ai_rating, w.ai_model_version,
            w.ai_rating_binary, w.ai_model_version_binary,
            w.ai_rating_regression, w.ai_model_version_regression,
+           w.calibration_multiplier,
            ls.firebase_url      as latest_snapshot_url,
            ls.captured_at       as latest_snapshot_captured_at,
            c.device_class,
@@ -139,6 +141,10 @@ export async function fetchTerminatorWebcams(): Promise<WindyWebcam[]> {
       aiRatingBinary: toMaybeNumber(row.ai_rating_binary),
       aiModelVersionBinary: row.ai_model_version_binary ?? undefined,
       aiRatingRegression: toMaybeNumber(row.ai_rating_regression),
+      // Per-camera tempering. The kiosk reads THIS payload, not
+      // db-all-webcams, so omitting it here would silently disable
+      // tempering on the one surface the showing runs on.
+      calibrationMultiplier: toMaybeNumber(row.calibration_multiplier),
       aiModelVersionRegression:
         row.ai_model_version_regression ?? undefined,
       liveAssetKind,

--- a/app/lib/types.ts
+++ b/app/lib/types.ts
@@ -93,6 +93,12 @@ export interface WindyWebcam {
   aiModelVersionBinary?: string; // Model version for binary score
   aiRatingRegression?: number; // 1-5 normalized regression score
   aiModelVersionRegression?: string; // Model version for regression score
+  /**
+   * Per-camera tempering multiplier in [0.5, 1]. Undefined = neutral.
+   * Applies to the TILE signal only — never the detection verdict.
+   * Spec: docs/superpowers/specs/2026-08-31-per-camera-calibration-design.md
+   */
+  calibrationMultiplier?: number;
 
   // Claude (LLM) judge — the third opinion, distinct from the two model
   // heads above. Do NOT proxy these into the aiRating* slots: that hides

--- a/database/migrations/20260901_camera_calibration.sql
+++ b/database/migrations/20260901_camera_calibration.sql
@@ -1,0 +1,64 @@
+-- Per-camera calibration (tempering prior).
+-- Spec: docs/superpowers/specs/2026-08-31-per-camera-calibration-design.md
+--
+-- Three things:
+--   camera_calibration_evidence  one APPEND-ONLY row per labeled frame per
+--                                model version, carrying the scores that made
+--                                it count so a tempering decision can be
+--                                re-examined later without rescoring through
+--                                ONNX. Nothing in this system deletes from it.
+--   camera_calibration_history   multiplier CHANGE events, so healing and
+--                                drift are observable rather than asserted.
+--   webcams.calibration_*        the live value the display reads.
+--                                NULL = neutral; new cameras need no backfill.
+--
+-- Forward-only, idempotent. Apply manually via:
+--   psql "$DATABASE_URL" -f database/migrations/20260901_camera_calibration.sql
+
+CREATE TABLE IF NOT EXISTS camera_calibration_evidence (
+  id              BIGSERIAL PRIMARY KEY,
+  webcam_id       BIGINT NOT NULL,
+  snapshot_id     BIGINT NOT NULL,
+  -- Scoping by model version is the fix for the exact defect that killed the
+  -- model-vs-Claude wide signal: evidence from a retired head must never
+  -- drive a live multiplier.
+  model_version   TEXT NOT NULL,
+  -- The leg-2 socket. A second writer appends rows; aggregation is unchanged.
+  evidence_source TEXT NOT NULL,
+  is_negative     BOOLEAN NOT NULL,
+  fired           BOOLEAN NOT NULL,
+  captured_on     DATE NOT NULL,
+  -- Frame record. firebase_url is denormalised ON PURPOSE: this table must
+  -- stay reviewable years from now, independent of webcam_snapshots.
+  p_sunset        NUMERIC(6,4) NOT NULL,
+  quality         NUMERIC(6,4),
+  tile            NUMERIC(6,4),
+  firebase_url    TEXT NOT NULL,
+  scored_at       TIMESTAMPTZ NOT NULL DEFAULT now(),
+  UNIQUE (snapshot_id, model_version, evidence_source)
+);
+
+-- Hot path: the nightly aggregation scans one model generation per camera.
+CREATE INDEX IF NOT EXISTS camera_calibration_evidence_cam_idx
+  ON camera_calibration_evidence (webcam_id, model_version, captured_on DESC);
+
+CREATE TABLE IF NOT EXISTS camera_calibration_history (
+  id                  BIGSERIAL PRIMARY KEY,
+  webcam_id           BIGINT NOT NULL,
+  computed_at         TIMESTAMPTZ NOT NULL DEFAULT now(),
+  multiplier          NUMERIC(4,3) NOT NULL,
+  previous_multiplier NUMERIC(4,3),
+  false_shows         NUMERIC(8,3) NOT NULL,
+  negative_frames     NUMERIC(8,3) NOT NULL,
+  raw_false_shows     INT NOT NULL,
+  false_show_days     INT NOT NULL,
+  model_version       TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS camera_calibration_history_cam_idx
+  ON camera_calibration_history (webcam_id, computed_at DESC);
+
+ALTER TABLE webcams
+  ADD COLUMN IF NOT EXISTS calibration_multiplier  NUMERIC(4,3),
+  ADD COLUMN IF NOT EXISTS calibration_evidence    JSONB,
+  ADD COLUMN IF NOT EXISTS calibration_computed_at TIMESTAMPTZ;

--- a/docs/superpowers/plans/2026-09-01-per-camera-calibration-leg1.md
+++ b/docs/superpowers/plans/2026-09-01-per-camera-calibration-leg1.md
@@ -1,0 +1,1569 @@
+# Per-Camera Calibration (Leg 1) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship a nightly job that derives a bounded, evidence-based tempering multiplier per camera and applies it to the mosaic tile signal only — never the detection verdict — with every contributing frame and every multiplier change retained for later review.
+
+**Architecture:** An offline ONNX writer (`ml/audit_camera_errors.py --emit-evidence`) persists one append-only row per operator-labeled frame into `camera_calibration_evidence`, including the scores that made it count. A pure-SQL nightly cron aggregates that evidence with time decay, computes the multiplier via a pure TS function, writes it to `webcams`, and records changes to `camera_calibration_history`. `getQualityScore` multiplies the above-floor part of the tile signal; `passesGate` is untouched.
+
+**Tech Stack:** Next.js App Router (route handlers), Neon Postgres via `@/app/lib/db` `sql` tagged template, Vitest, Python 3.11 + psycopg2 + onnxruntime in `.venv`.
+
+**Spec:** `docs/superpowers/specs/2026-08-31-per-camera-calibration-design.md`
+
+## Global Constants
+
+Copy verbatim into `app/lib/masterConfig.ts`. Every task's requirements implicitly include these.
+
+| constant | value |
+|---|---|
+| `CALIBRATION_MIN_EVENTS` | `3` |
+| `CALIBRATION_MIN_DAYS` | `2` |
+| `CALIBRATION_PRIOR_K` | `2` |
+| `CALIBRATION_MAX_TEMPER` | `0.5` |
+| `CALIBRATION_MIN_MULTIPLIER` | `0.5` |
+| `CALIBRATION_HALF_LIFE_DAYS` | `90` |
+| `CALIBRATION_WINDOW_DAYS` | `365` |
+
+## Global Constraints
+
+- **Branch is `feat/per-camera-calibration`** (stacked on `origin/measure/hard-negative-emphasis` for `ml/audit_camera_errors.py`). Verify with `git rev-parse --abbrev-ref HEAD` before EVERY commit — Jesse merges PRs in parallel and the shared checkout can shift mid-task.
+- **Stage explicit paths only.** Never `git add -A` / `git add .` — parallel sessions share this checkout and there are unrelated untracked `ml/artifacts/` paths sitting in it.
+- **Detection is frozen.** No task may change `passesGate`, `AI_BINARY_DECISION_THRESHOLD`, or any model file.
+- **Postgres `NUMERIC` arrives as a STRING** through the Neon driver (`"0.577"`, not `0.577`). Every read of a numeric column must go through `Number(...)`.
+- **The evidence table is append-only.** No task may write `DELETE` against `camera_calibration_evidence` or `camera_calibration_history`.
+- **Do NOT apply migrations to production.** Migrations are written and committed; Jesse applies them. `vercel env add/rm` is likewise classifier-blocked — hand those to Jesse.
+- Test runner is `npm run test` (vitest). Python is `.venv/bin/python`.
+
+## Pre-Registered Acceptance Test (all 8 clauses)
+
+Locked before implementation. Task 8 verifies the whole set.
+
+1. All four of `4057187`, `2947112`, `29095214`, `29275205` get multiplier < 1.0.
+2. Zero cameras outside the audit's 17-offender list temper.
+3. ≤25 cameras temper (measured baseline: exactly 17).
+4. `passesGate` output is bit-identical with and without a multiplier.
+5. Multiplier ∈ [0.5, 1.0] for all inputs including adversarial ones.
+6. A camera with no evidence gets exactly 1.0.
+7. Re-running the writer leaves row count unchanged and deletes nothing; a second `model_version` generation leaves the first intact.
+8. A multiplier change writes exactly one history row carrying the previous value; no change writes none.
+
+**Measured baseline (re-verified against current labels 2026-09-01):** 17 tempered, 0 non-offenders, Broome 0.577 / Coober Pedy 0.714 / Wagga 0.833 / Mt Gambier 0.882.
+
+---
+
+## File Structure
+
+| file | responsibility |
+|---|---|
+| `app/lib/cameraCalibration.ts` | **Create.** Pure multiplier math + decay. No I/O. |
+| `app/lib/cameraCalibration.test.ts` | **Create.** Clauses 4–6 + decay behavior. |
+| `app/lib/masterConfig.ts` | **Modify.** Append the 7 constants. |
+| `database/migrations/20260901_camera_calibration.sql` | **Create.** Both tables + 3 `webcams` columns. |
+| `ml/audit_camera_errors.py` | **Modify.** Add `--emit-evidence`. |
+| `app/api/cron/update-cameras/lib/dbOperations.ts` | **Modify.** Add 3 query functions. |
+| `app/api/cron/update-cameras/lib/recomputeCameraCalibration.ts` | **Create.** Orchestration. |
+| `app/api/cron/update-cameras/lib/recomputeCameraCalibration.test.ts` | **Create.** Clause 8. |
+| `app/api/cron/recompute-camera-calibration/route.ts` | **Create.** Cron entrypoint. |
+| `vercel.json` | **Modify.** Nightly cron entry. |
+| `app/components/mosaic/v1/qualitySignal.ts` | **Modify.** Apply multiplier in `getQualityScore`. |
+| `app/components/mosaic/v1/qualitySignal.test.ts` | **Modify.** Clause 4 + tempering tests. |
+| `app/lib/types.ts` | **Modify.** `calibrationMultiplier?: number` on `WindyWebcam`. |
+| `app/api/db-all-webcams/route.ts` | **Modify.** Select + map the column. |
+| `app/lib/opsTypes.ts` | **Modify.** Calibration row types. |
+| `app/api/admin/ops-stats/route.ts` | **Modify.** Serve calibration rows. |
+| `app/api/admin/calibration-frames/route.ts` | **Create.** Per-camera evidence frames, fetched on expand. |
+| `app/components/Ops/OpsPanels.tsx` | **Modify.** Calibration panel. |
+| `ml/verify_calibration_acceptance.py` | **Create.** Clauses 1–3, 7. |
+
+---
+
+### Task 1: Multiplier math (pure function)
+
+**Files:**
+- Create: `app/lib/cameraCalibration.ts`
+- Create: `app/lib/cameraCalibration.test.ts`
+- Modify: `app/lib/masterConfig.ts` (append constants)
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `CalibrationEvidence` interface, `computeTemperingMultiplier(e: CalibrationEvidence): number`, `decayWeight(ageDays: number, halfLifeDays: number): number`, `applyTempering(score: number, multiplier: number | undefined): number`.
+
+- [ ] **Step 1: Append constants to masterConfig**
+
+Add at the end of `app/lib/masterConfig.ts`:
+
+```ts
+/* -------------------------------------------------------------------------- */
+/* Per-camera calibration (tempering prior)                                    */
+/* Spec: docs/superpowers/specs/2026-08-31-per-camera-calibration-design.md    */
+/*                                                                            */
+/* A bounded multiplier on the TILE/QUALITY signal only. It must never move    */
+/* the detection verdict — passesGate does not read any of these.              */
+/* -------------------------------------------------------------------------- */
+
+// Recurrence bar: one bad frame is noise. Same standard that caught three
+// non-replicating detection "wins".
+export const CALIBRATION_MIN_EVENTS = 3;
+export const CALIBRATION_MIN_DAYS = 2;
+
+// Smoothing prior, so a camera with 3 false-shows out of 3 N frames does not
+// slam straight to the floor.
+export const CALIBRATION_PRIOR_K = 2;
+
+// MAX_TEMPER 0.5 was chosen because it DOMINATES 0.65: identical benefit
+// (8 big false-shows fixed) at 60% less harm (10 genuine >=4 frames demoted
+// vs 25). Lower to 0.35 to back off; that needs no other change.
+export const CALIBRATION_MAX_TEMPER = 0.5;
+export const CALIBRATION_MIN_MULTIPLIER = 0.5;
+
+// Decay shapes MAGNITUDE; the window governs ELIGIBILITY. Both are needed:
+// with an undecayed recurrence bar a camera could never fully heal.
+export const CALIBRATION_HALF_LIFE_DAYS = 90;
+export const CALIBRATION_WINDOW_DAYS = 365;
+```
+
+- [ ] **Step 2: Write the failing tests**
+
+Create `app/lib/cameraCalibration.test.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest';
+import {
+  computeTemperingMultiplier,
+  decayWeight,
+  applyTempering,
+  type CalibrationEvidence,
+} from './cameraCalibration';
+
+const neutral: CalibrationEvidence = {
+  falseShows: 0,
+  negativeFrames: 0,
+  falseShowDays: 0,
+  rawFalseShows: 0,
+};
+
+describe('computeTemperingMultiplier', () => {
+  it('returns exactly 1.0 for a camera with no evidence (clause 6)', () => {
+    expect(computeTemperingMultiplier(neutral)).toBe(1);
+  });
+
+  it('returns 1.0 below the event bar even with many negative frames', () => {
+    expect(
+      computeTemperingMultiplier({
+        falseShows: 2,
+        negativeFrames: 40,
+        falseShowDays: 2,
+        rawFalseShows: 2,
+      })
+    ).toBe(1);
+  });
+
+  it('returns 1.0 when false-shows do not recur across days', () => {
+    expect(
+      computeTemperingMultiplier({
+        falseShows: 5,
+        negativeFrames: 5,
+        falseShowDays: 1,
+        rawFalseShows: 5,
+      })
+    ).toBe(1);
+  });
+
+  it('reproduces the Broome baseline: 11/11 over 9 days -> 0.577', () => {
+    const m = computeTemperingMultiplier({
+      falseShows: 11,
+      negativeFrames: 11,
+      falseShowDays: 9,
+      rawFalseShows: 11,
+    });
+    expect(m).toBeCloseTo(0.577, 3);
+  });
+
+  it('reproduces Mount Gambier: 4/15 over 4 days -> 0.882', () => {
+    const m = computeTemperingMultiplier({
+      falseShows: 4,
+      negativeFrames: 15,
+      falseShowDays: 4,
+      rawFalseShows: 4,
+    });
+    expect(m).toBeCloseTo(0.882, 3);
+  });
+
+  it('never returns below MIN_MULTIPLIER even at a 100% false-show rate (clause 5)', () => {
+    const m = computeTemperingMultiplier({
+      falseShows: 1000,
+      negativeFrames: 1000,
+      falseShowDays: 50,
+      rawFalseShows: 1000,
+    });
+    expect(m).toBeGreaterThanOrEqual(0.5);
+  });
+
+  it('never returns above 1.0 (clause 5)', () => {
+    const m = computeTemperingMultiplier({
+      falseShows: 0,
+      negativeFrames: 100,
+      falseShowDays: 5,
+      rawFalseShows: 3,
+    });
+    expect(m).toBeLessThanOrEqual(1);
+  });
+
+  it('is bounded for adversarial input (negative, NaN, missing) (clause 5)', () => {
+    for (const e of [
+      { falseShows: -5, negativeFrames: -5, falseShowDays: 9, rawFalseShows: 9 },
+      { falseShows: NaN, negativeFrames: NaN, falseShowDays: 9, rawFalseShows: 9 },
+      { falseShows: 5, negativeFrames: 0, falseShowDays: 9, rawFalseShows: 5 },
+    ] as CalibrationEvidence[]) {
+      const m = computeTemperingMultiplier(e);
+      expect(Number.isFinite(m)).toBe(true);
+      expect(m).toBeGreaterThanOrEqual(0.5);
+      expect(m).toBeLessThanOrEqual(1);
+    }
+  });
+});
+
+describe('decayWeight', () => {
+  it('is 1 for a frame captured today', () => {
+    expect(decayWeight(0, 90)).toBe(1);
+  });
+
+  it('is 0.5 at exactly one half-life', () => {
+    expect(decayWeight(90, 90)).toBeCloseTo(0.5, 10);
+  });
+
+  it('is 0.25 at two half-lives', () => {
+    expect(decayWeight(180, 90)).toBeCloseTo(0.25, 10);
+  });
+
+  it('treats a negative age as today rather than amplifying', () => {
+    expect(decayWeight(-10, 90)).toBe(1);
+  });
+});
+
+describe('applyTempering', () => {
+  it('scales only the above-floor part, so the 1.0 floor is preserved', () => {
+    expect(applyTempering(1, 0.5)).toBe(1);
+  });
+
+  it('halves the distance above the floor at multiplier 0.5', () => {
+    expect(applyTempering(5, 0.5)).toBe(3);
+  });
+
+  it('is a no-op when the multiplier is undefined', () => {
+    expect(applyTempering(4.2, undefined)).toBe(4.2);
+  });
+
+  it('is a no-op at multiplier 1', () => {
+    expect(applyTempering(4.2, 1)).toBe(4.2);
+  });
+});
+```
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+Run: `npm run test -- app/lib/cameraCalibration.test.ts`
+Expected: FAIL — cannot resolve `./cameraCalibration`.
+
+- [ ] **Step 4: Write the implementation**
+
+Create `app/lib/cameraCalibration.ts`:
+
+```ts
+import {
+  CALIBRATION_MIN_EVENTS,
+  CALIBRATION_MIN_DAYS,
+  CALIBRATION_PRIOR_K,
+  CALIBRATION_MAX_TEMPER,
+  CALIBRATION_MIN_MULTIPLIER,
+} from './masterConfig';
+
+/**
+ * Per-camera tempering evidence, already windowed and decayed by the caller.
+ *
+ * The rate is conditioned on the camera's NEGATIVE frames only — "given a
+ * boring frame, does this camera fool the model?". That conditioning is
+ * load-bearing: whole-population rates rank Broome 8th-9th because its 21
+ * genuinely correct fires dilute the error rate. See the spec.
+ */
+export interface CalibrationEvidence {
+  /** Decayed weight of false-shows inside the window. */
+  falseShows: number;
+  /** Decayed weight of operator-negative frames inside the window. */
+  negativeFrames: number;
+  /** Distinct capture days with a false-show, inside the window. */
+  falseShowDays: number;
+  /** Undecayed false-show count inside the window — the recurrence bar. */
+  rawFalseShows: number;
+}
+
+const finiteOrZero = (n: number): number =>
+  Number.isFinite(n) ? Math.max(0, n) : 0;
+
+/**
+ * Exponential decay weight for a frame captured `ageDays` ago.
+ * A future-dated frame (clock skew) weighs the same as today's, never more.
+ */
+export function decayWeight(ageDays: number, halfLifeDays: number): number {
+  const age = Math.max(0, finiteOrZero(ageDays));
+  if (!(halfLifeDays > 0)) return 1;
+  return Math.pow(0.5, age / halfLifeDays);
+}
+
+/**
+ * The tempering multiplier. Bounded to [MIN_MULTIPLIER, 1] by construction.
+ *
+ * Returns exactly 1 (neutral) unless the recurrence bar is cleared, so new
+ * cameras and one-off mistakes are never tempered.
+ */
+export function computeTemperingMultiplier(e: CalibrationEvidence): number {
+  const rawFalseShows = finiteOrZero(e.rawFalseShows);
+  const falseShowDays = finiteOrZero(e.falseShowDays);
+
+  if (rawFalseShows < CALIBRATION_MIN_EVENTS) return 1;
+  if (falseShowDays < CALIBRATION_MIN_DAYS) return 1;
+
+  const falseShows = finiteOrZero(e.falseShows);
+  const negativeFrames = finiteOrZero(e.negativeFrames);
+
+  const rate = falseShows / (negativeFrames + CALIBRATION_PRIOR_K);
+  const raw = 1 - CALIBRATION_MAX_TEMPER * rate;
+
+  return Math.min(1, Math.max(CALIBRATION_MIN_MULTIPLIER, raw));
+}
+
+/**
+ * Apply a multiplier to a 1-5 tile score, scaling only the part ABOVE the
+ * floor of 1. Product intent is "show every image, just small" — a tempered
+ * frame gets smaller, never hidden, and 1 stays 1.
+ */
+export function applyTempering(
+  score: number,
+  multiplier: number | undefined
+): number {
+  if (multiplier == null || !Number.isFinite(multiplier)) return score;
+  return 1 + (score - 1) * multiplier;
+}
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `npm run test -- app/lib/cameraCalibration.test.ts`
+Expected: PASS, all cases.
+
+- [ ] **Step 6: Verify branch, then commit**
+
+```bash
+git rev-parse --abbrev-ref HEAD
+git add app/lib/cameraCalibration.ts app/lib/cameraCalibration.test.ts app/lib/masterConfig.ts
+git commit -m "feat(calibration): bounded per-camera tempering multiplier math"
+```
+
+---
+
+### Task 2: Migration — evidence table, history table, webcams columns
+
+**Files:**
+- Create: `database/migrations/20260901_camera_calibration.sql`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: tables `camera_calibration_evidence`, `camera_calibration_history`; columns `webcams.calibration_multiplier`, `webcams.calibration_evidence`, `webcams.calibration_computed_at`.
+
+- [ ] **Step 1: Write the migration**
+
+Create `database/migrations/20260901_camera_calibration.sql`:
+
+```sql
+-- Per-camera calibration (tempering prior).
+-- Spec: docs/superpowers/specs/2026-08-31-per-camera-calibration-design.md
+--
+-- Three things:
+--   camera_calibration_evidence  one APPEND-ONLY row per labeled frame per
+--                                model version, carrying the scores that made
+--                                it count so a tempering decision can be
+--                                re-examined later without rescoring through
+--                                ONNX. Nothing in this system deletes from it.
+--   camera_calibration_history   multiplier CHANGE events, so healing and
+--                                drift are observable rather than asserted.
+--   webcams.calibration_*        the live value the display reads.
+--                                NULL = neutral; new cameras need no backfill.
+--
+-- Forward-only, idempotent. Apply manually via:
+--   psql "$DATABASE_URL" -f database/migrations/20260901_camera_calibration.sql
+
+CREATE TABLE IF NOT EXISTS camera_calibration_evidence (
+  id              BIGSERIAL PRIMARY KEY,
+  webcam_id       BIGINT NOT NULL,
+  snapshot_id     BIGINT NOT NULL,
+  -- Scoping by model version is the fix for the exact defect that killed the
+  -- model-vs-Claude wide signal: evidence from a retired head must never
+  -- drive a live multiplier.
+  model_version   TEXT NOT NULL,
+  -- The leg-2 socket. A second writer appends rows; aggregation is unchanged.
+  evidence_source TEXT NOT NULL,
+  is_negative     BOOLEAN NOT NULL,
+  fired           BOOLEAN NOT NULL,
+  captured_on     DATE NOT NULL,
+  -- Frame record. firebase_url is denormalised ON PURPOSE: this table must
+  -- stay reviewable years from now, independent of webcam_snapshots.
+  p_sunset        NUMERIC(6,4) NOT NULL,
+  quality         NUMERIC(6,4),
+  tile            NUMERIC(6,4),
+  firebase_url    TEXT NOT NULL,
+  scored_at       TIMESTAMPTZ NOT NULL DEFAULT now(),
+  UNIQUE (snapshot_id, model_version, evidence_source)
+);
+
+-- Hot path: the nightly aggregation scans one model generation per camera.
+CREATE INDEX IF NOT EXISTS camera_calibration_evidence_cam_idx
+  ON camera_calibration_evidence (webcam_id, model_version, captured_on DESC);
+
+CREATE TABLE IF NOT EXISTS camera_calibration_history (
+  id                  BIGSERIAL PRIMARY KEY,
+  webcam_id           BIGINT NOT NULL,
+  computed_at         TIMESTAMPTZ NOT NULL DEFAULT now(),
+  multiplier          NUMERIC(4,3) NOT NULL,
+  previous_multiplier NUMERIC(4,3),
+  false_shows         NUMERIC(8,3) NOT NULL,
+  negative_frames     NUMERIC(8,3) NOT NULL,
+  raw_false_shows     INT NOT NULL,
+  false_show_days     INT NOT NULL,
+  model_version       TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS camera_calibration_history_cam_idx
+  ON camera_calibration_history (webcam_id, computed_at DESC);
+
+ALTER TABLE webcams
+  ADD COLUMN IF NOT EXISTS calibration_multiplier  NUMERIC(4,3),
+  ADD COLUMN IF NOT EXISTS calibration_evidence    JSONB,
+  ADD COLUMN IF NOT EXISTS calibration_computed_at TIMESTAMPTZ;
+```
+
+- [ ] **Step 2: Verify the SQL parses without applying it to production**
+
+Run: `.venv/bin/python -c "import sqlite3" 2>/dev/null; grep -c 'CREATE TABLE IF NOT EXISTS' database/migrations/20260901_camera_calibration.sql`
+Expected: `2`.
+
+Do NOT run this against `DATABASE_URL`. Applying migrations is Jesse's step.
+
+- [ ] **Step 3: Verify branch, then commit**
+
+```bash
+git rev-parse --abbrev-ref HEAD
+git add database/migrations/20260901_camera_calibration.sql
+git commit -m "feat(calibration): migration for evidence, history, webcams columns"
+```
+
+---
+
+### Task 3: Evidence writer — `--emit-evidence`
+
+**Files:**
+- Modify: `ml/audit_camera_errors.py`
+
+**Interfaces:**
+- Consumes: the migration's `camera_calibration_evidence` schema.
+- Produces: rows in `camera_calibration_evidence` with `evidence_source = 'operator_label'` and `model_version` = the binary ONNX directory name.
+
+- [ ] **Step 1: Add the CLI flag**
+
+In the `argparse` block of `ml/audit_camera_errors.py`, after `--dump-frames`, add:
+
+```python
+    p.add_argument("--emit-evidence", action="store_true",
+                   help="upsert per-frame rows into camera_calibration_evidence "
+                        "(the calibration job's input; see the 2026-08-31 "
+                        "per-camera calibration spec). Append-only: re-running "
+                        "refreshes scores for the same model generation and "
+                        "never deletes.")
+```
+
+- [ ] **Step 2: Derive the model version from the ONNX path**
+
+Add near the top-level helpers:
+
+```python
+def model_version_from_path(onnx_path: str) -> str:
+    """The run directory name is the model version stamped on webcams rows."""
+    return Path(onnx_path).parent.name
+```
+
+- [ ] **Step 3: Collect evidence rows in the scoring loop**
+
+Inside the per-frame loop, immediately after `tile` is computed and alongside the existing `dump_rows.append(...)`, add:
+
+```python
+        if args.emit_evidence:
+            evidence_rows.append((
+                int(wid), int(sid), model_version, "operator_label",
+                not bool(is_sunset), bool(shown), day,
+                round(float(p_sun), 4),
+                round(float(q), 4),
+                round(float(tile), 4),
+                str(url),
+            ))
+```
+
+Initialise `evidence_rows: list = []` and `model_version = model_version_from_path(args.binary_onnx)` next to the existing `dump_rows = []`.
+
+- [ ] **Step 4: Write the upsert after the loop**
+
+After scoring completes, before the report is written:
+
+```python
+    if args.emit_evidence:
+        conn2 = psycopg2.connect(os.environ["DATABASE_URL"])
+        cur2 = conn2.cursor()
+        # ON CONFLICT DO UPDATE, never DELETE: re-running refreshes scores for
+        # this model generation; a different model_version inserts a NEW
+        # generation beside the old so both stay answerable.
+        cur2.executemany(
+            """
+            INSERT INTO camera_calibration_evidence
+              (webcam_id, snapshot_id, model_version, evidence_source,
+               is_negative, fired, captured_on, p_sunset, quality, tile,
+               firebase_url)
+            VALUES (%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s)
+            ON CONFLICT (snapshot_id, model_version, evidence_source)
+            DO UPDATE SET
+              is_negative = EXCLUDED.is_negative,
+              fired       = EXCLUDED.fired,
+              p_sunset    = EXCLUDED.p_sunset,
+              quality     = EXCLUDED.quality,
+              tile        = EXCLUDED.tile,
+              scored_at   = now()
+            """,
+            evidence_rows,
+        )
+        conn2.commit()
+        cur2.execute(
+            "SELECT count(*) FROM camera_calibration_evidence WHERE model_version = %s",
+            (model_version,),
+        )
+        total = cur2.fetchone()[0]
+        conn2.close()
+        print(f"  emitted {len(evidence_rows)} evidence rows; "
+              f"{total} total for model_version={model_version}")
+```
+
+- [ ] **Step 5: Smoke-test the flag on a small slice**
+
+Run: `.venv/bin/python ml/audit_camera_errors.py --limit 50 --emit-evidence`
+Expected: prints `emitted 50 evidence rows; 50 total for model_version=20260829_062437_v5_binary_gold`.
+
+Run it a SECOND time. Expected: `emitted 50 evidence rows; 50 total` — the total does NOT grow. That is clause 7.
+
+- [ ] **Step 6: Populate the full evidence set**
+
+Run: `.venv/bin/python ml/audit_camera_errors.py --emit-evidence`
+Expected: `emitted 9118 evidence rows; 9118 total`.
+
+- [ ] **Step 7: Verify branch, then commit**
+
+```bash
+git rev-parse --abbrev-ref HEAD
+git add ml/audit_camera_errors.py
+git commit -m "feat(calibration): --emit-evidence writes append-only frame records"
+```
+
+---
+
+### Task 4: Nightly aggregation — DB layer
+
+**Files:**
+- Modify: `app/api/cron/update-cameras/lib/dbOperations.ts` (append to end)
+
+**Interfaces:**
+- Consumes: `CalibrationEvidence` from `app/lib/cameraCalibration.ts`.
+- Produces: `CameraCalibrationRow` interface; `findCalibrationEvidenceByCamera(modelVersion, windowDays, halfLifeDays)`, `updateCameraCalibrationBatch(updates)`, `insertCalibrationHistoryBatch(rows)`.
+
+- [ ] **Step 1: Write the aggregation query function**
+
+Append to `app/api/cron/update-cameras/lib/dbOperations.ts`:
+
+```ts
+/* -------------------------------------------------------------------------- */
+/* Per-camera calibration (tempering prior)                                    */
+/* Spec: docs/superpowers/specs/2026-08-31-per-camera-calibration-design.md    */
+/* -------------------------------------------------------------------------- */
+
+export interface CameraCalibrationRow {
+  webcamId: number;
+  falseShows: number;
+  negativeFrames: number;
+  falseShowDays: number;
+  rawFalseShows: number;
+  previousMultiplier: number | null;
+}
+
+/**
+ * Aggregate calibration evidence per camera, scoped to ONE model generation
+ * and a rolling window, with exponential decay applied in SQL.
+ *
+ * The window governs eligibility (so a camera with no recent false-show heals
+ * completely); the decay governs magnitude (so it relaxes smoothly first).
+ */
+export async function findCalibrationEvidenceByCamera(
+  modelVersion: string,
+  windowDays: number,
+  halfLifeDays: number,
+): Promise<CameraCalibrationRow[]> {
+  const rows = (await sql`
+    select e.webcam_id                                             as webcam_id,
+           sum(case when e.is_negative and e.fired
+                    then power(0.5, (current_date - e.captured_on)::numeric
+                                    / ${halfLifeDays}::numeric)
+                    else 0 end)                                    as false_shows,
+           sum(case when e.is_negative
+                    then power(0.5, (current_date - e.captured_on)::numeric
+                                    / ${halfLifeDays}::numeric)
+                    else 0 end)                                    as negative_frames,
+           count(distinct case when e.is_negative and e.fired
+                               then e.captured_on end)             as false_show_days,
+           count(*) filter (where e.is_negative and e.fired)        as raw_false_shows,
+           max(w.calibration_multiplier)                            as previous_multiplier
+    from camera_calibration_evidence e
+    join webcams w on w.id = e.webcam_id
+    where e.model_version = ${modelVersion}
+      and e.captured_on > current_date - ${windowDays}::int
+    group by e.webcam_id
+  `) as {
+    webcam_id: number;
+    false_shows: number | string;
+    negative_frames: number | string;
+    false_show_days: number | string;
+    raw_false_shows: number | string;
+    previous_multiplier: number | string | null;
+  }[];
+
+  // NUMERIC comes back as a STRING through the Neon driver — coerce every one.
+  return rows.map((r) => ({
+    webcamId: Number(r.webcam_id),
+    falseShows: Number(r.false_shows),
+    negativeFrames: Number(r.negative_frames),
+    falseShowDays: Number(r.false_show_days),
+    rawFalseShows: Number(r.raw_false_shows),
+    previousMultiplier:
+      r.previous_multiplier == null ? null : Number(r.previous_multiplier),
+  }));
+}
+
+/** One batched UPDATE for the whole fleet rather than a round-trip per camera. */
+export async function updateCameraCalibrationBatch(
+  updates: { webcamId: number; multiplier: number; evidence: unknown }[],
+): Promise<void> {
+  if (updates.length === 0) return;
+  const ids = updates.map((u) => u.webcamId);
+  const mults = updates.map((u) => u.multiplier);
+  const evidence = updates.map((u) => JSON.stringify(u.evidence));
+  await sql`
+    update webcams w
+    set calibration_multiplier = v.mult,
+        calibration_evidence = v.evidence::jsonb,
+        calibration_computed_at = now()
+    from unnest(${ids}::bigint[], ${mults}::numeric[], ${evidence}::text[])
+      as v(id, mult, evidence)
+    where w.id = v.id
+  `;
+}
+
+/** Append-only. Called only for cameras whose multiplier actually changed. */
+export async function insertCalibrationHistoryBatch(
+  rows: {
+    webcamId: number;
+    multiplier: number;
+    previousMultiplier: number | null;
+    falseShows: number;
+    negativeFrames: number;
+    rawFalseShows: number;
+    falseShowDays: number;
+    modelVersion: string;
+  }[],
+): Promise<void> {
+  if (rows.length === 0) return;
+  await sql`
+    insert into camera_calibration_history
+      (webcam_id, multiplier, previous_multiplier, false_shows,
+       negative_frames, raw_false_shows, false_show_days, model_version)
+    select * from unnest(
+      ${rows.map((r) => r.webcamId)}::bigint[],
+      ${rows.map((r) => r.multiplier)}::numeric[],
+      ${rows.map((r) => r.previousMultiplier)}::numeric[],
+      ${rows.map((r) => r.falseShows)}::numeric[],
+      ${rows.map((r) => r.negativeFrames)}::numeric[],
+      ${rows.map((r) => r.rawFalseShows)}::int[],
+      ${rows.map((r) => r.falseShowDays)}::int[],
+      ${rows.map((r) => r.modelVersion)}::text[]
+    )
+  `;
+}
+```
+
+- [ ] **Step 2: Typecheck**
+
+Run: `npx tsc --noEmit`
+Expected: no errors in `dbOperations.ts`.
+
+- [ ] **Step 3: Verify branch, then commit**
+
+```bash
+git rev-parse --abbrev-ref HEAD
+git add app/api/cron/update-cameras/lib/dbOperations.ts
+git commit -m "feat(calibration): per-camera evidence aggregation and batch writers"
+```
+
+---
+
+### Task 5: Nightly aggregation — orchestration + history (clause 8)
+
+**Files:**
+- Create: `app/api/cron/update-cameras/lib/recomputeCameraCalibration.ts`
+- Create: `app/api/cron/update-cameras/lib/recomputeCameraCalibration.test.ts`
+
+**Interfaces:**
+- Consumes: `findCalibrationEvidenceByCamera`, `updateCameraCalibrationBatch`, `insertCalibrationHistoryBatch` from Task 4; `computeTemperingMultiplier` from Task 1.
+- Produces: `recomputeCameraCalibration(opts: { modelVersion: string }): Promise<CalibrationResult>` where `CalibrationResult = { camerasEvaluated: number; tempered: number; changed: number }`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `app/api/cron/update-cameras/lib/recomputeCameraCalibration.test.ts`:
+
+```ts
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  findCalibrationEvidenceByCamera: vi.fn(),
+  updateCameraCalibrationBatch: vi.fn(),
+  insertCalibrationHistoryBatch: vi.fn(),
+}));
+
+vi.mock('./dbOperations', () => mocks);
+
+import { recomputeCameraCalibration } from './recomputeCameraCalibration';
+
+const MODEL = '20260829_062437_v5_binary_gold';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.updateCameraCalibrationBatch.mockResolvedValue(undefined);
+  mocks.insertCalibrationHistoryBatch.mockResolvedValue(undefined);
+});
+
+describe('recomputeCameraCalibration', () => {
+  it('tempers a camera clearing the recurrence bar and records history', async () => {
+    mocks.findCalibrationEvidenceByCamera.mockResolvedValue([
+      {
+        webcamId: 4057187,
+        falseShows: 11,
+        negativeFrames: 11,
+        falseShowDays: 9,
+        rawFalseShows: 11,
+        previousMultiplier: null,
+      },
+    ]);
+
+    const result = await recomputeCameraCalibration({ modelVersion: MODEL });
+
+    expect(result).toEqual({ camerasEvaluated: 1, tempered: 1, changed: 1 });
+
+    const [updates] = mocks.updateCameraCalibrationBatch.mock.calls[0];
+    expect(updates[0].webcamId).toBe(4057187);
+    expect(updates[0].multiplier).toBeCloseTo(0.577, 3);
+
+    const [history] = mocks.insertCalibrationHistoryBatch.mock.calls[0];
+    expect(history).toHaveLength(1);
+    expect(history[0].previousMultiplier).toBeNull();
+    expect(history[0].modelVersion).toBe(MODEL);
+  });
+
+  it('writes NO history row when the multiplier is unchanged (clause 8)', async () => {
+    mocks.findCalibrationEvidenceByCamera.mockResolvedValue([
+      {
+        webcamId: 4057187,
+        falseShows: 11,
+        negativeFrames: 11,
+        falseShowDays: 9,
+        rawFalseShows: 11,
+        previousMultiplier: 0.577,
+      },
+    ]);
+
+    const result = await recomputeCameraCalibration({ modelVersion: MODEL });
+
+    expect(result.changed).toBe(0);
+    const [history] = mocks.insertCalibrationHistoryBatch.mock.calls[0];
+    expect(history).toHaveLength(0);
+  });
+
+  it('writes a history row carrying the previous value when it changes', async () => {
+    mocks.findCalibrationEvidenceByCamera.mockResolvedValue([
+      {
+        webcamId: 4057187,
+        falseShows: 4,
+        negativeFrames: 15,
+        falseShowDays: 4,
+        rawFalseShows: 4,
+        previousMultiplier: 0.577,
+      },
+    ]);
+
+    await recomputeCameraCalibration({ modelVersion: MODEL });
+
+    const [history] = mocks.insertCalibrationHistoryBatch.mock.calls[0];
+    expect(history).toHaveLength(1);
+    expect(history[0].previousMultiplier).toBe(0.577);
+    expect(history[0].multiplier).toBeCloseTo(0.882, 3);
+  });
+
+  it('heals a camera back to 1.0 and records that as a change', async () => {
+    mocks.findCalibrationEvidenceByCamera.mockResolvedValue([
+      {
+        webcamId: 4057187,
+        falseShows: 0,
+        negativeFrames: 0,
+        falseShowDays: 0,
+        rawFalseShows: 0,
+        previousMultiplier: 0.577,
+      },
+    ]);
+
+    const result = await recomputeCameraCalibration({ modelVersion: MODEL });
+
+    expect(result.tempered).toBe(0);
+    const [updates] = mocks.updateCameraCalibrationBatch.mock.calls[0];
+    expect(updates[0].multiplier).toBe(1);
+    const [history] = mocks.insertCalibrationHistoryBatch.mock.calls[0];
+    expect(history[0].multiplier).toBe(1);
+  });
+
+  it('handles an empty fleet without writing anything', async () => {
+    mocks.findCalibrationEvidenceByCamera.mockResolvedValue([]);
+
+    const result = await recomputeCameraCalibration({ modelVersion: MODEL });
+
+    expect(result).toEqual({ camerasEvaluated: 0, tempered: 0, changed: 0 });
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm run test -- app/api/cron/update-cameras/lib/recomputeCameraCalibration.test.ts`
+Expected: FAIL — cannot resolve `./recomputeCameraCalibration`.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `app/api/cron/update-cameras/lib/recomputeCameraCalibration.ts`:
+
+```ts
+import { computeTemperingMultiplier } from '@/app/lib/cameraCalibration';
+import {
+  CALIBRATION_WINDOW_DAYS,
+  CALIBRATION_HALF_LIFE_DAYS,
+} from '@/app/lib/masterConfig';
+import {
+  findCalibrationEvidenceByCamera,
+  updateCameraCalibrationBatch,
+  insertCalibrationHistoryBatch,
+} from './dbOperations';
+
+export interface CalibrationResult {
+  camerasEvaluated: number;
+  tempered: number;
+  changed: number;
+}
+
+/** Multipliers are stored NUMERIC(4,3); anything smaller is not a real change. */
+const CHANGE_EPSILON = 0.001;
+
+/**
+ * Recompute every camera's tempering multiplier from accumulated evidence.
+ *
+ * Pure SQL + arithmetic: no image download, no ONNX. That is why this runs on
+ * its own nightly cron without the ml/artifacts bundle.
+ *
+ * History is written for CHANGES ONLY — writing every camera every night would
+ * add ~1,000 near-identical rows nightly, and webcams.calibration_computed_at
+ * already answers "did the job run".
+ */
+export async function recomputeCameraCalibration(opts: {
+  modelVersion: string;
+}): Promise<CalibrationResult> {
+  const rows = await findCalibrationEvidenceByCamera(
+    opts.modelVersion,
+    CALIBRATION_WINDOW_DAYS,
+    CALIBRATION_HALF_LIFE_DAYS,
+  );
+
+  const updates = rows.map((r) => {
+    const multiplier = computeTemperingMultiplier({
+      falseShows: r.falseShows,
+      negativeFrames: r.negativeFrames,
+      falseShowDays: r.falseShowDays,
+      rawFalseShows: r.rawFalseShows,
+    });
+    return { row: r, multiplier };
+  });
+
+  await updateCameraCalibrationBatch(
+    updates.map(({ row, multiplier }) => ({
+      webcamId: row.webcamId,
+      multiplier,
+      evidence: {
+        falseShows: row.falseShows,
+        negativeFrames: row.negativeFrames,
+        falseShowDays: row.falseShowDays,
+        rawFalseShows: row.rawFalseShows,
+        modelVersion: opts.modelVersion,
+      },
+    })),
+  );
+
+  const changed = updates.filter(
+    ({ row, multiplier }) =>
+      row.previousMultiplier == null ||
+      Math.abs(row.previousMultiplier - multiplier) > CHANGE_EPSILON,
+  );
+
+  await insertCalibrationHistoryBatch(
+    changed.map(({ row, multiplier }) => ({
+      webcamId: row.webcamId,
+      multiplier,
+      previousMultiplier: row.previousMultiplier,
+      falseShows: row.falseShows,
+      negativeFrames: row.negativeFrames,
+      rawFalseShows: row.rawFalseShows,
+      falseShowDays: row.falseShowDays,
+      modelVersion: opts.modelVersion,
+    })),
+  );
+
+  return {
+    camerasEvaluated: rows.length,
+    tempered: updates.filter((u) => u.multiplier < 1).length,
+    changed: changed.length,
+  };
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npm run test -- app/api/cron/update-cameras/lib/recomputeCameraCalibration.test.ts`
+Expected: PASS, all five cases.
+
+- [ ] **Step 5: Verify branch, then commit**
+
+```bash
+git rev-parse --abbrev-ref HEAD
+git add app/api/cron/update-cameras/lib/recomputeCameraCalibration.ts app/api/cron/update-cameras/lib/recomputeCameraCalibration.test.ts
+git commit -m "feat(calibration): nightly recompute with change-only history"
+```
+
+---
+
+### Task 6: Cron route + schedule
+
+**Files:**
+- Create: `app/api/cron/recompute-camera-calibration/route.ts`
+- Modify: `app/api/cron/update-cameras/lib/aiScoring.ts` (export one existing function)
+- Modify: `vercel.json`
+
+**Interfaces:**
+- Consumes: `recomputeCameraCalibration` from Task 5.
+- Produces: `GET|POST /api/cron/recompute-camera-calibration`; `resolveBinaryModelVersion()` becomes exported.
+
+- [ ] **Step 1: Export the effective model-version resolver**
+
+The cron must read the SAME model generation the scoring path stamps. The
+default constant is not enough — `AI_BINARY_MODEL_VERSION` can override it in
+env, and querying the wrong generation would silently aggregate zero evidence.
+
+In `app/api/cron/update-cameras/lib/aiScoring.ts` (~line 106), add `export`:
+
+```ts
+export function resolveBinaryModelVersion(): string {
+```
+
+Change nothing else in that file.
+
+- [ ] **Step 2: Write the route**
+
+Create `app/api/cron/recompute-camera-calibration/route.ts`:
+
+```ts
+import { NextResponse } from 'next/server';
+import { verifyCronAuth } from '../update-cameras/lib/auth';
+import { recomputeCameraCalibration } from '../update-cameras/lib/recomputeCameraCalibration';
+import { resolveBinaryModelVersion } from '../update-cameras/lib/aiScoring';
+
+export const dynamic = 'force-dynamic';
+export const maxDuration = 60;
+
+// Per-camera calibration recompute.
+// Spec: docs/superpowers/specs/2026-08-31-per-camera-calibration-design.md
+//
+// Derives a bounded per-camera tempering multiplier from accumulated error
+// evidence and writes it to the webcams row. Pure SQL recompute (no image
+// download, no ONNX), so it does NOT need the ml/artifacts bundle and runs on
+// its own nightly schedule, isolated from the live-scoring tick budget.
+//
+// It NEVER touches the detection verdict — only the tile/quality signal.
+
+async function handle(request: Request) {
+  if (!verifyCronAuth(request) && process.env.NODE_ENV !== 'development') {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+  try {
+    const result = await recomputeCameraCalibration({
+      // The EFFECTIVE version, not the default constant — env can override it,
+      // and the evidence rows are scoped by the version actually in use.
+      modelVersion: resolveBinaryModelVersion(),
+    });
+    return NextResponse.json({ ok: true, ...result });
+  } catch (error) {
+    console.error('[recompute-camera-calibration] failed:', error);
+    return NextResponse.json(
+      {
+        error: 'Internal server error',
+        details: error instanceof Error ? error.message : 'Unknown error',
+      },
+      { status: 500 },
+    );
+  }
+}
+
+export async function GET(request: Request) {
+  return handle(request);
+}
+
+export async function POST(request: Request) {
+  return handle(request);
+}
+```
+
+- [ ] **Step 3: Add the nightly cron entry**
+
+In `vercel.json`, add to the `crons` array:
+
+```json
+    {
+      "path": "/api/cron/recompute-camera-calibration",
+      "schedule": "15 4 * * *"
+    }
+```
+
+- [ ] **Step 4: Verify the route compiles and the config is valid JSON**
+
+Run: `npx tsc --noEmit && node -e "JSON.parse(require('fs').readFileSync('vercel.json','utf8')); console.log('vercel.json OK')"`
+Expected: no TS errors, then `vercel.json OK`.
+
+- [ ] **Step 5: Verify branch, then commit**
+
+```bash
+git rev-parse --abbrev-ref HEAD
+git add app/api/cron/recompute-camera-calibration/route.ts app/api/cron/update-cameras/lib/aiScoring.ts vercel.json
+git commit -m "feat(calibration): nightly cron route and schedule"
+```
+
+---
+
+### Task 7: Apply the multiplier to the tile signal (clause 4)
+
+**Files:**
+- Modify: `app/components/mosaic/v1/qualitySignal.ts`
+- Modify: `app/components/mosaic/v1/qualitySignal.test.ts`
+- Modify: `app/lib/types.ts`
+- Modify: `app/api/db-all-webcams/route.ts`
+
+**Interfaces:**
+- Consumes: `applyTempering` from Task 1.
+- Produces: `WindyWebcam.calibrationMultiplier?: number`; `getQualityScore` returns a tempered score.
+
+**⚠️ `qualitySignal.ts` is a shared helper.** CLAUDE.md requires a heads-up to the display lane when it changes. That message has already been sent for this change; if this task is executed later than 2026-09-01, re-send before committing.
+
+- [ ] **Step 1: Add the field to `WindyWebcam`**
+
+In `app/lib/types.ts`, next to the other ai rating fields (~line 95):
+
+```ts
+  /**
+   * Per-camera tempering multiplier in [0.5, 1]. Undefined = neutral.
+   * Applies to the TILE signal only — never the detection verdict.
+   * Spec: docs/superpowers/specs/2026-08-31-per-camera-calibration-design.md
+   */
+  calibrationMultiplier?: number;
+```
+
+- [ ] **Step 2: Write the failing tests**
+
+Append to `app/components/mosaic/v1/qualitySignal.test.ts`:
+
+```ts
+describe('per-camera tempering', () => {
+  it('shrinks the tile score for a tempered camera', () => {
+    const score = getQualityScore({
+      ...base,
+      aiRatingBinary: SHOWN,
+      aiRatingRegression: 5,
+      calibrationMultiplier: 0.5,
+    } as WindyWebcam);
+    expect(score).toBe(3);
+  });
+
+  it('is a no-op for an untempered camera', () => {
+    expect(
+      getQualityScore({
+        ...base,
+        aiRatingBinary: SHOWN,
+        aiRatingRegression: 3.7,
+      })
+    ).toBe(3.7);
+  });
+
+  it('keeps the floor at 1 for a rejected frame regardless of multiplier', () => {
+    expect(
+      getQualityScore({
+        ...base,
+        aiRatingBinary: REJECTED,
+        aiRatingRegression: 4.2,
+        calibrationMultiplier: 0.5,
+      } as WindyWebcam)
+    ).toBe(1);
+  });
+
+  it('leaves passesGate bit-identical with and without a multiplier (clause 4)', () => {
+    const atGate = 1 + 0.55 * 4; // 3.2
+    for (const binary of [REJECTED, atGate, SHOWN]) {
+      const without = passesGate({ ...base, aiRatingBinary: binary });
+      const with05 = passesGate({
+        ...base,
+        aiRatingBinary: binary,
+        calibrationMultiplier: 0.5,
+      } as WindyWebcam);
+      expect(with05).toBe(without);
+    }
+  });
+});
+```
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+Run: `npm run test -- app/components/mosaic/v1/qualitySignal.test.ts`
+Expected: FAIL — the tempering test gets 5 instead of 3.
+
+- [ ] **Step 4: Apply the multiplier**
+
+In `app/components/mosaic/v1/qualitySignal.ts`, add the import and change ONLY `getQualityScore`:
+
+```ts
+import { applyTempering } from '@/app/lib/cameraCalibration';
+```
+
+```ts
+export function getQualityScore(webcam: WindyWebcam): number | null {
+  const detection = webcam.aiRatingBinary;
+  if (typeof detection === 'number' && detection < GATE_AS_RATING) {
+    return 1;
+  }
+  const raw = webcam.aiRatingRegression ?? null;
+  if (raw == null) return null;
+  // Per-camera tempering scales only the part ABOVE the floor, so a tempered
+  // frame gets smaller but is never hidden. passesGate is deliberately NOT
+  // tempered — the detection verdict is frozen.
+  return applyTempering(raw, webcam.calibrationMultiplier);
+}
+```
+
+Do NOT modify `passesGate`.
+
+- [ ] **Step 5: Run the full mosaic test file**
+
+Run: `npm run test -- app/components/mosaic/v1/qualitySignal.test.ts`
+Expected: PASS, including all pre-existing tests.
+
+- [ ] **Step 6: Plumb the column through the API**
+
+In `app/api/db-all-webcams/route.ts`: add `w.calibration_multiplier` to the select list after `w.ai_model_version_regression`; add `calibration_multiplier: number | string | null;` to the row type; and add to the mapped object:
+
+```ts
+    calibrationMultiplier: toMaybeNumber(row.calibration_multiplier),
+```
+
+`toMaybeNumber` already handles the NUMERIC-as-string coercion.
+
+- [ ] **Step 7: Run the full suite**
+
+Run: `npm run test`
+Expected: all tests pass, no regressions.
+
+- [ ] **Step 8: Verify branch, then commit**
+
+```bash
+git rev-parse --abbrev-ref HEAD
+git add app/components/mosaic/v1/qualitySignal.ts app/components/mosaic/v1/qualitySignal.test.ts app/lib/types.ts app/api/db-all-webcams/route.ts
+git commit -m "feat(calibration): temper the tile signal, never the gate"
+```
+
+---
+
+### Task 8: Acceptance verification (clauses 1-3, 7)
+
+**Files:**
+- Create: `ml/verify_calibration_acceptance.py`
+
+**Interfaces:**
+- Consumes: populated `camera_calibration_evidence` (Task 3), the constants (Task 1).
+- Produces: a pass/fail report; exit code 1 on any failed clause.
+
+- [ ] **Step 1: Write the verifier**
+
+Create `ml/verify_calibration_acceptance.py`:
+
+```python
+#!/usr/bin/env python3
+"""Pre-registered acceptance test for per-camera calibration leg 1.
+
+Clauses 1-3 and 7 of the spec's 8-clause bar. Clauses 4-6 and 8 are covered by
+the TypeScript unit tests. Exits 1 if any clause fails.
+
+Usage:
+  .venv/bin/python ml/verify_calibration_acceptance.py
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+import psycopg2
+
+MODEL = "20260829_062437_v5_binary_gold"
+PRIOR_K, MAX_TEMPER, MIN_MULT = 2.0, 0.5, 0.5
+MIN_EVENTS, MIN_DAYS = 3, 2
+WINDOW_DAYS, HALF_LIFE = 365, 90
+
+GROUND_TRUTH = {4057187, 2947112, 29095214, 29275205}
+OFFENDERS = {
+    4057187, 2947112, 29095214, 29275205, 97, 3914190, 5961510, 160,
+    28894257, 2051, 3236, 404, 3309592, 2972357, 29048102, 27660488, 29182812,
+}
+
+
+def load_env_local() -> None:
+    env = Path(__file__).resolve().parent.parent / ".env.local"
+    if not env.exists():
+        return
+    for line in env.read_text().splitlines():
+        line = line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, _, val = line.partition("=")
+        os.environ.setdefault(key.strip(), val.strip().strip('"').strip("'"))
+
+
+def main() -> None:
+    load_env_local()
+    conn = psycopg2.connect(os.environ["DATABASE_URL"])
+    cur = conn.cursor()
+    cur.execute(
+        """
+        SELECT webcam_id,
+               SUM(CASE WHEN is_negative AND fired
+                        THEN power(0.5, (current_date - captured_on)::numeric / %s)
+                        ELSE 0 END),
+               SUM(CASE WHEN is_negative
+                        THEN power(0.5, (current_date - captured_on)::numeric / %s)
+                        ELSE 0 END),
+               COUNT(DISTINCT CASE WHEN is_negative AND fired THEN captured_on END),
+               COUNT(*) FILTER (WHERE is_negative AND fired)
+        FROM camera_calibration_evidence
+        WHERE model_version = %s AND captured_on > current_date - %s
+        GROUP BY webcam_id
+        """,
+        (HALF_LIFE, HALF_LIFE, MODEL, WINDOW_DAYS),
+    )
+    rows = cur.fetchall()
+
+    def mult(fs, nn, days, raw):
+        if raw < MIN_EVENTS or days < MIN_DAYS:
+            return 1.0
+        return max(MIN_MULT, min(1.0, 1.0 - MAX_TEMPER * (float(fs) / (float(nn) + PRIOR_K))))
+
+    tempered = {}
+    for wid, fs, nn, days, raw in rows:
+        m = mult(fs, nn, days, raw)
+        if m < 1.0:
+            tempered[wid] = m
+
+    failures = []
+
+    missing = GROUND_TRUTH - set(tempered)
+    print(f"clause 1  ground truth tempers: {len(GROUND_TRUTH - missing)}/4")
+    for g in sorted(GROUND_TRUTH):
+        print(f"            {g}: {tempered.get(g, 1.0):.3f}")
+    if missing:
+        failures.append(f"clause 1 FAILED — not tempered: {sorted(missing)}")
+
+    extra = set(tempered) - OFFENDERS
+    print(f"clause 2  non-offenders tempered: {len(extra)} (must be 0)")
+    if extra:
+        failures.append(f"clause 2 FAILED — unexpected: {sorted(extra)}")
+
+    print(f"clause 3  fleet bound: {len(tempered)} tempered (must be <= 25)")
+    if len(tempered) > 25:
+        failures.append(f"clause 3 FAILED — {len(tempered)} tempered")
+
+    cur.execute(
+        "SELECT count(*), count(DISTINCT snapshot_id) FROM camera_calibration_evidence "
+        "WHERE model_version = %s",
+        (MODEL,),
+    )
+    total, distinct = cur.fetchone()
+    print(f"clause 7  retention: {total} rows, {distinct} distinct snapshots")
+    if total != distinct:
+        failures.append(f"clause 7 FAILED — {total} rows for {distinct} snapshots (duplicates)")
+
+    conn.close()
+
+    print()
+    if failures:
+        for f in failures:
+            print(f"  {f}")
+        sys.exit(1)
+    print("  ALL CHECKED CLAUSES PASS (1, 2, 3, 7)")
+
+
+if __name__ == "__main__":
+    main()
+```
+
+- [ ] **Step 2: Run the verifier**
+
+Run: `.venv/bin/python ml/verify_calibration_acceptance.py`
+Expected:
+```
+clause 1  ground truth tempers: 4/4
+            2947112: 0.714
+            4057187: 0.577
+            29095214: 0.882
+            29275205: 0.833
+clause 2  non-offenders tempered: 0 (must be 0)
+clause 3  fleet bound: 17 tempered (must be <= 25)
+clause 7  retention: 9118 rows, 9118 distinct snapshots
+  ALL CHECKED CLAUSES PASS (1, 2, 3, 7)
+```
+
+If the multipliers differ from the baseline, STOP and report — do not adjust constants to make the test pass. That would be tuning on the acceptance set, the one forbidden move in this program.
+
+- [ ] **Step 3: Run the full test suite**
+
+Run: `npm run test`
+Expected: all pass.
+
+- [ ] **Step 4: Verify branch, then commit**
+
+```bash
+git rev-parse --abbrev-ref HEAD
+git add ml/verify_calibration_acceptance.py
+git commit -m "test(calibration): pre-registered acceptance verifier"
+```
+
+---
+
+### Task 9: Ops panel — current state, frames, history
+
+**Files:**
+- Modify: `app/lib/opsTypes.ts`
+- Modify: `app/api/admin/ops-stats/route.ts`
+- Create: `app/api/admin/calibration-frames/route.ts`
+- Modify: `app/components/Ops/OpsPanels.tsx`
+
+**Interfaces:**
+- Consumes: the two tables and `webcams.calibration_*`.
+- Produces: `CalibrationCameraRow`, `CalibrationHistoryRow`, `CalibrationFrameRow`; `GET /api/admin/calibration-frames?webcamId=<id>`.
+
+- [ ] **Step 1: Add the types**
+
+Append to `app/lib/opsTypes.ts`:
+
+```ts
+/** A tempered camera and the evidence behind it. */
+export interface CalibrationCameraRow {
+  webcam_id: number;
+  title: string | null;
+  multiplier: number;
+  false_shows: number;
+  negative_frames: number;
+  false_show_days: number;
+  computed_at: string | null;
+}
+
+/** One multiplier change, for the over-time view. */
+export interface CalibrationHistoryRow {
+  webcam_id: number;
+  computed_at: string;
+  multiplier: number;
+  previous_multiplier: number | null;
+}
+
+/**
+ * One false-show frame behind a camera's tempering — the "was this camera
+ * fairly tempered?" check. Fetched per-camera on expand, never bulk-loaded:
+ * the evidence table holds ~9k rows and grows.
+ */
+export interface CalibrationFrameRow {
+  snapshot_id: number;
+  captured_on: string;
+  p_sunset: number;
+  tile: number | null;
+  firebase_url: string;
+}
+```
+
+Add to `OpsStatsResponse`:
+
+```ts
+  calibrationCameras: CalibrationCameraRow[];
+  calibrationHistory: CalibrationHistoryRow[];
+```
+
+- [ ] **Step 2: Serve the rows**
+
+In `app/api/admin/ops-stats/route.ts`, add before the response is assembled:
+
+```ts
+  const calibrationCameras = (await sql`
+    select w.id as webcam_id, w.title,
+           w.calibration_multiplier::float as multiplier,
+           (w.calibration_evidence->>'falseShows')::float     as false_shows,
+           (w.calibration_evidence->>'negativeFrames')::float as negative_frames,
+           (w.calibration_evidence->>'falseShowDays')::int    as false_show_days,
+           w.calibration_computed_at::text as computed_at
+    from webcams w
+    where w.calibration_multiplier is not null
+      and w.calibration_multiplier < 1
+    order by w.calibration_multiplier asc
+    limit 100
+  `) as unknown as CalibrationCameraRow[];
+
+  const calibrationHistory = (await sql`
+    select webcam_id, computed_at::text as computed_at,
+           multiplier::float as multiplier,
+           previous_multiplier::float as previous_multiplier
+    from camera_calibration_history
+    order by computed_at desc
+    limit 200
+  `) as unknown as CalibrationHistoryRow[];
+```
+
+Add both to the `body` object, and import the two new types.
+
+**Note:** the `::float` casts are deliberate — `NUMERIC` otherwise arrives as a string.
+
+- [ ] **Step 3: Add the per-camera frames endpoint**
+
+Create `app/api/admin/calibration-frames/route.ts`:
+
+```ts
+import { NextResponse } from 'next/server';
+import { requireOwner } from '@/app/lib/owner';
+import { sql } from '@/app/lib/db';
+import type { CalibrationFrameRow } from '@/app/lib/opsTypes';
+
+export const dynamic = 'force-dynamic';
+export const runtime = 'nodejs';
+
+// The frames behind one camera's tempering multiplier. Fetched on expand
+// rather than bundled into ops-stats: the evidence table holds ~9k rows today
+// and only grows as labels accumulate.
+export async function GET(request: Request) {
+  const denied = await requireOwner();
+  if (denied) return denied;
+
+  const webcamId = Number(
+    new URL(request.url).searchParams.get('webcamId') ?? '',
+  );
+  if (!Number.isFinite(webcamId)) {
+    return NextResponse.json({ error: 'webcamId required' }, { status: 400 });
+  }
+
+  const frames = (await sql`
+    select snapshot_id, captured_on::text as captured_on,
+           p_sunset::float as p_sunset,
+           tile::float as tile,
+           firebase_url
+    from camera_calibration_evidence
+    where webcam_id = ${webcamId}
+      and is_negative = true
+      and fired = true
+    order by tile desc nulls last
+    limit 50
+  `) as unknown as CalibrationFrameRow[];
+
+  return NextResponse.json({ frames });
+}
+```
+
+- [ ] **Step 4: Add the panel**
+
+In `app/components/Ops/OpsPanels.tsx`, following the existing panel structure, add a "Camera calibration" panel with three parts:
+
+1. `calibrationCameras` as a table: camera (title + id), multiplier, `false_shows / negative_frames`, days, computed_at.
+2. Clicking a row fetches `/api/admin/calibration-frames?webcamId=<id>` and renders the returned frames as thumbnails (`firebase_url`) labelled with `p_sunset` and `tile`. This is the audit surface — it is what makes the retained frames reachable.
+3. The most recent `calibrationHistory` entries as `webcam_id: previous → multiplier (computed_at)`, showing "—" when `previous_multiplier` is null.
+
+Match the existing panels' class names and container markup rather than inventing new styling.
+
+- [ ] **Step 5: Run the ops tests and the suite**
+
+Run: `npm run test -- app/components/Ops app/api/admin/ops-stats`
+Expected: PASS.
+
+Run: `npm run test`
+Expected: all pass.
+
+- [ ] **Step 6: Verify branch, then commit**
+
+```bash
+git rev-parse --abbrev-ref HEAD
+git add app/lib/opsTypes.ts app/api/admin/ops-stats/route.ts app/api/admin/calibration-frames/route.ts app/components/Ops/OpsPanels.tsx
+git commit -m "feat(calibration): Ops panel with evidence frames and history"
+```
+
+---
+
+### Task 10: Build, push, PR
+
+**Files:** none created.
+
+- [ ] **Step 1: Full verification**
+
+Run: `npm run test && npm run lint && npm run build`
+Expected: all green. The build must NOT grow the function bundle — this cron carries no ONNX.
+
+- [ ] **Step 2: Verify branch and push**
+
+```bash
+git rev-parse --abbrev-ref HEAD
+git push -u origin feat/per-camera-calibration
+```
+
+- [ ] **Step 3: Open the PR**
+
+Base it on `measure/hard-negative-emphasis` (this branch is stacked on PR #105), and state in the body:
+- The 8 acceptance clauses and their measured results.
+- **Jesse must apply `database/migrations/20260901_camera_calibration.sql`** before the cron can write. Until then the cron 500s and the multiplier stays NULL (neutral) — the display is unaffected.
+- The cron entry is inert until deploy.
+
+---
+
+## Post-Merge Checklist (Jesse's steps — do not attempt these)
+
+- [ ] Apply `database/migrations/20260901_camera_calibration.sql`.
+- [ ] Run `.venv/bin/python ml/audit_camera_errors.py --emit-evidence` to populate evidence.
+- [ ] Deploy, then confirm `calibration_computed_at` is stamped after the first nightly tick.
+- [ ] Re-run `ml/verify_calibration_acceptance.py` against production.
+- [ ] Update `docs/superpowers/plans/2026-08-29-two-scale-model-STATE.md` with the calibration outcome.

--- a/docs/superpowers/specs/2026-08-31-per-camera-calibration-design.md
+++ b/docs/superpowers/specs/2026-08-31-per-camera-calibration-design.md
@@ -1,0 +1,506 @@
+---
+title: "Automatic per-camera calibration — design"
+date: 2026-08-31
+status: SIGNED OFF 2026-09-01 — implementing leg 1
+---
+
+# Automatic per-camera calibration (tempering prior)
+
+Committed direction from the hard-negative emphasis decision rule
+(`docs/superpowers/plans/2026-08-31-hard-negative-emphasis-experiment.md`):
+the emphasis run missed its pre-registered bar — the **fourth** detection
+change to do so — so the residual false-show class gets an evidence-derived
+**display-side tempering prior** instead of another model change.
+
+Evidence base: `docs/ml/2026-08-31-camera-error-audit.md`.
+
+**Not re-litigated here:** whether to fix this in the model. That question is
+closed. Detection stays frozen.
+
+---
+
+## Requirements (settled with Jesse, 2026-08-31)
+
+1. Nightly job, pattern-matching the existing `recompute-disagreements` cron.
+2. Per-camera rolling evidence from accumulated error history.
+3. Output is a **bounded multiplier on the tile/quality signal only** — it must
+   never move the detection verdict.
+4. Stored on the `webcams` row, visible in the Ops tab.
+5. New cameras start neutral; evidence decays so a cleaned-up view heals.
+6. **No hand-curated lists anywhere.** Must scale to 1000s of cameras.
+7. Known ground truth: `4057187` (Broome), `2947112` (Coober Pedy),
+   `29095214` (Mount Gambier), `29275205` (Wagga Wagga) must temper;
+   almost everything else must not.
+8. **Frames are retained so the calibration can be checked over time**
+   (added 2026-09-01). Every frame that contributes to a multiplier is kept
+   with the scores that made it count, and every change to a camera's
+   multiplier is recorded — so a tempering decision can be re-examined, and
+   drift or healing observed, without rescoring anything.
+
+---
+
+## Measurement first: one settled requirement turned out to be false
+
+The requirement list named **model-vs-Claude disagreement as the wide signal**.
+Measured against production on 2026-08-31, it cannot work — for two independent
+reasons.
+
+**No supply.** Claude rating stopped **2026-07-31** (46,079 ratings total, none
+since). Of snapshots captured in the last 60 days, **zero** carry both a model
+score and a Claude score.
+
+**Wrong model, wrong cameras.** The stored `model_disagreement_kind` compares
+*v2/v4-era* model scores against Claude — 29,711 rows are
+`20260314_070706_v2_mild_crop_balanced`, only 486 are the shipping
+`20260829_062437_v5_binary_gold` (all written today). It therefore measures a
+retired model's mistakes:
+
+| check | result |
+|---|---|
+| Broome `4057187` — worst camera in the fleet (11/11 false-shows, 9 days) | **0** disagreement events across 86 Claude-scored frames; ranks **111 / 366** |
+| Other three ground-truth cameras | 2, 0, 0 Claude-scored frames — no evidence at all |
+| Top 15 cameras by this signal | **disjoint** from the audit's 17 offenders |
+
+Shipping it would temper ~15 cameras the audit clears and leave Broome at full
+size — worse than doing nothing.
+
+### Three label-free replacements were tested. None has coverage.
+
+| candidate | result | verdict |
+|---|---|---|
+| Daylight false-fire (sun > +5°) | 174 of 9,118 labeled frames qualify; capture is window-scoped by design | dead |
+| Deep-twilight fire (sun < −12°, no sunset color physically possible) | sharp at the top (Broome ranks 5/49) but only **291 / 1,299** cameras reach ≥5 such frames in 30 days, and **two of the four** ground-truth cameras get zero | not viable for 2026-09-13; **best leg-2 candidate** |
+| Raw per-camera fire rate | 30+ cameras fire on 100% of labeled frames; median offender rank 87/284 | dead (hard-example population is biased toward frames the model liked) |
+
+**Conclusion:** exactly one evidence leg is viable today — operator false-show
+labels, scored through the shipping pair. The design ships that leg and gives
+the second leg a real socket, a written plan and a revival trigger (below),
+rather than an implementation against data that does not exist.
+
+**Requirement 6 still holds.** The offender set is *derived by a rule*, never
+curated. A new camera that starts fooling the model tempers automatically as
+soon as its frames are labeled. The scaling limit becomes label supply, not
+human curation.
+
+---
+
+## The statistic
+
+Per camera, over its **operator-N frames only**:
+
+```
+deceptiveness = false_shows / (n_negative_frames + PRIOR_K)
+multiplier    = clamp(1 − MAX_TEMPER × deceptiveness, MIN_MULT, 1.0)
+```
+
+gated by a recurrence bar: **≥3 false-shows across ≥2 distinct capture days**,
+the same standard that caught three non-replicating detection "wins".
+
+Conditioning on N frames is the load-bearing choice. Two alternatives were
+simulated and both **rank Broome 8th–9th**, because its 21 genuinely correct
+fires dilute a whole-population rate:
+
+| formula | Broome rank | why it fails |
+|---|---|---|
+| count rate `fs/(fs+tp+k)` | 8 / 17 | real sunsets dilute the error rate |
+| harm-weighted `badTile/(badTile+goodTile+k)` | 9 / 17 | Broome earns large *genuine* tiles too |
+| **`fs/(n_N+k)` — deceptiveness** | **1 / 17** | measures "given a boring frame, does this camera fool the model?" |
+
+### Validation against the ground truth
+
+Simulated on the audit's current-model scores for all 9,118 operator-labeled
+frames (`ml/artifacts/reports/audit_frames_v1.csv`):
+
+| multiplier | camera | fs / n_N | days |
+|---|---|---|---|
+| **0.577** | `4057187` Broome Intl Airport | 11 / 11 | 9 |
+| **0.714** | `2947112` Coober Pedy opal mine | 4 / 5 | 4 |
+| **0.833** | `29275205` Wagga Wagga Airport | 3 / 7 | 2 |
+| **0.882** | `29095214` Mount Gambier Airport | 4 / 15 | 4 |
+
+- **17 cameras temper** — of 1,071 with any operator-N frame (1.6%); 1,382 have labeled frames at all.
+- **All four ground-truth cameras temper.**
+- **All 17 audit offenders temper.**
+- **Zero non-offenders temper.**
+
+Wagga and Mount Gambier temper gently, correctly — they fool the model on only
+3/7 and 4/15 of their boring frames. The audit's own `fs_rate` agrees (0.43 and
+0.27).
+
+---
+
+## The one real trade-off, and how it was resolved
+
+Broome is not uniformly deceptive. It produces genuine 4s and 5s (tile
+0.89–1.02) **and** sodium-floodlight false-shows (tile 0.39–0.64). Tempering it
+shrinks both. Across the fleet, 65 of 1,237 operator-≥4 frames sit on cameras
+that would temper.
+
+`MAX_TEMPER` is a pure harm/benefit dial — it does **not** change *which*
+cameras temper (that is the recurrence bar's job), only how hard:
+
+| MAX_TEMPER | MIN_MULT | Broome mult | big false-shows fixed | genuine ≥4 demoted |
+|---|---|---|---|---|
+| 0.80 | 0.20 | 0.323 | 9 | 30 |
+| 0.65 | 0.35 | 0.450 | 8 | 25 |
+| **0.50** | **0.50** | **0.577** | **8** | **10** |
+| 0.35 | 0.65 | 0.704 | 7 | 9 |
+
+**MAX_TEMPER = 0.50 dominates 0.65**: identical benefit (8 big false-shows
+fixed), 60% less harm (10 demoted vs 25). At that setting, for Broome:
+
+- false-shows 0.39–0.64 → 0.22–0.37 — **0 of 11 remain above the 0.5 showcase line**
+- genuine ≥4 0.00–1.02 → 0.00–0.59 — **9 of 13 keep showcase size**
+
+**Decision: `MAX_TEMPER = 0.50`, `MIN_MULT = 0.50`.** Chosen because it
+dominates, not fitted to taste.
+
+Note this is a genuine, accepted cost: some real showcase frames on offender
+cameras render smaller. It is bounded, it never hides anything (the gate is
+untouched), and it reverses per-camera as labels accumulate.
+
+---
+
+## Constants
+
+Land in `app/lib/masterConfig.ts`:
+
+| constant | value | rationale |
+|---|---|---|
+| `CALIBRATION_MIN_EVENTS` | 3 | recurrence bar — one bad frame is noise |
+| `CALIBRATION_MIN_DAYS` | 2 | must recur across capture days |
+| `CALIBRATION_PRIOR_K` | 2 | smoothing; a camera with 3/3 doesn't slam to the floor |
+| `CALIBRATION_MAX_TEMPER` | 0.50 | dominant setting, table above |
+| `CALIBRATION_MIN_MULTIPLIER` | 0.50 | hard floor — bounded output |
+| `CALIBRATION_HALF_LIFE_DAYS` | 90 | a cleaned-up view heals over ~a quarter |
+| `CALIBRATION_WINDOW_DAYS` | 365 | eligibility window; enables full healing |
+
+**Half-life is chosen on principle, not fitted.** A sweep (none / 365 / 180 /
+120 / 90 / 60 / 30 days) moves Broome only 0.450 → 0.503 and changes neither
+the tempered set (17) nor the false-positive count (0) — because 74% of labeled
+frames are from the last 30 days. It is insensitive today and would be wrong to
+tune on.
+
+### Healing requires both decay and a window
+
+A draft of this rule applied the recurrence bar to *undecayed* counts, which
+means a camera's raw count stays ≥3 forever and **it can never fully heal** —
+violating requirement 5. Resolved by scoping evidence to a rolling
+`CALIBRATION_WINDOW_DAYS` window:
+
+- **Window** governs eligibility and the recurrence bar → a camera with no
+  false-show in 365 days drops out entirely, multiplier returns to 1.0.
+- **Decay** (half-life, on the frame's `captured_at`) governs magnitude → the
+  multiplier relaxes smoothly long before it drops out.
+
+Decay keys on `captured_at`, not `labeled_at` — the evidence is about what the
+camera looked like *then*, so a trimmed tree or a removed floodlight heals.
+
+---
+
+## Architecture
+
+Five units, each independently testable.
+
+### 1. `camera_calibration_evidence` (new table) — the socket, and the frame record
+
+One row per labeled frame per model version. Small (~9k rows today).
+
+```sql
+CREATE TABLE IF NOT EXISTS camera_calibration_evidence (
+  id             BIGSERIAL PRIMARY KEY,
+  webcam_id      BIGINT NOT NULL,
+  snapshot_id    BIGINT NOT NULL,
+  model_version  TEXT NOT NULL,     -- scoped: a head swap re-derives, never mixes
+  evidence_source TEXT NOT NULL,    -- 'operator_label' | future leg-2 sources
+  is_negative    BOOLEAN NOT NULL,  -- operator said N
+  fired          BOOLEAN NOT NULL,  -- model p_sunset >= gate
+  captured_on    DATE NOT NULL,     -- decay + recurrence basis
+  -- Frame record: what the model actually saw and did, kept so a tempering
+  -- decision can be re-examined later WITHOUT rescoring 9k frames through ONNX.
+  p_sunset       NUMERIC(6,4) NOT NULL,  -- detection probability behind `fired`
+  quality        NUMERIC(6,4),           -- quality head output
+  tile           NUMERIC(6,4),           -- composed tile size the display used
+  firebase_url   TEXT NOT NULL,          -- deliberately denormalised (see below)
+  scored_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+  UNIQUE (snapshot_id, model_version, evidence_source)
+);
+CREATE INDEX IF NOT EXISTS camera_calibration_evidence_cam_idx
+  ON camera_calibration_evidence (webcam_id, model_version, captured_on DESC);
+```
+
+`model_version` scoping is the fix for the exact defect that killed the wide
+signal: evidence from a retired head must never drive a live multiplier.
+
+`evidence_source` is the leg-2 socket — a second writer appends rows and the
+aggregation needs no change.
+
+**Retention is a hard rule, not an optimisation.** The table is
+**append-only**. Nothing in this system ever deletes an evidence row —
+not the nightly job (which only reads), not the writer (which upserts by
+the unique key), not a model swap. When the shipping head changes, the
+writer inserts a *new* generation of rows under the new `model_version`
+and the old generation stays, so "how did v5 and v6 judge this same frame?"
+stays answerable. This matches the standing no-deletion rule for frame
+storage.
+
+`firebase_url` is denormalised on purpose. Joining `webcam_snapshots` would
+normally be right, but the entire point of this table is to remain
+reviewable years later; a self-contained row survives any future pruning or
+reshaping of the snapshots table. The cost is ~9k duplicated strings.
+
+### 2. `camera_calibration_history` (new table) — drift over time
+
+The evidence table records *what the model saw*. This one records *what the
+system decided*, so a camera's tempering can be tracked over time rather than
+only observed in its current state.
+
+```sql
+CREATE TABLE IF NOT EXISTS camera_calibration_history (
+  id                  BIGSERIAL PRIMARY KEY,
+  webcam_id           BIGINT NOT NULL,
+  computed_at         TIMESTAMPTZ NOT NULL DEFAULT now(),
+  multiplier          NUMERIC(4,3) NOT NULL,
+  previous_multiplier NUMERIC(4,3),          -- NULL on a camera's first row
+  false_shows         NUMERIC(8,3) NOT NULL, -- decayed weight
+  negative_frames     NUMERIC(8,3) NOT NULL, -- decayed weight
+  raw_false_shows     INT NOT NULL,
+  false_show_days     INT NOT NULL,
+  model_version       TEXT NOT NULL
+);
+CREATE INDEX IF NOT EXISTS camera_calibration_history_cam_idx
+  ON camera_calibration_history (webcam_id, computed_at DESC);
+```
+
+Written by the nightly job **only when a camera's multiplier changes** by more
+than 0.001. Writing every camera every night would add ~1,000 rows/night of
+mostly-identical data; `webcams.calibration_computed_at` already answers "did
+the job run". Change-events answer the question that matters — *when did this
+camera start tempering, how hard, and is it healing?*
+
+This is what makes the healing requirement observable rather than merely
+asserted: a camera whose view is cleaned up produces a visible sequence of
+rows walking its multiplier back toward 1.0.
+
+### 3. Evidence writer — `ml/audit_camera_errors.py --emit-evidence`
+
+Extends the existing, already-proven audit script to upsert its per-frame
+results into `camera_calibration_evidence` in addition to the CSV/JSON it
+already writes. Offline, run when labels accumulate or the shipping head
+changes. Not on the nightly path — it needs ONNX, and operator labels only
+change when Jesse labels.
+
+It already computes every field the frame record needs (`p_sunset`, `quality`,
+`tile`, the URL, the capture day) — `--dump-frames` writes exactly these to
+CSV today. The writer persists them instead of leaving them in an artifact
+file, which is what makes requirement 8 hold: the frames behind a multiplier
+live in the database next to the decision, not in a CSV on a branch.
+
+Upsert is `ON CONFLICT (snapshot_id, model_version, evidence_source) DO UPDATE`
+— re-running the writer refreshes scores for the same generation but never
+deletes or duplicates.
+
+### 4. Nightly job — `/api/cron/recompute-camera-calibration`
+
+Pure SQL. Directly mirrors `recompute-disagreements`:
+
+- `app/api/cron/recompute-camera-calibration/route.ts` — `verifyCronAuth`,
+  `force-dynamic`, `maxDuration`, GET+POST, error envelope.
+- `app/api/cron/update-cameras/lib/recomputeCameraCalibration.ts` — the
+  orchestration, batched UPDATE.
+- `vercel.json` cron entry, nightly (`15 4 * * *`), off the live-scoring tick
+  budget.
+
+No image download, no ONNX — so it does **not** need the `ml/artifacts` bundle
+and cannot push the 250 MB function limit.
+
+### 5. Multiplier math — `app/lib/cameraCalibration.ts`
+
+Pure function, no DB, no I/O. Where the rule actually lives, and where the
+tests point.
+
+```ts
+export interface CalibrationEvidence {
+  falseShows: number;      // decayed weight, within window
+  negativeFrames: number;  // decayed weight, within window
+  falseShowDays: number;   // distinct capture days, within window
+  rawFalseShows: number;   // undecayed count, within window
+}
+
+export function computeTemperingMultiplier(e: CalibrationEvidence): number;
+```
+
+### Storage on `webcams`
+
+```sql
+ALTER TABLE webcams
+  ADD COLUMN IF NOT EXISTS calibration_multiplier  NUMERIC(4,3),
+  ADD COLUMN IF NOT EXISTS calibration_evidence    JSONB,
+  ADD COLUMN IF NOT EXISTS calibration_computed_at TIMESTAMPTZ;
+```
+
+**NULL = neutral** — new cameras start at 1.0 with no backfill (requirement 5).
+
+⚠️ `NUMERIC` serialises through the Neon driver as a **string**
+(`"0.577"`, not `0.577`). Cast on read and coerce in TS — this has bitten the
+project before.
+
+### Application point
+
+`app/components/mosaic/v1/qualitySignal.ts` — `getQualityScore` only:
+
+```ts
+const raw = webcam.aiRatingRegression ?? null;
+if (raw == null) return null;
+// Temper the above-floor part only: preserves the "rejected frames floor to 1,
+// never hidden" contract, and cannot move the gate.
+return 1 + (raw - 1) * (webcam.calibrationMultiplier ?? 1);
+```
+
+`passesGate` is **not touched**. This is requirement 3, and it gets an explicit
+test asserting the gate verdict is bit-identical with and without a multiplier.
+
+`calibrationMultiplier` joins `WindyWebcam` and the webcam-serving API.
+
+### Ops surface
+
+A "Camera calibration" panel in the Ops tab, following the existing
+`OpsPanels.tsx` patterns. Three things, because requirement 8 is only real if
+it is reachable:
+
+1. **Current state** — tempered cameras with multiplier, `fs / n_N`, distinct
+   days, `calibration_computed_at`, and a fleet-level tempered count.
+2. **The frames** — expanding a camera lists its false-show frames with
+   `p_sunset`, `tile` and a thumbnail from `firebase_url`. This is the "was
+   this camera fairly tempered?" check, and it is the reason the frame record
+   is denormalised.
+3. **The history** — a camera's multiplier changes over time from
+   `camera_calibration_history`, so healing and drift are visible rather than
+   inferred.
+
+---
+
+## Pre-registered acceptance test
+
+Locked **before** implementation, per the standing discipline in this program.
+The job is not allowed to ship unless, run against the frozen
+`audit_frames_v1` evidence, ALL of:
+
+1. **Ground truth tempers:** all four of `4057187`, `2947112`, `29095214`,
+   `29275205` receive multiplier < 1.0.
+2. **Precision:** zero cameras outside the audit's 17-offender list temper.
+3. **Fleet bound:** ≤25 cameras temper, against 1,071 with operator-N evidence (≤2.3%).
+4. **Detection untouched:** `passesGate` output is bit-identical for every
+   webcam with and without a multiplier applied. Unit-tested.
+5. **Bounded output:** multiplier ∈ [0.50, 1.0] for all inputs, including
+   adversarial ones (zero frames, all-false-shows, missing fields).
+6. **Neutral by default:** a camera with no evidence row gets exactly 1.0.
+7. **Retention holds:** re-running the evidence writer twice leaves the row
+   count unchanged (upsert, not duplicate) and deletes nothing; writing a
+   second `model_version` generation leaves the first generation's rows
+   intact and readable.
+8. **History is written:** a multiplier change produces exactly one
+   `camera_calibration_history` row carrying the previous value; an unchanged
+   multiplier produces none.
+
+Measured baseline to beat, from the simulation: 17 tempered, 0 false positives,
+all 4 ground-truth cameras caught.
+
+---
+
+## Leg 2 — the plan, not a promise
+
+Leg 2 exists to remove the label-supply ceiling: leg 1 can only temper cameras
+whose frames Jesse has labeled. Two candidate writers, in priority order.
+
+### Writer A — `production_deep_twilight` (recommended)
+
+**What it is.** Frames captured with solar elevation < −12° (nautical/
+astronomical twilight) have no sunset colour physically available. A shipping
+head that fires there is reacting to artificial light or warm terrain — exactly
+the Broome/Coober Pedy failure class. Such a frame is written as
+`is_negative = true, fired = (p >= gate)` with no operator label required.
+
+**Why it is the right leg 2.** It needs no Claude spend, no operator time, and
+it strengthens automatically as production accrues. Measured discrimination on
+current-model scores: Broome ranks **5 / 49** on this signal, and 2 of the 3
+eligible audit offenders land in the top 20.
+
+**Why it cannot ship now.** Coverage. Only **291 / 1,299** cameras reach ≥5
+deep-twilight frames in 30 days; Broome gets 4; two of the four ground-truth
+cameras get **zero**. And v5-era production scoring only began 2026-08-31 (486
+snapshots, 141 cameras).
+
+**Revival trigger (pre-registered):** enable when a coverage query shows
+**≥300 cameras with ≥5 deep-twilight frames scored by the current head across
+≥2 distinct days**. Re-check monthly; it is a single SQL query.
+
+**Bar it must clear before it may move any multiplier:** the same six-clause
+acceptance test above, re-run with writer A's rows included. If adding leg 2
+tempers cameras outside the then-current audit offender list, leg 2 is wrong,
+not the audit.
+
+`suncalc` is already a dependency and `app/lib/cameraHealth.ts` already
+computes window geometry — reuse it rather than re-deriving solar position.
+
+### Writer B — `model_vs_claude` (parked)
+
+The originally specified wide signal. **Revival trigger:** Claude rating
+resumes *and* ≥30 days of rows exist where `llm_is_sunset` and
+`ai_model_version_binary = <current head>` are both present. Until both hold it
+stays unimplemented — the measurements above show why implementing it early
+would actively mislead.
+
+If it is ever revived, `model_disagreement_kind` must be **recomputed against
+the current head**, never read from the archive.
+
+### What leg 1 must do now to make leg 2 cheap
+
+Nothing beyond the design above: `evidence_source` + `model_version` on the
+evidence table, and aggregation that is agnostic to which writer produced a
+row. Leg 2 is then a writer plus a config flag — no change to the multiplier
+math, the cron, the storage, or the display path.
+
+---
+
+## Implementation phases
+
+| phase | content | gate |
+|---|---|---|
+| 1 | `cameraCalibration.ts` + unit tests (pure math, clauses 4–6) | tests green |
+| 2 | Migration: both tables + `webcams` columns | applies clean, idempotent |
+| 3 | `--emit-evidence` writer; populate from existing labels | clauses 1–3 + 7 reproduce the simulation |
+| 4 | Nightly cron route + lib + `vercel.json`, mirroring `recompute-disagreements`; writes history | tests green, clause 8, dry-run locally |
+| 5 | `qualitySignal.ts` application + `WindyWebcam` plumbing | gate-identity test green (clause 4) |
+| 6 | Ops panel — current state, frames, history | visual check |
+| 7 | Deploy + verify via `calibration_computed_at` stamps | stamps present post-deploy |
+
+Phases 1 and 3 carry the risk; 4–6 are pattern-matching existing code.
+
+---
+
+## Dependencies and risks
+
+- **Blocked on PRs #104 / #105.** `ml/audit_camera_errors.py` and
+  `audit_frames_v1.csv` live on `measure/camera-error-audit` and
+  `measure/hard-negative-emphasis`. Leg 1's evidence writer extends that
+  script — those must merge (or this branch must build on them) first.
+- **Migration is a production DB change.** Not applied unsupervised. Additive
+  and idempotent (`ADD COLUMN IF NOT EXISTS`), NULL-default, so it is inert
+  until the cron writes.
+- **Accepted cost:** ~10 genuine ≥4 frames across the fleet render smaller.
+  Bounded, never hidden, reverses as labels accumulate.
+- **Label-supply ceiling** is the real limit on leg 1's reach. That is what
+  leg 2 exists to remove.
+
+---
+
+## Resolved at sign-off (2026-09-01)
+
+**Jesse, 2026-09-01: proceed with leg 1**, with the added requirement that
+frames be retained so the calibration can be checked over time (requirement 8,
+above). The trade-off question — demoting ~10 genuine operator-≥4 frames to
+remove 8 big false-shows — is accepted at `CALIBRATION_MAX_TEMPER = 0.50`.
+
+`CALIBRATION_MAX_TEMPER = 0.35` (7 fixed, 9 demoted) remains a one-constant
+retreat if the showing suggests the tempering bites too hard.

--- a/ml/audit_camera_errors.py
+++ b/ml/audit_camera_errors.py
@@ -59,6 +59,11 @@ def load_env_local() -> None:
         os.environ.setdefault(key.strip(), val.strip().strip('"').strip("'"))
 
 
+def model_version_from_path(onnx_path: str) -> str:
+    """The run directory name is the model version stamped on webcams rows."""
+    return Path(onnx_path).parent.name
+
+
 def main() -> None:
     p = argparse.ArgumentParser(description="Per-camera error audit vs operator truth")
     p.add_argument("--gate", type=float, default=0.55)
@@ -69,6 +74,12 @@ def main() -> None:
     p.add_argument("--quality-onnx", default=QUALITY_DEFAULT)
     p.add_argument("--cache-dir", default="ml/artifacts/image_cache")
     p.add_argument("--limit", type=int, default=None, help="frame cap, for smoke runs")
+    p.add_argument("--emit-evidence", action="store_true",
+                   help="upsert per-frame rows into camera_calibration_evidence "
+                        "(the calibration job's input; see the 2026-08-31 "
+                        "per-camera calibration spec). Append-only: re-running "
+                        "refreshes scores for the same model generation and "
+                        "never deletes.")
     p.add_argument("--dump-frames", default=None,
                    help="also write per-frame scores to this CSV (the input for "
                         "hard-negative mining — see the 2026-08-31 emphasis plan)")
@@ -109,6 +120,8 @@ def main() -> None:
     ))
     skipped = 0
     dump_rows = []
+    evidence_rows: list = []
+    model_version = model_version_from_path(args.binary_onnx)
     for i, (sid, wid, is_sunset, rating, day, url, title, city, country) in enumerate(frames):
         if i and i % 1000 == 0:
             print(f"  …{i}/{len(frames)} (skipped {skipped})")
@@ -126,6 +139,16 @@ def main() -> None:
                               "" if rating is None else rating, str(day),
                               round(p_sun, 4), round(q, 4), int(shown),
                               round(tile, 4), url))
+
+        if args.emit_evidence:
+            evidence_rows.append((
+                int(wid), int(sid), model_version, "operator_label",
+                not bool(is_sunset), bool(shown), day,
+                round(float(p_sun), 4),
+                round(float(q), 4),
+                round(float(tile), 4),
+                str(url),
+            ))
 
         c = cams[wid]
         c["n"] += 1
@@ -195,6 +218,41 @@ def main() -> None:
     for r in miss_offenders[:10]:
         print(f"    cam {r['webcam_id']:>8}  miss4 {r['miss4']} / {r['n_ge4']} "
               f"over {r['distinct_days']}d  {r['meta']}")
+
+    if args.emit_evidence:
+        conn2 = psycopg2.connect(os.environ["DATABASE_URL"])
+        cur2 = conn2.cursor()
+        # ON CONFLICT DO UPDATE, never DELETE: re-running refreshes scores for
+        # this model generation; a different model_version inserts a NEW
+        # generation beside the old so both stay answerable.
+        cur2.executemany(
+            """
+            INSERT INTO camera_calibration_evidence
+              (webcam_id, snapshot_id, model_version, evidence_source,
+               is_negative, fired, captured_on, p_sunset, quality, tile,
+               firebase_url)
+            VALUES (%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s)
+            ON CONFLICT (snapshot_id, model_version, evidence_source)
+            DO UPDATE SET
+              is_negative = EXCLUDED.is_negative,
+              fired       = EXCLUDED.fired,
+              p_sunset    = EXCLUDED.p_sunset,
+              quality     = EXCLUDED.quality,
+              tile        = EXCLUDED.tile,
+              scored_at   = now()
+            """,
+            evidence_rows,
+        )
+        conn2.commit()
+        cur2.execute(
+            "SELECT count(*) FROM camera_calibration_evidence "
+            "WHERE model_version = %s",
+            (model_version,),
+        )
+        total = cur2.fetchone()[0]
+        conn2.close()
+        print(f"  emitted {len(evidence_rows)} evidence rows; "
+              f"{total} total for model_version={model_version}")
 
     if args.dump_frames:
         import csv

--- a/ml/verify_calibration_acceptance.py
+++ b/ml/verify_calibration_acceptance.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+"""Pre-registered acceptance test for per-camera calibration leg 1.
+
+Clauses 1-3 and 7 of the spec's 8-clause bar. Clauses 4-6 and 8 are covered by
+the TypeScript unit tests. Exits 1 if any clause fails.
+
+If the multipliers differ from the recorded baseline, STOP and report — do not
+adjust constants to make this pass. That would be tuning on the acceptance set,
+the one forbidden move in this program.
+
+Usage:
+  .venv/bin/python ml/verify_calibration_acceptance.py
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+import psycopg2
+
+MODEL = "20260829_062437_v5_binary_gold"
+PRIOR_K, MAX_TEMPER, MIN_MULT = 2.0, 0.5, 0.5
+MIN_EVENTS, MIN_DAYS = 3, 2
+WINDOW_DAYS, HALF_LIFE = 365, 90
+
+GROUND_TRUTH = {4057187, 2947112, 29095214, 29275205}
+OFFENDERS = {
+    4057187, 2947112, 29095214, 29275205, 97, 3914190, 5961510, 160,
+    28894257, 2051, 3236, 404, 3309592, 2972357, 29048102, 27660488, 29182812,
+}
+
+
+def load_env_local() -> None:
+    env = Path(__file__).resolve().parent.parent / ".env.local"
+    if not env.exists():
+        return
+    for line in env.read_text().splitlines():
+        line = line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, _, val = line.partition("=")
+        os.environ.setdefault(key.strip(), val.strip().strip('"').strip("'"))
+
+
+def main() -> None:
+    load_env_local()
+    conn = psycopg2.connect(os.environ["DATABASE_URL"])
+    cur = conn.cursor()
+    cur.execute(
+        """
+        SELECT webcam_id,
+               SUM(CASE WHEN is_negative AND fired
+                        THEN power(0.5, (current_date - captured_on)::numeric / %s)
+                        ELSE 0 END),
+               SUM(CASE WHEN is_negative
+                        THEN power(0.5, (current_date - captured_on)::numeric / %s)
+                        ELSE 0 END),
+               COUNT(DISTINCT CASE WHEN is_negative AND fired THEN captured_on END),
+               COUNT(*) FILTER (WHERE is_negative AND fired)
+        FROM camera_calibration_evidence
+        WHERE model_version = %s AND captured_on > current_date - %s
+        GROUP BY webcam_id
+        """,
+        (HALF_LIFE, HALF_LIFE, MODEL, WINDOW_DAYS),
+    )
+    rows = cur.fetchall()
+
+    def mult(fs, nn, days, raw):
+        if raw < MIN_EVENTS or days < MIN_DAYS:
+            return 1.0
+        return max(
+            MIN_MULT,
+            min(1.0, 1.0 - MAX_TEMPER * (float(fs) / (float(nn) + PRIOR_K))),
+        )
+
+    tempered = {}
+    for wid, fs, nn, days, raw in rows:
+        m = mult(fs, nn, days, raw)
+        if m < 1.0:
+            tempered[wid] = m
+
+    failures = []
+
+    missing = GROUND_TRUTH - set(tempered)
+    print(f"clause 1  ground truth tempers: {len(GROUND_TRUTH - missing)}/4")
+    for g in sorted(GROUND_TRUTH):
+        print(f"            {g}: {tempered.get(g, 1.0):.3f}")
+    if missing:
+        failures.append(f"clause 1 FAILED - not tempered: {sorted(missing)}")
+
+    extra = set(tempered) - OFFENDERS
+    print(f"clause 2  non-offenders tempered: {len(extra)} (must be 0)")
+    if extra:
+        failures.append(f"clause 2 FAILED - unexpected: {sorted(extra)}")
+
+    print(f"clause 3  fleet bound: {len(tempered)} tempered (must be <= 25)")
+    if len(tempered) > 25:
+        failures.append(f"clause 3 FAILED - {len(tempered)} tempered")
+
+    cur.execute(
+        "SELECT count(*), count(DISTINCT snapshot_id) "
+        "FROM camera_calibration_evidence WHERE model_version = %s",
+        (MODEL,),
+    )
+    total, distinct = cur.fetchone()
+    print(f"clause 7  retention: {total} rows, {distinct} distinct snapshots")
+    if total != distinct:
+        failures.append(
+            f"clause 7 FAILED - {total} rows for {distinct} snapshots (duplicates)"
+        )
+
+    conn.close()
+
+    print()
+    if failures:
+        for f in failures:
+            print(f"  {f}")
+        sys.exit(1)
+    print("  ALL CHECKED CLAUSES PASS (1, 2, 3, 7)")
+
+
+if __name__ == "__main__":
+    main()

--- a/vercel.json
+++ b/vercel.json
@@ -7,6 +7,10 @@
     {
       "path": "/api/cron/recompute-disagreements",
       "schedule": "30 * * * *"
+    },
+    {
+      "path": "/api/cron/recompute-camera-calibration",
+      "schedule": "15 4 * * *"
     }
   ],
   "functions": {


### PR DESCRIPTION
Implements leg 1 of the signed-off design (#106). Nightly job derives a bounded
per-camera tempering multiplier from accumulated error evidence and applies it
to the **tile signal only** — never the detection verdict.

Stacked on #105 (the evidence writer extends `ml/audit_camera_errors.py`).

## ⚠️ Two things Jesse must do, in this order

**1. Apply the migration BEFORE this deploys.**

```
psql "$DATABASE_URL" -f database/migrations/20260901_camera_calibration.sql
```

`db-all-webcams` now selects `w.calibration_multiplier`. If this deploys before
the migration runs, that endpoint 500s and the map breaks. The migration is
additive and idempotent (`CREATE TABLE IF NOT EXISTS` / `ADD COLUMN IF NOT
EXISTS`), so applying it early is harmless — the columns just sit NULL, which
reads as neutral.

**2. Populate the evidence** (one ~9k-frame ONNX pass, ~minutes):

```
.venv/bin/python ml/audit_camera_errors.py --emit-evidence
```

Until then every camera is neutral and the display is unchanged.

## Acceptance test status

The spec's 8 clauses. Four are verified green now; four need the evidence
populated, which is gated on step 1.

| clause | how | status |
|---|---|---|
| 4 — `passesGate` bit-identical with/without a multiplier | unit test | ✅ green |
| 5 — multiplier ∈ [0.5, 1] incl. adversarial input | unit test | ✅ green |
| 6 — no evidence ⇒ exactly 1.0 | unit test | ✅ green |
| 8 — history on change only, carrying previous value | unit test | ✅ green |
| 1 — all 4 ground-truth cameras temper | `ml/verify_calibration_acceptance.py` | ⏳ needs evidence |
| 2 — zero non-offenders temper | same | ⏳ needs evidence |
| 3 — ≤25 cameras temper | same | ⏳ needs evidence |
| 7 — retention holds under re-run | same | ⏳ needs evidence |

Expected on the frozen evidence (re-verified against current labels
2026-09-01, after the 24 label corrections from the rubric lane — zero
`is_sunset` flips, baseline unchanged): **17 tempered, 0 non-offenders,**
Broome 0.577 / Coober Pedy 0.714 / Wagga 0.833 / Mt Gambier 0.882.

If the verifier disagrees with those numbers, that is a real signal — do not
adjust constants to make it pass.

## Frame retention (the 2026-09-01 requirement)

`camera_calibration_evidence` is **append-only** and keeps `p_sunset`,
`quality`, `tile` and `firebase_url` per frame, so a tempering decision can be
re-examined later without rescoring 9k frames. A model swap inserts a **new
`model_version` generation beside the old**, so "how did v5 and v6 judge this
frame?" stays answerable. `camera_calibration_history` records multiplier
change-events, which is what makes healing observable rather than asserted.

The Ops tab surfaces all three: current tempering, the frames behind a camera
(click a row — fetched per-camera, not bulk-loaded), and recent changes.

## Verification

- `npm run test` — **170 files, 1032 tests, all pass**, no regressions
- `npm run lint` — only pre-existing warnings
- `npm run build` — succeeds; no ONNX in this cron, so the bundle is unchanged
- `npx tsc --noEmit` — 167 errors before and after this branch (all pre-existing
  in unrelated test files)

## Notes

- Cron is `15 4 * * *`, off the live-scoring tick budget. Pure SQL — no image
  download, no ONNX.
- `resolveBinaryModelVersion()` is now exported and used by the cron, so it
  reads the *effective* model version rather than the default constant; env can
  override it and querying the wrong generation would silently aggregate zero
  evidence.
- `qualitySignal.ts` is a shared helper — the display lane was given a heads-up
  before this change; they confirmed no collision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L1VVD4fW576hjqzEcgvdyk
