### PR TITLE
Adaptive terminator widening: sweep extra rings when a feed runs thin

### DIFF
--- a/.claude/hooks/git-freshness.sh
+++ b/.claude/hooks/git-freshness.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# SessionStart hook: fetch, then report ONLY if this checkout is behind origin.
+#
+# Why this exists: on 2026-09-02 a session designed a feature that had shipped
+# the night before, because its checkout was 42 commits stale. A worktree would
+# have been equally stale — the fix is knowing, not isolating.
+#
+# Silent when the tree is current, so the common case costs no context.
+set -uo pipefail
+cd "${CLAUDE_PROJECT_DIR:-$(pwd)}" 2>/dev/null || exit 0
+git rev-parse --git-dir >/dev/null 2>&1 || exit 0
+
+# Never let an auth prompt block the session opening.
+export GIT_TERMINAL_PROMPT=0 GIT_ASKPASS=true SSH_ASKPASS=true
+git fetch --quiet --all >/dev/null 2>&1 || exit 0
+
+branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null) || exit 0
+notes=""
+
+# How far the current branch trails its own upstream, when it has one.
+if upstream=$(git rev-parse --abbrev-ref '@{upstream}' 2>/dev/null); then
+  behind=$(git rev-list --count "HEAD..$upstream" 2>/dev/null || echo 0)
+  [ "${behind:-0}" -gt 0 ] && notes="$branch is $behind commit(s) behind $upstream."
+fi
+
+# How far local main trails origin/main — the one that causes duplicated work,
+# since it is what a new branch would fork from. Skipped when main IS the
+# current branch, because the upstream check above already said it.
+if [ "$branch" != "main" ] &&
+   git rev-parse --verify --quiet main >/dev/null 2>&1 &&
+   git rev-parse --verify --quiet origin/main >/dev/null 2>&1; then
+  mb=$(git rev-list --count main..origin/main 2>/dev/null || echo 0)
+  if [ "${mb:-0}" -gt 0 ]; then
+    [ -n "$notes" ] && notes="$notes "
+    notes="${notes}Local main is $mb commit(s) behind origin/main."
+  fi
+fi
+
+[ -z "$notes" ] && exit 0
+
+printf '%s' "$notes" | jq -Rs '{
+  hookSpecificOutput: {
+    hookEventName: "SessionStart",
+    additionalContext: ("Git freshness: " + . + " Pull or read origin/main before planning any new work — a stale tree is how features get designed twice.")
+  }
+}'

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/git-freshness.sh",
+            "timeout": 20,
+            "statusMessage": "Checking git freshness..."
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/app/api/cron/update-cameras/lib/dailyDigest.test.ts
+++ b/app/api/cron/update-cameras/lib/dailyDigest.test.ts
@@ -7,7 +7,11 @@ vi.mock('@/app/lib/db', () => ({
     sqlMock(strings, ...values),
 }));
 
-import { sendDailyUsageDigest, formatCalibrationLine } from './dailyDigest';
+import {
+  sendDailyUsageDigest,
+  formatCalibrationLine,
+  formatSweepLine,
+} from './dailyDigest';
 
 const NOW = new Date('2026-08-03T00:20:00Z');
 const SUNSET = 'noisy-leaf-96391119';
@@ -182,5 +186,93 @@ describe('formatCalibrationLine', () => {
       healed: 0,
     });
     expect(html).toContain('1 newly tempered');
+  });
+});
+
+describe('formatSweepLine', () => {
+  const quiet = {
+    ticks: 96,
+    escalatedTicks: 0,
+    budgetExhaustedTicks: 0,
+    sunriseThinTicks: 0,
+    sunsetThinTicks: 0,
+    sunriseShortTicks: 0,
+    sunsetShortTicks: 0,
+    baseBoxes: 2976,
+    escalationBoxes: 0,
+    rings: [
+      {
+        offsetDeg: 0,
+        ringsSwept: 96,
+        boxesAttempted: 2976,
+        boxesEmpty: 300,
+        newWebcams: 400,
+        framesScored: 380,
+        framesGatePassed: 130,
+      },
+    ],
+  };
+
+  it('renders nothing when no sweep was recorded', () => {
+    expect(formatSweepLine(null)).toBe('');
+  });
+
+  it('collapses a quiet day to one clause', () => {
+    const html = formatSweepLine(quiet);
+    expect(html).toContain('no feed fell under the floor');
+    expect(html).toContain('2,976');
+    // Nothing was widened, so there is no cost and no per-ring comparison.
+    expect(html).not.toContain('gate-passed');
+  });
+
+  it('names the thin feed, the escalation cost, and its share of the baseline', () => {
+    const html = formatSweepLine({
+      ...quiet,
+      escalatedTicks: 12,
+      sunsetThinTicks: 12,
+      sunsetShortTicks: 4,
+      escalationBoxes: 180,
+    });
+    expect(html).toContain('sunset thin on 12 of 96 ticks');
+    expect(html).toContain('4 still short');
+    expect(html).toContain('+180 boxes');
+    expect(html).toContain('2,976 base');
+    expect(html).toContain('+6%');
+    expect(html).not.toContain('sunrise thin');
+  });
+
+  it('compares gate-pass rates per ring, which is the golden-hour question', () => {
+    const html = formatSweepLine({
+      ...quiet,
+      escalatedTicks: 12,
+      sunsetThinTicks: 12,
+      escalationBoxes: 180,
+      rings: [
+        ...quiet.rings,
+        {
+          offsetDeg: 15.75,
+          ringsSwept: 12,
+          boxesAttempted: 180,
+          boxesEmpty: 20,
+          newWebcams: 45,
+          framesScored: 40,
+          framesGatePassed: 4,
+        },
+      ],
+    });
+    expect(html).toContain('base 130/380 gate-passed (34%)');
+    expect(html).toContain('+15.75');
+    expect(html).toContain('4/40');
+    expect(html).toContain('10%');
+  });
+
+  it('flags a budget-starved day and a rising empty-box share', () => {
+    const html = formatSweepLine({
+      ...quiet,
+      budgetExhaustedTicks: 7,
+      rings: [{ ...quiet.rings[0], boxesEmpty: 1500 }],
+    });
+    expect(html).toContain('7 ticks hit the sweep budget');
+    expect(html).toContain('50% of boxes empty');
   });
 });

--- a/app/api/cron/update-cameras/lib/dailyDigest.ts
+++ b/app/api/cron/update-cameras/lib/dailyDigest.ts
@@ -3,6 +3,7 @@ import {
   getCalibrationDigestSummary,
   type CalibrationDigestSummary,
 } from './dbOperations';
+import { getSweepDigestSummary, type SweepDigestSummary } from './sweepStats';
 import { deriveDailyDeltas } from '@/app/components/Ops/opsMath';
 import type { ProviderUsageRow, CostEventRow } from '@/app/lib/opsTypes';
 import {
@@ -47,6 +48,92 @@ export function formatCalibrationLine(
   return `<p style="font:12px sans-serif">Calibration: ${parts.join(' · ')}</p>`;
 }
 
+const pct = (n: number, d: number) => (d > 0 ? Math.round((n / d) * 100) : 0);
+const count = (n: number) => n.toLocaleString('en-US');
+
+/** `base`, `+15.75°`, `-15.75°`. */
+function ringLabel(offsetDeg: number): string {
+  if (offsetDeg === 0) return 'base';
+  return `${offsetDeg > 0 ? '+' : ''}${offsetDeg}°`;
+}
+
+/**
+ * Two-line adaptive-widening summary for the digest.
+ *
+ * Answers the two questions the feature was built to make answerable day to
+ * day: how often did a feed fall under the camera floor, and what did the
+ * extra rings cost against the ~3,000 boxes/day baseline.
+ *
+ * The per-ring gate-pass rates are the second line, and they are the whole
+ * point of splitting the telemetry by ring. The widening's self-concealing
+ * failure mode is a day-side ring that adds cameras the detection gate then
+ * floors: escalations and new cameras both read as success while the panel
+ * stays exactly as empty. A day-side rate far under the base rate is what
+ * that looks like, and it is the evidence for making the floor count only
+ * gate-passers rather than for raising the floor.
+ *
+ * `null` (no sweep recorded, or the tables are not migrated yet) renders
+ * nothing rather than an error line, like the calibration section.
+ */
+export function formatSweepLine(summary: SweepDigestSummary | null): string {
+  if (!summary) return '';
+  const s = summary;
+  const totalBoxes = s.baseBoxes + s.escalationBoxes;
+  const emptyBoxes = s.rings.reduce((sum, r) => sum + r.boxesEmpty, 0);
+
+  const parts: string[] = [];
+  const thin: Array<[string, number, number]> = [
+    ['sunrise', s.sunriseThinTicks, s.sunriseShortTicks],
+    ['sunset', s.sunsetThinTicks, s.sunsetShortTicks],
+  ];
+  const thinClauses = thin
+    .filter(([, ticks]) => ticks > 0)
+    .map(([feed, ticks, short]) => {
+      const clause = `<b>${feed} thin on ${ticks} of ${s.ticks} ticks</b>`;
+      // thin minus short is what widening recovered; short is what it did not.
+      return short > 0 ? `${clause} (${short} still short)` : clause;
+    });
+  parts.push(
+    thinClauses.length > 0
+      ? thinClauses.join(', ')
+      : `no feed fell under the floor in ${s.ticks} ticks`,
+  );
+
+  parts.push(
+    s.escalationBoxes > 0
+      ? `+${count(s.escalationBoxes)} boxes on ${count(s.baseBoxes)} base (+${pct(
+          s.escalationBoxes,
+          s.baseBoxes,
+        )}%)`
+      : `${count(totalBoxes)} boxes`,
+  );
+
+  if (s.budgetExhaustedTicks > 0) {
+    parts.push(`${s.budgetExhaustedTicks} ticks hit the sweep budget`);
+  }
+  // Empty conflates "no cameras there" with "the call failed". Rising empty
+  // against flat discovery is the signature of a Windy quota ceiling, which
+  // is why it rides in the summary line rather than waiting for a dashboard.
+  parts.push(`${pct(emptyBoxes, totalBoxes)}% of boxes empty`);
+
+  const lines = [`Widening: ${parts.join(' · ')}`];
+
+  if (s.rings.length > 1) {
+    const ringClauses = s.rings.map((r, i) => {
+      const rate =
+        r.framesScored > 0
+          ? `${r.framesGatePassed}/${r.framesScored}${
+              i === 0 ? ' gate-passed' : ''
+            } (${pct(r.framesGatePassed, r.framesScored)}%)`
+          : `${count(r.newWebcams)} new, unscored`;
+      return `${ringLabel(r.offsetDeg)} ${rate}`;
+    });
+    lines.push(`Rings: ${ringClauses.join(' · ')}`);
+  }
+
+  return `<p style="font:12px sans-serif">${lines.join('<br/>')}</p>`;
+}
+
 // Daily usage digest email, sent right after the once-per-UTC-day provider
 // snapshot lands (the caller gates on that, which gives once-a-day semantics
 // for free). Reads the same table the Ops chart reads, so the email can never
@@ -78,6 +165,9 @@ export async function sendDailyUsageDigest(
     // failures and returns null, so a missing calibration table degrades this
     // section to silence instead of killing the cost email.
     const calibration = await getCalibrationDigestSummary();
+    // Same isolation contract: swallows its own failures and returns null, so
+    // an unmigrated sweep table degrades this section to silence.
+    const sweep = await getSweepDigestSummary();
 
     const rows = usage.map((r) => ({ ...r, compute_time_s: Number(r.compute_time_s) }));
     const deltas = deriveDailyDeltas(rows);
@@ -149,6 +239,7 @@ export async function sendDailyUsageDigest(
         }
         ${eventList}
         ${formatCalibrationLine(calibration)}
+        ${formatSweepLine(sweep)}
         <p style="font:11px sans-serif;color:#6b7280">
           Same data as the Ops tab. Estimate uses $${NEON_COST_PER_CU_HOUR}/CU-hr;
           the invoice of record is Vercel → Settings → Billing.

--- a/app/api/cron/update-cameras/lib/dailyStats.test.ts
+++ b/app/api/cron/update-cameras/lib/dailyStats.test.ts
@@ -8,7 +8,9 @@ vi.mock('@/app/lib/db', () => ({
 
 import { computeTickStats, upsertDailyStats } from './dailyStats';
 
-beforeEach(() => sqlMock.mockReset());
+beforeEach(() => {
+  sqlMock.mockReset();
+});
 
 describe('computeTickStats', () => {
   it('computes count, avg, percentiles, and above-threshold count', () => {

--- a/app/api/cron/update-cameras/lib/sweepStats.test.ts
+++ b/app/api/cron/update-cameras/lib/sweepStats.test.ts
@@ -1,0 +1,232 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const sqlMock = vi.fn();
+vi.mock('@/app/lib/db', () => ({
+  sql: (strings: TemplateStringsArray, ...values: unknown[]) =>
+    sqlMock(strings, ...values),
+}));
+
+import {
+  ringOffsetByWebcamId,
+  computeSweepTickStats,
+  upsertSweepStats,
+  getSweepDigestSummary,
+} from './sweepStats';
+import type { SweepTelemetry } from './terminatorSweep';
+
+// Braces, not a concise arrow: `mockReset()` returns the mock, and Vitest
+// treats a value returned from a hook as a teardown callback -- it would call
+// sqlMock() after every test, which under a rejecting implementation surfaces
+// as an unhandled rejection blamed on the test that installed it.
+beforeEach(() => {
+  sqlMock.mockReset();
+});
+
+/** A healthy tick: base ring only, both feeds over the floor. */
+const healthy: SweepTelemetry = {
+  rings: [
+    {
+      offsetDeg: 0,
+      feedsSwept: ['sunrise', 'sunset'],
+      attempted: 31,
+      empty: 4,
+      newWebcams: 3,
+      newWebcamIds: [101, 102, 103],
+    },
+  ],
+  counts: { sunrise: 18, sunset: 21 },
+  thinAfterBase: [],
+  escalations: 0,
+  budgetExhausted: false,
+};
+
+/** Sunset thin after the base ring; the day-side ring recovers it. */
+const escalated: SweepTelemetry = {
+  rings: [
+    {
+      offsetDeg: 0,
+      feedsSwept: ['sunrise', 'sunset'],
+      attempted: 31,
+      empty: 4,
+      newWebcams: 3,
+      newWebcamIds: [101, 102, 103],
+    },
+    {
+      offsetDeg: 15.75,
+      feedsSwept: ['sunset'],
+      attempted: 15,
+      empty: 2,
+      newWebcams: 2,
+      newWebcamIds: [201, 202],
+    },
+  ],
+  counts: { sunrise: 18, sunset: 17 },
+  thinAfterBase: ['sunset'],
+  escalations: 1,
+  budgetExhausted: false,
+};
+
+describe('ringOffsetByWebcamId', () => {
+  it('attributes each camera to the ring that first saw it', () => {
+    const map = ringOffsetByWebcamId(escalated);
+    expect(map.get(101)).toBe(0);
+    expect(map.get(201)).toBe(15.75);
+    expect(map.get(999)).toBeUndefined();
+  });
+});
+
+describe('computeSweepTickStats', () => {
+  it('counts a healthy tick as one tick and nothing else', () => {
+    const s = computeSweepTickStats({ telemetry: healthy, floor: 15 });
+    expect(s.ticks).toBe(1);
+    expect(s.escalatedTicks).toBe(0);
+    expect(s.sunriseThinTicks).toBe(0);
+    expect(s.sunsetThinTicks).toBe(0);
+    expect(s.sunriseShortTicks).toBe(0);
+    expect(s.sunsetShortTicks).toBe(0);
+    expect(s.baseBoxes).toBe(31);
+    expect(s.escalationBoxes).toBe(0);
+  });
+
+  it('splits boxes into base and escalation, and marks the thin feed', () => {
+    const s = computeSweepTickStats({ telemetry: escalated, floor: 15 });
+    expect(s.escalatedTicks).toBe(1);
+    expect(s.sunsetThinTicks).toBe(1);
+    expect(s.sunriseThinTicks).toBe(0);
+    expect(s.baseBoxes).toBe(31);
+    expect(s.escalationBoxes).toBe(15);
+  });
+
+  it('separates a feed that widened from one that widening did not recover', () => {
+    // Sunset was thin AND is still under the floor after every ring: the
+    // failure the digest exists to make visible.
+    const stillShort: SweepTelemetry = {
+      ...escalated,
+      counts: { sunrise: 18, sunset: 9 },
+    };
+    const s = computeSweepTickStats({ telemetry: stillShort, floor: 15 });
+    expect(s.sunsetThinTicks).toBe(1);
+    expect(s.sunsetShortTicks).toBe(1);
+  });
+
+  it('records a thin feed even when the budget stopped the sweep', () => {
+    // thinAfterBase, not feedsSwept, is the source: a tick that ran out of
+    // budget before ring 1 has a thin feed and no escalation ring to show it.
+    const starved: SweepTelemetry = {
+      rings: [healthy.rings[0]],
+      counts: { sunrise: 4, sunset: 21 },
+      thinAfterBase: ['sunrise'],
+      escalations: 0,
+      budgetExhausted: true,
+    };
+    const s = computeSweepTickStats({ telemetry: starved, floor: 15 });
+    expect(s.sunriseThinTicks).toBe(1);
+    expect(s.escalationBoxes).toBe(0);
+    expect(s.budgetExhaustedTicks).toBe(1);
+  });
+
+  it('folds per-ring gate outcomes onto the ring that found the camera', () => {
+    const s = computeSweepTickStats({
+      telemetry: escalated,
+      floor: 15,
+      gateByOffset: new Map([
+        [0, { scored: 3, gatePassed: 1 }],
+        [15.75, { scored: 2, gatePassed: 0 }],
+      ]),
+    });
+    const day = s.rings.find((r) => r.offsetDeg === 15.75)!;
+    expect(day).toMatchObject({
+      ringsSwept: 1,
+      boxesAttempted: 15,
+      boxesEmpty: 2,
+      newWebcams: 2,
+      framesScored: 2,
+      framesGatePassed: 0,
+    });
+    expect(s.rings.find((r) => r.offsetDeg === 0)!.framesGatePassed).toBe(1);
+  });
+
+  it('leaves gate counts at zero when no scoring outcomes are supplied', () => {
+    const s = computeSweepTickStats({ telemetry: escalated, floor: 15 });
+    expect(s.rings.every((r) => r.framesScored === 0)).toBe(true);
+  });
+});
+
+describe('upsertSweepStats', () => {
+  it('writes the tick counters and one row per ring', async () => {
+    sqlMock.mockResolvedValue([]);
+    const stats = computeSweepTickStats({ telemetry: escalated, floor: 15 });
+    await upsertSweepStats(new Date('2026-09-03T00:20:00Z'), stats, 'v5');
+
+    // one daily_sunset_stats upsert + one row per ring
+    expect(sqlMock).toHaveBeenCalledTimes(3);
+    const [tickCall, ...ringCalls] = sqlMock.mock.calls;
+    expect(tickCall[0].join('?')).toContain('daily_sunset_stats');
+    expect(tickCall).toContain('2026-09-03');
+    for (const call of ringCalls) {
+      expect(call[0].join('?')).toContain('daily_sweep_ring_stats');
+      expect(call).toContain('2026-09-03');
+    }
+    expect(ringCalls.some((c) => c.includes(15.75))).toBe(true);
+  });
+
+  it('never throws when the tables are missing', async () => {
+    sqlMock.mockImplementation(async () => {
+      throw new Error('no such table');
+    });
+    const stats = computeSweepTickStats({ telemetry: healthy, floor: 15 });
+    await expect(
+      upsertSweepStats(new Date('2026-09-03T00:20:00Z'), stats, 'v5'),
+    ).resolves.toBeUndefined();
+  });
+});
+
+describe('getSweepDigestSummary', () => {
+  it('returns yesterday-s tick counters joined to their ring rows', async () => {
+    sqlMock
+      .mockResolvedValueOnce([
+        {
+          sweep_ticks: 96,
+          sweep_escalated_ticks: 12,
+          sweep_budget_exhausted_ticks: 1,
+          sweep_sunrise_thin_ticks: 0,
+          sweep_sunset_thin_ticks: 12,
+          sweep_sunrise_short_ticks: 0,
+          sweep_sunset_short_ticks: 4,
+          sweep_base_boxes: 2976,
+          sweep_escalation_boxes: 180,
+        },
+      ])
+      .mockResolvedValueOnce([
+        {
+          offset_deg: '0.00',
+          rings_swept: 96,
+          boxes_attempted: 2976,
+          boxes_empty: 300,
+          new_webcams: 400,
+          frames_scored: 380,
+          frames_gate_passed: 130,
+        },
+      ]);
+    const summary = await getSweepDigestSummary();
+    expect(summary).not.toBeNull();
+    expect(summary!.ticks).toBe(96);
+    expect(summary!.escalationBoxes).toBe(180);
+    // NUMERIC comes back from the Neon driver as a string; the summary must
+    // hand the formatter a number or the ring lookup silently misses.
+    expect(summary!.rings[0].offsetDeg).toBe(0);
+    expect(summary!.rings[0].framesGatePassed).toBe(130);
+  });
+
+  it('returns null when nothing was recorded', async () => {
+    sqlMock.mockResolvedValueOnce([]).mockResolvedValueOnce([]);
+    expect(await getSweepDigestSummary()).toBeNull();
+  });
+
+  it('returns null rather than throwing when the table is missing', async () => {
+    sqlMock.mockImplementation(async () => {
+      throw new Error('no such table');
+    });
+    expect(await getSweepDigestSummary()).toBeNull();
+  });
+});

--- a/app/api/cron/update-cameras/lib/sweepStats.ts
+++ b/app/api/cron/update-cameras/lib/sweepStats.ts
@@ -1,0 +1,277 @@
+import { sql } from '@/app/lib/db';
+import type { Feed, SweepTelemetry } from './terminatorSweep';
+
+/** Scoring outcomes for the cameras one ring was first to find, this tick. */
+export interface RingGateCounts {
+  /** Frames that reached the ONNX head. Cache hits are excluded: no verdict. */
+  scored: number;
+  /** Of those, frames the binary head called a sunset. */
+  gatePassed: number;
+}
+
+export interface SweepRingStats {
+  offsetDeg: number;
+  ringsSwept: number;
+  boxesAttempted: number;
+  boxesEmpty: number;
+  newWebcams: number;
+  framesScored: number;
+  framesGatePassed: number;
+}
+
+/**
+ * One tick's contribution to the day. Every tick-level field is 0 or 1 so the
+ * accumulated column reads directly as "N of today's ticks".
+ */
+export interface SweepTickStats {
+  ticks: number;
+  escalatedTicks: number;
+  budgetExhaustedTicks: number;
+  /** The feed was under the floor after the base ring. */
+  sunriseThinTicks: number;
+  sunsetThinTicks: number;
+  /** The feed was STILL under the floor after every ring the tick swept. */
+  sunriseShortTicks: number;
+  sunsetShortTicks: number;
+  /** Windy boxes attributable to the base ring — the ~3,000/day baseline. */
+  baseBoxes: number;
+  /** Windy boxes attributable to widening — the bill this feature adds. */
+  escalationBoxes: number;
+  rings: SweepRingStats[];
+}
+
+/**
+ * Which ring first saw each camera, this tick.
+ *
+ * `newWebcamIds` is already a per-ring first-sighting list, so the map is a
+ * flatten. It exists so the scoring loop can attribute a gate verdict to the
+ * ring that paid for the camera, which is the only way to answer the spec's
+ * golden-hour risk: do day-side frames pass the detection gate, or does
+ * widening buy tiles the panel will floor?
+ */
+export function ringOffsetByWebcamId(
+  telemetry: SweepTelemetry,
+): Map<number, number> {
+  const byId = new Map<number, number>();
+  for (const ring of telemetry.rings) {
+    for (const id of ring.newWebcamIds) {
+      if (!byId.has(id)) byId.set(id, ring.offsetDeg);
+    }
+  }
+  return byId;
+}
+
+export function computeSweepTickStats(input: {
+  telemetry: SweepTelemetry;
+  floor: number;
+  gateByOffset?: Map<number, RingGateCounts>;
+}): SweepTickStats {
+  const { telemetry, floor, gateByOffset } = input;
+  const thin = new Set<Feed>(telemetry.thinAfterBase);
+  const short = (feed: Feed) => (telemetry.counts[feed] < floor ? 1 : 0);
+
+  // Ring 0 is always the base sweep; everything after it is widening. Keyed
+  // on position rather than on offsetDeg === 0 so a future base ring with a
+  // non-zero offset does not silently move its cost into the widening column.
+  const [base, ...escalation] = telemetry.rings;
+
+  const byOffset = new Map<number, SweepRingStats>();
+  for (const ring of telemetry.rings) {
+    const acc = byOffset.get(ring.offsetDeg) ?? {
+      offsetDeg: ring.offsetDeg,
+      ringsSwept: 0,
+      boxesAttempted: 0,
+      boxesEmpty: 0,
+      newWebcams: 0,
+      framesScored: 0,
+      framesGatePassed: 0,
+    };
+    acc.ringsSwept += 1;
+    acc.boxesAttempted += ring.attempted;
+    acc.boxesEmpty += ring.empty;
+    acc.newWebcams += ring.newWebcams;
+    byOffset.set(ring.offsetDeg, acc);
+  }
+  for (const [offsetDeg, gate] of gateByOffset ?? []) {
+    const acc = byOffset.get(offsetDeg);
+    if (!acc) continue;
+    acc.framesScored += gate.scored;
+    acc.framesGatePassed += gate.gatePassed;
+  }
+
+  return {
+    ticks: 1,
+    escalatedTicks: escalation.length > 0 ? 1 : 0,
+    budgetExhaustedTicks: telemetry.budgetExhausted ? 1 : 0,
+    sunriseThinTicks: thin.has('sunrise') ? 1 : 0,
+    sunsetThinTicks: thin.has('sunset') ? 1 : 0,
+    sunriseShortTicks: short('sunrise'),
+    sunsetShortTicks: short('sunset'),
+    baseBoxes: base?.attempted ?? 0,
+    escalationBoxes: escalation.reduce((sum, r) => sum + r.attempted, 0),
+    rings: [...byOffset.values()],
+  };
+}
+
+function utcDateString(d: Date): string {
+  return d.toISOString().slice(0, 10);
+}
+
+/**
+ * Accumulate one tick into today's rows.
+ *
+ * Every counter ADDS, so an intra-day rerun is additive and the columns keep
+ * their "N of today's ticks" reading. Non-fatal by contract: telemetry is
+ * never worth failing a cron tick over, and the tables may not exist yet on a
+ * deploy that lands before the migration is applied.
+ *
+ * `modelVersion` is passed because daily_sunset_stats.model_version is NOT
+ * NULL and either writer may be the one that creates the day's row. Both
+ * writers are handed the same value in the same tick.
+ */
+export async function upsertSweepStats(
+  now: Date,
+  stats: SweepTickStats,
+  modelVersion: string,
+): Promise<void> {
+  const date = utcDateString(now);
+  try {
+    await sql`
+      insert into daily_sunset_stats (
+        date, model_version,
+        sweep_ticks, sweep_escalated_ticks, sweep_budget_exhausted_ticks,
+        sweep_sunrise_thin_ticks, sweep_sunset_thin_ticks,
+        sweep_sunrise_short_ticks, sweep_sunset_short_ticks,
+        sweep_base_boxes, sweep_escalation_boxes,
+        updated_at
+      ) values (
+        ${date}, ${modelVersion},
+        ${stats.ticks}, ${stats.escalatedTicks}, ${stats.budgetExhaustedTicks},
+        ${stats.sunriseThinTicks}, ${stats.sunsetThinTicks},
+        ${stats.sunriseShortTicks}, ${stats.sunsetShortTicks},
+        ${stats.baseBoxes}, ${stats.escalationBoxes},
+        now()
+      )
+      on conflict (date) do update set
+        sweep_ticks = daily_sunset_stats.sweep_ticks + excluded.sweep_ticks,
+        sweep_escalated_ticks =
+          daily_sunset_stats.sweep_escalated_ticks + excluded.sweep_escalated_ticks,
+        sweep_budget_exhausted_ticks =
+          daily_sunset_stats.sweep_budget_exhausted_ticks
+          + excluded.sweep_budget_exhausted_ticks,
+        sweep_sunrise_thin_ticks =
+          daily_sunset_stats.sweep_sunrise_thin_ticks + excluded.sweep_sunrise_thin_ticks,
+        sweep_sunset_thin_ticks =
+          daily_sunset_stats.sweep_sunset_thin_ticks + excluded.sweep_sunset_thin_ticks,
+        sweep_sunrise_short_ticks =
+          daily_sunset_stats.sweep_sunrise_short_ticks + excluded.sweep_sunrise_short_ticks,
+        sweep_sunset_short_ticks =
+          daily_sunset_stats.sweep_sunset_short_ticks + excluded.sweep_sunset_short_ticks,
+        sweep_base_boxes = daily_sunset_stats.sweep_base_boxes + excluded.sweep_base_boxes,
+        sweep_escalation_boxes =
+          daily_sunset_stats.sweep_escalation_boxes + excluded.sweep_escalation_boxes,
+        updated_at = now()
+    `;
+
+    for (const ring of stats.rings) {
+      await sql`
+        insert into daily_sweep_ring_stats (
+          date, offset_deg,
+          rings_swept, boxes_attempted, boxes_empty,
+          new_webcams, frames_scored, frames_gate_passed,
+          updated_at
+        ) values (
+          ${date}, ${ring.offsetDeg},
+          ${ring.ringsSwept}, ${ring.boxesAttempted}, ${ring.boxesEmpty},
+          ${ring.newWebcams}, ${ring.framesScored}, ${ring.framesGatePassed},
+          now()
+        )
+        on conflict (date, offset_deg) do update set
+          rings_swept = daily_sweep_ring_stats.rings_swept + excluded.rings_swept,
+          boxes_attempted =
+            daily_sweep_ring_stats.boxes_attempted + excluded.boxes_attempted,
+          boxes_empty = daily_sweep_ring_stats.boxes_empty + excluded.boxes_empty,
+          new_webcams = daily_sweep_ring_stats.new_webcams + excluded.new_webcams,
+          frames_scored =
+            daily_sweep_ring_stats.frames_scored + excluded.frames_scored,
+          frames_gate_passed =
+            daily_sweep_ring_stats.frames_gate_passed + excluded.frames_gate_passed,
+          updated_at = now()
+      `;
+    }
+  } catch (error) {
+    console.warn('[sweepStats] persist failed:', error);
+  }
+}
+
+export interface SweepDigestSummary {
+  ticks: number;
+  escalatedTicks: number;
+  budgetExhaustedTicks: number;
+  sunriseThinTicks: number;
+  sunsetThinTicks: number;
+  sunriseShortTicks: number;
+  sunsetShortTicks: number;
+  baseBoxes: number;
+  escalationBoxes: number;
+  rings: SweepRingStats[];
+}
+
+/**
+ * Yesterday's sweep rollup for the digest email.
+ *
+ * Yesterday, not today: the digest rides the once-per-UTC-day provider
+ * snapshot, which lands just after midnight UTC, so CURRENT_DATE - 1 is the
+ * only complete day. `null` (no rows, or no table) renders nothing rather
+ * than an error line, matching the calibration section's contract.
+ */
+export async function getSweepDigestSummary(): Promise<SweepDigestSummary | null> {
+  try {
+    const rows = (await sql`
+      select
+        sweep_ticks, sweep_escalated_ticks, sweep_budget_exhausted_ticks,
+        sweep_sunrise_thin_ticks, sweep_sunset_thin_ticks,
+        sweep_sunrise_short_ticks, sweep_sunset_short_ticks,
+        sweep_base_boxes, sweep_escalation_boxes
+      from daily_sunset_stats
+      where date = CURRENT_DATE - 1
+    `) as Record<string, number | string>[];
+    const row = rows[0];
+    if (!row || Number(row.sweep_ticks) === 0) return null;
+
+    const ringRows = (await sql`
+      select
+        offset_deg, rings_swept, boxes_attempted, boxes_empty,
+        new_webcams, frames_scored, frames_gate_passed
+      from daily_sweep_ring_stats
+      where date = CURRENT_DATE - 1
+      order by offset_deg desc
+    `) as Record<string, number | string>[];
+
+    return {
+      ticks: Number(row.sweep_ticks),
+      escalatedTicks: Number(row.sweep_escalated_ticks),
+      budgetExhaustedTicks: Number(row.sweep_budget_exhausted_ticks),
+      sunriseThinTicks: Number(row.sweep_sunrise_thin_ticks),
+      sunsetThinTicks: Number(row.sweep_sunset_thin_ticks),
+      sunriseShortTicks: Number(row.sweep_sunrise_short_ticks),
+      sunsetShortTicks: Number(row.sweep_sunset_short_ticks),
+      baseBoxes: Number(row.sweep_base_boxes),
+      escalationBoxes: Number(row.sweep_escalation_boxes),
+      // offset_deg is NUMERIC, which the Neon driver hands back as a string.
+      // Number() here or every downstream comparison against 15.75 misses.
+      rings: ringRows.map((r) => ({
+        offsetDeg: Number(r.offset_deg),
+        ringsSwept: Number(r.rings_swept),
+        boxesAttempted: Number(r.boxes_attempted),
+        boxesEmpty: Number(r.boxes_empty),
+        newWebcams: Number(r.new_webcams),
+        framesScored: Number(r.frames_scored),
+        framesGatePassed: Number(r.frames_gate_passed),
+      })),
+    };
+  } catch (error) {
+    console.warn('[sweepStats] digest summary unavailable:', error);
+    return null;
+  }
+}

--- a/app/api/cron/update-cameras/lib/terminatorSweep.test.ts
+++ b/app/api/cron/update-cameras/lib/terminatorSweep.test.ts
@@ -44,6 +44,35 @@ describe('feedsBelowFloor', () => {
 });
 
 describe('sweepWithEscalation', () => {
+  it('records which feeds were thin after the base ring, budget aside', async () => {
+    // thinAfterBase is what the daily digest counts, so it must be true of
+    // the base ring's own result and not of whether an escalation ring got
+    // to run. A budget-starved tick still had a thin feed.
+    const res = await sweepWithEscalation({
+      buildRing: ring,
+      fetchCoords: stubFetcher({ 0: [cam(1), cam(2), cam(4)] }),
+      classify,
+      floor: 2,
+      offsets: [15.75],
+      hasBudget: () => false,
+    });
+    expect(res.telemetry.thinAfterBase).toEqual(['sunrise']);
+    expect(res.telemetry.budgetExhausted).toBe(true);
+    expect(res.telemetry.escalations).toBe(0);
+  });
+
+  it('reports no thin feed when the base ring clears the floor for both', async () => {
+    const res = await sweepWithEscalation({
+      buildRing: ring,
+      fetchCoords: stubFetcher({ 0: [cam(1), cam(2), cam(3), cam(4)] }),
+      classify,
+      floor: 2,
+      offsets: [15.75, -15.75],
+      hasBudget: () => true,
+    });
+    expect(res.telemetry.thinAfterBase).toEqual([]);
+  });
+
   it('does not escalate when the base ring already clears the floor', async () => {
     const seen: Location[][] = [];
     const res = await sweepWithEscalation({

--- a/app/api/cron/update-cameras/lib/terminatorSweep.test.ts
+++ b/app/api/cron/update-cameras/lib/terminatorSweep.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect, vi } from 'vitest';
+import { feedsBelowFloor, sweepWithEscalation } from './terminatorSweep';
+import type { Location, WindyWebcam } from '@/app/lib/types';
+
+const cam = (id: number, lat = 0): WindyWebcam =>
+  ({ webcamId: id, location: { latitude: lat, longitude: 0 } } as WindyWebcam);
+
+const ring = (offsetDeg: number) => ({
+  sunriseCoords: [{ lat: offsetDeg, lng: 1 }] as Location[],
+  sunsetCoords: [{ lat: offsetDeg, lng: 2 }] as Location[],
+});
+
+/** Hands back `perRing[offset]` cameras, and records which coords were asked for. */
+function stubFetcher(perRing: Record<number, WindyWebcam[]>, seen: Location[][] = []) {
+  return async (coords: Location[]) => {
+    seen.push(coords);
+    const offset = coords[0]?.lat ?? 0;
+    const webcams = perRing[offset] ?? [];
+    return { webcams, attempted: coords.length, empty: 0 };
+  };
+}
+
+/** Splits on webcamId parity: odd ids are sunrise, even ids are sunset. */
+const classify = (webcams: WindyWebcam[]) => ({
+  sunrise: webcams.filter((w) => w.webcamId % 2 === 1),
+  sunset: webcams.filter((w) => w.webcamId % 2 === 0),
+});
+
+describe('feedsBelowFloor', () => {
+  it('names only the feeds under the floor', () => {
+    expect(feedsBelowFloor({ sunrise: 4, sunset: 21 }, 15)).toEqual(['sunrise']);
+  });
+  it('is empty when both feeds are healthy', () => {
+    expect(feedsBelowFloor({ sunrise: 30, sunset: 21 }, 15)).toEqual([]);
+  });
+  it('treats the floor itself as healthy', () => {
+    expect(feedsBelowFloor({ sunrise: 15, sunset: 15 }, 15)).toEqual([]);
+  });
+  it('names both when both are thin', () => {
+    expect(feedsBelowFloor({ sunrise: 1, sunset: 2 }, 15)).toEqual([
+      'sunrise', 'sunset',
+    ]);
+  });
+});
+
+describe('sweepWithEscalation', () => {
+  it('does not escalate when the base ring already clears the floor', async () => {
+    const seen: Location[][] = [];
+    const res = await sweepWithEscalation({
+      buildRing: ring,
+      fetchCoords: stubFetcher({ 0: [cam(1), cam(2), cam(3), cam(4)] }, seen),
+      classify,
+      floor: 2,
+      offsets: [15.75, -15.75],
+      hasBudget: () => true,
+    });
+    expect(res.telemetry.escalations).toBe(0);
+    expect(res.telemetry.rings).toHaveLength(1);
+    expect(seen).toHaveLength(1);
+  });
+
+  it('escalates to the day ring for the thin feed only', async () => {
+    const seen: Location[][] = [];
+    const res = await sweepWithEscalation({
+      buildRing: ring,
+      fetchCoords: stubFetcher(
+        { 0: [cam(2), cam(4)], 15.75: [cam(1), cam(3)] },
+        seen
+      ),
+      classify,
+      floor: 2,
+      offsets: [15.75, -15.75],
+      hasBudget: () => true,
+    });
+    expect(res.telemetry.escalations).toBe(1);
+    expect(res.telemetry.rings[1].offsetDeg).toBe(15.75);
+    expect(res.telemetry.rings[1].feedsSwept).toEqual(['sunrise']);
+    // Only the sunrise half of the day ring was requested.
+    expect(seen[1]).toEqual([{ lat: 15.75, lng: 1 }]);
+  });
+
+  it('tries the day side before the night side', async () => {
+    const res = await sweepWithEscalation({
+      buildRing: ring,
+      fetchCoords: stubFetcher({ 0: [] }),
+      classify,
+      floor: 5,
+      offsets: [15.75, -15.75],
+      hasBudget: () => true,
+    });
+    expect(res.telemetry.rings.map((r) => r.offsetDeg)).toEqual([
+      0, 15.75, -15.75,
+    ]);
+  });
+
+  it('stops escalating when the budget is gone', async () => {
+    const res = await sweepWithEscalation({
+      buildRing: ring,
+      fetchCoords: stubFetcher({ 0: [] }),
+      classify,
+      floor: 5,
+      offsets: [15.75, -15.75],
+      hasBudget: () => false,
+    });
+    expect(res.telemetry.rings).toHaveLength(1);
+    expect(res.telemetry.budgetExhausted).toBe(true);
+  });
+
+  it('deduplicates cameras seen on more than one ring', async () => {
+    const res = await sweepWithEscalation({
+      buildRing: ring,
+      fetchCoords: stubFetcher({ 0: [cam(1)], 15.75: [cam(1), cam(3)] }),
+      classify,
+      floor: 3,
+      offsets: [15.75],
+      hasBudget: () => true,
+    });
+    expect(res.webcams.map((w) => w.webcamId).sort()).toEqual([1, 3]);
+    expect(res.telemetry.rings[1].newWebcams).toBe(1);
+  });
+
+  it('unions coordinates across every ring it swept', async () => {
+    const res = await sweepWithEscalation({
+      buildRing: ring,
+      fetchCoords: stubFetcher({ 0: [] }),
+      classify,
+      floor: 5,
+      offsets: [15.75],
+      hasBudget: () => true,
+    });
+    expect(res.coords.sunriseCoords).toEqual([
+      { lat: 0, lng: 1 }, { lat: 15.75, lng: 1 },
+    ]);
+  });
+});

--- a/app/api/cron/update-cameras/lib/terminatorSweep.test.ts
+++ b/app/api/cron/update-cameras/lib/terminatorSweep.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect } from 'vitest';
 import { feedsBelowFloor, sweepWithEscalation } from './terminatorSweep';
 import type { Location, WindyWebcam } from '@/app/lib/types';
 
@@ -57,6 +57,8 @@ describe('sweepWithEscalation', () => {
     expect(res.telemetry.escalations).toBe(0);
     expect(res.telemetry.rings).toHaveLength(1);
     expect(seen).toHaveLength(1);
+    expect(res.telemetry.rings[0].newWebcams).toBe(4);
+    expect(res.telemetry.rings[0].newWebcamIds).toEqual([1, 2, 3, 4]);
   });
 
   it('escalates to the day ring for the thin feed only', async () => {
@@ -77,6 +79,11 @@ describe('sweepWithEscalation', () => {
     expect(res.telemetry.rings[1].feedsSwept).toEqual(['sunrise']);
     // Only the sunrise half of the day ring was requested.
     expect(seen[1]).toEqual([{ lat: 15.75, lng: 1 }]);
+    // Which ring each camera came from, not just how many. Without the ids
+    // the spec's "do golden-hour frames pass the gate?" question is not
+    // answerable from telemetry.
+    expect(res.telemetry.rings[0].newWebcamIds).toEqual([2, 4]);
+    expect(res.telemetry.rings[1].newWebcamIds).toEqual([1, 3]);
   });
 
   it('tries the day side before the night side', async () => {
@@ -117,6 +124,9 @@ describe('sweepWithEscalation', () => {
     });
     expect(res.webcams.map((w) => w.webcamId).sort()).toEqual([1, 3]);
     expect(res.telemetry.rings[1].newWebcams).toBe(1);
+    // Camera 1 was already seen on the base ring, so only 3 is credited here.
+    expect(res.telemetry.rings[0].newWebcamIds).toEqual([1]);
+    expect(res.telemetry.rings[1].newWebcamIds).toEqual([3]);
   });
 
   it('unions coordinates across every ring it swept', async () => {
@@ -130,6 +140,32 @@ describe('sweepWithEscalation', () => {
     });
     expect(res.coords.sunriseCoords).toEqual([
       { lat: 0, lng: 1 }, { lat: 15.75, lng: 1 },
+    ]);
+  });
+
+  it('does not hand out its module-level feed list in the telemetry', async () => {
+    // The base ring sweeps both feeds. If `feedsSwept` aliased the module-level
+    // FEEDS constant, mutating the returned telemetry (a sort, a reverse) would
+    // permanently flip escalation priority for the rest of the process.
+    const run = () =>
+      sweepWithEscalation({
+        buildRing: ring,
+        fetchCoords: stubFetcher({ 0: [] }),
+        classify,
+        floor: 5,
+        offsets: [],
+        hasBudget: () => true,
+      });
+
+    const first = await run();
+    expect(first.telemetry.rings[0].feedsSwept).toEqual([
+      'sunrise', 'sunset',
+    ]);
+    first.telemetry.rings[0].feedsSwept.reverse();
+
+    const second = await run();
+    expect(second.telemetry.rings[0].feedsSwept).toEqual([
+      'sunrise', 'sunset',
     ]);
   });
 });

--- a/app/api/cron/update-cameras/lib/terminatorSweep.ts
+++ b/app/api/cron/update-cameras/lib/terminatorSweep.ts
@@ -31,6 +31,15 @@ export interface RingTelemetry {
 export interface SweepTelemetry {
   rings: RingTelemetry[];
   counts: Record<Feed, number>;
+  /**
+   * Feeds under the floor once the base ring was in, before any widening.
+   *
+   * This, not `rings[1].feedsSwept`, is the honest "a feed went thin today"
+   * signal the daily digest counts: a tick that ran out of sweep budget
+   * before the first escalation ring had a thin feed and no escalation ring
+   * to record it.
+   */
+  thinAfterBase: Feed[];
   escalations: number;
   budgetExhausted: boolean;
 }
@@ -142,6 +151,7 @@ export async function sweepWithEscalation(
   // flip escalation priority for the rest of the process.
   await sweep(0, [...FEEDS]);
   let counts = currentCounts();
+  const thinAfterBase = feedsBelowFloor(counts, opts.floor);
 
   for (const offsetDeg of opts.offsets) {
     const thin = feedsBelowFloor(counts, opts.floor);
@@ -160,6 +170,7 @@ export async function sweepWithEscalation(
     telemetry: {
       rings,
       counts,
+      thinAfterBase,
       escalations: rings.length - 1,
       budgetExhausted,
     },

--- a/app/api/cron/update-cameras/lib/terminatorSweep.ts
+++ b/app/api/cron/update-cameras/lib/terminatorSweep.ts
@@ -15,6 +15,17 @@ export interface RingTelemetry {
   empty: number;
   /** Cameras this ring contributed that no earlier ring had seen. */
   newWebcams: number;
+  /**
+   * The ids behind `newWebcams`, in the order the ring returned them.
+   *
+   * Carried so the spec's open question is answerable from telemetry alone:
+   * do golden-hour frames (the +15.75 ring) actually pass the detection gate,
+   * or does the day-side ring only add tiles that get floored? Answering that
+   * means comparing gate-pass rates for cameras first seen on ring 1 against
+   * ring 0, which needs the ids and not just the count. `newWebcams` stays as
+   * the cheap scalar for logs and dashboards.
+   */
+  newWebcamIds: number[];
 }
 
 export interface SweepTelemetry {
@@ -94,13 +105,20 @@ export async function sweepWithEscalation(
     }
     const before = byId.size;
     const res = await opts.fetchCoords(coords);
-    for (const w of res.webcams) byId.set(w.webcamId, w);
+    // Record the ids this ring is first to see, before inserting them, so the
+    // delta is against every EARLIER ring rather than against this one.
+    const newWebcamIds: number[] = [];
+    for (const w of res.webcams) {
+      if (!byId.has(w.webcamId)) newWebcamIds.push(w.webcamId);
+      byId.set(w.webcamId, w);
+    }
     rings.push({
       offsetDeg,
       feedsSwept: feeds,
       attempted: res.attempted,
       empty: res.empty,
       newWebcams: byId.size - before,
+      newWebcamIds,
     });
   };
 
@@ -117,7 +135,12 @@ export async function sweepWithEscalation(
     return { sunrise: split.sunrise.length, sunset: split.sunset.length };
   };
 
-  await sweep(0, FEEDS);
+  // Copy FEEDS: `sweep` stores the array it is handed straight into the
+  // returned telemetry, so passing the module-level constant would make
+  // `telemetry.rings[0].feedsSwept` an alias of FEEDS. Any caller that sorted
+  // or otherwise mutated the telemetry would permanently reorder FEEDS and
+  // flip escalation priority for the rest of the process.
+  await sweep(0, [...FEEDS]);
   let counts = currentCounts();
 
   for (const offsetDeg of opts.offsets) {

--- a/app/api/cron/update-cameras/lib/terminatorSweep.ts
+++ b/app/api/cron/update-cameras/lib/terminatorSweep.ts
@@ -1,0 +1,144 @@
+import type { Location, WindyWebcam } from '@/app/lib/types';
+import type { CoordFetchResult } from './windyApi';
+
+export type Feed = 'sunrise' | 'sunset';
+
+export interface RingCoords {
+  sunriseCoords: Location[];
+  sunsetCoords: Location[];
+}
+
+export interface RingTelemetry {
+  offsetDeg: number;
+  feedsSwept: Feed[];
+  attempted: number;
+  empty: number;
+  /** Cameras this ring contributed that no earlier ring had seen. */
+  newWebcams: number;
+}
+
+export interface SweepTelemetry {
+  rings: RingTelemetry[];
+  counts: Record<Feed, number>;
+  escalations: number;
+  budgetExhausted: boolean;
+}
+
+export interface SweepResult {
+  webcams: WindyWebcam[];
+  coords: RingCoords;
+  telemetry: SweepTelemetry;
+}
+
+export interface SweepOptions {
+  buildRing: (offsetDeg: number) => RingCoords;
+  fetchCoords: (coords: Location[]) => Promise<CoordFetchResult>;
+  classify: (
+    webcams: WindyWebcam[],
+    sunriseCoords: Location[],
+    sunsetCoords: Location[]
+  ) => { sunrise: WindyWebcam[]; sunset: WindyWebcam[] };
+  floor: number;
+  offsets: readonly number[];
+  hasBudget: () => boolean;
+}
+
+const FEEDS: Feed[] = ['sunrise', 'sunset'];
+
+/** Feeds whose camera count is under the floor. Order is stable: sunrise first. */
+export function feedsBelowFloor(
+  counts: Record<Feed, number>,
+  floor: number
+): Feed[] {
+  return FEEDS.filter((f) => counts[f] < floor);
+}
+
+/**
+ * Sweep the terminator, widening within THIS tick while any feed is short.
+ *
+ * The escalation level is never stored. It is re-derived every tick from what
+ * the sweep actually returned, so it relaxes on its own the moment the
+ * terminator moves back over land. Cross-tick hysteresis was considered and
+ * rejected: widening succeeds, the count rises past the high-water mark, the
+ * next tick narrows, the count collapses, and it oscillates.
+ *
+ * Ring order matters. `offsets` is day-side first (positive offset shrinks the
+ * ring radius, moving it toward the sun), because the day-side ring lands in
+ * golden hour while the night-side one lands ~29 degrees below the horizon,
+ * where frames get gated anyway. Measured 2026-09-02: the +15.75 ring returned
+ * 100% cameras the base ring had never seen.
+ *
+ * Only the thin feed's half of an escalation ring is swept. The two feeds are
+ * routinely short at different times (4 vs 21 the day this was written), so
+ * this halves the cost of the common case.
+ */
+export async function sweepWithEscalation(
+  opts: SweepOptions
+): Promise<SweepResult> {
+  const byId = new Map<number, WindyWebcam>();
+  const sunriseCoords: Location[] = [];
+  const sunsetCoords: Location[] = [];
+  const rings: RingTelemetry[] = [];
+  let budgetExhausted = false;
+
+  const sweep = async (offsetDeg: number, feeds: Feed[]) => {
+    const ring = opts.buildRing(offsetDeg);
+    const coords: Location[] = [];
+    if (feeds.includes('sunrise')) {
+      sunriseCoords.push(...ring.sunriseCoords);
+      coords.push(...ring.sunriseCoords);
+    }
+    if (feeds.includes('sunset')) {
+      sunsetCoords.push(...ring.sunsetCoords);
+      coords.push(...ring.sunsetCoords);
+    }
+    const before = byId.size;
+    const res = await opts.fetchCoords(coords);
+    for (const w of res.webcams) byId.set(w.webcamId, w);
+    rings.push({
+      offsetDeg,
+      feedsSwept: feeds,
+      attempted: res.attempted,
+      empty: res.empty,
+      newWebcams: byId.size - before,
+    });
+  };
+
+  // Classify against the FULL coordinate set gathered so far, never against
+  // the triggering feed alone. A day-side box on the sunrise half can hold a
+  // camera that genuinely belongs to sunset, and forcing it into the feed that
+  // triggered the sweep would corrupt the split.
+  const currentCounts = (): Record<Feed, number> => {
+    const split = opts.classify(
+      [...byId.values()],
+      sunriseCoords,
+      sunsetCoords
+    );
+    return { sunrise: split.sunrise.length, sunset: split.sunset.length };
+  };
+
+  await sweep(0, FEEDS);
+  let counts = currentCounts();
+
+  for (const offsetDeg of opts.offsets) {
+    const thin = feedsBelowFloor(counts, opts.floor);
+    if (thin.length === 0) break;
+    if (!opts.hasBudget()) {
+      budgetExhausted = true;
+      break;
+    }
+    await sweep(offsetDeg, thin);
+    counts = currentCounts();
+  }
+
+  return {
+    webcams: [...byId.values()],
+    coords: { sunriseCoords, sunsetCoords },
+    telemetry: {
+      rings,
+      counts,
+      escalations: rings.length - 1,
+      budgetExhausted,
+    },
+  };
+}

--- a/app/api/cron/update-cameras/lib/windyApi.test.ts
+++ b/app/api/cron/update-cameras/lib/windyApi.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest';
+import { boundingBox } from './windyApi';
+
+describe('boundingBox', () => {
+  it('returns an unclamped box away from the edges', () => {
+    expect(boundingBox({ lat: 45, lng: 10 }, 11)).toEqual({
+      northLat: 56, southLat: 34, eastLon: 21, westLon: -1,
+    });
+  });
+
+  it('clamps latitude at the north pole', () => {
+    const box = boundingBox({ lat: 85, lng: 0 }, 11);
+    expect(box.northLat).toBe(90);
+    expect(box.southLat).toBe(74);
+  });
+
+  it('clamps latitude at the south pole', () => {
+    const box = boundingBox({ lat: -85, lng: 0 }, 11);
+    expect(box.southLat).toBe(-90);
+    expect(box.northLat).toBe(-74);
+  });
+
+  it('clamps longitude at the antimeridian', () => {
+    expect(boundingBox({ lat: 0, lng: 175 }, 11).eastLon).toBe(180);
+    expect(boundingBox({ lat: 0, lng: -175 }, 11).westLon).toBe(-180);
+  });
+
+  it('never produces a span wider than the Windy zoom-4 cap', () => {
+    for (const lat of [-90, -85, -45, 0, 45, 85, 90]) {
+      const box = boundingBox({ lat, lng: 0 }, 11);
+      expect(box.northLat - box.southLat).toBeLessThanOrEqual(22.5);
+    }
+  });
+});

--- a/app/api/cron/update-cameras/lib/windyApi.test.ts
+++ b/app/api/cron/update-cameras/lib/windyApi.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect } from 'vitest';
-import { boundingBox } from './windyApi';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { boundingBox, fetchCoordsCounted } from './windyApi';
 
 describe('boundingBox', () => {
   it('returns an unclamped box away from the edges', () => {
@@ -30,5 +30,34 @@ describe('boundingBox', () => {
       const box = boundingBox({ lat, lng: 0 }, 11);
       expect(box.northLat - box.southLat).toBeLessThanOrEqual(22.5);
     }
+  });
+});
+
+describe('fetchCoordsCounted', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn(async (url: string) => {
+      // Boxes centred on lng 99 answer with one webcam; everything else 400s.
+      if (url.includes('westLon=88')) {
+        return { ok: true, json: async () => [{ webcamId: 1, location: {} }] };
+      }
+      return { ok: false, status: 400, statusText: 'Bad Request' };
+    }));
+  });
+  afterEach(() => vi.unstubAllGlobals());
+
+  it('reports how many boxes were tried and how many came back empty', async () => {
+    const res = await fetchCoordsCounted(
+      [{ lat: 0, lng: 99 }, { lat: 0, lng: 5 }, { lat: 0, lng: 20 }],
+      5,
+      0
+    );
+    expect(res.attempted).toBe(3);
+    expect(res.empty).toBe(2);
+    expect(res.webcams).toHaveLength(1);
+  });
+
+  it('is a no-op on an empty coordinate list', async () => {
+    const res = await fetchCoordsCounted([], 5, 0);
+    expect(res).toEqual({ webcams: [], attempted: 0, empty: 0 });
   });
 });

--- a/app/api/cron/update-cameras/lib/windyApi.ts
+++ b/app/api/cron/update-cameras/lib/windyApi.ts
@@ -171,11 +171,15 @@ export async function fetchCoordsCounted(
   delayMs = 1000
 ): Promise<CoordFetchResult> {
   if (coords.length === 0) return { webcams: [], attempted: 0, empty: 0 };
-  const batches = await fetchWebcamsInBatches(coords, batchSize, delayMs);
+  // One entry per COORDINATE, not per batch: fetchWebcamsInBatches spreads
+  // each batch's results back in, so the array is 1:1 with `coords`. That
+  // invariant is what makes `attempted` and `empty` correct, and the old
+  // `batches` name hid it.
+  const perCoord = await fetchWebcamsInBatches(coords, batchSize, delayMs);
   return {
-    webcams: batches.flat(),
+    webcams: perCoord.flat(),
     attempted: coords.length,
-    empty: batches.filter((b) => b.length === 0).length,
+    empty: perCoord.filter((r) => r.length === 0).length,
   };
 }
 

--- a/app/api/cron/update-cameras/lib/windyApi.ts
+++ b/app/api/cron/update-cameras/lib/windyApi.ts
@@ -9,6 +9,36 @@ import {
   WINDY_FETCH_STAGGER_WITHIN_BATCH_MS,
 } from '@/app/lib/masterConfig';
 
+export interface BoundingBox {
+  northLat: number;
+  southLat: number;
+  eastLon: number;
+  westLon: number;
+}
+
+/**
+ * Query box for one ring point, clamped to the ranges Windy accepts.
+ *
+ * Verified live 2026-09-02: the clusters endpoint 400s on northLat > 90,
+ * southLat < -90, eastLon > 180 or westLon < -180, and `fetchWebcamsFor`
+ * turns that into a silent empty array. The ring genuinely reaches both
+ * the pole and the antimeridian, so ~2 of 31 boxes per sweep were being
+ * lost that way.
+ *
+ * Clamping shrinks the box rather than wrapping it, so a box straddling
+ * the antimeridian loses the sliver on the far side. Splitting into two
+ * boxes would recover it; not done here because that stretch is open
+ * ocean and a shrunken box still beats a 400.
+ */
+export function boundingBox(loc: Location, radiusDeg: number): BoundingBox {
+  return {
+    northLat: Math.min(90, loc.lat + radiusDeg),
+    southLat: Math.max(-90, loc.lat - radiusDeg),
+    eastLon: Math.min(180, loc.lng + radiusDeg),
+    westLon: Math.max(-180, loc.lng - radiusDeg),
+  };
+}
+
 /**
  * Fetch webcams from Windy API for a given location
  */
@@ -21,10 +51,11 @@ export async function fetchWebcamsFor(
     await new Promise((resolve) => setTimeout(resolve, delayMs));
   }
 
+  const box = boundingBox(loc, SEARCH_RADIUS_DEG);
   const url = `https://api.windy.com/webcams/api/v3/map/clusters?lang=en&northLat=${
-    loc.lat + SEARCH_RADIUS_DEG
-  }&southLat=${loc.lat - SEARCH_RADIUS_DEG}&eastLon=${loc.lng + SEARCH_RADIUS_DEG}&westLon=${
-    loc.lng - SEARCH_RADIUS_DEG
+    box.northLat
+  }&southLat=${box.southLat}&eastLon=${box.eastLon}&westLon=${
+    box.westLon
   }&zoom=4&include=images&include=urls&include=player&include=location&include=categories`;
 
   console.log(

--- a/app/api/cron/update-cameras/lib/windyApi.ts
+++ b/app/api/cron/update-cameras/lib/windyApi.ts
@@ -147,3 +147,35 @@ export function dedupeWebcams(webcams: WindyWebcam[]): Map<number, WindyWebcam> 
   return windyById;
 }
 
+export interface CoordFetchResult {
+  webcams: WindyWebcam[];
+  /** Boxes we sent to Windy. */
+  attempted: number;
+  /**
+   * Boxes that returned nothing. Conflates "no cameras there" with "the call
+   * failed", because `fetchWebcamsFor` swallows non-OK responses. That
+   * conflation is the point: a rising `empty` count against a flat camera
+   * count is the signature of an API wall, which is the thing we need to be
+   * able to see.
+   */
+  empty: number;
+}
+
+/**
+ * Batched sweep over ring coordinates that reports coverage, not just
+ * results. Wraps `fetchWebcamsInBatches` so rate limiting stays in one place.
+ */
+export async function fetchCoordsCounted(
+  coords: Location[],
+  batchSize = 5,
+  delayMs = 1000
+): Promise<CoordFetchResult> {
+  if (coords.length === 0) return { webcams: [], attempted: 0, empty: 0 };
+  const batches = await fetchWebcamsInBatches(coords, batchSize, delayMs);
+  return {
+    webcams: batches.flat(),
+    attempted: coords.length,
+    empty: batches.filter((b) => b.length === 0).length,
+  };
+}
+

--- a/app/api/cron/update-cameras/route.test.ts
+++ b/app/api/cron/update-cameras/route.test.ts
@@ -41,12 +41,16 @@ vi.mock('@/app/lib/webcamSnapshot', () => ({
 vi.mock('./lib/auth', () => ({ verifyCronAuth: () => verifyAuthMock() }));
 vi.mock('./lib/windyApi', () => ({
   dedupeCoords: (x: unknown) => x,
-  dedupeWebcams: (webcams: Array<{ webcamId: number | string; [k: string]: unknown }>) => {
-    const m = new Map<string, typeof webcams[number]>();
-    for (const w of webcams) m.set(String(w.webcamId), w);
-    return m;
+  fetchCoordsCounted: async (coords: unknown[], ...rest: unknown[]) => {
+    const batches = (await fetchBatchesMock(coords, ...rest)) as Array<
+      Array<{ webcamId: number | string; [k: string]: unknown }>
+    >;
+    return {
+      webcams: batches.flat(),
+      attempted: Array.isArray(coords) ? coords.length : 0,
+      empty: batches.filter((b) => b.length === 0).length,
+    };
   },
-  fetchWebcamsInBatches: (...a: unknown[]) => fetchBatchesMock(...a),
 }));
 vi.mock('./lib/webcamClassification', () => ({
   classifyWebcamsByPhase: (...a: unknown[]) => classifyMock(...a),

--- a/app/api/cron/update-cameras/route.test.ts
+++ b/app/api/cron/update-cameras/route.test.ts
@@ -89,6 +89,18 @@ vi.mock('./lib/providerUsage', () => ({
   captureProviderUsageDaily: (...a: unknown[]) =>
     captureProviderUsageDailyMock(...a),
 }));
+// sweepStats is only partially mocked below, so importOriginal pulls in the
+// real module -- and with it @/app/lib/db, which calls neon() at import time
+// and throws without DATABASE_URL. Nothing in this file uses sql directly.
+vi.mock('@/app/lib/db', () => ({ sql: vi.fn() }));
+
+const upsertSweepStatsMock = vi.fn();
+// Only the write is stubbed. computeSweepTickStats and ringOffsetByWebcamId
+// stay real so this file exercises the actual telemetry -> row mapping.
+vi.mock('./lib/sweepStats', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('./lib/sweepStats')>()),
+  upsertSweepStats: (...a: unknown[]) => upsertSweepStatsMock(...a),
+}));
 const sendDailyUsageDigestMock = vi.fn();
 vi.mock('./lib/dailyDigest', () => ({
   sendDailyUsageDigest: (...a: unknown[]) => sendDailyUsageDigestMock(...a),
@@ -168,6 +180,7 @@ beforeEach(() => {
   upsertStatsMock.mockReset().mockResolvedValue(undefined);
   captureProviderUsageDailyMock.mockReset().mockResolvedValue({ captured: 0 });
   sendDailyUsageDigestMock.mockReset().mockResolvedValue({ sent: true });
+  upsertSweepStatsMock.mockReset().mockResolvedValue(undefined);
   setCachedMock.mockReset().mockResolvedValue(undefined);
   markKioskTickRanMock.mockReset().mockResolvedValue(undefined);
   fetchTerminatorWebcamsMock.mockReset().mockResolvedValue([]);
@@ -251,6 +264,12 @@ describe('GET /api/cron/update-cameras', () => {
     expect(markKioskTickRanMock).toHaveBeenCalled();
   });
 
+  // The next three tests override classifyMock with sub-floor counts, so the
+  // sweep escalates through all three rings as a side effect. Harmless here —
+  // they assert on upsertStateMock/deactivateMock, not on sweep-derived
+  // values. But a `fetchBatchesMock.mockResolvedValueOnce` added to any of
+  // them applies to ring 0 only; rings 1 and 2 fall back to the beforeEach
+  // default.
   it('unions custom cams into the upsert active set', async () => {
     classifyMock.mockReturnValue({
       sunrise: [{ webcamId: 'wA', location: { latitude: 0, longitude: 0 } }],
@@ -567,6 +586,83 @@ describe('GET /api/cron/update-cameras', () => {
       // Only the thin feed's half of each escalation ring is swept.
       expect(body.sweep.rings[1].feedsSwept).toEqual(['sunrise']);
       expect(body.sweep.rings[2].feedsSwept).toEqual(['sunrise']);
+    });
+
+    it('persists the tick to daily_sunset_stats, split base vs escalation', async () => {
+      classifyMock.mockReturnValue({
+        sunrise: Array.from(
+          { length: TERMINATOR_CAMERA_FLOOR - 1 },
+          (_, i) => ({ webcamId: `thin-${i}` }),
+        ),
+        sunset: HEALTHY_CLASSIFY_RESULT.sunset,
+      });
+      const res = await GET(makeReq());
+      expect(res.status).toBe(200);
+
+      expect(upsertSweepStatsMock).toHaveBeenCalledTimes(1);
+      const [, stats, modelVersion] = upsertSweepStatsMock.mock.calls[0] as [
+        Date,
+        {
+          ticks: number;
+          escalatedTicks: number;
+          sunriseThinTicks: number;
+          sunsetThinTicks: number;
+          sunriseShortTicks: number;
+          baseBoxes: number;
+          escalationBoxes: number;
+          rings: Array<{ offsetDeg: number }>;
+        },
+        string,
+      ];
+      expect(stats.ticks).toBe(1);
+      expect(stats.escalatedTicks).toBe(1);
+      expect(stats.sunriseThinTicks).toBe(1);
+      expect(stats.sunsetThinTicks).toBe(0);
+      // The classify mock is fixed, so widening never lifts sunrise over the
+      // floor: thin and short are both set, which is the "widening did not
+      // recover the feed" case the digest calls out.
+      expect(stats.sunriseShortTicks).toBe(1);
+      expect(stats.baseBoxes).toBe(2);
+      expect(stats.escalationBoxes).toBe(2);
+      expect(stats.rings.map((r) => r.offsetDeg)).toEqual([0, 15.75, -15.75]);
+      // Shares daily_sunset_stats.model_version with the rollup writer;
+      // either call may be the one that creates the day's row.
+      expect(modelVersion).toBe('v4');
+    });
+
+    it('attributes a gate verdict to the ring that first saw the camera', async () => {
+      scoreMock.mockResolvedValue({
+        rawScore: 0.6,
+        aiRating: 3.0,
+        modelVersion: 'v4',
+        imageHash: 'newhash',
+        source: 'windy',
+        pathTaken: 'onnx',
+        binaryIsSunset: true,
+      });
+      const res = await GET(makeReq());
+      expect(res.status).toBe(200);
+
+      const [, stats] = upsertSweepStatsMock.mock.calls[0] as [
+        Date,
+        { rings: Array<{ offsetDeg: number; framesScored: number; framesGatePassed: number }> },
+      ];
+      const base = stats.rings.find((r) => r.offsetDeg === 0)!;
+      expect(base.framesScored).toBe(1);
+      expect(base.framesGatePassed).toBe(1);
+    });
+
+    it('leaves gate counts empty when the binary head produced no verdict', async () => {
+      // Default scoreMock omits binaryIsSunset. A scored-but-ungated frame
+      // must not land in framesScored, or the per-ring rate reads as a gate
+      // failure when in fact no gate ran.
+      const res = await GET(makeReq());
+      expect(res.status).toBe(200);
+      const [, stats] = upsertSweepStatsMock.mock.calls[0] as [
+        Date,
+        { rings: Array<{ framesScored: number }> },
+      ];
+      expect(stats.rings.every((r) => r.framesScored === 0)).toBe(true);
     });
   });
 });

--- a/app/api/cron/update-cameras/route.test.ts
+++ b/app/api/cron/update-cameras/route.test.ts
@@ -41,13 +41,18 @@ vi.mock('@/app/lib/webcamSnapshot', () => ({
 vi.mock('./lib/auth', () => ({ verifyCronAuth: () => verifyAuthMock() }));
 vi.mock('./lib/windyApi', () => ({
   dedupeCoords: (x: unknown) => x,
+  // Mirrors the real fetchCoordsCounted (lib/windyApi.ts): an empty coord
+  // list short-circuits to zero webcams without calling the batch fetcher.
   fetchCoordsCounted: async (coords: unknown[], ...rest: unknown[]) => {
+    if (!Array.isArray(coords) || coords.length === 0) {
+      return { webcams: [], attempted: 0, empty: 0 };
+    }
     const batches = (await fetchBatchesMock(coords, ...rest)) as Array<
       Array<{ webcamId: number | string; [k: string]: unknown }>
     >;
     return {
       webcams: batches.flat(),
-      attempted: Array.isArray(coords) ? coords.length : 0,
+      attempted: coords.length,
       empty: batches.filter((b) => b.length === 0).length,
     };
   },
@@ -92,7 +97,13 @@ vi.mock('@/app/components/Map/lib/subsolarLocation', () => ({
   subsolarPoint: () => ({ raHours: 0, gmstHours: 0 }),
 }));
 vi.mock('@/app/components/Map/lib/terminatorRing', () => ({
-  createTerminatorQueryRing: () => ({ sunriseCoords: [], sunsetCoords: [] }),
+  // One coordinate per feed so fetchCoords actually receives non-empty
+  // input — an all-empty ring would make fetchCoordsCounted's real
+  // short-circuit fire on every call and never exercise the fetch seam.
+  createTerminatorQueryRing: () => ({
+    sunriseCoords: [{ lat: 0, lng: 0 }],
+    sunsetCoords: [{ lat: 1, lng: 1 }],
+  }),
 }));
 
 // Mutable capture toggles — keep the real masterConfig values, override only
@@ -118,7 +129,21 @@ vi.mock('@/app/lib/masterConfig', async (importOriginal) => {
   };
 });
 
+import { TERMINATOR_CAMERA_FLOOR } from '@/app/lib/masterConfig';
 import { GET } from './route';
+
+// A classify result at/above the floor for both feeds, so the default tick
+// in this file is the common, non-escalating case — the sweep should not
+// widen when neither feed is thin. Escalation gets its own explicit test
+// below (see 'escalates to the widen offsets when a feed is thin').
+const HEALTHY_CLASSIFY_RESULT = {
+  sunrise: Array.from({ length: TERMINATOR_CAMERA_FLOOR }, (_, i) => ({
+    webcamId: `sunrise-${i}`,
+  })),
+  sunset: Array.from({ length: TERMINATOR_CAMERA_FLOOR }, (_, i) => ({
+    webcamId: `sunset-${i}`,
+  })),
+};
 
 beforeEach(() => {
   fetchBatchesMock.mockReset().mockResolvedValue([[{
@@ -126,7 +151,7 @@ beforeEach(() => {
     images: { current: { preview: 'https://x/p.jpg' } },
     viewCount: 1, rating: 3,
   }]]);
-  classifyMock.mockReset().mockReturnValue({ sunrise: [], sunset: [] });
+  classifyMock.mockReset().mockReturnValue(HEALTHY_CLASSIFY_RESULT);
   getIdMapMock.mockReset().mockResolvedValue(new Map([['7', 700]]));
   upsertWebcamsMock.mockReset().mockResolvedValue(undefined);
   upsertStateMock.mockReset().mockResolvedValue(undefined);
@@ -506,5 +531,42 @@ describe('GET /api/cron/update-cameras', () => {
     const res = await GET(makeReq());
     expect(res.status).toBe(200);
     expect((await res.json()).digest).toEqual({ skipped: 'send-failed' });
+  });
+
+  describe('terminator sweep telemetry', () => {
+    it('does not escalate on a healthy tick (both feeds at/above the floor)', async () => {
+      // Default beforeEach classifyMock already returns a healthy split
+      // (HEALTHY_CLASSIFY_RESULT); this pins that the base ring alone is
+      // enough, so a future refactor that widens by default fails loudly.
+      const res = await GET(makeReq());
+      const body = await res.json();
+      expect(res.status).toBe(200);
+      expect(body.sweep.escalations).toBe(0);
+      expect(body.sweep.rings).toHaveLength(1);
+      expect(body.sweep.rings[0].offsetDeg).toBe(0);
+    });
+
+    it('escalates to the widen offsets, day side first, when a feed is thin', async () => {
+      classifyMock.mockReturnValue({
+        sunrise: Array.from(
+          { length: TERMINATOR_CAMERA_FLOOR - 1 },
+          (_, i) => ({ webcamId: `thin-${i}` }),
+        ),
+        sunset: HEALTHY_CLASSIFY_RESULT.sunset,
+      });
+      const res = await GET(makeReq());
+      const body = await res.json();
+      expect(res.status).toBe(200);
+      expect(body.sweep.escalations).toBe(2);
+      expect(body.sweep.rings).toHaveLength(3);
+      // Day side (+15.75) before night side (-15.75) — the escalation
+      // priority order, not just membership.
+      expect(body.sweep.rings.map((r: { offsetDeg: number }) => r.offsetDeg)).toEqual([
+        0, 15.75, -15.75,
+      ]);
+      // Only the thin feed's half of each escalation ring is swept.
+      expect(body.sweep.rings[1].feedsSwept).toEqual(['sunrise']);
+      expect(body.sweep.rings[2].feedsSwept).toEqual(['sunrise']);
+    });
   });
 });

--- a/app/api/cron/update-cameras/route.ts
+++ b/app/api/cron/update-cameras/route.ts
@@ -18,6 +18,7 @@ import { createTerminatorQueryRing } from '@/app/components/Map/lib/terminatorRi
 import {
   TERMINATOR_CAMERA_FLOOR,
   TERMINATOR_WIDEN_OFFSETS_DEG,
+  TERMINATOR_SWEEP_BUDGET_MS,
   TERMINATOR_PRECISION_DEG,
   TERMINATOR_SUN_ALTITUDE_DEG,
   WINDY_FETCH_BATCH_SIZE,
@@ -98,8 +99,8 @@ export async function GET(req: Request) {
     offsets: TERMINATOR_WIDEN_OFFSETS_DEG,
     // Escalation rings are the first thing sacrificed on a slow tick: the
     // scoring loop below needs the remaining budget more than the pool needs
-    // extra cameras. Half the deadline is the cutoff.
-    hasBudget: () => Date.now() - tickStartedAt < TICK_DEADLINE_MS / 2,
+    // extra cameras. See TERMINATOR_SWEEP_BUDGET_MS for the cutoff rationale.
+    hasBudget: () => Date.now() - tickStartedAt < TERMINATOR_SWEEP_BUDGET_MS,
   });
 
   const sunriseCoords = sweep.coords.sunriseCoords;

--- a/app/api/cron/update-cameras/route.ts
+++ b/app/api/cron/update-cameras/route.ts
@@ -51,6 +51,15 @@ import { captureProviderUsageDaily } from './lib/providerUsage';
 import { sendDailyUsageDigest } from './lib/dailyDigest';
 import { downloadImage, uploadToFirebase } from '@/app/lib/webcamSnapshot';
 
+// Platform ceiling for this route, declared rather than inherited. TICK_DEADLINE_MS
+// below is the in-process budget and only means anything if the platform gives the
+// tick at least that long; 60s leaves a 10s margin over it. Adaptive widening made
+// a slow tick likelier — tickStartedAt now starts before the Windy fetch, and an
+// escalated sweep can spend up to TERMINATOR_SWEEP_BUDGET_MS of the tick — so the
+// two numbers need to stay pinned together. Raising TICK_DEADLINE_MS means raising
+// this too.
+export const maxDuration = 60;
+
 const TICK_DEADLINE_MS = 50_000;
 const PER_IMAGE_TIMEOUT_MS = 3_000;
 // Concurrency limit for ONNX scoring — distinct from WINDY_FETCH_BATCH_SIZE

--- a/app/api/cron/update-cameras/route.ts
+++ b/app/api/cron/update-cameras/route.ts
@@ -36,6 +36,12 @@ import { dedupeCoords, fetchCoordsCounted } from './lib/windyApi';
 import { classifyWebcamsByPhase } from './lib/webcamClassification';
 import { sweepWithEscalation } from './lib/terminatorSweep';
 import {
+  ringOffsetByWebcamId,
+  computeSweepTickStats,
+  upsertSweepStats,
+  type RingGateCounts,
+} from './lib/sweepStats';
+import {
   upsertWebcams,
   getWebcamIdMap,
   getWebcamImageHashMap,
@@ -118,6 +124,24 @@ export async function GET(req: Request) {
 
   console.log('🛰️ terminator sweep:', JSON.stringify(sweep.telemetry));
 
+  // Ring attribution for the detection-gate comparison. Each camera is
+  // credited to the ring that first saw it this tick, so the digest can print
+  // the day-side ring's gate-pass rate beside the base ring's. That
+  // comparison is the only way to tell widening that adds sunsets from
+  // widening that adds cameras the gate then floors — the failure the spec
+  // flags as self-concealing, because escalations and newWebcams both read as
+  // success while the panel stays exactly as empty.
+  const ringOffsetOf = ringOffsetByWebcamId(sweep.telemetry);
+  const gateByOffset = new Map<number, RingGateCounts>();
+  function recordGateOutcome(externalId: number, isSunset: boolean) {
+    const offsetDeg = ringOffsetOf.get(externalId);
+    if (offsetDeg === undefined) return;
+    const acc = gateByOffset.get(offsetDeg) ?? { scored: 0, gatePassed: 0 };
+    acc.scored += 1;
+    if (isSunset) acc.gatePassed += 1;
+    gateByOffset.set(offsetDeg, acc);
+  }
+
   // Upsert all webcams to database (only updates if fields changed)
   await upsertWebcams(windyAll);
 
@@ -190,6 +214,13 @@ export async function GET(req: Request) {
       }
       scoringPaths.onnx += 1;
       windyScores.push(scored.rawScore);
+      // Only frames carrying a real binary verdict are counted. Without the
+      // binary head configured there is no gate outcome to attribute, and a
+      // scored-but-ungated frame would deflate the ring's rate rather than
+      // leave it undefined.
+      if (typeof scored.binaryIsSunset === 'boolean') {
+        recordGateOutcome(webcam.webcamId, scored.binaryIsSunset);
+      }
 
       // Write Neon first: if the DB write fails, Redis hash is not committed
       // and the next tick will re-score. Committing the hash before the DB
@@ -420,6 +451,18 @@ export async function GET(req: Request) {
   } catch (err) {
     console.error('[update-cameras] daily_sunset_stats UPSERT failed:', err);
   }
+
+  // Sweep telemetry, persisted so the daily digest can still answer "how
+  // often did a feed go thin" and "what did widening cost" a day later. Until
+  // now it reached only this response and one log line, neither of which
+  // survives the tick. Same model version as the rollup above: either writer
+  // may be the one that creates the day's row, and the column is NOT NULL.
+  const sweepStats = computeSweepTickStats({
+    telemetry: sweep.telemetry,
+    floor: TERMINATOR_CAMERA_FLOOR,
+    gateByOffset,
+  });
+  await upsertSweepStats(new Date(), sweepStats, tickStats.modelVersion);
 
   // Once per UTC day, snapshot Neon usage counters for the Ops tab. Never
   // allowed to fail the tick.

--- a/app/api/cron/update-cameras/route.ts
+++ b/app/api/cron/update-cameras/route.ts
@@ -16,7 +16,8 @@ import { NextResponse } from 'next/server';
 import { subsolarPoint } from '@/app/components/Map/lib/subsolarLocation';
 import { createTerminatorQueryRing } from '@/app/components/Map/lib/terminatorRing';
 import {
-  TERMINATOR_RING_OFFSETS_DEG,
+  TERMINATOR_CAMERA_FLOOR,
+  TERMINATOR_WIDEN_OFFSETS_DEG,
   TERMINATOR_PRECISION_DEG,
   TERMINATOR_SUN_ALTITUDE_DEG,
   WINDY_FETCH_BATCH_SIZE,
@@ -30,12 +31,9 @@ import {
 } from '@/app/lib/masterConfig';
 import { classifyCustomCamerasForTick } from './lib/customClassification';
 import { verifyCronAuth } from './lib/auth';
-import {
-  dedupeCoords,
-  fetchWebcamsInBatches,
-  dedupeWebcams,
-} from './lib/windyApi';
+import { dedupeCoords, fetchCoordsCounted } from './lib/windyApi';
 import { classifyWebcamsByPhase } from './lib/webcamClassification';
+import { sweepWithEscalation } from './lib/terminatorSweep';
 import {
   upsertWebcams,
   getWebcamIdMap,
@@ -73,48 +71,42 @@ export async function GET(req: Request) {
   const now = new Date();
   const { raHours, gmstHours } = subsolarPoint(now);
 
-  // Generate terminator rings for all configured offsets
-  const ringResults = TERMINATOR_RING_OFFSETS_DEG.map((offsetDeg) =>
-    createTerminatorQueryRing(
-      now,
-      raHours,
-      gmstHours,
-      TERMINATOR_PRECISION_DEG,
-      TERMINATOR_SUN_ALTITUDE_DEG,
-      offsetDeg,
-    ),
-  );
-
-  // Deduplicate coordinates across all rings
-  const sunriseCoords = dedupeCoords(
-    ringResults.flatMap((r) => r.sunriseCoords),
-  );
-  const sunsetCoords = dedupeCoords(
-    ringResults.flatMap((r) => r.sunsetCoords),
-  );
-
-  console.log('📍 Coords:', {
-    sunrise: sunriseCoords.length,
-    sunset: sunsetCoords.length,
-    offsets: TERMINATOR_RING_OFFSETS_DEG,
+  const tickStartedAt = Date.now();
+  const sweep = await sweepWithEscalation({
+    buildRing: (offsetDeg) => {
+      const r = createTerminatorQueryRing(
+        now,
+        raHours,
+        gmstHours,
+        TERMINATOR_PRECISION_DEG,
+        TERMINATOR_SUN_ALTITUDE_DEG,
+        offsetDeg,
+      );
+      return {
+        sunriseCoords: dedupeCoords(r.sunriseCoords),
+        sunsetCoords: dedupeCoords(r.sunsetCoords),
+      };
+    },
+    fetchCoords: (coords) =>
+      fetchCoordsCounted(
+        dedupeCoords(coords),
+        WINDY_FETCH_BATCH_SIZE,
+        WINDY_FETCH_DELAY_BETWEEN_BATCHES_MS,
+      ),
+    classify: classifyWebcamsByPhase,
+    floor: TERMINATOR_CAMERA_FLOOR,
+    offsets: TERMINATOR_WIDEN_OFFSETS_DEG,
+    // Escalation rings are the first thing sacrificed on a slow tick: the
+    // scoring loop below needs the remaining budget more than the pool needs
+    // extra cameras. Half the deadline is the cutoff.
+    hasBudget: () => Date.now() - tickStartedAt < TICK_DEADLINE_MS / 2,
   });
 
-  // Fetch webcams at all coordinates
-  const allCoords = dedupeCoords([...sunriseCoords, ...sunsetCoords]);
-  console.log(`🌐 Total terminator coordinates: ${allCoords.length}`);
+  const sunriseCoords = sweep.coords.sunriseCoords;
+  const sunsetCoords = sweep.coords.sunsetCoords;
+  const windyAll = sweep.webcams.filter((w) => w.location);
 
-  // Fetch webcams in batches with rate limiting
-  const batches = await fetchWebcamsInBatches(
-    allCoords,
-    WINDY_FETCH_BATCH_SIZE,
-    WINDY_FETCH_DELAY_BETWEEN_BATCHES_MS,
-  );
-  console.log('📦 All batches received:', batches.length);
-
-  // Deduplicate webcams by webcamId
-  const windyById = dedupeWebcams(batches.flat());
-  const windyAll = [...windyById.values()].filter((w) => w.location);
-  console.log('🗂️ Total unique webcams:', windyAll.length);
+  console.log('🛰️ terminator sweep:', JSON.stringify(sweep.telemetry));
 
   // Upsert all webcams to database (only updates if fields changed)
   await upsertWebcams(windyAll);
@@ -138,7 +130,6 @@ export async function GET(req: Request) {
   const hashByWebcamId = await getWebcamImageHashMap([...idByExternal.values()]);
 
   // AI scoring via real image pipeline — per-tick counters.
-  const tickStartedAt = Date.now();
   const windyScores: number[] = [];
   let cacheHits = 0;
   let fallbacks = 0;
@@ -455,5 +446,6 @@ export async function GET(req: Request) {
     archiveBackfill: backfillResult,
     providerUsage,
     digest,
+    sweep: sweep.telemetry,
   });
 }

--- a/app/api/cron/update-cameras/route.ts
+++ b/app/api/cron/update-cameras/route.ts
@@ -19,6 +19,7 @@ import {
   TERMINATOR_CAMERA_FLOOR,
   TERMINATOR_WIDEN_OFFSETS_DEG,
   TERMINATOR_SWEEP_BUDGET_MS,
+  TICK_DEADLINE_MS,
   TERMINATOR_PRECISION_DEG,
   TERMINATOR_SUN_ALTITUDE_DEG,
   WINDY_FETCH_BATCH_SIZE,
@@ -62,11 +63,11 @@ import { downloadImage, uploadToFirebase } from '@/app/lib/webcamSnapshot';
 // tick at least that long; 60s leaves a 10s margin over it. Adaptive widening made
 // a slow tick likelier — tickStartedAt now starts before the Windy fetch, and an
 // escalated sweep can spend up to TERMINATOR_SWEEP_BUDGET_MS of the tick — so the
-// two numbers need to stay pinned together. Raising TICK_DEADLINE_MS means raising
-// this too.
+// two numbers need to stay pinned together. Raising TICK_DEADLINE_MS (now in
+// masterConfig.ts, where a test guards its ratio to the sweep budget) means
+// raising this too.
 export const maxDuration = 60;
 
-const TICK_DEADLINE_MS = 50_000;
 const PER_IMAGE_TIMEOUT_MS = 3_000;
 // Concurrency limit for ONNX scoring — distinct from WINDY_FETCH_BATCH_SIZE
 // (API call batch size in masterConfig).

--- a/app/api/cron/update-youtube/route.ts
+++ b/app/api/cron/update-youtube/route.ts
@@ -16,6 +16,7 @@ import {
   SEARCH_RADIUS_DEG,
   YOUTUBE_FETCH_BATCH_SIZE,
   YOUTUBE_FETCH_DELAY_BETWEEN_BATCHES_MS,
+  YOUTUBE_MAX_LOCATION_RADIUS_KM,
 } from '@/app/lib/masterConfig';
 
 type YTItem = {
@@ -121,8 +122,15 @@ export async function GET(req: Request) {
   // Batch requests to respect quotas
   const batchSize = YOUTUBE_FETCH_BATCH_SIZE;
   const delayMs = YOUTUBE_FETCH_DELAY_BETWEEN_BATCHES_MS; // between batches
-  // Convert SEARCH_RADIUS_DEG to km: 1° ≈ 111 km
-  const searchRadiusKm = SEARCH_RADIUS_DEG * 111;
+  // Convert SEARCH_RADIUS_DEG to km: 1° ≈ 111 km, then clamp to YouTube's own
+  // ceiling. SEARCH_RADIUS_DEG is tuned against Windy's box-span cap, which is
+  // a different limit; without the clamp a Windy-driven widening silently
+  // pushes every YouTube search past `locationRadius` max and the API's 400 is
+  // swallowed as zero results by searchYouTubeLiveNear.
+  const searchRadiusKm = Math.min(
+    SEARCH_RADIUS_DEG * 111,
+    YOUTUBE_MAX_LOCATION_RADIUS_KM
+  );
   const ytItems: (YTItem & { searchLocation: Location })[] = [];
   for (let i = 0; i < allCoords.length; i += batchSize) {
     const batch = allCoords.slice(i, i + batchSize);

--- a/app/api/webcams/route.test.ts
+++ b/app/api/webcams/route.test.ts
@@ -50,4 +50,24 @@ describe('API Route Test', () => {
     expect(data).toHaveProperty('error');
     expect(data.error).toContain('Windy API error: 401');
   });
+
+  it('clamps the query box to the bounds Windy accepts', async () => {
+    // A user-panned map near the pole and across the antimeridian produces
+    // northLat > 90 and eastLon > 180. Windy 400s on either, and the route
+    // surfaces that as "no results" rather than as an error, so the failure
+    // is invisible. Clamping shrinks the box and keeps the call.
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, json: async () => [] });
+    global.fetch = fetchMock;
+
+    const request = new NextRequest(
+      'http://test.com/api/webcams?centerLat=85&centerLng=175&boxSize=11',
+    );
+    await GET(request);
+
+    const url = String(fetchMock.mock.calls[0][0]);
+    expect(url).toContain('northLat=90');
+    expect(url).toContain('southLat=74');
+    expect(url).toContain('eastLon=180');
+    expect(url).toContain('westLon=164');
+  });
 });

--- a/app/api/webcams/route.ts
+++ b/app/api/webcams/route.ts
@@ -2,6 +2,7 @@
 // database and the terminator rings on the backend
 
 import { NextRequest, NextResponse } from 'next/server';
+import { boundingBox } from '@/app/api/cron/update-cameras/lib/windyApi';
 
 interface WindyWebcam {
   webcamId: number;
@@ -40,11 +41,15 @@ export async function GET(request: NextRequest) {
     );
     const boxSize = parseFloat(searchParams.get('boxSize') || '11');
 
-    // 🎯 Create bounding box around center point
-    const northLat = (centerLat + boxSize).toString();
-    const southLat = (centerLat - boxSize).toString();
-    const eastLon = (centerLng + boxSize).toString();
-    const westLon = (centerLng - boxSize).toString();
+    // 🎯 Create bounding box around center point, clamped to the ranges Windy
+    // accepts. Same helper the cron sweep uses — a panned map near the pole or
+    // across the antimeridian otherwise builds northLat > 90 or eastLon > 180,
+    // which Windy 400s on and this route reports as "no results".
+    const box = boundingBox({ lat: centerLat, lng: centerLng }, boxSize);
+    const northLat = box.northLat.toString();
+    const southLat = box.southLat.toString();
+    const eastLon = box.eastLon.toString();
+    const westLon = box.westLon.toString();
 
     console.log(`📍 Center: ${centerLat}, ${centerLng}`);
     console.log(

--- a/app/components/Map/hooks/useUpdateTerminatorRing.ts
+++ b/app/components/Map/hooks/useUpdateTerminatorRing.ts
@@ -27,10 +27,7 @@ import { subsolarPoint } from '../lib/subsolarLocation';
 import { createTerminatorVisualizationRing } from '../lib/terminatorRing';
 import { createTerminatorRingHiRes } from '../lib/terminatorRingHiRes';
 import { createSearchRadiusCircles } from '../lib/searchRadiusCircles';
-import {
-  TERMINATOR_RING_OFFSETS_DEG,
-  TERMINATOR_SUN_ALTITUDE_DEG,
-} from '@/app/lib/masterConfig';
+import { TERMINATOR_SUN_ALTITUDE_DEG } from '@/app/lib/masterConfig';
 import type { Location as TerminatorLocation } from '@/app/lib/types';
 
 export function useUpdateTerminatorRing(
@@ -61,18 +58,20 @@ export function useUpdateTerminatorRing(
     return createTerminatorRingHiRes(currentTime);
   }, [currentTime]);
 
-  // Use the same precision as the cron job for accurate visualization
+  // One ring at offset 0. Escalation rings are a fetch-time concern that
+  // varies tick to tick; drawing them would imply the map is showing cameras
+  // from all of them. Do not import TERMINATOR_WIDEN_OFFSETS_DEG here.
   const ringResults = useMemo(() => {
-    return TERMINATOR_RING_OFFSETS_DEG.map((offsetDeg) =>
+    return [
       createTerminatorVisualizationRing(
         currentTime,
         raHours,
         gmstHours,
         precisionDeg,
         TERMINATOR_SUN_ALTITUDE_DEG,
-        offsetDeg,
+        0,
       ),
-    );
+    ];
   }, [currentTime, raHours, gmstHours, precisionDeg]);
 
   const mainRing = ringResults[0];

--- a/app/components/Map/hooks/useUpdateTerminatorRing.ts
+++ b/app/components/Map/hooks/useUpdateTerminatorRing.ts
@@ -58,24 +58,22 @@ export function useUpdateTerminatorRing(
     return createTerminatorRingHiRes(currentTime);
   }, [currentTime]);
 
-  // One ring at offset 0. Escalation rings are a fetch-time concern that
-  // varies tick to tick; drawing them would imply the map is showing cameras
-  // from all of them. Do not import TERMINATOR_WIDEN_OFFSETS_DEG here.
-  const ringResults = useMemo(() => {
-    return [
-      createTerminatorVisualizationRing(
-        currentTime,
-        raHours,
-        gmstHours,
-        precisionDeg,
-        TERMINATOR_SUN_ALTITUDE_DEG,
-        0,
-      ),
-    ];
+  // Exactly one ring, at offset 0. Escalation rings are a fetch-time concern
+  // that varies tick to tick; drawing them would imply the map is showing
+  // cameras from all of them. Do not import TERMINATOR_WIDEN_OFFSETS_DEG here.
+  // Kept singular rather than a one-element list: the list shape carried a
+  // `ringResults[1]` reader and a GeoJSON layer for a ring that could never
+  // exist, which read as if a second ring might appear.
+  const ring = useMemo(() => {
+    return createTerminatorVisualizationRing(
+      currentTime,
+      raHours,
+      gmstHours,
+      precisionDeg,
+      TERMINATOR_SUN_ALTITUDE_DEG,
+      0,
+    );
   }, [currentTime, raHours, gmstHours, precisionDeg]);
-
-  const mainRing = ringResults[0];
-  const offsetRing = ringResults[1];
 
   const {
     sunriseCoords,
@@ -84,7 +82,7 @@ export function useUpdateTerminatorRing(
     sunrise,
     sunset,
     entireTerminatorRing,
-  } = mainRing;
+  } = ring;
 
   // Memoize the coordinate arrays to prevent unnecessary re-renders
 
@@ -99,17 +97,13 @@ export function useUpdateTerminatorRing(
 
   // Combine sunrise and sunset coords to get all terminator points used for API queries
   const allTerminatorPoints: TerminatorLocation[] = useMemo(() => {
-    const allPoints = ringResults.flatMap((ring) => [
-      ...ring.sunriseCoords,
-      ...ring.sunsetCoords,
-    ]);
     const byKey = new Map<string, TerminatorLocation>();
-    for (const point of allPoints) {
+    for (const point of [...ring.sunriseCoords, ...ring.sunsetCoords]) {
       const key = `${point.lat.toFixed(6)},${point.lng.toFixed(6)}`;
       if (!byKey.has(key)) byKey.set(key, point);
     }
     return [...byKey.values()];
-  }, [ringResults]);
+  }, [ring]);
 
   // Convert GeoJSON features to format for Mapbox
   const terminatorGeoJSON = useMemo(() => {
@@ -121,14 +115,6 @@ export function useUpdateTerminatorRing(
     }
     return entireHiResTerminatorRing;
   }, [entireHiResTerminatorRing]);
-
-  const offsetTerminatorGeoJSON = useMemo(() => {
-    if (!offsetRing) return null;
-    return {
-      type: 'FeatureCollection' as const,
-      features: [offsetRing.entireTerminatorRing],
-    };
-  }, [offsetRing]);
 
   // Create search radius circles GeoJSON if enabled
   const searchRadiusGeoJSON = useMemo(() => {
@@ -229,40 +215,6 @@ export function useUpdateTerminatorRing(
       } else {
         // Update existing layer opacity when data changes
         map.setPaintProperty(terminatorLayerId, 'line-opacity', 0);
-      }
-
-      // Add offset terminator line if configured
-      if (offsetTerminatorGeoJSON) {
-        const offsetSourceId = 'terminator-line-offset-source';
-        const offsetLayerId = 'terminator-line-offset-layer';
-
-        if (!map.getSource(offsetSourceId)) {
-          map.addSource(offsetSourceId, {
-            type: 'geojson',
-            data: offsetTerminatorGeoJSON,
-          });
-          sourcesAddedRef.current.add(offsetSourceId);
-        } else {
-          (
-            map.getSource(offsetSourceId) as mapboxgl.GeoJSONSource
-          ).setData(offsetTerminatorGeoJSON);
-        }
-
-        if (!map.getLayer(offsetLayerId)) {
-          map.addLayer({
-            id: offsetLayerId,
-            type: 'line',
-            source: offsetSourceId,
-            paint: {
-              'line-color': '#96a6c8', // Slightly bluish gray for offset ring
-              'line-width': 2,
-              'line-opacity': 0.2,
-            },
-          });
-          layersAddedRef.current.add(offsetLayerId);
-        } else {
-          map.setPaintProperty(offsetLayerId, 'line-opacity', 0.2);
-        }
       }
 
       // Add search radius circles if enabled
@@ -389,7 +341,6 @@ export function useUpdateTerminatorRing(
     mapLoaded,
     attachToMap,
     terminatorGeoJSON,
-    offsetTerminatorGeoJSON,
     searchRadiusGeoJSON,
     pointsGeoJSON,
     showSearchRadius,

--- a/app/components/Map/lib/terminatorRing.test.ts
+++ b/app/components/Map/lib/terminatorRing.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect } from 'vitest';
 import { createTerminatorRing } from './terminatorRing';
+import { subsolarPoint } from './subsolarLocation';
+import {
+  TERMINATOR_SUN_ALTITUDE_DEG,
+  TERMINATOR_PRECISION_DEG,
+  TERMINATOR_WIDEN_OFFSETS_DEG,
+} from '../../../lib/masterConfig';
 
 describe('Terminator ring', () => {
   it('creates a list of sunset and sunrise points', () => {
@@ -26,5 +32,84 @@ describe('Terminator ring', () => {
     expect(result.sunset.geometry.coordinates.length).toBeGreaterThan(
       0
     );
+  });
+});
+
+/**
+ * The ring-offset SIGN CONVENTION, pinned by geometry.
+ *
+ * The whole adaptive-widening feature rests on "positive offset moves the ring
+ * toward day": the escalation list in masterConfig tries +15.75 (golden hour)
+ * before -15.75 (deep night). `terminatorPolygon` implements that as
+ * `radius = 90 - (sunAltitude + offsetDeg)`, so a POSITIVE offset SHRINKS the
+ * circle around the subsolar point.
+ *
+ * That reads backwards to anyone expecting "positive = away from the sun", and
+ * flipping it would leave every other test in this suite green while every
+ * escalation swept deep night first — doubling the Windy call cost to fetch
+ * frames the detection gate floors anyway. So assert the geometry directly:
+ * how far the ring sits from the subsolar point, not what the constant says.
+ */
+describe('Terminator ring offset sign convention', () => {
+  const testDate = new Date('2026-09-02T00:00:00Z');
+  const { lat: subLat, lng: subLng, raHours, gmstHours } =
+    subsolarPoint(testDate);
+
+  /** Great-circle angular separation, in degrees. */
+  const angularDistanceDeg = (
+    a: { lat: number; lng: number },
+    b: { lat: number; lng: number }
+  ) => {
+    const toRad = (d: number) => (d * Math.PI) / 180;
+    const cos =
+      Math.sin(toRad(a.lat)) * Math.sin(toRad(b.lat)) +
+      Math.cos(toRad(a.lat)) *
+        Math.cos(toRad(b.lat)) *
+        Math.cos(toRad(b.lng - a.lng));
+    return (Math.acos(Math.min(1, Math.max(-1, cos))) * 180) / Math.PI;
+  };
+
+  /** Mean angular distance from the subsolar point to the ring's vertices. */
+  const ringDistanceFromSun = (offsetDeg: number) => {
+    const { allTerminatorCoords } = createTerminatorRing(
+      testDate,
+      raHours,
+      gmstHours,
+      TERMINATOR_PRECISION_DEG,
+      TERMINATOR_SUN_ALTITUDE_DEG,
+      offsetDeg
+    );
+    const sun = { lat: subLat, lng: subLng };
+    const distances = allTerminatorCoords.map((c) =>
+      angularDistanceDeg(sun, c)
+    );
+    return distances.reduce((a, b) => a + b, 0) / distances.length;
+  };
+
+  it('puts a positive-offset ring closer to the subsolar point than the base ring', () => {
+    expect(ringDistanceFromSun(15.75)).toBeLessThan(
+      ringDistanceFromSun(0)
+    );
+  });
+
+  it('puts a negative-offset ring further from the subsolar point than the base ring', () => {
+    expect(ringDistanceFromSun(-15.75)).toBeGreaterThan(
+      ringDistanceFromSun(0)
+    );
+  });
+
+  it('moves the ring one degree toward the sun per degree of positive offset', () => {
+    const base = ringDistanceFromSun(0);
+    expect(ringDistanceFromSun(15.75)).toBeCloseTo(base - 15.75, 6);
+    expect(ringDistanceFromSun(-15.75)).toBeCloseTo(base + 15.75, 6);
+  });
+
+  it('sweeps the escalation offsets day side first, measured as geometry', () => {
+    // The shipped escalation list, checked by where its rings actually land
+    // rather than by the sign of its numbers.
+    const distances = TERMINATOR_WIDEN_OFFSETS_DEG.map(ringDistanceFromSun);
+    const base = ringDistanceFromSun(0);
+    expect(distances[0]).toBeLessThan(base); // day side tried first
+    expect(distances[1]).toBeGreaterThan(base); // night side is the fallback
   });
 });

--- a/app/lib/masterConfig.test.ts
+++ b/app/lib/masterConfig.test.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect } from 'vitest';
+import { SEARCH_RADIUS_DEG } from './masterConfig';
+
+// Verified live against the Windy clusters endpoint 2026-09-02:
+//   {"message":"Maximal distance between north and south latitudes on the
+//    zoom level 4, should be 22.5!","error":"Bad Request","statusCode":400}
+// The box span is 2 x SEARCH_RADIUS_DEG, and zoom < 4 is rejected outright,
+// so 11.25 is a hard ceiling, not a preference.
+const WINDY_ZOOM4_MAX_LAT_SPAN_DEG = 22.5;
+
+describe('SEARCH_RADIUS_DEG', () => {
+  it('keeps the query box inside the Windy zoom-4 span cap', () => {
+    expect(SEARCH_RADIUS_DEG * 2).toBeLessThanOrEqual(
+      WINDY_ZOOM4_MAX_LAT_SPAN_DEG
+    );
+  });
+
+  it('is widened to 11, the practical maximum', () => {
+    expect(SEARCH_RADIUS_DEG).toBe(11);
+  });
+});

--- a/app/lib/masterConfig.test.ts
+++ b/app/lib/masterConfig.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from 'vitest';
 import { SEARCH_RADIUS_DEG } from './masterConfig';
+import {
+  TERMINATOR_CAMERA_FLOOR,
+  TERMINATOR_WIDEN_OFFSETS_DEG,
+} from './masterConfig';
 
 // Verified live against the Windy clusters endpoint 2026-09-02:
 //   {"message":"Maximal distance between north and south latitudes on the
@@ -17,5 +21,25 @@ describe('SEARCH_RADIUS_DEG', () => {
 
   it('is widened to 11, the practical maximum', () => {
     expect(SEARCH_RADIUS_DEG).toBe(11);
+  });
+});
+
+describe('terminator widening constants', () => {
+  it('starts the camera floor at 15 per feed', () => {
+    expect(TERMINATOR_CAMERA_FLOOR).toBe(15);
+  });
+
+  it('tries the day side before the night side', () => {
+    // Positive offset shrinks the ring radius, moving it toward the sun.
+    expect(TERMINATOR_WIDEN_OFFSETS_DEG[0]).toBeGreaterThan(0);
+    expect(TERMINATOR_WIDEN_OFFSETS_DEG).toEqual([15.75, -15.75]);
+  });
+
+  it('offsets the ring by more than a box width, or it re-finds the same cameras', () => {
+    // Measured 2026-09-02: a 3-degree offset against an 18-degree box returned
+    // only 26-35% new cameras; 15.75 returned 92-100%.
+    for (const off of TERMINATOR_WIDEN_OFFSETS_DEG) {
+      expect(Math.abs(off)).toBeGreaterThanOrEqual(SEARCH_RADIUS_DEG);
+    }
   });
 });

--- a/app/lib/masterConfig.test.ts
+++ b/app/lib/masterConfig.test.ts
@@ -3,6 +3,7 @@ import { SEARCH_RADIUS_DEG } from './masterConfig';
 import {
   TERMINATOR_CAMERA_FLOOR,
   TERMINATOR_WIDEN_OFFSETS_DEG,
+  YOUTUBE_MAX_LOCATION_RADIUS_KM,
 } from './masterConfig';
 
 // Verified live against the Windy clusters endpoint 2026-09-02:
@@ -41,5 +42,26 @@ describe('terminator widening constants', () => {
     for (const off of TERMINATOR_WIDEN_OFFSETS_DEG) {
       expect(Math.abs(off)).toBeGreaterThanOrEqual(SEARCH_RADIUS_DEG);
     }
+  });
+});
+
+describe('YOUTUBE_MAX_LOCATION_RADIUS_KM', () => {
+  // The YouTube Data API v3 documents `locationRadius` as capped at 1000 km.
+  // This is a SEPARATE ceiling from Windy's 22.5-degree box-span cap above,
+  // even though the YouTube cron derives its radius from SEARCH_RADIUS_DEG —
+  // and searchYouTubeLiveNear swallows a non-OK response as an empty array, so
+  // a breach reads as "no live streams anywhere" rather than as an error.
+  it('is the documented YouTube Data API v3 ceiling', () => {
+    expect(YOUTUBE_MAX_LOCATION_RADIUS_KM).toBe(1000);
+  });
+
+  it('keeps the radius the YouTube cron sends inside the cap', () => {
+    // Mirrors the derivation in app/api/cron/update-youtube/route.ts:
+    // 1 degree ~ 111 km, then clamped. At SEARCH_RADIUS_DEG = 11 the raw value
+    // is 1221 km, so the clamp is load-bearing today, not decorative.
+    const rawKm = SEARCH_RADIUS_DEG * 111;
+    const sentKm = Math.min(rawKm, YOUTUBE_MAX_LOCATION_RADIUS_KM);
+    expect(sentKm).toBeLessThanOrEqual(YOUTUBE_MAX_LOCATION_RADIUS_KM);
+    expect(sentKm).toBe(Math.min(rawKm, 1000));
   });
 });

--- a/app/lib/masterConfig.test.ts
+++ b/app/lib/masterConfig.test.ts
@@ -1,8 +1,10 @@
 import { describe, it, expect } from 'vitest';
-import { SEARCH_RADIUS_DEG } from './masterConfig';
 import {
+  SEARCH_RADIUS_DEG,
   TERMINATOR_CAMERA_FLOOR,
   TERMINATOR_WIDEN_OFFSETS_DEG,
+  TERMINATOR_SWEEP_BUDGET_MS,
+  TICK_DEADLINE_MS,
   YOUTUBE_MAX_LOCATION_RADIUS_KM,
 } from './masterConfig';
 
@@ -30,18 +32,27 @@ describe('terminator widening constants', () => {
     expect(TERMINATOR_CAMERA_FLOOR).toBe(15);
   });
 
-  it('tries the day side before the night side', () => {
+  it('pins the two measured offsets, day side before night side', () => {
     // Positive offset shrinks the ring radius, moving it toward the sun.
+    //
+    // 15.75 is EMPIRICAL, not derived. Measured 2026-09-02: a 3-degree offset
+    // returned 26-35% cameras the base ring had not seen; 15.75 returned
+    // 92-100%. Note it is well under the 22-degree box span, so the query
+    // boxes at this offset do overlap the base ring's -- the yield is a
+    // measurement, and no inequality against SEARCH_RADIUS_DEG stands in for
+    // it. A new offset needs its own live measurement, which is why this test
+    // pins exact values rather than a threshold a guess could clear.
     expect(TERMINATOR_WIDEN_OFFSETS_DEG[0]).toBeGreaterThan(0);
     expect(TERMINATOR_WIDEN_OFFSETS_DEG).toEqual([15.75, -15.75]);
   });
 
-  it('offsets the ring by more than a box width, or it re-finds the same cameras', () => {
-    // Measured 2026-09-02: a 3-degree offset against an 18-degree box returned
-    // only 26-35% new cameras; 15.75 returned 92-100%.
-    for (const off of TERMINATOR_WIDEN_OFFSETS_DEG) {
-      expect(Math.abs(off)).toBeGreaterThanOrEqual(SEARCH_RADIUS_DEG);
-    }
+  it('leaves the scoring loop at least as long as the sweep may take', () => {
+    // hasBudget is a START gate, checked once before each ring and never
+    // during one, so a ring beginning just under the budget runs to
+    // completion. Worst case the sweep spends close to twice its budget, and
+    // the scoring loop gets what is left of TICK_DEADLINE_MS. The two numbers
+    // used to live in different files with only a comment between them.
+    expect(TERMINATOR_SWEEP_BUDGET_MS * 2).toBeLessThanOrEqual(TICK_DEADLINE_MS);
   });
 });
 

--- a/app/lib/masterConfig.ts
+++ b/app/lib/masterConfig.ts
@@ -255,6 +255,19 @@ export const WINDY_FETCH_STAGGER_WITHIN_BATCH_MS = 200;
 export const YOUTUBE_FETCH_BATCH_SIZE = 5;
 export const YOUTUBE_FETCH_DELAY_BETWEEN_BATCHES_MS = 800;
 
+// Documented maximum for the YouTube Data API v3 `locationRadius` search
+// parameter. Anything larger is rejected, and the caller swallows a non-OK
+// response as an empty result, so breaching this yields silent zeroes rather
+// than an error.
+//
+// This is a DIFFERENT ceiling from Windy's 22.5-degree box-span cap, even
+// though the YouTube cron derives its radius from SEARCH_RADIUS_DEG. Widening
+// SEARCH_RADIUS_DEG for Windy (9 -> 11 on 2026-09-02) pushed the derived
+// YouTube radius from 999 km to 1221 km, past this cap. Keep the two ceilings
+// separate: one constant must never be silently load-bearing for both APIs.
+// The YouTube call site clamps against this; guarded by masterConfig.test.ts.
+export const YOUTUBE_MAX_LOCATION_RADIUS_KM = 1000;
+
 // ---------------------------------------------------------------------------
 // Ops tab (owner-only cost/health panel in the drawer)
 // ---------------------------------------------------------------------------

--- a/app/lib/masterConfig.ts
+++ b/app/lib/masterConfig.ts
@@ -47,6 +47,14 @@ export const TERMINATOR_CAMERA_FLOOR = 15;
 // full ring's worth of API calls; 15.75 returned 92-100%.
 export const TERMINATOR_WIDEN_OFFSETS_DEG = [15.75, -15.75] as const;
 
+// Wall-clock budget for the whole terminator sweep (base ring + any
+// escalation rings), in milliseconds. The scoring loop that follows needs
+// the remaining tick more than the pool needs extra cameras, so escalation
+// rings are the first thing sacrificed on a slow tick. Chosen against a
+// single observation (half of the 50s tick deadline, 2026-09-02); expect to
+// tune it once the sweep telemetry has a few days of history.
+export const TERMINATOR_SWEEP_BUDGET_MS = 25_000;
+
 // How recent a custom camera's most-recent snapshot must be for the camera
 // to qualify for terminator visibility. Mirrors Windy's "API returned it
 // this tick" semantics — custom cams without a fresh capture are

--- a/app/lib/masterConfig.ts
+++ b/app/lib/masterConfig.ts
@@ -24,11 +24,11 @@ export const TERMINATOR_SUN_ALTITUDE_DEG = -13;
 // -10 works when precision is 14 and radius is 11
 // -8 showed too much day time
 
-export const SEARCH_RADIUS_DEG = 9; // Search radius per API call in degrees
-// 12 doesn't work
-// 11 is the widest that works
-// 10 works
-// 6 works
+// Search radius per Windy API call, in degrees. The query box spans
+// 2 x this value, and Windy's clusters endpoint caps the north-south span
+// at 22.5 degrees on zoom 4 (and rejects zoom < 4), so 11.25 is a hard
+// ceiling. Verified live 2026-09-02; guarded by masterConfig.test.ts.
+export const SEARCH_RADIUS_DEG = 11;
 
 // West-only offset ring for parallel search/visualization, in degrees.
 // 0 = main ring, positive values shift the ring westward from the subsolar geometry.

--- a/app/lib/masterConfig.ts
+++ b/app/lib/masterConfig.ts
@@ -41,10 +41,13 @@ export const TERMINATOR_CAMERA_FLOOR = 15;
 // ring at -13 misses entirely), and -15.75 puts it near -28.75 (deep night,
 // where the detection gate floors the frames anyway). Day side first.
 //
-// The magnitude is not arbitrary: the query box is 2 x SEARCH_RADIUS_DEG
-// across, so an offset smaller than the box mostly re-finds the same cameras.
-// Measured 2026-09-02 — a 3-degree offset returned 26-35% new cameras for a
-// full ring's worth of API calls; 15.75 returned 92-100%.
+// The magnitude is EMPIRICAL, not derived. Measured 2026-09-02 at
+// SEARCH_RADIUS_DEG = 11: a 3-degree offset returned 26-35% cameras the base
+// ring had not seen, for a full ring's worth of API calls; 15.75 returned
+// 92-100%. Note 15.75 is well under the 22-degree box span, so these rings'
+// query boxes DO overlap the base ring's — overlap is not what predicts
+// yield here, and no inequality against SEARCH_RADIUS_DEG substitutes for a
+// live measurement of a new offset.
 export const TERMINATOR_WIDEN_OFFSETS_DEG = [15.75, -15.75] as const;
 
 // Wall-clock budget for the whole terminator sweep (base ring + any
@@ -54,6 +57,18 @@ export const TERMINATOR_WIDEN_OFFSETS_DEG = [15.75, -15.75] as const;
 // single observation (half of the 50s tick deadline, 2026-09-02); expect to
 // tune it once the sweep telemetry has a few days of history.
 export const TERMINATOR_SWEEP_BUDGET_MS = 25_000;
+
+// In-process deadline for one update-cameras tick, after which the scoring
+// loop stops starting batches. Lives here rather than in the route so its
+// relationship to TERMINATOR_SWEEP_BUDGET_MS is a guarded invariant instead of
+// a comment: the sweep may burn its budget before the escalation loop stops,
+// and the scoring loop needs at least as long again. masterConfig.test.ts
+// pins TERMINATOR_SWEEP_BUDGET_MS * 2 <= TICK_DEADLINE_MS.
+//
+// The route's `maxDuration` stays a literal there: Next.js reads it by static
+// analysis of the route module and an imported constant is not guaranteed to
+// resolve. Raising this means raising that too.
+export const TICK_DEADLINE_MS = 50_000;
 
 // How recent a custom camera's most-recent snapshot must be for the camera
 // to qualify for terminator visibility. Mirrors Windy's "API returned it

--- a/app/lib/masterConfig.ts
+++ b/app/lib/masterConfig.ts
@@ -34,6 +34,23 @@ export const SEARCH_RADIUS_DEG = 11;
 // 0 = main ring, positive values shift the ring westward from the subsolar geometry.
 export const TERMINATOR_RING_OFFSETS_DEG = [0]; //was   0,1.75 * SEARCH_RADIUS_DEG,//was 1,.75
 
+// Per-feed camera count below which that feed sweeps an extra ring. Chosen
+// against a single observation (4 sunrise, 21 sunset on 2026-09-02); expect
+// to tune it once the sweep telemetry has a few days of history.
+export const TERMINATOR_CAMERA_FLOOR = 15;
+
+// Extra rings to sweep when a feed is under the floor, tried in this order.
+// radius = 90 - (sunAltitude + offset), so POSITIVE MOVES TOWARD DAY: +15.75
+// puts the ring near +2.75 degrees solar altitude (golden hour, which the base
+// ring at -13 misses entirely), and -15.75 puts it near -28.75 (deep night,
+// where the detection gate floors the frames anyway). Day side first.
+//
+// The magnitude is not arbitrary: the query box is 2 x SEARCH_RADIUS_DEG
+// across, so an offset smaller than the box mostly re-finds the same cameras.
+// Measured 2026-09-02 — a 3-degree offset returned 26-35% new cameras for a
+// full ring's worth of API calls; 15.75 returned 92-100%.
+export const TERMINATOR_WIDEN_OFFSETS_DEG = [15.75, -15.75] as const;
+
 // How recent a custom camera's most-recent snapshot must be for the camera
 // to qualify for terminator visibility. Mirrors Windy's "API returned it
 // this tick" semantics — custom cams without a fresh capture are

--- a/app/lib/masterConfig.ts
+++ b/app/lib/masterConfig.ts
@@ -30,10 +30,6 @@ export const TERMINATOR_SUN_ALTITUDE_DEG = -13;
 // ceiling. Verified live 2026-09-02; guarded by masterConfig.test.ts.
 export const SEARCH_RADIUS_DEG = 11;
 
-// West-only offset ring for parallel search/visualization, in degrees.
-// 0 = main ring, positive values shift the ring westward from the subsolar geometry.
-export const TERMINATOR_RING_OFFSETS_DEG = [0]; //was   0,1.75 * SEARCH_RADIUS_DEG,//was 1,.75
-
 // Per-feed camera count below which that feed sweeps an extra ring. Chosen
 // against a single observation (4 sunrise, 21 sunset on 2026-09-02); expect
 // to tune it once the sweep telemetry has a few days of history.

--- a/database/migrations/20260902_sweep_telemetry.sql
+++ b/database/migrations/20260902_sweep_telemetry.sql
@@ -1,0 +1,63 @@
+-- Adaptive terminator widening: persist the sweep telemetry.
+--
+-- The sweep already reports rings, boxes and per-ring discovery in the cron's
+-- JSON response and one log line. Neither survives the tick, so the two
+-- questions the feature exists to answer -- "how often did a feed fall under
+-- the camera floor" and "what did the extra rings cost in API calls" -- were
+-- unanswerable a day later. This is the migration the widening design
+-- deferred, now with a concrete consumer: the daily digest email.
+--
+-- Split deliberately in two:
+--   1. daily_sunset_stats gains TICK-level counters. One tick contributes at
+--      most 1 to each, so every column reads as "N of today's ticks".
+--   2. daily_sweep_ring_stats is RING-level, at most 3 rows a day (offsets
+--      0, +15.75, -15.75). Per-ring gate-pass counts live here because the
+--      spec's golden-hour risk is exactly a per-ring rate comparison:
+--      do frames first seen on the +15.75 ring pass the detection gate at
+--      anything like the base ring's rate, or does widening only add tiles
+--      the panel will floor?
+--
+-- Forward-only, idempotent. Apply manually via:
+--   psql "$DATABASE_URL" -f database/migrations/20260902_sweep_telemetry.sql
+
+ALTER TABLE daily_sunset_stats
+  -- Ticks that ran a sweep at all. The denominator for every column below.
+  ADD COLUMN IF NOT EXISTS sweep_ticks                  INTEGER NOT NULL DEFAULT 0,
+  -- Ticks that swept at least one escalation ring.
+  ADD COLUMN IF NOT EXISTS sweep_escalated_ticks        INTEGER NOT NULL DEFAULT 0,
+  -- Ticks that wanted another ring but had spent TERMINATOR_SWEEP_BUDGET_MS.
+  ADD COLUMN IF NOT EXISTS sweep_budget_exhausted_ticks INTEGER NOT NULL DEFAULT 0,
+  -- Ticks where the feed was under TERMINATOR_CAMERA_FLOOR after the base
+  -- ring, i.e. widening was triggered for it.
+  ADD COLUMN IF NOT EXISTS sweep_sunrise_thin_ticks     INTEGER NOT NULL DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS sweep_sunset_thin_ticks      INTEGER NOT NULL DEFAULT 0,
+  -- Ticks where the feed was STILL under the floor after every ring was
+  -- swept. thin > short means widening recovered the feed; thin == short
+  -- means it did not, and that is the case worth reading the ring rates for.
+  ADD COLUMN IF NOT EXISTS sweep_sunrise_short_ticks    INTEGER NOT NULL DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS sweep_sunset_short_ticks     INTEGER NOT NULL DEFAULT 0,
+  -- Windy boxes sent, split by what caused them. base is the ~3,000/day
+  -- baseline the widening's cost has to be read against; escalation is the
+  -- bill this feature adds.
+  ADD COLUMN IF NOT EXISTS sweep_base_boxes             INTEGER NOT NULL DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS sweep_escalation_boxes       INTEGER NOT NULL DEFAULT 0;
+
+CREATE TABLE IF NOT EXISTS daily_sweep_ring_stats (
+  date                 DATE NOT NULL,                 -- UTC date, matches daily_sunset_stats
+  offset_deg           NUMERIC(6,2) NOT NULL,         -- 0, 15.75, -15.75
+  rings_swept          INTEGER NOT NULL DEFAULT 0,    -- ticks this ring ran
+  boxes_attempted      INTEGER NOT NULL DEFAULT 0,
+  -- Empty boxes conflate "no cameras there" with "the call failed", because
+  -- fetchWebcamsFor swallows non-OK responses. Rising empty against flat
+  -- new_webcams is the signature of an undiscovered Windy quota ceiling --
+  -- the second open risk in the widening spec.
+  boxes_empty          INTEGER NOT NULL DEFAULT 0,
+  -- Cameras this ring was the first in its tick to see.
+  new_webcams          INTEGER NOT NULL DEFAULT 0,
+  -- Of those cameras, frames that actually reached the ONNX head this tick.
+  -- Cache hits are excluded: no verdict was produced for them.
+  frames_scored        INTEGER NOT NULL DEFAULT 0,
+  frames_gate_passed   INTEGER NOT NULL DEFAULT 0,    -- binary head said sunset
+  updated_at           TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  PRIMARY KEY (date, offset_deg)
+);

--- a/docs/superpowers/plans/2026-09-02-adaptive-terminator-widening-followups.md
+++ b/docs/superpowers/plans/2026-09-02-adaptive-terminator-widening-followups.md
@@ -1,0 +1,91 @@
+# Adaptive terminator widening — deferred follow-ups
+
+**Date:** 2026-09-02
+**Branch it came from:** `feat/adaptive-terminator-widening`
+**Spec:** `docs/superpowers/specs/2026-09-02-adaptive-terminator-widening-design.md`
+
+Every finding raised during that branch's reviews that was triaged as
+"fine to defer" rather than fixed. None blocks merge; all were verified
+harmless at the time. Recorded so they are not rediscovered from scratch.
+
+## Wants production telemetry before it can be settled
+
+**The camera floor counts gate-failers, so widening can satisfy itself
+with frames the panel will floor.** `TERMINATOR_CAMERA_FLOOR` is compared
+against every camera the sweep found, detection-gate failures included. If
+the day-side ring adds 16 daylight cameras that all get floored, the count
+clears 15, escalation stops, and the panel stays blank — the widening
+reports success while producing the outcome it exists to prevent. When the
+telemetry has a few days of history, the question to ask is "should the
+floor count only gate-passers?", not "should the floor be 20?".
+
+**`hasBudget` is a start-gate, not a deadline.** It is evaluated once
+before each ring, never during. A ring starting just under
+`TERMINATOR_SWEEP_BUDGET_MS` runs to completion — roughly 5-7s for a
+half-ring, given `WINDY_FETCH_DELAY_BETWEEN_BATCHES_MS` plus network. Worst
+case the sweep ends near 32s of the 50s `TICK_DEADLINE_MS`, leaving the
+scoring loop less headroom than the design assumes. `maxDuration = 60` was
+added to make the platform ceiling explicit; the start-gate itself is
+unchanged. If ticks start running long, subtract an estimated ring duration
+in the predicate.
+
+**Nothing enforces `TERMINATOR_SWEEP_BUDGET_MS * 2 <= TICK_DEADLINE_MS`.**
+The budget lives in `masterConfig.ts`; the deadline is a route-local const
+in `route.ts`. Their relationship is now only a comment. Either add a guard
+test or move `TICK_DEADLINE_MS` into `masterConfig.ts` and derive.
+
+## Latent traps, harmless today
+
+**Escalating one feed can push the other feed under the floor.**
+`classifyWebcamsByPhase` assigns each camera to whichever coord set is
+nearer, with no distance cutoff. Adding only the sunrise half of a ring can
+only lower `minSunriseDistance`, so cameras migrate sunset→sunrise and never
+back. Near the ring's poleward extremes this is geometrically reachable: a
+healthy sunset feed at 18 could be dragged to 14 and trigger a night sweep it
+never needed. Bounded at 3 rings. When reading telemetry, a rising `counts`
+with a flat `newWebcams` means reassignment, not discovery.
+
+**No cross-ring coordinate dedupe.** Each ring's coords are deduped within
+themselves and within their own fetch union, but not across rings. Harmless
+at ±15.75 because the rings do not overlap. A future *smaller* offset would
+re-pay API calls for boxes an earlier ring already covered and inflate
+`attempted` — degrading the one metric this feature exists to produce. Any
+new offset must stay larger than `2 × SEARCH_RADIUS_DEG` or this needs
+fixing first.
+
+**Three route tests incidentally drive 3-ring escalations.**
+`route.test.ts:255,277,298` override the classify mock with sub-floor counts,
+so they escalate as a side effect of the floor-based default. Verified
+harmless — they assert on `upsertStateMock`/`deactivateMock`, not on
+sweep-derived values. But anyone adding a `fetchBatchesMock.mockResolvedValueOnce`
+to those tests will be surprised that rings 2 and 3 fall back to the
+`beforeEach` default. Wants a comment.
+
+**`app/api/webcams/route.ts:44-48` builds the same bounding box without
+clamping.** Its callers pass `SEARCH_RADIUS_DEG`, so the widening to 11 makes
+an out-of-range box marginally likelier from a user-panned map. Low impact
+(client-side, shows as "no results"), but `boundingBox()` now exists and this
+is its second natural call site.
+
+## Dead or cosmetic
+
+- `useUpdateTerminatorRing.ts:78` — `offsetRing` is now provably `undefined`
+  (`ringResults` is a one-element literal), so its guard and the GeoJSON memo
+  below it are dead code that reads as if a second ring might appear.
+- `windyApi.ts` — the `batches` local in `fetchCoordsCounted` is a flat
+  per-coordinate array, not batch-grouped. The name obscures the 1:1 counting
+  invariant that makes `attempted`/`empty` correct.
+- `masterConfig.test.ts` — two back-to-back imports from the same module.
+- `masterConfig.test.ts` — the offset-magnitude test asserts only
+  `|offset| >= SEARCH_RADIUS_DEG`, pinning a qualitative threshold. It would
+  pass for an unmeasured value between 11 and 15.75.
+
+## Process note, worth keeping
+
+The gaps the final review found were concentrated exactly where the plan's
+scope ended: the *other* readers of `SEARCH_RADIUS_DEG`. Task 2 changed a
+constant with seven call sites and verified two. The YouTube ceiling bug
+(`1221 km` against that API's documented 1000 km cap, failing silently) would
+have been caught by a "who else reads this constant, and what does each one
+assume" step with a named verdict per call site. Worth adding to any future
+plan that changes a shared constant.

--- a/docs/superpowers/plans/2026-09-02-adaptive-terminator-widening-followups.md
+++ b/docs/superpowers/plans/2026-09-02-adaptive-terminator-widening-followups.md
@@ -8,6 +8,22 @@ Every finding raised during that branch's reviews that was triaged as
 "fine to defer" rather than fixed. None blocks merge; all were verified
 harmless at the time. Recorded so they are not rediscovered from scratch.
 
+## Status as of 2026-09-02 evening
+
+| item | state |
+| --- | --- |
+| Digest + `daily_sunset_stats` migration | **DONE** — commit "persist sweep telemetry and surface it in the daily digest" |
+| Five latent-trap / dead-code findings | **DONE** — commit "clear the deferred findings that did not need production data" |
+| Camera-refresh pricing | **DONE** — `docs/superpowers/specs/2026-09-02-camera-refresh-cost-design.md`; verdict is *change nothing*: Windy publishes a new preview every 10.1 minutes, so a 1-2 minute cadence is not purchasable at any price |
+| Three findings that want production telemetry | **BLOCKED** — PR #112 is still open, so the widening has never run in production and there is nothing to read. Recipe below. |
+
+**One claim in this document was wrong and is corrected below**: the rule
+"any new offset must stay larger than `2 x SEARCH_RADIUS_DEG`" is not
+supported. `2 x 11 = 22`, and the shipped offset is 15.75, so the escalation
+rings' query boxes already overlap the base ring's. They yielded 92-100% new
+cameras anyway. Box overlap is not what predicts yield, and no inequality
+substitutes for measuring a new offset live.
+
 ## Wants production telemetry before it can be settled
 
 **The camera floor counts gate-failers, so widening can satisfy itself
@@ -30,9 +46,10 @@ unchanged. If ticks start running long, subtract an estimated ring duration
 in the predicate.
 
 **Nothing enforces `TERMINATOR_SWEEP_BUDGET_MS * 2 <= TICK_DEADLINE_MS`.**
-The budget lives in `masterConfig.ts`; the deadline is a route-local const
-in `route.ts`. Their relationship is now only a comment. Either add a guard
-test or move `TICK_DEADLINE_MS` into `masterConfig.ts` and derive.
+*(FIXED — `TICK_DEADLINE_MS` moved into `masterConfig.ts` and the inequality
+is a test. `maxDuration` stays a literal in the route, because Next.js reads
+it by static analysis.)* This one did not actually need telemetry; it was
+filed under the budget discussion and inherited its "wait" label.
 
 ## Latent traps, harmless today
 
@@ -46,14 +63,27 @@ never needed. Bounded at 3 rings. When reading telemetry, a rising `counts`
 with a flat `newWebcams` means reassignment, not discovery.
 
 **No cross-ring coordinate dedupe.** Each ring's coords are deduped within
-themselves and within their own fetch union, but not across rings. Harmless
-at ±15.75 because the rings do not overlap. A future *smaller* offset would
-re-pay API calls for boxes an earlier ring already covered and inflate
-`attempted` — degrading the one metric this feature exists to produce. Any
-new offset must stay larger than `2 × SEARCH_RADIUS_DEG` or this needs
-fixing first.
+themselves and within their own fetch union, but not across rings.
 
-**Three route tests incidentally drive 3-ring escalations.**
+Two separate things were conflated here, and the correction matters:
+
+- *Coordinate* duplication across rings is impossible for any non-zero
+  offset. `radius = 90 - (sunAltitude + offset)`, so two rings at different
+  offsets have different radii and share no ring point. Cross-ring coord
+  dedupe would never remove anything.
+- *Box* overlap is real and is already happening. The box spans
+  `2 × SEARCH_RADIUS_DEG` = 22 degrees and the offset is 15.75, so escalation
+  boxes overlap the base ring's ground by roughly 6 degrees today. The rings
+  still returned 92-100% new cameras, so overlap is a weak predictor of
+  wasted calls at this geometry.
+
+The original "must stay larger than `2 × SEARCH_RADIUS_DEG`" rule is
+therefore wrong: the shipped configuration violates it and works. A smaller
+offset is still a bad idea, but the reason is the measured 26-35% yield at 3
+degrees, not an inequality. **Measure any new offset live.**
+
+**Three route tests incidentally drive 3-ring escalations.** *(FIXED — the
+comment is in place above the first of the three.)*
 `route.test.ts:255,277,298` override the classify mock with sub-floor counts,
 so they escalate as a side effect of the floor-based default. Verified
 harmless — they assert on `upsertStateMock`/`deactivateMock`, not on
@@ -62,29 +92,35 @@ to those tests will be surprised that rings 2 and 3 fall back to the
 `beforeEach` default. Wants a comment.
 
 **`app/api/webcams/route.ts:44-48` builds the same bounding box without
-clamping.** Its callers pass `SEARCH_RADIUS_DEG`, so the widening to 11 makes
+clamping.** *(FIXED — it calls `boundingBox()` now, with a test that panning
+to lat 85 / lon 175 produces an in-range box.)* Its callers pass `SEARCH_RADIUS_DEG`, so the widening to 11 makes
 an out-of-range box marginally likelier from a user-panned map. Low impact
 (client-side, shows as "no results"), but `boundingBox()` now exists and this
 is its second natural call site.
 
 ## Dead or cosmetic
 
-- `useUpdateTerminatorRing.ts:78` — `offsetRing` is now provably `undefined`
-  (`ringResults` is a one-element literal), so its guard and the GeoJSON memo
-  below it are dead code that reads as if a second ring might appear.
+All four are FIXED.
+
+- `useUpdateTerminatorRing.ts:78` — `offsetRing` was provably `undefined`
+  (`ringResults` was a one-element literal), so its guard, the GeoJSON memo
+  and a whole Mapbox layer were dead code that read as if a second ring might
+  appear. Collapsed to a single `ring`.
 - `windyApi.ts` — the `batches` local in `fetchCoordsCounted` is a flat
-  per-coordinate array, not batch-grouped. The name obscures the 1:1 counting
-  invariant that makes `attempted`/`empty` correct.
-- `masterConfig.test.ts` — two back-to-back imports from the same module.
-- `masterConfig.test.ts` — the offset-magnitude test asserts only
-  `|offset| >= SEARCH_RADIUS_DEG`, pinning a qualitative threshold. It would
-  pass for an unmeasured value between 11 and 15.75.
+  per-coordinate array, not batch-grouped. Renamed `perCoord`, with the 1:1
+  invariant that makes `attempted`/`empty` correct spelled out.
+- `masterConfig.test.ts` — two back-to-back imports from the same module,
+  merged.
+- `masterConfig.test.ts` — the offset-magnitude test asserted only
+  `|offset| >= SEARCH_RADIUS_DEG`, which an unmeasured value between 11 and
+  15.75 would clear. Replaced by the exact measured pair, with the reason the
+  values are empirical rather than derived.
 
 ## Requested follow-on work (not review findings)
 
 These came from Jesse on 2026-09-02, after the branch was finished.
 
-**Put widening frequency and its cost into the daily digest.** The digest
+**Put widening frequency and its cost into the daily digest.** **DONE.** The digest
 (`app/api/cron/update-cameras/lib/dailyDigest.ts`, sent ~5pm PT) is where
 this feature's behaviour should surface day to day: how often a feed fell
 under the floor, which rings got swept, and what that did to the API call
@@ -96,7 +132,15 @@ response and one log line — nothing persists it. This is the deferred
 and a concrete reason. Cost framing matters more than raw counts: calls/day
 attributable to escalation, against the ~3,000/day baseline.
 
-**Understand camera refresh and what it costs.** Deliberately excluded from
+**Understand camera refresh and what it costs.** **DONE**, and the answer is
+that the ask cannot be met from this source. Measured 2026-09-02 across 8
+production cameras: Windy publishes a new preview every 10.1 minutes, median
+of 10 observed gaps. The cron is not in the image path at all — preview URLs
+are stable and the browser fetches them from Windy's CDN — so cadence changes
+nothing, and a 2-minute cron would multiply Windy calls, ONNX scoring and
+Neon compute by 7.5x for zero freshness. The custom Pi cameras are the only
+path to 1-2 minutes. Full pricing in
+`docs/superpowers/specs/2026-09-02-camera-refresh-cost-design.md`. Deliberately excluded from
 the widening spec as a separate decision with its own price. Two distinct
 clocks were conflated during that design conversation and should stay
 separate: the *camera list* turns over as the terminator sweeps, roughly
@@ -105,6 +149,75 @@ every 90 minutes, which a 15-minute tick already tracks six times over; the
 Only the second is a real ask. Price it properly before changing
 `vercel.json` — the cron currently runs 96 times a day, and every-2-minutes
 is 720.
+
+## Reading the telemetry, once there is any
+
+Nothing below can run until PR #112 merges and the cron has swept for a few
+days. The migration is `database/migrations/20260902_sweep_telemetry.sql`;
+apply it before the deploy or the first ticks silently drop their telemetry
+(`upsertSweepStats` swallows a missing table by design, so a missed migration
+looks like a quiet feature rather than an error).
+
+**Risk 1 — do golden-hour frames pass the detection gate?**
+
+```sql
+select offset_deg,
+       sum(new_webcams)        as found,
+       sum(frames_scored)      as scored,
+       sum(frames_gate_passed) as passed,
+       round(100.0 * sum(frames_gate_passed) / nullif(sum(frames_scored), 0), 1) as pass_pct
+from daily_sweep_ring_stats
+where date > current_date - 14
+group by offset_deg
+order by offset_deg desc;
+```
+
+The day-side row is `offset_deg = 15.75`. Compare its `pass_pct` against the
+base row's. If the day side is close, the ordering is right and the floor
+stays a plain camera count. If it is far below, that is the self-concealing
+failure: widening adds tiles the panel floors. The fix to consider then is
+**making the floor count only gate-passers**, not raising the floor — raising
+it buys more API calls for more floored tiles. The digest prints this
+comparison nightly, so it should not need a query at all.
+
+**Risk 2 — is there an undiscovered Windy quota ceiling?**
+
+```sql
+select date, offset_deg, boxes_attempted, boxes_empty,
+       round(100.0 * boxes_empty / nullif(boxes_attempted, 0), 1) as empty_pct,
+       new_webcams
+from daily_sweep_ring_stats
+where date > current_date - 30
+order by date desc, offset_deg desc;
+```
+
+The signature is `empty_pct` rising while `new_webcams` stays flat. `empty`
+deliberately conflates "no cameras there" with "the call failed", because
+`fetchWebcamsFor` swallows non-OK responses — that conflation is what makes
+the counter a wall detector. The digest carries the whole-day `empty_pct` in
+its summary line.
+
+**Risk 3 — is the floor of 15 right, and is the budget crowding scoring?**
+
+```sql
+select date, sweep_ticks, sweep_escalated_ticks,
+       sweep_sunrise_thin_ticks, sweep_sunrise_short_ticks,
+       sweep_sunset_thin_ticks,  sweep_sunset_short_ticks,
+       sweep_budget_exhausted_ticks,
+       sweep_base_boxes, sweep_escalation_boxes
+from daily_sunset_stats
+where date > current_date - 30 order by date desc;
+```
+
+`thin` minus `short` is what widening recovered. `thin ≈ short` means the
+rings did not help and the ordering or the offsets are wrong.
+`sweep_budget_exhausted_ticks` above roughly zero is the signal to subtract
+an estimated ring duration inside `hasBudget`, the start-gate finding above.
+
+**Reference point for "is the widening expensive":** on 2026-09-02 the
+production feed carried 8 sunrise and 45 sunset active cameras, and Neon
+compute for this project ran 2.5-3.3 CU-hr/day, about $0.35-0.46/day at the
+$0.14/CU-hr the digest assumes.
 
 ## Process note, worth keeping
 

--- a/docs/superpowers/plans/2026-09-02-adaptive-terminator-widening-followups.md
+++ b/docs/superpowers/plans/2026-09-02-adaptive-terminator-widening-followups.md
@@ -80,6 +80,32 @@ is its second natural call site.
   `|offset| >= SEARCH_RADIUS_DEG`, pinning a qualitative threshold. It would
   pass for an unmeasured value between 11 and 15.75.
 
+## Requested follow-on work (not review findings)
+
+These came from Jesse on 2026-09-02, after the branch was finished.
+
+**Put widening frequency and its cost into the daily digest.** The digest
+(`app/api/cron/update-cameras/lib/dailyDigest.ts`, sent ~5pm PT) is where
+this feature's behaviour should surface day to day: how often a feed fell
+under the floor, which rings got swept, and what that did to the API call
+count. The sweep telemetry already carries everything needed
+(`RingTelemetry.attempted` / `empty` / `newWebcams` / `newWebcamIds`, and
+`SweepTelemetry.escalations`), but it currently reaches only the cron's JSON
+response and one log line — nothing persists it. This is the deferred
+`daily_sunset_stats` migration from the spec, now with a concrete consumer
+and a concrete reason. Cost framing matters more than raw counts: calls/day
+attributable to escalation, against the ~3,000/day baseline.
+
+**Understand camera refresh and what it costs.** Deliberately excluded from
+the widening spec as a separate decision with its own price. Two distinct
+clocks were conflated during that design conversation and should stay
+separate: the *camera list* turns over as the terminator sweeps, roughly
+every 90 minutes, which a 15-minute tick already tracks six times over; the
+*images themselves* are what wanted a 1-2 minute cadence for the exhibit.
+Only the second is a real ask. Price it properly before changing
+`vercel.json` — the cron currently runs 96 times a day, and every-2-minutes
+is 720.
+
 ## Process note, worth keeping
 
 The gaps the final review found were concentrated exactly where the plan's
@@ -89,3 +115,48 @@ constant with seven call sites and verified two. The YouTube ceiling bug
 have been caught by a "who else reads this constant, and what does each one
 assume" step with a named verdict per call site. Worth adding to any future
 plan that changes a shared constant.
+
+---
+
+## Ready-to-use prompt for the next session
+
+Paste this to pick the work up cold.
+
+> Read `docs/superpowers/plans/2026-09-02-adaptive-terminator-widening-followups.md`
+> and its spec, `docs/superpowers/specs/2026-09-02-adaptive-terminator-widening-design.md`.
+> The adaptive terminator widening feature shipped; these are the threads it
+> left open.
+>
+> Do these three, in this order:
+>
+> 1. **Persist the sweep telemetry and surface it in the daily digest.** This
+>    needs the `daily_sunset_stats` migration the spec deferred. The digest
+>    should answer two questions at a glance: how often did a feed fall under
+>    the camera floor today, and what did the extra rings cost in API calls
+>    against the ~3,000/day baseline. Ring attribution (`newWebcamIds`) is
+>    already recorded per ring — use it.
+>
+> 2. **Answer the spec's two open risks from real data**, once the telemetry
+>    has a few days of history. Whether golden-hour frames from the +15.75
+>    ring actually pass the detection gate, which decides if day-side-first
+>    is the right ordering at all; and whether an undiscovered Windy quota
+>    ceiling exists, which reads as `empty` rising while `newWebcams` stays
+>    flat. If the gate rejects most golden-hour frames, revisit whether the
+>    camera floor should count only gate-passers — see the first section of
+>    the follow-ups doc for why that failure mode is self-concealing.
+>
+> 3. **Price camera refresh as its own decision.** Not the camera *list*,
+>    which a 15-minute tick already over-samples, but image freshness for the
+>    exhibit. Measure before proposing a cadence.
+>
+> Then triage the deferred findings in that doc. Three want production
+> telemetry and should wait for step 2. The rest are latent traps and dead
+> code; the `app/api/webcams/route.ts` bounding-box clamp is the one with a
+> user-visible failure mode.
+>
+> Constraints that still bind: `SEARCH_RADIUS_DEG` may never exceed 11.25
+> (Windy caps the box span at 22.5° on zoom 4, and rejects zoom < 4); any new
+> ring offset must exceed `2 × SEARCH_RADIUS_DEG` or it re-finds cameras the
+> base ring already has; and before changing any shared constant, enumerate
+> every call site and give each one a named verdict — that step's absence is
+> how a silent YouTube API breach reached a commit on the original branch.

--- a/docs/superpowers/plans/2026-09-02-adaptive-terminator-widening.md
+++ b/docs/superpowers/plans/2026-09-02-adaptive-terminator-widening.md
@@ -359,6 +359,23 @@ git commit -m "feat(cron): report attempted and empty box counts from a sweep"
 
 The heart of the feature, and deliberately pure. Every dependency arrives as a function argument so the policy is tested with no network, no clock, and no database.
 
+**Two amendments to the code sketched below, folded back in from review. The
+sketch is otherwise as shipped.**
+
+1. **`RingTelemetry` also carries `newWebcamIds: number[]`**, populated from the
+   same `byId` delta as `newWebcams` — record an id before inserting it, so the
+   delta is against every *earlier* ring rather than against the current one.
+   `newWebcams` stays as the cheap scalar. The ids are required, not a nicety:
+   "Verification after merge" step 4 asks which ring each camera came from, and
+   a bare count cannot answer that.
+2. **The base ring is swept as `sweep(0, [...FEEDS])`, not `sweep(0, FEEDS)`.**
+   `sweep` stores the array it is handed straight into the returned telemetry,
+   so passing the module-level constant makes `telemetry.rings[0].feedsSwept`
+   an alias of `FEEDS`; any caller that sorted or mutated the telemetry would
+   permanently reorder `FEEDS` and flip escalation priority for the rest of the
+   process. (`feedsBelowFloor` already returns a fresh array, so escalation
+   rings were never affected.)
+
 **Files:**
 - Create: `app/api/cron/update-cameras/lib/terminatorSweep.ts`
 - Test: `app/api/cron/update-cameras/lib/terminatorSweep.test.ts` (create)
@@ -837,10 +854,26 @@ git commit -m "feat(cron): add widening constants, retire the fixed offset ring 
 
 **Files:**
 - Modify: `app/api/cron/update-cameras/route.ts:75-115` (the ring + fetch block) and the final `NextResponse.json`
+- Modify: `app/lib/masterConfig.ts` (add `TERMINATOR_SWEEP_BUDGET_MS`, delete `TERMINATOR_RING_OFFSETS_DEG`)
 
 **Interfaces:**
 - Consumes: `sweepWithEscalation`, `SweepTelemetry` (Task 4); `fetchCoordsCounted` (Task 3); `TERMINATOR_CAMERA_FLOOR`, `TERMINATOR_WIDEN_OFFSETS_DEG` (Task 5)
-- Produces: a `sweep: SweepTelemetry` field on the cron's JSON response
+- Produces: `TERMINATOR_SWEEP_BUDGET_MS`; a `sweep: SweepTelemetry` field on the cron's JSON response
+
+**The sweep budget is a named constant, not an inline expression.** An earlier
+draft of this task wrote `hasBudget` as `Date.now() - tickStartedAt <
+TICK_DEADLINE_MS / 2`. Review replaced it: `TICK_DEADLINE_MS / 2` is a tuning
+number living inline in a route, which the Global Constraints forbid, and it
+tied the sweep budget to the scoring deadline by arithmetic accident rather
+than by decision — halving `TICK_DEADLINE_MS` would silently halve the sweep
+budget too. It is now `TERMINATOR_SWEEP_BUDGET_MS = 25_000` in
+`masterConfig.ts`, added by this task, and the two numbers are free to move
+independently. The steps below reflect that.
+
+Note that `hasBudget` is a **start-gate, not a deadline**: it is checked once
+before each escalation ring and never during one, so a ring that starts just
+under the budget runs to completion (roughly 5–7s for a half-ring). Accepted;
+see the spec's Risks.
 
 - [ ] **Step 1: Replace the sweep block**
 
@@ -873,8 +906,8 @@ In `route.ts`, replace everything from `// Generate terminator rings for all con
     offsets: TERMINATOR_WIDEN_OFFSETS_DEG,
     // Escalation rings are the first thing sacrificed on a slow tick: the
     // scoring loop below needs the remaining budget more than the pool needs
-    // extra cameras. Half the deadline is the cutoff.
-    hasBudget: () => Date.now() - tickStartedAt < TICK_DEADLINE_MS / 2,
+    // extra cameras. See TERMINATOR_SWEEP_BUDGET_MS for the cutoff rationale.
+    hasBudget: () => Date.now() - tickStartedAt < TERMINATOR_SWEEP_BUDGET_MS,
   });
 
   const sunriseCoords = sweep.coords.sunriseCoords;
@@ -890,16 +923,42 @@ Three edits, all verified against the current file rather than left as checks:
 
 1. **`tickStartedAt` must move.** It is declared at `route.ts:141`, *after* the sweep block you just replaced at 75–116, so `hasBudget` would hit a temporal-dead-zone `ReferenceError`. Move `const tickStartedAt = Date.now();` up so it sits immediately above the `sweepWithEscalation` call, and delete the old line 141 declaration.
 2. **`dedupeWebcams` is now unused.** Its only reader was line 115, which the replacement deleted. Remove it from the `./lib/windyApi` import or lint fails. `fetchWebcamsInBatches` is not imported by `route.ts` at all — leave it exported from `windyApi.ts`, since `fetchCoordsCounted` wraps it.
-3. **Swap the constants.** Remove `TERMINATOR_RING_OFFSETS_DEG` from the `masterConfig` import, add `TERMINATOR_CAMERA_FLOOR` and `TERMINATOR_WIDEN_OFFSETS_DEG`, and add `fetchCoordsCounted` to the `./lib/windyApi` import. Then add:
+3. **Swap the constants.** Remove `TERMINATOR_RING_OFFSETS_DEG` from the `masterConfig` import, add `TERMINATOR_CAMERA_FLOOR`, `TERMINATOR_WIDEN_OFFSETS_DEG` and `TERMINATOR_SWEEP_BUDGET_MS`, and add `fetchCoordsCounted` to the `./lib/windyApi` import. Then add:
 
 ```ts
 import { sweepWithEscalation } from './lib/terminatorSweep';
 ```
 
-- [ ] **Step 2b: Delete the retired constant**
+4. **Declare the route's ceiling.** `TICK_DEADLINE_MS` only means anything if
+   the platform grants the tick at least that long, and this route inherited
+   its limit rather than declaring one. Add `export const maxDuration = 60;`
+   above `TICK_DEADLINE_MS`, as `app/api/kiosk/scenes/route.ts` and
+   `app/api/snapshots/capture/route.ts` do. Widening makes a slow tick likelier
+   — `tickStartedAt` now starts before the Windy fetch, and an escalated sweep
+   can spend up to `TERMINATOR_SWEEP_BUDGET_MS` — so the two numbers stay
+   pinned together: raising `TICK_DEADLINE_MS` means raising `maxDuration`.
 
-`route.ts` was its last reader. In `app/lib/masterConfig.ts`, delete the
-`TERMINATOR_RING_OFFSETS_DEG` export and its comment block. Confirm with:
+- [ ] **Step 2b: Add the budget constant and delete the retired one**
+
+In `app/lib/masterConfig.ts`, add the sweep budget beside the other terminator
+constants Task 5 introduced:
+
+```ts
+// Wall-clock budget for the whole terminator sweep (base ring + any
+// escalation rings), in milliseconds. The scoring loop that follows needs
+// the remaining tick more than the pool needs extra cameras, so escalation
+// rings are the first thing sacrificed on a slow tick. Chosen against a
+// single observation (half of the 50s tick deadline, 2026-09-02); expect to
+// tune it once the sweep telemetry has a few days of history.
+export const TERMINATOR_SWEEP_BUDGET_MS = 25_000;
+```
+
+It starts at half of `TICK_DEADLINE_MS`, but as a value rather than as an
+expression — the two are independently tunable and must not drift together by
+accident.
+
+Then delete the `TERMINATOR_RING_OFFSETS_DEG` export and its comment block;
+`route.ts` was its last reader. Confirm with:
 
 Run: `grep -rn "TERMINATOR_RING_OFFSETS_DEG" app/ --include=*.ts --include=*.tsx`
 Expected: no hits.
@@ -946,7 +1005,8 @@ The telemetry is the whole point; check it before trusting the feature.
 1. Hit the cron endpoint and read `sweep` in the JSON response. On a healthy tick expect `escalations: 0` and one ring entry.
 2. Wait for a thin period and confirm `escalations` rises, `rings[1].offsetDeg` is `15.75`, and `rings[1].newWebcams` is a meaningful fraction of `attempted`.
 3. **Watch `empty` across rings.** A rising `empty` count against a flat `newWebcams` count is the signature of a Windy quota wall, which is the one risk the spec calls out and cannot be measured from outside.
-4. **Check whether golden-hour frames actually pass the gate.** The spec's second risk: if the +15.75 ring's cameras are all gated to floor size, the day-side-first ordering is buying tiles that do not read as sunsets. Compare `passesGate` rates for cameras first seen on ring 1 versus ring 0.
+4. **Check whether golden-hour frames actually pass the gate.** The spec's second risk: if the +15.75 ring's cameras are all gated to floor size, the day-side-first ordering is buying tiles that do not read as sunsets. Compare `passesGate` rates for the ids in `rings[1].newWebcamIds` against those in `rings[0].newWebcamIds` — `RingTelemetry` carries the ids for exactly this, since the `newWebcams` scalar alone cannot answer it.
+5. **Then ask whether the floor should count only gate-passers.** The floor is compared against every camera the sweep found, gate-failers included, so a day-side ring that adds 16 floored daylight cameras clears the floor of 15 and stops escalation while the panel stays blank. Step 4's gate-pass rates decide this. If golden-hour frames largely pass, it is moot. If they do not, the fix is to count gate-passers — **not** to raise the floor, which buys more calls for more floored tiles.
 
 ## Deferred, deliberately
 

--- a/docs/superpowers/plans/2026-09-02-adaptive-terminator-widening.md
+++ b/docs/superpowers/plans/2026-09-02-adaptive-terminator-widening.md
@@ -419,7 +419,7 @@ function stubFetcher(perRing: Record<number, WindyWebcam[]>, seen: Location[][] 
   };
 }
 
-/** Splits by longitude: lng 1 is sunrise, everything else sunset. */
+/** Splits on webcamId parity: odd ids are sunrise, even ids are sunset. */
 const classify = (webcams: WindyWebcam[]) => ({
   sunrise: webcams.filter((w) => w.webcamId % 2 === 1),
   sunset: webcams.filter((w) => w.webcamId % 2 === 0),
@@ -719,7 +719,12 @@ git commit -m "feat(cron): per-feed terminator widening, decided within the tick
 
 **Interfaces:**
 - Produces: `TERMINATOR_CAMERA_FLOOR = 15`, `TERMINATOR_WIDEN_OFFSETS_DEG = [15.75, -15.75]`
-- Removes: `TERMINATOR_RING_OFFSETS_DEG`
+
+**Do NOT delete `TERMINATOR_RING_OFFSETS_DEG` in this task.** `route.ts:19`
+imports it until Task 6 rewrites that block, so deleting it here leaves the
+branch failing `tsc` at a committed checkpoint. Task 6 deletes it, where its
+last reader disappears. Leave the old constant in place and add the new ones
+beneath it.
 
 - [ ] **Step 1: Write the failing test**
 
@@ -785,10 +790,10 @@ export const TERMINATOR_WIDEN_OFFSETS_DEG = [15.75, -15.75] as const;
 Run: `npm run test -- --run app/lib/masterConfig.test.ts`
 Expected: PASS, 5 tests.
 
-- [ ] **Step 5: Confirm the old constant has no remaining readers**
+- [ ] **Step 5: Take the map hook off the old constant**
 
 Run: `grep -rn "TERMINATOR_RING_OFFSETS_DEG" app/ --include=*.ts --include=*.tsx`
-Expected: two hits, both in files Task 6 rewrites — `app/api/cron/update-cameras/route.ts` and `app/components/Map/hooks/useUpdateTerminatorRing.ts`.
+Expected before this step: two readers — `app/api/cron/update-cameras/route.ts` (Task 6 handles it) and `app/components/Map/hooks/useUpdateTerminatorRing.ts` (this step). After this step, only `route.ts` should remain.
 
 The map hook draws the ring the operator sees. In `useUpdateTerminatorRing.ts`, replace the `ringResults` memo:
 
@@ -879,15 +884,25 @@ In `route.ts`, replace everything from `// Generate terminator rings for all con
   console.log('🛰️ terminator sweep:', JSON.stringify(sweep.telemetry));
 ```
 
-- [ ] **Step 2: Fix the imports**
+- [ ] **Step 2: Fix the imports and the `tickStartedAt` ordering**
 
-Remove `TERMINATOR_RING_OFFSETS_DEG` from the `masterConfig` import and add the two new constants. Remove `fetchWebcamsInBatches` and `dedupeWebcams` from the `./lib/windyApi` import if nothing else in the file uses them (check with `grep -n "dedupeWebcams\|fetchWebcamsInBatches" app/api/cron/update-cameras/route.ts`), and add `fetchCoordsCounted`. Add:
+Three edits, all verified against the current file rather than left as checks:
+
+1. **`tickStartedAt` must move.** It is declared at `route.ts:141`, *after* the sweep block you just replaced at 75–116, so `hasBudget` would hit a temporal-dead-zone `ReferenceError`. Move `const tickStartedAt = Date.now();` up so it sits immediately above the `sweepWithEscalation` call, and delete the old line 141 declaration.
+2. **`dedupeWebcams` is now unused.** Its only reader was line 115, which the replacement deleted. Remove it from the `./lib/windyApi` import or lint fails. `fetchWebcamsInBatches` is not imported by `route.ts` at all — leave it exported from `windyApi.ts`, since `fetchCoordsCounted` wraps it.
+3. **Swap the constants.** Remove `TERMINATOR_RING_OFFSETS_DEG` from the `masterConfig` import, add `TERMINATOR_CAMERA_FLOOR` and `TERMINATOR_WIDEN_OFFSETS_DEG`, and add `fetchCoordsCounted` to the `./lib/windyApi` import. Then add:
 
 ```ts
 import { sweepWithEscalation } from './lib/terminatorSweep';
 ```
 
-`tickStartedAt` is already defined in this handler; confirm it is assigned before the sweep block and move its declaration up if not.
+- [ ] **Step 2b: Delete the retired constant**
+
+`route.ts` was its last reader. In `app/lib/masterConfig.ts`, delete the
+`TERMINATOR_RING_OFFSETS_DEG` export and its comment block. Confirm with:
+
+Run: `grep -rn "TERMINATOR_RING_OFFSETS_DEG" app/ --include=*.ts --include=*.tsx`
+Expected: no hits.
 
 - [ ] **Step 3: Surface the telemetry on the response**
 
@@ -911,7 +926,7 @@ Expected: PASS. If a test asserted the old response shape, update it to expect t
 
 ```bash
 git rev-parse --abbrev-ref HEAD   # must print feat/adaptive-terminator-widening
-git add app/api/cron/update-cameras/route.ts
+git add app/api/cron/update-cameras/route.ts app/lib/masterConfig.ts
 git commit -m "feat(cron): sweep extra terminator rings when a feed runs thin"
 ```
 

--- a/docs/superpowers/plans/2026-09-02-adaptive-terminator-widening.md
+++ b/docs/superpowers/plans/2026-09-02-adaptive-terminator-widening.md
@@ -1,0 +1,940 @@
+# Adaptive Terminator Widening Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** When a kiosk feed runs short of cameras, have the cron automatically sweep additional terminator rings — day side first — within the same tick, and stop as soon as the pool recovers.
+
+**Architecture:** A pure orchestrator (`terminatorSweep.ts`) owns the escalation decision and receives its ring builder, fetcher, and classifier as injected functions, so the whole policy is unit-testable with no network. `route.ts` shrinks to wiring. Separately, the Windy bounding-box builder gains latitude and longitude clamping, which recovers roughly 2 of 31 boxes that currently 400 and silently return nothing.
+
+**Tech Stack:** TypeScript, Next.js App Router route handlers, Vitest.
+
+**Spec:** `docs/superpowers/specs/2026-09-02-adaptive-terminator-widening-design.md` — read it first; it carries the live measurements this plan argues from.
+
+## Global Constraints
+
+- **Branch:** `feat/adaptive-terminator-widening`. **Verify before every commit** with `git rev-parse --abbrev-ref HEAD`. Jesse merges PRs in parallel sessions and the branch can shift mid-task. If it is not that branch, STOP and report.
+- **Never `git add -A` / `git add .`.** Other sessions share this checkout and have unrelated `ml/` artifacts untracked. Stage only the explicit paths each task names.
+- **No worktrees.** Plain branches in the single main checkout (`CLAUDE.md`).
+- **Windy API hard limits, verified live 2026-09-02** — the bounding box must satisfy all of these or the call 400s:
+  - `northLat - southLat <= 22.5` at `zoom=4` (the span cap scales with zoom; `zoom < 4` is rejected outright)
+  - `northLat <= 90`, `southLat >= -90`
+  - `eastLon <= 180`, `westLon >= -180`
+- **`SEARCH_RADIUS_DEG` may never exceed 11.25**, since the box span is `2 × radius`. Task 2 adds a guard test; do not remove it.
+- **Ring offset sign:** `radius = 90 - (sunAltitude + offsetDeg)`, so **positive offset moves the ring toward day**. `+15.75` is golden hour, `-15.75` is deep night. Day side is always tried first.
+- **No cron cadence change.** `vercel.json` stays at `*/15 * * * *`. Out of scope, deliberately.
+- Run tests with `npm run test -- --run <path>`. Lint with `npm run lint`.
+- Every new constant lives in `app/lib/masterConfig.ts`, never inline in a route.
+
+---
+
+## File Structure
+
+| File | Responsibility |
+| --- | --- |
+| `app/api/cron/update-cameras/lib/windyApi.ts` (modify) | Add `boundingBox()` with clamping; add `fetchCoordsCounted()` that reports attempt/failure counts |
+| `app/api/cron/update-cameras/lib/windyApi.test.ts` (create) | Bounding-box clamping and failure-counting tests |
+| `app/api/cron/update-cameras/lib/terminatorSweep.ts` (create) | Pure escalation policy: which feeds are under floor, which rings to sweep, in what order, under what budget |
+| `app/api/cron/update-cameras/lib/terminatorSweep.test.ts` (create) | Escalation policy tests, fully stubbed |
+| `app/lib/masterConfig.ts` (modify) | `SEARCH_RADIUS_DEG` 9 → 11; add `TERMINATOR_CAMERA_FLOOR`, `TERMINATOR_WIDEN_OFFSETS_DEG`; remove `TERMINATOR_RING_OFFSETS_DEG` |
+| `app/lib/masterConfig.test.ts` (create) | Guard test for the Windy span cap |
+| `app/api/cron/update-cameras/route.ts` (modify) | Replace the fixed multi-ring sweep block with a call into `sweepWithEscalation`; surface telemetry |
+
+---
+
+## Task 1: Clamp the Windy bounding box
+
+Two boxes per sweep currently 400 and return nothing: one near the pole at some declinations, one near the antimeridian. `fetchWebcamsFor` swallows both as an empty array. Clamping recovers roughly 6% of coverage for free.
+
+**Files:**
+- Modify: `app/api/cron/update-cameras/lib/windyApi.ts`
+- Test: `app/api/cron/update-cameras/lib/windyApi.test.ts` (create)
+
+**Interfaces:**
+- Consumes: `Location` from `@/app/lib/types` (`{ lat: number; lng: number }`)
+- Produces: `boundingBox(loc: Location, radiusDeg: number): BoundingBox` where `BoundingBox = { northLat: number; southLat: number; eastLon: number; westLon: number }`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `app/api/cron/update-cameras/lib/windyApi.test.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { boundingBox } from './windyApi';
+
+describe('boundingBox', () => {
+  it('returns an unclamped box away from the edges', () => {
+    expect(boundingBox({ lat: 45, lng: 10 }, 11)).toEqual({
+      northLat: 56, southLat: 34, eastLon: 21, westLon: -1,
+    });
+  });
+
+  it('clamps latitude at the north pole', () => {
+    const box = boundingBox({ lat: 85, lng: 0 }, 11);
+    expect(box.northLat).toBe(90);
+    expect(box.southLat).toBe(74);
+  });
+
+  it('clamps latitude at the south pole', () => {
+    const box = boundingBox({ lat: -85, lng: 0 }, 11);
+    expect(box.southLat).toBe(-90);
+    expect(box.northLat).toBe(-74);
+  });
+
+  it('clamps longitude at the antimeridian', () => {
+    expect(boundingBox({ lat: 0, lng: 175 }, 11).eastLon).toBe(180);
+    expect(boundingBox({ lat: 0, lng: -175 }, 11).westLon).toBe(-180);
+  });
+
+  it('never produces a span wider than the Windy zoom-4 cap', () => {
+    for (const lat of [-90, -85, -45, 0, 45, 85, 90]) {
+      const box = boundingBox({ lat, lng: 0 }, 11);
+      expect(box.northLat - box.southLat).toBeLessThanOrEqual(22.5);
+    }
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm run test -- --run app/api/cron/update-cameras/lib/windyApi.test.ts`
+Expected: FAIL — `boundingBox` is not exported from `./windyApi`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `app/api/cron/update-cameras/lib/windyApi.ts`, add above `fetchWebcamsFor`:
+
+```ts
+export interface BoundingBox {
+  northLat: number;
+  southLat: number;
+  eastLon: number;
+  westLon: number;
+}
+
+/**
+ * Query box for one ring point, clamped to the ranges Windy accepts.
+ *
+ * Verified live 2026-09-02: the clusters endpoint 400s on northLat > 90,
+ * southLat < -90, eastLon > 180 or westLon < -180, and `fetchWebcamsFor`
+ * turns that into a silent empty array. The ring genuinely reaches both
+ * the pole and the antimeridian, so ~2 of 31 boxes per sweep were being
+ * lost that way.
+ *
+ * Clamping shrinks the box rather than wrapping it, so a box straddling
+ * the antimeridian loses the sliver on the far side. Splitting into two
+ * boxes would recover it; not done here because that stretch is open
+ * ocean and a shrunken box still beats a 400.
+ */
+export function boundingBox(loc: Location, radiusDeg: number): BoundingBox {
+  return {
+    northLat: Math.min(90, loc.lat + radiusDeg),
+    southLat: Math.max(-90, loc.lat - radiusDeg),
+    eastLon: Math.min(180, loc.lng + radiusDeg),
+    westLon: Math.max(-180, loc.lng - radiusDeg),
+  };
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npm run test -- --run app/api/cron/update-cameras/lib/windyApi.test.ts`
+Expected: PASS, 5 tests.
+
+- [ ] **Step 5: Use it in the fetcher**
+
+In `fetchWebcamsFor`, replace the inline URL arithmetic:
+
+```ts
+  const box = boundingBox(loc, SEARCH_RADIUS_DEG);
+  const url = `https://api.windy.com/webcams/api/v3/map/clusters?lang=en&northLat=${
+    box.northLat
+  }&southLat=${box.southLat}&eastLon=${box.eastLon}&westLon=${
+    box.westLon
+  }&zoom=4&include=images&include=urls&include=player&include=location&include=categories`;
+```
+
+- [ ] **Step 6: Run the full cron lib suite**
+
+Run: `npm run test -- --run app/api/cron/update-cameras/lib/`
+Expected: PASS, no regressions.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git rev-parse --abbrev-ref HEAD   # must print feat/adaptive-terminator-widening
+git add app/api/cron/update-cameras/lib/windyApi.ts \
+        app/api/cron/update-cameras/lib/windyApi.test.ts
+git commit -m "fix(cron): clamp the Windy bounding box to the ranges it accepts"
+```
+
+---
+
+## Task 2: Widen the base search radius to 11
+
+Free coverage: same call count, 22% more ground per call. The guard test is the durable part — it encodes the API cap that the old `// 12 doesn't work` comment only hinted at.
+
+**Files:**
+- Modify: `app/lib/masterConfig.ts:27-31`
+- Test: `app/lib/masterConfig.test.ts` (create)
+
+**Interfaces:**
+- Produces: `SEARCH_RADIUS_DEG = 11`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `app/lib/masterConfig.test.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { SEARCH_RADIUS_DEG } from './masterConfig';
+
+// Verified live against the Windy clusters endpoint 2026-09-02:
+//   {"message":"Maximal distance between north and south latitudes on the
+//    zoom level 4, should be 22.5!","error":"Bad Request","statusCode":400}
+// The box span is 2 x SEARCH_RADIUS_DEG, and zoom < 4 is rejected outright,
+// so 11.25 is a hard ceiling, not a preference.
+const WINDY_ZOOM4_MAX_LAT_SPAN_DEG = 22.5;
+
+describe('SEARCH_RADIUS_DEG', () => {
+  it('keeps the query box inside the Windy zoom-4 span cap', () => {
+    expect(SEARCH_RADIUS_DEG * 2).toBeLessThanOrEqual(
+      WINDY_ZOOM4_MAX_LAT_SPAN_DEG
+    );
+  });
+
+  it('is widened to 11, the practical maximum', () => {
+    expect(SEARCH_RADIUS_DEG).toBe(11);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm run test -- --run app/lib/masterConfig.test.ts`
+Expected: FAIL on the second test — received 9, expected 11.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `app/lib/masterConfig.ts`, replace the `SEARCH_RADIUS_DEG` block:
+
+```ts
+// Search radius per Windy API call, in degrees. The query box spans
+// 2 x this value, and Windy's clusters endpoint caps the north-south span
+// at 22.5 degrees on zoom 4 (and rejects zoom < 4), so 11.25 is a hard
+// ceiling. Verified live 2026-09-02; guarded by masterConfig.test.ts.
+export const SEARCH_RADIUS_DEG = 11;
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npm run test -- --run app/lib/masterConfig.test.ts`
+Expected: PASS, 2 tests.
+
+- [ ] **Step 5: Run the wider suite**
+
+Run: `npm run test -- --run app/api/cron/ app/components/Map/`
+Expected: PASS. `SimpleMap.tsx` and `searchRadiusCircles.ts` read this constant to draw the search circles; they scale off it and need no edit, but confirm nothing asserted the old 9.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git rev-parse --abbrev-ref HEAD   # must print feat/adaptive-terminator-widening
+git add app/lib/masterConfig.ts app/lib/masterConfig.test.ts
+git commit -m "feat(cron): widen the base search radius to 11, guarded by the API cap"
+```
+
+---
+
+## Task 3: Count sweep attempts and failures
+
+More calls means more of `fetchWebcamsFor`'s silent `return []`. The escalation logic needs to know how many boxes actually answered, or a quota wall looks identical to an empty ocean.
+
+**Files:**
+- Modify: `app/api/cron/update-cameras/lib/windyApi.ts`
+- Test: `app/api/cron/update-cameras/lib/windyApi.test.ts`
+
+**Interfaces:**
+- Consumes: `boundingBox` (Task 1); `fetchWebcamsInBatches(coords, batchSize, delay): Promise<WindyWebcam[][]>` (existing)
+- Produces: `fetchCoordsCounted(coords: Location[], batchSize?: number, delayMs?: number): Promise<CoordFetchResult>` where `CoordFetchResult = { webcams: WindyWebcam[]; attempted: number; empty: number }`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `app/api/cron/update-cameras/lib/windyApi.test.ts`. Merge these imports into the two import statements already at the top of that file rather than adding duplicates — a second `from 'vitest'` import trips `import/no-duplicates`:
+
+```ts
+// top of file becomes:
+//   import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+//   import { boundingBox, fetchCoordsCounted } from './windyApi';
+
+describe('fetchCoordsCounted', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn(async (url: string) => {
+      // Boxes centred on lng 99 answer with one webcam; everything else 400s.
+      if (url.includes('westLon=88')) {
+        return { ok: true, json: async () => [{ webcamId: 1, location: {} }] };
+      }
+      return { ok: false, status: 400, statusText: 'Bad Request' };
+    }));
+  });
+  afterEach(() => vi.unstubAllGlobals());
+
+  it('reports how many boxes were tried and how many came back empty', async () => {
+    const res = await fetchCoordsCounted(
+      [{ lat: 0, lng: 99 }, { lat: 0, lng: 5 }, { lat: 0, lng: 20 }],
+      5,
+      0
+    );
+    expect(res.attempted).toBe(3);
+    expect(res.empty).toBe(2);
+    expect(res.webcams).toHaveLength(1);
+  });
+
+  it('is a no-op on an empty coordinate list', async () => {
+    const res = await fetchCoordsCounted([], 5, 0);
+    expect(res).toEqual({ webcams: [], attempted: 0, empty: 0 });
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm run test -- --run app/api/cron/update-cameras/lib/windyApi.test.ts`
+Expected: FAIL — `fetchCoordsCounted` is not exported.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Append to `app/api/cron/update-cameras/lib/windyApi.ts`:
+
+```ts
+export interface CoordFetchResult {
+  webcams: WindyWebcam[];
+  /** Boxes we sent to Windy. */
+  attempted: number;
+  /**
+   * Boxes that returned nothing. Conflates "no cameras there" with "the call
+   * failed", because `fetchWebcamsFor` swallows non-OK responses. That
+   * conflation is the point: a rising `empty` count against a flat camera
+   * count is the signature of an API wall, which is the thing we need to be
+   * able to see.
+   */
+  empty: number;
+}
+
+/**
+ * Batched sweep over ring coordinates that reports coverage, not just
+ * results. Wraps `fetchWebcamsInBatches` so rate limiting stays in one place.
+ */
+export async function fetchCoordsCounted(
+  coords: Location[],
+  batchSize = 5,
+  delayMs = 1000
+): Promise<CoordFetchResult> {
+  if (coords.length === 0) return { webcams: [], attempted: 0, empty: 0 };
+  const batches = await fetchWebcamsInBatches(coords, batchSize, delayMs);
+  return {
+    webcams: batches.flat(),
+    attempted: coords.length,
+    empty: batches.filter((b) => b.length === 0).length,
+  };
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npm run test -- --run app/api/cron/update-cameras/lib/windyApi.test.ts`
+Expected: PASS, 7 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git rev-parse --abbrev-ref HEAD   # must print feat/adaptive-terminator-widening
+git add app/api/cron/update-cameras/lib/windyApi.ts \
+        app/api/cron/update-cameras/lib/windyApi.test.ts
+git commit -m "feat(cron): report attempted and empty box counts from a sweep"
+```
+
+---
+
+## Task 4: The escalation policy
+
+The heart of the feature, and deliberately pure. Every dependency arrives as a function argument so the policy is tested with no network, no clock, and no database.
+
+**Files:**
+- Create: `app/api/cron/update-cameras/lib/terminatorSweep.ts`
+- Test: `app/api/cron/update-cameras/lib/terminatorSweep.test.ts` (create)
+
+**Interfaces:**
+- Consumes: `Location`, `WindyWebcam` from `@/app/lib/types`; `CoordFetchResult` from `./windyApi` (Task 3)
+- Produces:
+
+```ts
+export type Feed = 'sunrise' | 'sunset';
+export interface RingCoords { sunriseCoords: Location[]; sunsetCoords: Location[] }
+export interface RingTelemetry {
+  offsetDeg: number;
+  feedsSwept: Feed[];
+  attempted: number;
+  empty: number;
+  newWebcams: number;
+}
+export interface SweepTelemetry {
+  rings: RingTelemetry[];
+  counts: Record<Feed, number>;
+  escalations: number;
+  budgetExhausted: boolean;
+}
+export interface SweepResult {
+  webcams: WindyWebcam[];
+  coords: RingCoords;
+  telemetry: SweepTelemetry;
+}
+export function feedsBelowFloor(counts: Record<Feed, number>, floor: number): Feed[]
+export async function sweepWithEscalation(opts: SweepOptions): Promise<SweepResult>
+```
+
+- [ ] **Step 1: Write the failing test**
+
+Create `app/api/cron/update-cameras/lib/terminatorSweep.test.ts`:
+
+```ts
+import { describe, it, expect, vi } from 'vitest';
+import { feedsBelowFloor, sweepWithEscalation } from './terminatorSweep';
+import type { Location, WindyWebcam } from '@/app/lib/types';
+
+const cam = (id: number, lat = 0): WindyWebcam =>
+  ({ webcamId: id, location: { latitude: lat, longitude: 0 } } as WindyWebcam);
+
+const ring = (offsetDeg: number) => ({
+  sunriseCoords: [{ lat: offsetDeg, lng: 1 }] as Location[],
+  sunsetCoords: [{ lat: offsetDeg, lng: 2 }] as Location[],
+});
+
+/** Hands back `perRing[offset]` cameras, and records which coords were asked for. */
+function stubFetcher(perRing: Record<number, WindyWebcam[]>, seen: Location[][] = []) {
+  return async (coords: Location[]) => {
+    seen.push(coords);
+    const offset = coords[0]?.lat ?? 0;
+    const webcams = perRing[offset] ?? [];
+    return { webcams, attempted: coords.length, empty: 0 };
+  };
+}
+
+/** Splits by longitude: lng 1 is sunrise, everything else sunset. */
+const classify = (webcams: WindyWebcam[]) => ({
+  sunrise: webcams.filter((w) => w.webcamId % 2 === 1),
+  sunset: webcams.filter((w) => w.webcamId % 2 === 0),
+});
+
+describe('feedsBelowFloor', () => {
+  it('names only the feeds under the floor', () => {
+    expect(feedsBelowFloor({ sunrise: 4, sunset: 21 }, 15)).toEqual(['sunrise']);
+  });
+  it('is empty when both feeds are healthy', () => {
+    expect(feedsBelowFloor({ sunrise: 30, sunset: 21 }, 15)).toEqual([]);
+  });
+  it('treats the floor itself as healthy', () => {
+    expect(feedsBelowFloor({ sunrise: 15, sunset: 15 }, 15)).toEqual([]);
+  });
+  it('names both when both are thin', () => {
+    expect(feedsBelowFloor({ sunrise: 1, sunset: 2 }, 15)).toEqual([
+      'sunrise', 'sunset',
+    ]);
+  });
+});
+
+describe('sweepWithEscalation', () => {
+  it('does not escalate when the base ring already clears the floor', async () => {
+    const seen: Location[][] = [];
+    const res = await sweepWithEscalation({
+      buildRing: ring,
+      fetchCoords: stubFetcher({ 0: [cam(1), cam(2), cam(3), cam(4)] }, seen),
+      classify,
+      floor: 2,
+      offsets: [15.75, -15.75],
+      hasBudget: () => true,
+    });
+    expect(res.telemetry.escalations).toBe(0);
+    expect(res.telemetry.rings).toHaveLength(1);
+    expect(seen).toHaveLength(1);
+  });
+
+  it('escalates to the day ring for the thin feed only', async () => {
+    const seen: Location[][] = [];
+    const res = await sweepWithEscalation({
+      buildRing: ring,
+      fetchCoords: stubFetcher(
+        { 0: [cam(2), cam(4)], 15.75: [cam(1), cam(3)] },
+        seen
+      ),
+      classify,
+      floor: 2,
+      offsets: [15.75, -15.75],
+      hasBudget: () => true,
+    });
+    expect(res.telemetry.escalations).toBe(1);
+    expect(res.telemetry.rings[1].offsetDeg).toBe(15.75);
+    expect(res.telemetry.rings[1].feedsSwept).toEqual(['sunrise']);
+    // Only the sunrise half of the day ring was requested.
+    expect(seen[1]).toEqual([{ lat: 15.75, lng: 1 }]);
+  });
+
+  it('tries the day side before the night side', async () => {
+    const res = await sweepWithEscalation({
+      buildRing: ring,
+      fetchCoords: stubFetcher({ 0: [] }),
+      classify,
+      floor: 5,
+      offsets: [15.75, -15.75],
+      hasBudget: () => true,
+    });
+    expect(res.telemetry.rings.map((r) => r.offsetDeg)).toEqual([
+      0, 15.75, -15.75,
+    ]);
+  });
+
+  it('stops escalating when the budget is gone', async () => {
+    const res = await sweepWithEscalation({
+      buildRing: ring,
+      fetchCoords: stubFetcher({ 0: [] }),
+      classify,
+      floor: 5,
+      offsets: [15.75, -15.75],
+      hasBudget: () => false,
+    });
+    expect(res.telemetry.rings).toHaveLength(1);
+    expect(res.telemetry.budgetExhausted).toBe(true);
+  });
+
+  it('deduplicates cameras seen on more than one ring', async () => {
+    const res = await sweepWithEscalation({
+      buildRing: ring,
+      fetchCoords: stubFetcher({ 0: [cam(1)], 15.75: [cam(1), cam(3)] }),
+      classify,
+      floor: 3,
+      offsets: [15.75],
+      hasBudget: () => true,
+    });
+    expect(res.webcams.map((w) => w.webcamId).sort()).toEqual([1, 3]);
+    expect(res.telemetry.rings[1].newWebcams).toBe(1);
+  });
+
+  it('unions coordinates across every ring it swept', async () => {
+    const res = await sweepWithEscalation({
+      buildRing: ring,
+      fetchCoords: stubFetcher({ 0: [] }),
+      classify,
+      floor: 5,
+      offsets: [15.75],
+      hasBudget: () => true,
+    });
+    expect(res.coords.sunriseCoords).toEqual([
+      { lat: 0, lng: 1 }, { lat: 15.75, lng: 1 },
+    ]);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm run test -- --run app/api/cron/update-cameras/lib/terminatorSweep.test.ts`
+Expected: FAIL — cannot resolve `./terminatorSweep`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `app/api/cron/update-cameras/lib/terminatorSweep.ts`:
+
+```ts
+import type { Location, WindyWebcam } from '@/app/lib/types';
+import type { CoordFetchResult } from './windyApi';
+
+export type Feed = 'sunrise' | 'sunset';
+
+export interface RingCoords {
+  sunriseCoords: Location[];
+  sunsetCoords: Location[];
+}
+
+export interface RingTelemetry {
+  offsetDeg: number;
+  feedsSwept: Feed[];
+  attempted: number;
+  empty: number;
+  /** Cameras this ring contributed that no earlier ring had seen. */
+  newWebcams: number;
+}
+
+export interface SweepTelemetry {
+  rings: RingTelemetry[];
+  counts: Record<Feed, number>;
+  escalations: number;
+  budgetExhausted: boolean;
+}
+
+export interface SweepResult {
+  webcams: WindyWebcam[];
+  coords: RingCoords;
+  telemetry: SweepTelemetry;
+}
+
+export interface SweepOptions {
+  buildRing: (offsetDeg: number) => RingCoords;
+  fetchCoords: (coords: Location[]) => Promise<CoordFetchResult>;
+  classify: (
+    webcams: WindyWebcam[],
+    sunriseCoords: Location[],
+    sunsetCoords: Location[]
+  ) => { sunrise: WindyWebcam[]; sunset: WindyWebcam[] };
+  floor: number;
+  offsets: readonly number[];
+  hasBudget: () => boolean;
+}
+
+const FEEDS: Feed[] = ['sunrise', 'sunset'];
+
+/** Feeds whose camera count is under the floor. Order is stable: sunrise first. */
+export function feedsBelowFloor(
+  counts: Record<Feed, number>,
+  floor: number
+): Feed[] {
+  return FEEDS.filter((f) => counts[f] < floor);
+}
+
+/**
+ * Sweep the terminator, widening within THIS tick while any feed is short.
+ *
+ * The escalation level is never stored. It is re-derived every tick from what
+ * the sweep actually returned, so it relaxes on its own the moment the
+ * terminator moves back over land. Cross-tick hysteresis was considered and
+ * rejected: widening succeeds, the count rises past the high-water mark, the
+ * next tick narrows, the count collapses, and it oscillates.
+ *
+ * Ring order matters. `offsets` is day-side first (positive offset shrinks the
+ * ring radius, moving it toward the sun), because the day-side ring lands in
+ * golden hour while the night-side one lands ~29 degrees below the horizon,
+ * where frames get gated anyway. Measured 2026-09-02: the +15.75 ring returned
+ * 100% cameras the base ring had never seen.
+ *
+ * Only the thin feed's half of an escalation ring is swept. The two feeds are
+ * routinely short at different times (4 vs 21 the day this was written), so
+ * this halves the cost of the common case.
+ */
+export async function sweepWithEscalation(
+  opts: SweepOptions
+): Promise<SweepResult> {
+  const byId = new Map<number, WindyWebcam>();
+  const sunriseCoords: Location[] = [];
+  const sunsetCoords: Location[] = [];
+  const rings: RingTelemetry[] = [];
+  let budgetExhausted = false;
+
+  const sweep = async (offsetDeg: number, feeds: Feed[]) => {
+    const ring = opts.buildRing(offsetDeg);
+    const coords: Location[] = [];
+    if (feeds.includes('sunrise')) {
+      sunriseCoords.push(...ring.sunriseCoords);
+      coords.push(...ring.sunriseCoords);
+    }
+    if (feeds.includes('sunset')) {
+      sunsetCoords.push(...ring.sunsetCoords);
+      coords.push(...ring.sunsetCoords);
+    }
+    const before = byId.size;
+    const res = await opts.fetchCoords(coords);
+    for (const w of res.webcams) byId.set(w.webcamId, w);
+    rings.push({
+      offsetDeg,
+      feedsSwept: feeds,
+      attempted: res.attempted,
+      empty: res.empty,
+      newWebcams: byId.size - before,
+    });
+  };
+
+  // Classify against the FULL coordinate set gathered so far, never against
+  // the triggering feed alone. A day-side box on the sunrise half can hold a
+  // camera that genuinely belongs to sunset, and forcing it into the feed that
+  // triggered the sweep would corrupt the split.
+  const currentCounts = (): Record<Feed, number> => {
+    const split = opts.classify(
+      [...byId.values()],
+      sunriseCoords,
+      sunsetCoords
+    );
+    return { sunrise: split.sunrise.length, sunset: split.sunset.length };
+  };
+
+  await sweep(0, FEEDS);
+  let counts = currentCounts();
+
+  for (const offsetDeg of opts.offsets) {
+    const thin = feedsBelowFloor(counts, opts.floor);
+    if (thin.length === 0) break;
+    if (!opts.hasBudget()) {
+      budgetExhausted = true;
+      break;
+    }
+    await sweep(offsetDeg, thin);
+    counts = currentCounts();
+  }
+
+  return {
+    webcams: [...byId.values()],
+    coords: { sunriseCoords, sunsetCoords },
+    telemetry: {
+      rings,
+      counts,
+      escalations: rings.length - 1,
+      budgetExhausted,
+    },
+  };
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npm run test -- --run app/api/cron/update-cameras/lib/terminatorSweep.test.ts`
+Expected: PASS, 10 tests.
+
+- [ ] **Step 5: Lint**
+
+Run: `npm run lint`
+Expected: clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git rev-parse --abbrev-ref HEAD   # must print feat/adaptive-terminator-widening
+git add app/api/cron/update-cameras/lib/terminatorSweep.ts \
+        app/api/cron/update-cameras/lib/terminatorSweep.test.ts
+git commit -m "feat(cron): per-feed terminator widening, decided within the tick"
+```
+
+---
+
+## Task 5: Add the tuning constants
+
+**Files:**
+- Modify: `app/lib/masterConfig.ts:33-35` (the `TERMINATOR_RING_OFFSETS_DEG` block)
+- Test: `app/lib/masterConfig.test.ts`
+
+**Interfaces:**
+- Produces: `TERMINATOR_CAMERA_FLOOR = 15`, `TERMINATOR_WIDEN_OFFSETS_DEG = [15.75, -15.75]`
+- Removes: `TERMINATOR_RING_OFFSETS_DEG`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `app/lib/masterConfig.test.ts`:
+
+```ts
+import {
+  TERMINATOR_CAMERA_FLOOR,
+  TERMINATOR_WIDEN_OFFSETS_DEG,
+} from './masterConfig';
+
+describe('terminator widening constants', () => {
+  it('starts the camera floor at 15 per feed', () => {
+    expect(TERMINATOR_CAMERA_FLOOR).toBe(15);
+  });
+
+  it('tries the day side before the night side', () => {
+    // Positive offset shrinks the ring radius, moving it toward the sun.
+    expect(TERMINATOR_WIDEN_OFFSETS_DEG[0]).toBeGreaterThan(0);
+    expect(TERMINATOR_WIDEN_OFFSETS_DEG).toEqual([15.75, -15.75]);
+  });
+
+  it('offsets the ring by more than a box width, or it re-finds the same cameras', () => {
+    // Measured 2026-09-02: a 3-degree offset against an 18-degree box returned
+    // only 26-35% new cameras; 15.75 returned 92-100%.
+    for (const off of TERMINATOR_WIDEN_OFFSETS_DEG) {
+      expect(Math.abs(off)).toBeGreaterThanOrEqual(SEARCH_RADIUS_DEG);
+    }
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm run test -- --run app/lib/masterConfig.test.ts`
+Expected: FAIL — the constants are not exported.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `app/lib/masterConfig.ts`, replace the whole `TERMINATOR_RING_OFFSETS_DEG` block:
+
+```ts
+// Per-feed camera count below which that feed sweeps an extra ring. Chosen
+// against a single observation (4 sunrise, 21 sunset on 2026-09-02); expect
+// to tune it once the sweep telemetry has a few days of history.
+export const TERMINATOR_CAMERA_FLOOR = 15;
+
+// Extra rings to sweep when a feed is under the floor, tried in this order.
+// radius = 90 - (sunAltitude + offset), so POSITIVE MOVES TOWARD DAY: +15.75
+// puts the ring near +2.75 degrees solar altitude (golden hour, which the base
+// ring at -13 misses entirely), and -15.75 puts it near -28.75 (deep night,
+// where the detection gate floors the frames anyway). Day side first.
+//
+// The magnitude is not arbitrary: the query box is 2 x SEARCH_RADIUS_DEG
+// across, so an offset smaller than the box mostly re-finds the same cameras.
+// Measured 2026-09-02 — a 3-degree offset returned 26-35% new cameras for a
+// full ring's worth of API calls; 15.75 returned 92-100%.
+export const TERMINATOR_WIDEN_OFFSETS_DEG = [15.75, -15.75] as const;
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npm run test -- --run app/lib/masterConfig.test.ts`
+Expected: PASS, 5 tests.
+
+- [ ] **Step 5: Confirm the old constant has no remaining readers**
+
+Run: `grep -rn "TERMINATOR_RING_OFFSETS_DEG" app/ --include=*.ts --include=*.tsx`
+Expected: two hits, both in files Task 6 rewrites — `app/api/cron/update-cameras/route.ts` and `app/components/Map/hooks/useUpdateTerminatorRing.ts`.
+
+The map hook draws the ring the operator sees. In `useUpdateTerminatorRing.ts`, replace the `ringResults` memo:
+
+```ts
+  // One ring at offset 0. Escalation rings are a fetch-time concern that
+  // varies tick to tick; drawing them would imply the map is showing cameras
+  // from all of them. Do not import TERMINATOR_WIDEN_OFFSETS_DEG here.
+  const ringResults = useMemo(() => {
+    return [
+      createTerminatorVisualizationRing(
+        currentTime,
+        raHours,
+        gmstHours,
+        precisionDeg,
+        TERMINATOR_SUN_ALTITUDE_DEG,
+        0,
+      ),
+    ];
+  }, [currentTime, raHours, gmstHours, precisionDeg]);
+```
+
+`offsetRing` on the next line becomes `ringResults[1]`, i.e. `undefined`. That is already the runtime behaviour today, since `TERMINATOR_RING_OFFSETS_DEG` is `[0]` and the array has one entry, so every consumer of `offsetRing` already handles undefined. Leave those consumers alone. Then drop `TERMINATOR_RING_OFFSETS_DEG` from this file's `masterConfig` import.
+
+- [ ] **Step 6: Run the map suite**
+
+Run: `npm run test -- --run app/components/Map/`
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git rev-parse --abbrev-ref HEAD   # must print feat/adaptive-terminator-widening
+git add app/lib/masterConfig.ts app/lib/masterConfig.test.ts \
+        app/components/Map/hooks/useUpdateTerminatorRing.ts
+git commit -m "feat(cron): add widening constants, retire the fixed offset ring list"
+```
+
+---
+
+## Task 6: Wire the escalation into the cron
+
+**Files:**
+- Modify: `app/api/cron/update-cameras/route.ts:75-115` (the ring + fetch block) and the final `NextResponse.json`
+
+**Interfaces:**
+- Consumes: `sweepWithEscalation`, `SweepTelemetry` (Task 4); `fetchCoordsCounted` (Task 3); `TERMINATOR_CAMERA_FLOOR`, `TERMINATOR_WIDEN_OFFSETS_DEG` (Task 5)
+- Produces: a `sweep: SweepTelemetry` field on the cron's JSON response
+
+- [ ] **Step 1: Replace the sweep block**
+
+In `route.ts`, replace everything from `// Generate terminator rings for all configured offsets` through `console.log('🗂️ Total unique webcams:', windyAll.length);` with:
+
+```ts
+  const sweep = await sweepWithEscalation({
+    buildRing: (offsetDeg) => {
+      const r = createTerminatorQueryRing(
+        now,
+        raHours,
+        gmstHours,
+        TERMINATOR_PRECISION_DEG,
+        TERMINATOR_SUN_ALTITUDE_DEG,
+        offsetDeg,
+      );
+      return {
+        sunriseCoords: dedupeCoords(r.sunriseCoords),
+        sunsetCoords: dedupeCoords(r.sunsetCoords),
+      };
+    },
+    fetchCoords: (coords) =>
+      fetchCoordsCounted(
+        dedupeCoords(coords),
+        WINDY_FETCH_BATCH_SIZE,
+        WINDY_FETCH_DELAY_BETWEEN_BATCHES_MS,
+      ),
+    classify: classifyWebcamsByPhase,
+    floor: TERMINATOR_CAMERA_FLOOR,
+    offsets: TERMINATOR_WIDEN_OFFSETS_DEG,
+    // Escalation rings are the first thing sacrificed on a slow tick: the
+    // scoring loop below needs the remaining budget more than the pool needs
+    // extra cameras. Half the deadline is the cutoff.
+    hasBudget: () => Date.now() - tickStartedAt < TICK_DEADLINE_MS / 2,
+  });
+
+  const sunriseCoords = sweep.coords.sunriseCoords;
+  const sunsetCoords = sweep.coords.sunsetCoords;
+  const windyAll = sweep.webcams.filter((w) => w.location);
+
+  console.log('🛰️ terminator sweep:', JSON.stringify(sweep.telemetry));
+```
+
+- [ ] **Step 2: Fix the imports**
+
+Remove `TERMINATOR_RING_OFFSETS_DEG` from the `masterConfig` import and add the two new constants. Remove `fetchWebcamsInBatches` and `dedupeWebcams` from the `./lib/windyApi` import if nothing else in the file uses them (check with `grep -n "dedupeWebcams\|fetchWebcamsInBatches" app/api/cron/update-cameras/route.ts`), and add `fetchCoordsCounted`. Add:
+
+```ts
+import { sweepWithEscalation } from './lib/terminatorSweep';
+```
+
+`tickStartedAt` is already defined in this handler; confirm it is assigned before the sweep block and move its declaration up if not.
+
+- [ ] **Step 3: Surface the telemetry on the response**
+
+In the final `NextResponse.json({...})`, add one field:
+
+```ts
+    sweep: sweep.telemetry,
+```
+
+- [ ] **Step 4: Typecheck and lint**
+
+Run: `npx tsc --noEmit`
+Expected: clean. Then `npm run lint`.
+
+- [ ] **Step 5: Run the whole suite**
+
+Run: `npm run test -- --run`
+Expected: PASS. If a test asserted the old response shape, update it to expect the added `sweep` field rather than deleting the assertion.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git rev-parse --abbrev-ref HEAD   # must print feat/adaptive-terminator-widening
+git add app/api/cron/update-cameras/route.ts
+git commit -m "feat(cron): sweep extra terminator rings when a feed runs thin"
+```
+
+- [ ] **Step 7: Push**
+
+```bash
+git -c credential.helper= -c credential.helper='!gh auth git-credential' \
+  push origin feat/adaptive-terminator-widening
+```
+
+---
+
+## Verification after merge
+
+The telemetry is the whole point; check it before trusting the feature.
+
+1. Hit the cron endpoint and read `sweep` in the JSON response. On a healthy tick expect `escalations: 0` and one ring entry.
+2. Wait for a thin period and confirm `escalations` rises, `rings[1].offsetDeg` is `15.75`, and `rings[1].newWebcams` is a meaningful fraction of `attempted`.
+3. **Watch `empty` across rings.** A rising `empty` count against a flat `newWebcams` count is the signature of a Windy quota wall, which is the one risk the spec calls out and cannot be measured from outside.
+4. **Check whether golden-hour frames actually pass the gate.** The spec's second risk: if the +15.75 ring's cameras are all gated to floor size, the day-side-first ordering is buying tiles that do not read as sunsets. Compare `passesGate` rates for cameras first seen on ring 1 versus ring 0.
+
+## Deferred, deliberately
+
+- **Persisting sweep telemetry to `daily_sunset_stats` for the Ops tab.** The spec asks for the Ops surface; this plan stops at the cron response and a structured log line, because persistence needs a migration and the response is enough to answer the two open risk questions. Follow-up once the shape has settled.
+- **Splitting antimeridian boxes.** Task 1 clamps rather than wrapping, losing a sliver of ocean.
+- **Cron cadence and image freshness.** Out of scope by decision.

--- a/docs/superpowers/specs/2026-09-02-adaptive-terminator-widening-design.md
+++ b/docs/superpowers/specs/2026-09-02-adaptive-terminator-widening-design.md
@@ -147,12 +147,27 @@ Extra rings are swept only if the tick has time left, reusing the existing
 drops the extra rings rather than overrunning. Budget is checked before
 each escalation step, not per call.
 
-### 5. Pole clamp
+### 5. Clamp the query box to the ranges Windy accepts
 
-At some declinations the ring passes within a degree of the pole and a box
-is built past ±90° latitude. That call fails and returns nothing. Measured:
-1 of 31 boxes on the sweep run for this design. Clamp the latitude bounds
-and keep the call.
+The box is built by unclamped arithmetic on the ring point, and Windy rejects
+four different out-of-range bounds. Verified live 2026-09-02:
+
+```
+northLat must not be greater than 90
+eastLon must not be greater than 180
+westLon must not be less than -180
+```
+
+Both edges are reached in practice. At some declinations the ring passes
+within a degree of the pole; and it crosses the antimeridian on every sweep.
+Measured on the run done for this design: **2 of 31 boxes lost**, one to each
+cause. `fetchWebcamsFor` swallows both as an empty array, so this has been
+invisible.
+
+Clamp all four bounds and keep the call. Clamping *shrinks* a box at the
+antimeridian rather than wrapping it, so a sliver on the far side is still
+lost; splitting into two boxes would recover it, but that stretch is open
+ocean and a shrunken box already beats a 400.
 
 ### 6. Instrumentation
 
@@ -164,9 +179,17 @@ Per tick, record and log:
 
 - escalation level reached, per feed
 - unique cameras contributed by each ring, per feed
-- boxes attempted, boxes failed, boxes skipped
+- boxes attempted, and boxes that came back empty
 
-Surfaced in the Ops tab alongside the existing cron counters.
+The empty count deliberately conflates "no cameras there" with "the call
+failed", because `fetchWebcamsFor` swallows non-OK responses. That
+conflation is the useful signal: a rising empty count against a flat camera
+count is the signature of an API wall.
+
+**Surface:** the cron's JSON response plus one structured log line. Persisting
+to `daily_sunset_stats` for the Ops tab needs a migration and is deferred
+until the telemetry shape has settled — the response is enough to answer both
+open risks below.
 
 ## Explicitly not doing
 

--- a/docs/superpowers/specs/2026-09-02-adaptive-terminator-widening-design.md
+++ b/docs/superpowers/specs/2026-09-02-adaptive-terminator-widening-design.md
@@ -1,0 +1,228 @@
+# Adaptive terminator widening — design
+
+**Date:** 2026-09-02
+**Status:** design, awaiting review
+**Branch:** `feat/adaptive-terminator-widening`
+
+## Problem
+
+Kiosk panels go blank. Not because tiles are hidden — the mosaic shows every
+frame, gate-failers pinned to floor size — but because the terminator pool
+genuinely runs out of cameras.
+
+Measured live on 2026-09-02: **25 cameras active** (4 sunrise, 21 sunset).
+A full independent sweep run against Windy at the same moment returned **23
+unique cameras from 29 successful boxes**. Nothing downstream is filtering
+them out. The sweep is finding that little.
+
+The operator wants the system to go looking for more cameras on its own when
+a panel goes thin, and to stop looking once it recovers.
+
+## What we measured
+
+All numbers from live Windy calls on 2026-09-02, same ring, same instant.
+
+### The search radius is capped by Windy, not by us
+
+`masterConfig.ts` carries the note "12 doesn't work / 11 is the widest that
+works" with no explanation. It is an API rule:
+
+```
+{"message":"Maximal distance between north and south latitudes on the
+zoom level 4, should be 22.5!","error":"Bad Request","statusCode":400}
+```
+
+The query box spans `2 × SEARCH_RADIUS_DEG`, so the hard ceiling is 11.25.
+`zoom` cannot be lowered to buy more — the API rejects `zoom < 4` outright.
+
+| search radius | lat span | result |
+| --- | --- | --- |
+| 9 (today) | 18° | 200 |
+| 11 | 22° | 200 |
+| 12 | 24° | 400 — over the cap |
+
+**Consequence:** widening a single ring is nearly exhausted. 9 → 11 is all
+that is available, about 22% more ground.
+
+### Small ring offsets mostly re-find the same cameras
+
+Each ring costs ~30 API calls. Yield per ring, against the base sweep:
+
+| ring offset | cameras | new | share new |
+| --- | --- | --- | --- |
+| base (0°) | 23 | — | — |
+| +3° | 26 | 9 | 35% |
+| −3° | 27 | 7 | 26% |
+| +15.75° | 33 | 33 | 100% |
+| −15.75° | 26 | 24 | 92% |
+
+The search box is 18° across. Shifting its center by 3° leaves it on
+substantially the same ground. To find new cameras the offset must be
+comparable to the box size — which is what the commented-out
+`1.75 * SEARCH_RADIUS_DEG` (15.75°) in `masterConfig.ts` already was.
+
+### The two sides are not equivalent
+
+`radius = 90 - (sunAltitude + offsetDeg)`, so a **positive offset moves the
+ring toward day**.
+
+| ring | sun altitude at ring | band with box spread | character |
+| --- | --- | --- | --- |
+| base | −13° | ≈ −22° to −4° | twilight into night |
+| +15.75° | ≈ +2.75° | ≈ −6° to +12° | **golden hour** |
+| −15.75° | ≈ −28.75° | ≈ −38° to −20° | deep night |
+
+The current single-ring configuration misses golden hour entirely. The
+day-side ring is where sunsets actually are; the night-side ring returns
+frames the detection gate will floor anyway.
+
+**Consequence:** widening is asymmetric. Day side first, night side only as
+a last resort.
+
+## Design
+
+### 1. Baseline: search radius 9 → 11
+
+Free. Same 30 calls, 22% more ground per call, still inside the 22.5° cap.
+This is a baseline change, not a widening level.
+
+### 2. Escalate within a tick, per feed
+
+The decision happens **inside one cron tick**, not across ticks:
+
+1. Sweep the base ring. Classify results into sunrise/sunset.
+2. For each feed under `TERMINATOR_CAMERA_FLOOR`, sweep that feed's half of
+   the **day-side** ring (+15.75°).
+3. For each feed still under the floor, sweep that feed's half of the
+   **night-side** ring (−15.75°).
+
+Cameras returned by an escalation ring are classified the same way as the
+base sweep — nearest ring coordinate across the full coordinate set, not
+assumed to belong to the feed that triggered the sweep. A day-side box on
+the sunrise half can legitimately contain a camera closer to the sunset
+half, and silently forcing it into the triggering feed would corrupt the
+split.
+
+Nothing is stored between ticks. The level is re-derived every tick from what
+the sweep actually returned, so it relaxes on its own the moment the
+terminator moves back over land.
+
+**Why not cross-tick hysteresis:** it oscillates. Widening succeeds, the
+count rises above the high-water mark, the next tick narrows, the count
+collapses, and it widens again. Deciding inside the tick has no such mode.
+
+**Why per feed:** the ring already arrives split into halves
+(`createTerminatorQueryRing` returns `sunriseCoords` / `sunsetCoords`), and
+the two feeds are routinely thin at different times — 4 vs 21 on the day
+this was written. Widening only the thin half halves the cost of the common
+case. Note the cron currently unions both halves into `allCoords` before
+fetching and classifies afterward; this design needs the base sweep
+classified before the escalation decision.
+
+### 3. Cost
+
+Calls per tick, at `TERMINATOR_PRECISION_DEG = 12` (31 ring points, all
+usable once the pole clamp lands). A feed's half-ring is ~15 points.
+
+| situation | calls |
+| --- | --- |
+| both feeds healthy | ~31 |
+| one feed thin, day ring | ~46 |
+| one feed thin, both rings | ~61 |
+| both feeds thin, both rings | ~91 |
+
+At the unchanged 15-minute cadence that is ~3,000 calls/day today, rising
+only on blank ticks.
+
+**Read the measured yields with care.** The +15.75 / −15.75 numbers in the
+table above were full-ring sweeps: one extra full ring took the pool from
+23 to 56, both took it to 80. Per-feed escalation sweeps a half-ring, so a
+single thin feed should expect roughly half that yield for half the calls.
+The yield *rate* is what carries over, not the absolute counts.
+
+### 4. Fail-soft on the tick budget
+
+Extra rings are swept only if the tick has time left, reusing the existing
+`TICK_DEADLINE_MS` check that already bounds the scoring loop. A slow tick
+drops the extra rings rather than overrunning. Budget is checked before
+each escalation step, not per call.
+
+### 5. Pole clamp
+
+At some declinations the ring passes within a degree of the pole and a box
+is built past ±90° latitude. That call fails and returns nothing. Measured:
+1 of 31 boxes on the sweep run for this design. Clamp the latitude bounds
+and keep the call.
+
+### 6. Instrumentation
+
+Required, not optional. Without it we cannot tell whether widening helped or
+whether we bought 60 extra calls for nothing — and more calls means more of
+`fetchWebcamsFor`'s silent `return []` on a non-OK response.
+
+Per tick, record and log:
+
+- escalation level reached, per feed
+- unique cameras contributed by each ring, per feed
+- boxes attempted, boxes failed, boxes skipped
+
+Surfaced in the Ops tab alongside the existing cron counters.
+
+## Explicitly not doing
+
+- **No cron cadence change.** The camera list tracks the terminator, which
+  sweeps 15°/hour across a ~22° band, so the scene turns over roughly every
+  90 minutes. A 15-minute tick is already six times finer. Widening more
+  often would not find cameras sooner. Image freshness is a separate
+  decision with its own cost, to be taken deliberately.
+- **No small offsets.** Measured at 26–35% new; not worth 30 calls.
+- **No stored escalation level.** Derived per tick.
+- **No `zoom` change.** The API rejects `zoom < 4`.
+
+## Constants
+
+New, in `masterConfig.ts`:
+
+| name | value | meaning |
+| --- | --- | --- |
+| `TERMINATOR_CAMERA_FLOOR` | 15 | per-feed camera count below which that feed widens |
+| `TERMINATOR_WIDEN_OFFSETS_DEG` | `[15.75, -15.75]` | escalation rings, in order; day side first |
+
+Changed:
+
+| name | from | to |
+| --- | --- | --- |
+| `SEARCH_RADIUS_DEG` | 9 | 11 |
+
+`TERMINATOR_RING_OFFSETS_DEG` (currently `[0]`, with the 15.75 value
+commented beside it) is superseded by the escalation list and should be
+removed rather than left as a second, contradictory widening mechanism.
+
+## Testing
+
+The escalation decision and the ring geometry are pure functions and get
+unit tests:
+
+- level selection: below floor escalates, at/above floor does not, per feed
+  independently
+- ordering: day-side ring is always tried before night-side
+- budget: no escalation when the deadline has passed
+- pole clamp: a ring point near the pole yields an in-range box
+- offset geometry: `+15.75` produces a smaller radius than base
+
+The Windy client (`fetchWebcamsFor`) is already isolated and is stubbed in
+these tests. No live API calls in the suite.
+
+## Risks
+
+- **Windy quota is unknown.** The API publishes no rate-limit headers. Today's
+  ~2,900 calls/day rises only on blank ticks under this design, so the risk is
+  small, but if an undiscovered ceiling exists, exhausting it makes blank
+  screens *more* common. The instrumentation's failed-box counter is the
+  detector.
+- **Golden-hour frames may not read as sunsets.** The +15.75 ring reaches sun
+  altitudes above the horizon. Whether the detection head passes those frames
+  is unmeasured. If it gates most of them, the day-side ring adds tiles at
+  floor size rather than real sunsets. Worth measuring once live.
+- **The 15 floor is a guess.** Chosen against a single observation (4 sunrise,
+  21 sunset). Expect to tune it.

--- a/docs/superpowers/specs/2026-09-02-adaptive-terminator-widening-design.md
+++ b/docs/superpowers/specs/2026-09-02-adaptive-terminator-widening-design.md
@@ -188,8 +188,38 @@ count is the signature of an API wall.
 
 **Surface:** the cron's JSON response plus one structured log line. Persisting
 to `daily_sunset_stats` for the Ops tab needs a migration and is deferred
-until the telemetry shape has settled — the response is enough to answer both
+until the telemetry shape has settled — the response is enough to answer the
 open risks below.
+
+`RingTelemetry` carries both `newWebcams` (a scalar, for logs and dashboards)
+and `newWebcamIds` (the ids behind it). The ids are what make the golden-hour
+risk below *measurable*: without knowing which ring a camera came from, the
+gate-pass comparison the risk asks for cannot be run against what shipped.
+
+### 7. Escalation rings also widen custom-camera eligibility — accepted
+
+`sweep.coords` is the **union across every ring swept this tick**, and that
+union is what `classifyCustomCamerasForTick` receives. It uses
+`SEARCH_RADIUS_DEG` as a hard distance threshold against those coordinates,
+so on an escalated tick the eligible set includes the golden-hour ring's
+points, and a custom camera can be classified as an active sunset camera
+while it is in broad daylight.
+
+This is accepted, not a defect:
+
+- It is the same rule the Windy half already follows. An escalated tick pulls
+  Windy cameras from the day-side ring too; excluding custom cams from the
+  widening would make the operator's own cameras *less* visible than
+  third-party ones on exactly the ticks where the panel is thin.
+- Custom cams are the cameras the operator can actually inspect. A daylight
+  frame from one is diagnostic, not noise.
+- The detection gate still applies downstream. A daylight custom frame is
+  pinned to floor size like any other gate-failer; nothing claims it is a
+  sunset.
+
+Passing the base ring's coordinates alone to the custom classifier would
+undo this, and is the change to make if daylight custom cams turn out to be
+a problem in practice. Do not make it speculatively.
 
 ## Explicitly not doing
 
@@ -246,6 +276,35 @@ these tests. No live API calls in the suite.
 - **Golden-hour frames may not read as sunsets.** The +15.75 ring reaches sun
   altitudes above the horizon. Whether the detection head passes those frames
   is unmeasured. If it gates most of them, the day-side ring adds tiles at
-  floor size rather than real sunsets. Worth measuring once live.
+  floor size rather than real sunsets. Worth measuring once live — compare
+  gate-pass rates for the ids in `rings[1].newWebcamIds` against
+  `rings[0].newWebcamIds`.
+- **The floor counts cameras, not gate-passers — so widening can report
+  success while the panel stays blank.** `TERMINATOR_CAMERA_FLOOR` is compared
+  against every camera the sweep found, gate-failers included; the escalation
+  loop has no visibility into the detection gate at all. Combine that with the
+  risk above and there is a specific failure the telemetry will look healthy
+  through: the day-side ring adds 16 daylight cameras, all of them floored by
+  the gate, the count clears 15, escalation stops, and the panel is exactly as
+  empty as before. `escalations: 1` and a fat `newWebcams` would both read as
+  the feature working.
+
+  Recorded here so that when the telemetry arrives the right question gets
+  asked. The question is **"should the floor count only gate-passers?"** — not
+  "should the floor be 20?" Raising the floor treats the symptom and buys more
+  API calls for more floored tiles. Answering it needs the gate-pass rates
+  from the risk above; if golden-hour frames largely pass, this is moot and
+  the floor stays a plain camera count.
+- **`hasBudget` is a start-gate, not a deadline.** It is checked once before
+  each escalation ring, never during one, so a ring that starts just under
+  `TERMINATOR_SWEEP_BUDGET_MS` runs to completion — roughly 5–7s for a
+  half-ring at the current settings (~15 points at `WINDY_FETCH_BATCH_SIZE` 5
+  is 3 batches, each carrying up to 800 ms of within-batch stagger plus fetch
+  latency, with two 1s inter-batch delays). Worst case the sweep
+  overshoots its budget by about that much, still comfortably inside
+  `TICK_DEADLINE_MS` (50s) and the route's declared `maxDuration` (60s).
+  Accepted as-is: per-call budget checks would leave a ring half-swept, which
+  is worse telemetry than a slightly long one. Revisit if production ticks
+  show the sweep crowding the scoring loop.
 - **The 15 floor is a guess.** Chosen against a single observation (4 sunrise,
   21 sunset). Expect to tune it.

--- a/docs/superpowers/specs/2026-09-02-camera-refresh-cost-design.md
+++ b/docs/superpowers/specs/2026-09-02-camera-refresh-cost-design.md
@@ -1,0 +1,147 @@
+# Camera refresh — what it costs, and why the cron is the wrong lever
+
+**Date:** 2026-09-02
+**Status:** measured; recommendation is *change nothing*
+**Comes from:** `docs/superpowers/plans/2026-09-02-adaptive-terminator-widening-followups.md`
+**Related:** `docs/superpowers/specs/2026-09-02-adaptive-terminator-widening-design.md`
+
+## The question, split
+
+The widening design refused to touch cron cadence and left this as a separate
+decision with its own price. Two clocks were being conflated in that
+conversation and they stay separate here:
+
+- **The camera list** turns over as the terminator sweeps, roughly every 90
+  minutes. A 15-minute tick already samples that six times over. Not the ask.
+- **The images themselves** are what wanted a 1-2 minute cadence for the
+  exhibit. That is the real ask, and it is the only thing priced below.
+
+## The answer
+
+**A 1-2 minute image cadence is not purchasable at any price, because Windy
+publishes a new preview every 10.1 minutes.** Nothing downstream — not the
+cron, not the CDN, not the browser — can produce a frame that does not exist.
+
+Measured 2026-09-02, 8 active production cameras, 10 samples each over 11
+minutes, each request cache-busted so it reached the origin rather than an
+edge copy. Cadence is the gap between distinct `last-modified` stamps.
+
+| camera | distinct frames | gaps (min) |
+| --- | --- | --- |
+| 1622614150 | 2 | 10.1 |
+| 1649934103 | 2 | 10.1 |
+| 1689792515 | 3 | 10.2, 10.1 |
+| 1716072397 | 2 | 20.3 |
+| 1737960418 | 2 | 10.2 |
+| 1753860434 | 2 | 10.1 |
+| 1760443221 | 2 | 10.1 |
+| 1793907964 | 3 | 10.2, 10.1 |
+
+Ten gaps, median 10.1 minutes, and the single 20.3 is one camera missing a
+slot rather than a different schedule. This is a publishing clock, not a
+per-camera property.
+
+## Why the cron cannot help even at 10 minutes
+
+Windy preview URLs are stable per camera and content-updating:
+
+```
+https://imgproxy.windy.com/_/preview/plain/current/<webcamId>/original.jpg?v=2
+```
+
+The cron stores that URL in `webcams.images`; the browser fetches the bytes
+straight from Windy's CDN. Running the cron more often re-stores the same
+string more often. Not one pixel changes sooner. The cron is not in the image
+path at all.
+
+## What does govern on-glass freshness
+
+Three gates. The first dominates by a factor of four.
+
+1. **Windy's 10.1-minute publishing clock.** The hard ceiling.
+2. **`cache-control: public, max-age=150` on the CDN response.** A browser
+   holds a fetched preview for 150 s. Already four times finer than gate 1,
+   so it adds at most 2.5 minutes of staleness on top.
+3. **The kiosk re-creating the image elements.** Already finer than gate 2:
+   `useLoadTerminatorWebcams` polls with SWR every 60 s, the store rebuilds
+   its arrays on every payload, and `useLoadedTiles` constructs a fresh
+   `new Image()` per webcam whenever that array changes.
+
+Worst case on glass is about 12.5 minutes old, typical is around 5. Gates 2
+and 3 are not worth touching: eliminating gate 2 entirely would improve the
+worst case by 20%, and gate 3 is already doing its job.
+
+The edge cache is looser than `max-age=150` suggests, incidentally. One
+camera served an edge copy stamped 17:04:00 at 17:12:30 while a cache-busted
+request at 17:14:43 returned one stamped 17:14:15 — the edge had re-fetched
+at a moment when the origin was itself between publications. That is a
+consequence of gate 1, not a separate problem.
+
+## What raising the cron cadence would cost
+
+15 minutes to 2 minutes is 96 ticks/day to 720: a 7.5x multiplier on
+everything the tick does, for zero image freshness.
+
+| axis | today | at 2 minutes |
+| --- | --- | --- |
+| Windy cluster calls | ~2,980/day (31 boxes x 96) | ~22,300/day |
+| Frames scored (ONNX) | 5,400-7,450/day, measured | damped by the image-hash cache, but the cache only helps because most polls would find *the same frame* |
+| Neon compute, whole project | 2.5-3.3 CU-hr/day, measured | the cron's share x 7.5 |
+| Vercel function time | 96 x tick duration | 720 x tick duration |
+| Image freshness | — | **unchanged** |
+
+The Neon figure needs care: 2.5-3.3 CU-hr/day is the whole project, roughly
+$0.35-0.46/day at the $0.14/CU-hr the digest assumes, and the cron is only
+part of it. If the cron were even half, 7.5x on that half is about
++$1.30-1.70/day, turning a $13/month bill into roughly $50/month.
+
+Two numbers are **not** measured here and would need to be before any cadence
+change: the update-cameras function's wall-clock duration, and the cron's
+share of Neon compute. Neither changes the recommendation, because the
+benefit side is zero.
+
+The worst cost is not on that table. Windy publishes no rate limit and no
+quota headers. 22,300 calls/day is the most likely way to discover a ceiling,
+and discovering it makes panels *blanker* — the outcome the widening feature
+exists to prevent.
+
+## Recommendation
+
+**Change nothing.** Do not touch `vercel.json`, and do not add a client-side
+cache-buster either — that was the fallback before the 10-minute clock was
+measured, and against a 10-minute publisher it would burn roughly 0.6 MB of
+kiosk bandwidth per cycle (53 cameras at a measured 5.3-18.0 KB, mean 11.1
+KB) to re-fetch bytes that are usually identical.
+
+**If 1-2 minute freshness is genuinely required for the exhibit, Windy is the
+wrong source and no amount of tuning fixes that.** The custom Pi cameras are
+the only path to it, since their upload cadence is ours to choose — see
+`docs/device-protocol.md`. That is a hardware and bandwidth decision, priced
+separately, and it does not touch the cron.
+
+## A different question the numbers did raise
+
+The cron ticks every 15 minutes against a 10.1-minute publisher, so it is
+slightly *coarser* than the source: some published frames are never scored,
+and the leaderboard never sees them as candidates. Matching the cron to the
+publishing clock at 10 minutes would cost 1.5x rather than 7.5x and would
+stop dropping frames.
+
+This is a **scoring**-coverage argument, not an image-freshness one, and
+nobody has asked for it. It is written down so it does not get folded into an
+image-freshness change silently, and so the 1.5x option is on the table if
+frame coverage ever turns out to matter for the leaderboard.
+
+## Facts this rests on, all measured 2026-09-02
+
+| fact | value |
+| --- | --- |
+| Windy publishing cadence | 10.1 min median over 10 observed gaps, 8 cameras |
+| Preview URL shape | `imgproxy.windy.com/_/preview/plain/current/<id>/original.jpg?v=2`, stable per camera |
+| CDN cache policy | `public, max-age=150` |
+| Preview size | 5.3-18.0 KB, mean 11.1 KB, 80 samples |
+| Active cameras | 8 sunrise, 45 sunset |
+| Frames scored | 5,403 (9/1), 7,450 (8/31), 6,920 (8/30) per day |
+| Neon compute, this project | 2.50-4.84 CU-hr/day over 8/24-9/01 |
+| Kiosk payload poll | SWR, 60 s |
+| Kiosk image reload | `new Image()` per webcam on every payload change |


### PR DESCRIPTION
## What this does

Kiosk panels go blank because the terminator pool genuinely runs out of cameras. Measured live on 2026-09-02: **25 cameras active**, and an independent full sweep at the same moment returned **23**. Nothing downstream was filtering them — the sweep was finding that little.

This makes the sweep widen itself. When a feed comes back under a camera floor, the same tick sweeps an extra ring offset toward day, then if still short, one into night. Nothing is stored between ticks, so it relaxes on its own the moment the terminator moves back over land.

## Three things measured against the live API, not assumed

**The `// 12 doesn't work` note in `masterConfig.ts` was a Windy API rule, not our bug.** The clusters endpoint caps the box's north-south span at 22.5° on zoom 4 and rejects `zoom < 4` outright, so `SEARCH_RADIUS_DEG` is hard-capped at 11.25. That folklore is now an enforced guard test.

**Small ring offsets mostly re-find the same cameras.** The search box is 18° across, so a 3° shift lands on substantially the same ground.

| ring offset | cameras | new | share new |
| --- | --- | --- | --- |
| base | 23 | — | — |
| +3° | 26 | 9 | 35% |
| −3° | 27 | 7 | 26% |
| +15.75° | 33 | 33 | 100% |
| −15.75° | 26 | 24 | 92% |

**The two sides are not equivalent.** `radius = 90 - (sunAltitude + offset)`, so positive moves toward day. The `+15.75` ring sits near +2.75° solar altitude — golden hour, which the base ring at −13° misses entirely. The `-15.75` ring sits near −28.75°, deep night, where the detection gate floors the frames anyway. So widening is asymmetric: day side first.

## Also fixes a silent failure that was invisible

The query box was built by unclamped arithmetic. Windy rejects `northLat > 90`, `eastLon > 180` and `westLon < -180`, and `fetchWebcamsFor` swallows every non-OK response as an empty array. The ring reaches the pole at some declinations and crosses the antimeridian on every sweep — **2 of 31 boxes lost per sweep**, silently, for as long as this has been running.

## Cost

Calls rise only on thin ticks. Cadence is unchanged at 15 minutes, deliberately: the camera list tracks the terminator, which turns over about every 90 minutes, so a 15-minute tick already over-samples it six times over.

| situation | calls/tick |
| --- | --- |
| both feeds healthy | ~31 |
| one feed thin, day ring | ~46 |
| both feeds thin, both rings | ~91 |

## Review notes

Six tasks, each TDD with its own review. The final whole-branch review caught a real bug in an accepted assumption: raising `SEARCH_RADIUS_DEG` from 9 to 11 also feeds `update-youtube`, which converts it to kilometres. That was 999 km, tuned just under the YouTube Data API's documented 1000 km `locationRadius` cap; at 11 it becomes 1221 km, which that API rejects and that code swallows. The cron is currently disabled, so nothing breaks today — it was armed for whoever re-enables it. Now clamped, with its own named constant and guard test.

**Two risks are deliberately unresolved in code**, because both need production telemetry and guessing now would bake in a second unmeasured number. Both are written into the spec's Risks:

- The camera floor counts gate-failers, so a day-side ring of floored daylight frames could satisfy the floor and suppress the night ring — reporting success while leaving the panel blank.
- `hasBudget` is a start-gate, not a deadline; a ring starting just under budget runs to completion.

Twelve further deferred findings, plus a paste-ready prompt for the follow-up work, are in `docs/superpowers/plans/2026-09-02-adaptive-terminator-widening-followups.md`.

## Testing

Full suite green: **1227 tests across 188 files**. The sign convention everything depends on is now pinned by a test that measures real great-circle geometry rather than restating the implementation's arithmetic — verified by mutation, flipping the sign fails four tests.

## Added after the original description

Three follow-up commits landed on this branch before merge.

**The sweep telemetry is now persisted and reaches the daily digest.** It
previously reached only the cron's JSON response and one log line, so neither
question the feature exists to answer survived the tick: how often did a feed
fall under the camera floor, and what did the extra rings cost against the
~3,000 boxes/day baseline. `daily_sunset_stats` gains tick-level counters,
each 0 or 1 per tick so a column reads as "N of today's ticks", and a new
`daily_sweep_ring_stats` holds at most three rows a day, one per ring offset.

That split is what makes the **first unresolved risk above measurable rather
than deferred**. Each camera is credited to the ring that first saw it, so a
gate verdict at scoring time lands on the ring that paid for it. A day-side
ring adding cameras the detection gate then floors looks identical to one
that works — escalations rise, new-camera counts rise, the panel stays blank.
Only the per-ring gate-pass rates separate them, and the digest now prints
the day-side rate beside the base rate every night.

**The second risk is now a guarded invariant.** `TICK_DEADLINE_MS` moved out
of the route into `masterConfig.ts`, where a test pins
`TERMINATOR_SWEEP_BUDGET_MS * 2 <= TICK_DEADLINE_MS`. The start-gate itself is
unchanged; what changed is that the relationship is no longer a comment
spanning two files.

**Five of the twelve deferred findings are closed**, the ones that did not
need production data: the unclamped bounding box in the public webcams route,
which now reuses `boundingBox()`; dead offset-ring code and a whole Mapbox
layer for a ring that could never exist; the deadline invariant above; an
offset-magnitude assertion weak enough that an unmeasured value would clear
it; and a local name that hid the 1:1 counting invariant in
`fetchCoordsCounted`.

**Camera refresh was priced and the answer is to change nothing.** Measured
across 8 production cameras, Windy publishes a new preview every 10.1 minutes
(median of 10 observed gaps, cache-busted to reach the origin). The cron is
not in the image path at all — preview URLs are stable per camera and the
browser fetches the bytes from Windy's CDN — so a 2-minute cron would
multiply Windy calls from ~2,980 to ~22,300 a day and change zero pixels. The
custom Pi cameras are the only path to 1-2 minute freshness. Full pricing in
`docs/superpowers/specs/2026-09-02-camera-refresh-cost-design.md`.

**One correction to this branch's own documents.** They stated that a new
ring offset must exceed `2 x SEARCH_RADIUS_DEG`. That is 22, the shipped
offset is 15.75, so the escalation boxes already overlap the base ring's
ground and the configuration works anyway. The 92-100% yield in the table
above is measured, not implied by geometry.

**Deploy note:** `database/migrations/20260902_sweep_telemetry.sql` must be
applied or `upsertSweepStats` swallows the missing table by design and the
telemetry is silently dropped. Applied to production 2026-09-02.

Suite green at **1250 tests across 189 files**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LQrLTX6fu6hHtvCEuQd6sj

