### PR TITLE
feat(mosaic): put the sunrise and sunset panels on one ruler

### DIFF
--- a/app/components/mosaic/types.ts
+++ b/app/components/mosaic/types.ts
@@ -12,6 +12,13 @@ export interface MosaicProps {
   width: number;
   height: number;
   feed: 'sunrise' | 'sunset';
+  /**
+   * The OTHER feed's pool. Purely for cross-panel coordination: a version
+   * may use it to size or scale this panel on the same ruler as its twin,
+   * and must render nothing from it. Surfaces showing one panel alone omit
+   * it, and every version must still compose correctly without it.
+   */
+  peerWebcams?: WindyWebcam[];
   setupMode?: boolean;
   onSelect?: (webcam: WindyWebcam) => void;
   /** Raw query string of the hosting page, for version-specific params. */

--- a/app/components/mosaic/v2/engine/bands.test.ts
+++ b/app/components/mosaic/v2/engine/bands.test.ts
@@ -6,6 +6,7 @@ import type { SizedTile, V2Config } from './types';
 const cfg = (over: Partial<V2Config> = {}): V2Config => ({
   qualitySource: 'auto', gateThreshold: 0.55, failedCamPolicy: 'showAtFloor', maxTiles: 0,
   floorPx: 100, ceilingPx: 500, curve: 'linear',
+  scoreFloor: 0, scoreCeiling: 1, sharedScale: true,
   strategy: 'latitudeBands', bandCount: 4, horizontalAnchor: 'order',
   rowAlign: 'center', geographicFidelity: 0.7, tileGapPx: 0, latNorth: 80, latSouth: -80,
   showFeedLabel: true, showTileRatings: false, showModelReadout: false,

--- a/app/components/mosaic/v2/engine/compose.test.ts
+++ b/app/components/mosaic/v2/engine/compose.test.ts
@@ -5,6 +5,7 @@ import type { TileInput, V2Config } from './types';
 const cfg = (over: Partial<V2Config> = {}): V2Config => ({
   qualitySource: 'auto', gateThreshold: 0.55, failedCamPolicy: 'showAtFloor', maxTiles: 0,
   floorPx: 100, ceilingPx: 400, curve: 'percentileAmongPassers',
+  scoreFloor: 0, scoreCeiling: 1, sharedScale: true,
   strategy: 'anchorRelax', bandCount: 8, horizontalAnchor: 'solarAltitude',
   rowAlign: 'center', geographicFidelity: 0.7, tileGapPx: 6, latNorth: 70, latSouth: -60,
   showFeedLabel: true, showTileRatings: false, showModelReadout: false,
@@ -146,5 +147,58 @@ describe('compose — strategies', () => {
     const a = compose(pool, viewport, cfg(), 'sunset');
     const b = compose(pool, viewport, cfg(), 'sunset');
     expect(a).toEqual(b);
+  });
+});
+
+describe('compose — one scale across both panels', () => {
+  const panel = { width: 600, height: 800 };
+  const crowded = Array.from({ length: 80 }, (_, i) => tile(i + 1, 60 - i * 1.5, false, 0.1));
+  const sparse = [tile(901, 50, true, 0.9), tile(902, 20, true, 0.8)];
+
+  it('shrinks the sparse panel to match its crowded twin', () => {
+    const alone = compose(sparse, panel, cfg(), 'sunrise');
+    const paired = compose(sparse, panel, cfg(), 'sunrise', crowded);
+    expect(alone.scale).toBe(1);
+    expect(paired.scale).toBeLessThan(1);
+    expect(paired.scale).toBe(compose(crowded, panel, cfg(), 'sunset', sparse).scale);
+  });
+
+  it('leaves the crowded panel on the scale it already needed', () => {
+    const alone = compose(crowded, panel, cfg(), 'sunset');
+    const paired = compose(crowded, panel, cfg(), 'sunset', sparse);
+    expect(paired.scale).toBe(alone.scale);
+  });
+
+  it('renders a floor tile at the same height on both panels', () => {
+    const c = cfg({ curve: 'linear', floorPx: 100, ceilingPx: 400 });
+    const sunriseFloor = compose(
+      [...sparse, tile(903, 0, false, null)], panel, c, 'sunrise', crowded
+    ).tiles.find((t) => t.id === 903)!;
+    const sunsetFloor = compose(crowded, panel, c, 'sunset', sparse).tiles[0];
+    expect(sunriseFloor.height).toBeCloseTo(sunsetFloor.height, 6);
+  });
+
+  it('is off by the sharedScale knob', () => {
+    const paired = compose(sparse, panel, cfg({ sharedScale: false }), 'sunrise', crowded);
+    expect(paired.scale).toBe(1);
+  });
+
+  it('ignores an empty peer pool', () => {
+    expect(compose(sparse, panel, cfg(), 'sunrise', []).scale).toBe(1);
+  });
+
+  it('composes identically when no peer is supplied at all', () => {
+    expect(compose(crowded, panel, cfg(), 'sunset')).toEqual(
+      compose(crowded, panel, cfg(), 'sunset', [])
+    );
+  });
+
+  it('still drops rather than overflowing when the shared scale is not enough', () => {
+    const huge = Array.from({ length: 400 }, (_, i) =>
+      tile(i + 1, 60 - i * 0.3, i === 0, i === 0 ? 0.99 : 0.01)
+    );
+    const layout = compose(huge, { width: 300, height: 400 }, cfg(), 'sunset', sparse);
+    expect(layout.dropped.length).toBeGreaterThan(0);
+    expect(layout.tiles.some((t) => t.id === 1)).toBe(true);
   });
 });

--- a/app/components/mosaic/v2/engine/compose.ts
+++ b/app/components/mosaic/v2/engine/compose.ts
@@ -31,6 +31,56 @@ function fits(
 }
 
 /**
+ * The visible candidate set for a pool: gate split, the operator's
+ * failed-cam policy, then the hard tile cap. Pulled out of `compose` so the
+ * peer feed can be run through exactly the same funnel when the two panels
+ * share one scale.
+ */
+export function selectCandidates(
+  tiles: TileInput[],
+  viewport: { width: number; height: number },
+  cfg: V2Config
+): TileInput[] {
+  const { passers, failers } = splitPool(tiles);
+  const candidates =
+    cfg.failedCamPolicy === 'showIfRoom'
+      ? [
+          ...passers,
+          ...failers.slice(0, largestFittingCount(passers, failers, viewport, cfg, 1)),
+        ]
+      : applyPolicy(passers, failers, cfg);
+  return capTiles(candidates, cfg.maxTiles);
+}
+
+/**
+ * Smallest uniform scale this candidate set needs to fit the panel: 1 when
+ * it already fits, never below MIN_COMPOSITION_SCALE.
+ *
+ * The iterative step can exhaust its passes while still overflowing and
+ * still above the floor — extent is not linear in scale (gaps do not scale,
+ * and re-formed rows repack at smaller widths). Forcing the floor in that
+ * case is what makes "nothing is dropped until scaling has bottomed out"
+ * hold literally rather than approximately.
+ */
+export function requiredScale(
+  candidates: TileInput[],
+  viewport: { width: number; height: number },
+  cfg: V2Config
+): number {
+  let scale = 1;
+  let extent = arrange(sizeTiles(candidates, cfg), viewport, cfg).extent;
+
+  for (let pass = 0; pass < MAX_SCALE_PASSES && extent > viewport.height; pass++) {
+    const next = Math.max(MIN_COMPOSITION_SCALE, scale * (viewport.height / extent));
+    if (next === scale) break;
+    scale = next;
+    extent = arrange(scaleTiles(sizeTiles(candidates, cfg), scale), viewport, cfg).extent;
+  }
+
+  return extent > viewport.height ? MIN_COMPOSITION_SCALE : scale;
+}
+
+/**
  * Largest prefix of `ordered` that still fits when appended to `base`.
  * Binary search, not one-at-a-time: more tiles is monotonically taller, and
  * a 400-tile pool would otherwise mean 400 full recompositions — the kind of
@@ -60,27 +110,25 @@ function largestFittingCount(
  * Overflow NEVER culls arbitrarily (v1's named failure). The composition
  * shrinks uniformly first; only once it hits MIN_COMPOSITION_SCALE does it
  * drop, and then deterministically from the lowest-scoring gate-failers up.
+ *
+ * `peerTiles` is the OTHER feed's pool. With cfg.sharedScale on, both panels
+ * adopt the tighter of the two scales, so a floor tile is the same number of
+ * pixels on the sunrise screen as on the sunset screen. Without it each
+ * panel shrinks to its own crowding and the two screens stop agreeing on
+ * what "small" means. Surfaces that show one panel alone omit it.
  */
 export function compose(
   tiles: TileInput[],
   viewport: { width: number; height: number },
   cfg: V2Config,
-  feed: 'sunrise' | 'sunset'
+  feed: 'sunrise' | 'sunset',
+  peerTiles: TileInput[] = []
 ): Layout {
   if (tiles.length === 0) {
     return { tiles: [], dropped: [], scale: 1, viewport };
   }
 
-  const { passers, failers } = splitPool(tiles);
-
-  let candidates: TileInput[];
-  if (cfg.failedCamPolicy === 'showIfRoom') {
-    const room = largestFittingCount(passers, failers, viewport, cfg, 1);
-    candidates = [...passers, ...failers.slice(0, room)];
-  } else {
-    candidates = applyPolicy(passers, failers, cfg);
-  }
-  candidates = capTiles(candidates, cfg.maxTiles);
+  let candidates = selectCandidates(tiles, viewport, cfg);
 
   // `dropped` reports overflow casualties ONLY. Tiles the operator's own
   // visibility policy removed (failedCamPolicy: 'hide', or a maxTiles cap)
@@ -88,29 +136,16 @@ export function compose(
   // overlay's counter claim the composition is struggling when it isn't.
   const droppedIds = new Set<number>();
 
-  let sized = sizeTiles(candidates, cfg);
-  let scale = 1;
+  let scale = requiredScale(candidates, viewport, cfg);
+  if (cfg.sharedScale && peerTiles.length > 0) {
+    scale = Math.min(
+      scale,
+      requiredScale(selectCandidates(peerTiles, viewport, cfg), viewport, cfg)
+    );
+  }
+
+  let sized = scaleTiles(sizeTiles(candidates, cfg), scale);
   let placement = arrange(sized, viewport, cfg);
-
-  for (let pass = 0; pass < MAX_SCALE_PASSES && placement.extent > viewport.height; pass++) {
-    const needed = viewport.height / placement.extent;
-    const next = Math.max(MIN_COMPOSITION_SCALE, scale * needed);
-    if (next === scale) break;
-    scale = next;
-    sized = scaleTiles(sizeTiles(candidates, cfg), scale);
-    placement = arrange(sized, viewport, cfg);
-  }
-
-  // The iterative step above can exhaust its passes while still overflowing
-  // and still above the floor — extent is not linear in scale (gaps do not
-  // scale, and re-formed rows repack at smaller widths). Force the floor
-  // before considering any drop, so "nothing is dropped until scaling has
-  // bottomed out" holds literally rather than approximately.
-  if (placement.extent > viewport.height && scale > MIN_COMPOSITION_SCALE) {
-    scale = MIN_COMPOSITION_SCALE;
-    sized = scaleTiles(sizeTiles(candidates, cfg), scale);
-    placement = arrange(sized, viewport, cfg);
-  }
 
   // Last resort: still overflowing at the scale floor. Keep the longest
   // prefix that fits — candidates run passers-first, weakest failers last,

--- a/app/components/mosaic/v2/engine/horizontalPlace.test.ts
+++ b/app/components/mosaic/v2/engine/horizontalPlace.test.ts
@@ -5,6 +5,7 @@ import type { PlacedRow, SizedTile, V2Config } from './types';
 const cfg = (over: Partial<V2Config> = {}): V2Config => ({
   qualitySource: 'auto', gateThreshold: 0.55, failedCamPolicy: 'showAtFloor', maxTiles: 0,
   floorPx: 100, ceilingPx: 500, curve: 'linear',
+  scoreFloor: 0, scoreCeiling: 1, sharedScale: true,
   strategy: 'anchorRelax', bandCount: 8, horizontalAnchor: 'order',
   rowAlign: 'center', geographicFidelity: 0.7, tileGapPx: 10, latNorth: 70, latSouth: -60,
   showFeedLabel: true, showTileRatings: false, showModelReadout: false,

--- a/app/components/mosaic/v2/engine/sizing.test.ts
+++ b/app/components/mosaic/v2/engine/sizing.test.ts
@@ -9,6 +9,7 @@ const tile = (id: number, passes: boolean, score: number | null): TileInput => (
 const cfg = (over: Partial<V2Config> = {}): V2Config => ({
   qualitySource: 'auto', gateThreshold: 0.55, failedCamPolicy: 'showAtFloor', maxTiles: 0,
   floorPx: 100, ceilingPx: 500, curve: 'linear',
+  scoreFloor: 0, scoreCeiling: 1, sharedScale: true,
   strategy: 'anchorRelax', bandCount: 8, horizontalAnchor: 'solarAltitude',
   rowAlign: 'center', geographicFidelity: 0.7, tileGapPx: 6, latNorth: 70, latSouth: -60,
   showFeedLabel: true, showTileRatings: false, showModelReadout: false,
@@ -95,5 +96,50 @@ describe('sizeTiles — geometry', () => {
     // A tiny source must still render at the floor, not below it.
     const tiny: TileInput = { ...tile(1, false, null), srcWidth: 8, srcHeight: 6 };
     expect(sizeTiles([tiny], cfg())[0].height).toBe(100);
+  });
+});
+
+describe('sizeTiles — the absolute score window', () => {
+  it('gives a tile the same height regardless of what else is in its pool', () => {
+    // The whole point of coordinating the two panels: a 0.6 is a 0.6 whether
+    // it is the best frame on a dull screen or the worst on a brilliant one.
+    const alone = sizeTiles([tile(1, true, 0.6)], cfg({ curve: 'linear' }));
+    const amongBetter = sizeTiles(
+      [tile(1, true, 0.6), tile(2, true, 0.95), tile(3, true, 0.99)],
+      cfg({ curve: 'linear' })
+    );
+    expect(amongBetter[0].height).toBe(alone[0].height);
+  });
+
+  it('maps scoreFloor to the floor and scoreCeiling to the ceiling', () => {
+    const c = cfg({ curve: 'linear', scoreFloor: 0.4, scoreCeiling: 0.8 });
+    const out = sizeTiles([tile(1, true, 0.4), tile(2, true, 0.6), tile(3, true, 0.8)], c);
+    expect(out[0].height).toBe(100);
+    expect(out[1].height).toBeCloseTo(300, 6);
+    expect(out[2].height).toBe(500);
+  });
+
+  it('clamps scores outside the window rather than escaping floor or ceiling', () => {
+    const c = cfg({ curve: 'linear', scoreFloor: 0.4, scoreCeiling: 0.8 });
+    const out = sizeTiles([tile(1, true, 0.1), tile(2, true, 1)], c);
+    expect(out.map((t) => t.height)).toEqual([100, 500]);
+  });
+
+  it('treats a degenerate window as a hard step, not a divide by zero', () => {
+    const c = cfg({ curve: 'linear', scoreFloor: 0.6, scoreCeiling: 0.6 });
+    const out = sizeTiles([tile(1, true, 0.59), tile(2, true, 0.6)], c);
+    expect(out.map((t) => t.height)).toEqual([100, 500]);
+  });
+
+  it('easeIn squares the windowed value, not the raw score', () => {
+    const c = cfg({ curve: 'easeIn', scoreFloor: 0.5, scoreCeiling: 1 });
+    // 0.75 sits halfway through the window, so easeIn lands on 0.25.
+    expect(sizeTiles([tile(1, true, 0.75)], c)[0].height).toBe(200);
+  });
+
+  it('leaves percentileAmongPassers untouched — it ranks, it does not read scores', () => {
+    const c = cfg({ curve: 'percentileAmongPassers', scoreFloor: 0.4, scoreCeiling: 0.8 });
+    const out = sizeTiles([tile(1, true, 0.01), tile(2, true, 0.02)], c);
+    expect(out.map((t) => t.height)).toEqual([100, 500]);
   });
 });

--- a/app/components/mosaic/v2/engine/sizing.ts
+++ b/app/components/mosaic/v2/engine/sizing.ts
@@ -31,11 +31,28 @@ function percentilesAmongPassers(passers: TileInput[]): Map<number, number> {
 }
 
 /**
+ * Maps a raw score onto [0, 1] through the absolute score window. This is
+ * what makes sunrise and sunset comparable: the same score is the same
+ * height on either panel, regardless of what else is on that panel. A
+ * degenerate window (ceiling at or below floor) becomes a hard step.
+ */
+export function normalizeScore(score: number, cfg: V2Config): number {
+  const span = cfg.scoreCeiling - cfg.scoreFloor;
+  if (span <= 0) return score >= cfg.scoreCeiling ? 1 : 0;
+  return Math.min(1, Math.max(0, (score - cfg.scoreFloor) / span));
+}
+
+/**
  * Sizes every tile by height, then derives width from the source aspect
  * ratio. Two rules are fixed directives, not knobs:
  *   - gate-failers pin to the EXACT floor, never spreading across the curve
  *   - there is no upscale clamp (v1's upscaleMax), because a clamp would
  *     silently push small sources below the floor
+ *
+ * `linear` and `easeIn` are ABSOLUTE: height is a function of the score
+ * alone, so a mediocre night looks mediocre instead of promoting its own
+ * best frame to the ceiling. `percentileAmongPassers` is relative and is
+ * kept only for comparison — it cannot agree across two panels.
  */
 export function sizeTiles(tiles: TileInput[], cfg: V2Config): SizedTile[] {
   const span = cfg.ceilingPx - cfg.floorPx;
@@ -49,8 +66,10 @@ export function sizeTiles(tiles: TileInput[], cfg: V2Config): SizedTile[] {
     if (t.passes && t.score !== null) {
       let unit: number;
       if (percentiles) unit = percentiles.get(t.id) ?? 0;
-      else if (cfg.curve === 'easeIn') unit = t.score * t.score;
-      else unit = t.score;
+      else {
+        const norm = normalizeScore(t.score, cfg);
+        unit = cfg.curve === 'easeIn' ? norm * norm : norm;
+      }
       height = cfg.floorPx + span * unit;
     }
     const aspect = t.srcHeight > 0 ? t.srcWidth / t.srcHeight : 4 / 3;

--- a/app/components/mosaic/v2/engine/types.ts
+++ b/app/components/mosaic/v2/engine/types.ts
@@ -56,6 +56,9 @@ export interface V2Config {
   floorPx: number;
   ceilingPx: number;
   curve: SizingCurve;
+  scoreFloor: number; // score that renders at floorPx (absolute curves only)
+  scoreCeiling: number; // score that renders at ceilingPx (absolute curves only)
+  sharedScale: boolean; // adopt one overflow scale across both feeds
   // arrangement
   strategy: ArrangementStrategy;
   bandCount: number;

--- a/app/components/mosaic/v2/engine/verticalPlace.test.ts
+++ b/app/components/mosaic/v2/engine/verticalPlace.test.ts
@@ -5,6 +5,7 @@ import type { Row, SizedTile, V2Config } from './types';
 const cfg = (over: Partial<V2Config> = {}): V2Config => ({
   qualitySource: 'auto', gateThreshold: 0.55, failedCamPolicy: 'showAtFloor', maxTiles: 0,
   floorPx: 100, ceilingPx: 500, curve: 'linear',
+  scoreFloor: 0, scoreCeiling: 1, sharedScale: true,
   strategy: 'anchorRelax', bandCount: 8, horizontalAnchor: 'solarAltitude',
   rowAlign: 'center', geographicFidelity: 1, tileGapPx: 0, latNorth: 70, latSouth: -60,
   showFeedLabel: true, showTileRatings: false, showModelReadout: false,

--- a/app/components/mosaic/v2/engine/visibility.test.ts
+++ b/app/components/mosaic/v2/engine/visibility.test.ts
@@ -9,6 +9,7 @@ const tile = (id: number, passes: boolean, score: number | null): TileInput => (
 const cfg = (over: Partial<V2Config> = {}): V2Config => ({
   qualitySource: 'auto', gateThreshold: 0.55, failedCamPolicy: 'showAtFloor', maxTiles: 0,
   floorPx: 100, ceilingPx: 480, curve: 'percentileAmongPassers',
+  scoreFloor: 0, scoreCeiling: 1, sharedScale: true,
   strategy: 'anchorRelax', bandCount: 8, horizontalAnchor: 'solarAltitude',
   rowAlign: 'center', geographicFidelity: 0.7, tileGapPx: 6, latNorth: 70, latSouth: -60,
   showFeedLabel: true, showTileRatings: false, showModelReadout: false,

--- a/app/components/mosaic/v2/index.tsx
+++ b/app/components/mosaic/v2/index.tsx
@@ -12,6 +12,9 @@ import { TileRatings } from './overlays/TileRatings';
 import { V2_SETTINGS_SCHEMA, configFromSettings } from './settingsSchema';
 import { useLoadedTiles } from './useLoadedTiles';
 
+/** Stable identity: a fresh [] each render would re-run the loader effect. */
+const NO_PEERS: NonNullable<MosaicProps['peerWebcams']> = [];
+
 /**
  * v2 — latitude anchoring plus depth-into-twilight arrangement, entirely
  * schema-driven. Precedence, as everywhere: URL param, then profile setting,
@@ -22,6 +25,7 @@ export function MosaicV2({
   width,
   height,
   feed,
+  peerWebcams = NO_PEERS,
   setupMode = false,
   onSelect,
   search = '',
@@ -39,15 +43,16 @@ export function MosaicV2({
     };
   }, [search, settings]);
 
-  const { tiles, byId, skipped } = useLoadedTiles(webcams, {
-    qualitySource: cfg.qualitySource,
-    gateThreshold: cfg.gateThreshold,
-    at,
-  });
+  const signal = { qualitySource: cfg.qualitySource, gateThreshold: cfg.gateThreshold, at };
+  const { tiles, byId, skipped } = useLoadedTiles(webcams, signal);
+  // Loaded, never drawn: the peer pool exists only so both panels can settle
+  // on one overflow scale. Its images cost a fetch each, but they are the
+  // same frames the twin screen is already loading.
+  const { tiles: peerTiles } = useLoadedTiles(peerWebcams, signal);
 
   const layout = useMemo(
-    () => compose(tiles, { width, height }, cfg, feed),
-    [tiles, width, height, cfg, feed]
+    () => compose(tiles, { width, height }, cfg, feed, peerTiles),
+    [tiles, peerTiles, width, height, cfg, feed]
   );
 
   return (

--- a/app/components/mosaic/v2/settingsSchema.ts
+++ b/app/components/mosaic/v2/settingsSchema.ts
@@ -42,8 +42,23 @@ export const V2_SETTINGS_SCHEMA: SettingsSchema = [
   {
     key: 'curve', kind: 'enum',
     options: ['linear', 'easeIn', 'percentileAmongPassers'] as const,
-    default: 'percentileAmongPassers', label: 'curve', section: 'sizing',
-    description: 'How passer scores map onto the floor-to-ceiling range. percentileAmongPassers ranks within the passers only.',
+    default: 'linear', label: 'curve', section: 'sizing',
+    description: 'How passer scores map onto the floor-to-ceiling range. linear and easeIn are absolute, so the same score is the same height on both screens. percentileAmongPassers ranks within one panel and cannot agree across two.',
+  },
+  {
+    key: 'scoreFloor', kind: 'number', min: 0, max: 1, step: 0.01, default: 0,
+    label: 'score at floor', section: 'sizing',
+    description: 'Score that renders at floor height. Raise it to stop weak passers looking big. Ignored by percentileAmongPassers.',
+  },
+  {
+    key: 'scoreCeiling', kind: 'number', min: 0, max: 1, step: 0.01, default: 1,
+    label: 'score at ceiling', section: 'sizing',
+    description: 'Score that renders at ceiling height. Lower it when real scores never reach 1 and the panel looks uniformly small. Ignored by percentileAmongPassers.',
+  },
+  {
+    key: 'sharedScale', kind: 'boolean', default: true,
+    label: 'match both screens', section: 'sizing',
+    description: 'Shrink both panels by the same amount, taken from whichever is more crowded. Off, each panel shrinks to its own tile count and a sunrise floor tile can outgrow a sunset ceiling tile.',
   },
   {
     key: 'strategy', kind: 'enum',
@@ -115,6 +130,9 @@ export function configFromSettings(values: SettingsValues): V2Config {
     floorPx: values.floorPx as number,
     ceilingPx: values.ceilingPx as number,
     curve: values.curve as V2Config['curve'],
+    scoreFloor: values.scoreFloor as number,
+    scoreCeiling: values.scoreCeiling as number,
+    sharedScale: values.sharedScale as boolean,
     strategy: values.strategy as V2Config['strategy'],
     bandCount: values.bandCount as number,
     horizontalAnchor: values.horizontalAnchor as V2Config['horizontalAnchor'],

--- a/app/kiosk/sunrise/page.test.tsx
+++ b/app/kiosk/sunrise/page.test.tsx
@@ -70,6 +70,16 @@ describe('SunriseKioskPage', () => {
     expect(canvas.getAttribute('data-count')).toBe('2');
   });
 
+  it('hands the sunset pool over as the peer, so both screens share one scale', () => {
+    vi.mocked(useTerminatorStore).mockImplementation(
+      (selector: (state: { sunrise: unknown[]; sunset: unknown[] }) => unknown) =>
+        selector({ sunrise: [{ webcamId: 1 }], sunset: [{ webcamId: 7 }, { webcamId: 8 }] })
+    );
+
+    render(<SunriseKioskPage />);
+    expect(getMosaicProps().peerWebcams).toHaveLength(2);
+  });
+
   it('does not set setupMode without ?setup=1', () => {
     useSearchParamsMock.mockReturnValue(new URLSearchParams());
     render(<SunriseKioskPage />);

--- a/app/kiosk/sunrise/page.tsx
+++ b/app/kiosk/sunrise/page.tsx
@@ -16,6 +16,8 @@ function SunriseKioskContent() {
   const { dozing, liveSettings } = useKioskRuntime();
   useLoadTerminatorWebcams({ paused: dozing });
   const webcams = useTerminatorStore((t) => t.sunrise);
+  // The twin screen's pool, so both panels shrink by the same amount.
+  const peerWebcams = useTerminatorStore((t) => t.sunset);
   const searchParams = useSearchParams();
   const queryString = searchParams.toString();
   const liveShared = mergeSettings(SHARED_SCHEMA, liveSettings?.namespaces.shared);
@@ -52,6 +54,7 @@ function SunriseKioskContent() {
         width={stage.width}
         height={stage.height}
         feed="sunrise"
+        peerWebcams={peerWebcams}
         setupMode={searchParams.get('setup') === '1'}
         search={queryString}
         settings={liveSettings?.namespaces[versionName]}

--- a/app/kiosk/sunset/page.test.tsx
+++ b/app/kiosk/sunset/page.test.tsx
@@ -71,6 +71,16 @@ describe('SunsetKioskPage', () => {
     expect(canvas.getAttribute('data-count')).toBe('3');
   });
 
+  it('hands the sunrise pool over as the peer, so both screens share one scale', () => {
+    vi.mocked(useTerminatorStore).mockImplementation(
+      (selector: (state: { sunrise: unknown[]; sunset: unknown[] }) => unknown) =>
+        selector({ sunset: [{ webcamId: 1 }], sunrise: [{ webcamId: 7 }, { webcamId: 8 }] })
+    );
+
+    render(<SunsetKioskPage />);
+    expect(getMosaicProps().peerWebcams).toHaveLength(2);
+  });
+
   it('does not set setupMode without ?setup=1', () => {
     useSearchParamsMock.mockReturnValue(new URLSearchParams());
     render(<SunsetKioskPage />);

--- a/app/kiosk/sunset/page.tsx
+++ b/app/kiosk/sunset/page.tsx
@@ -16,6 +16,8 @@ function SunsetKioskContent() {
   const { dozing, liveSettings } = useKioskRuntime();
   useLoadTerminatorWebcams({ paused: dozing });
   const webcams = useTerminatorStore((t) => t.sunset);
+  // The twin screen's pool, so both panels shrink by the same amount.
+  const peerWebcams = useTerminatorStore((t) => t.sunrise);
   const searchParams = useSearchParams();
   const queryString = searchParams.toString();
   const liveShared = mergeSettings(SHARED_SCHEMA, liveSettings?.namespaces.shared);
@@ -52,6 +54,7 @@ function SunsetKioskContent() {
         width={stage.width}
         height={stage.height}
         feed="sunset"
+        peerWebcams={peerWebcams}
         setupMode={searchParams.get('setup') === '1'}
         search={queryString}
         settings={liveSettings?.namespaces[versionName]}

--- a/app/studio/PreviewPane.test.tsx
+++ b/app/studio/PreviewPane.test.tsx
@@ -27,16 +27,19 @@ global.ResizeObserver = StubResizeObserver;
 
 let capturedFeeds: string[] = [];
 let capturedAt: Array<string | number | undefined> = [];
+const capturedPeers = new Map<string, Array<{ webcamId: number }>>();
 
 vi.mock('@/app/components/mosaic/registry', () => ({
   resolveMosaic: () =>
     (props: {
       feed: string;
       webcams: Array<{ webcamId: number }>;
+      peerWebcams?: Array<{ webcamId: number }>;
       at?: string | number;
     }) => {
       capturedFeeds.push(props.feed);
       capturedAt.push(props.at);
+      capturedPeers.set(props.feed, props.peerWebcams ?? []);
       return (
         <div data-testid={`mosaic-${props.feed}`}>
           {props.webcams.map((w) => (
@@ -62,6 +65,7 @@ describe('PreviewPane', () => {
   beforeEach(() => {
     capturedFeeds = [];
     capturedAt = [];
+    capturedPeers.clear();
     useTerminatorStore.setState({
       sunrise: fakeWebcams(),
       sunset: fakeWebcams(),
@@ -84,6 +88,45 @@ describe('PreviewPane', () => {
 
     expect(screen.getAllByTestId('studio-panel-stage')).toHaveLength(2);
     expect(capturedFeeds.sort()).toEqual(['sunrise', 'sunset']);
+  });
+
+  it('gives each panel the other feed as its peer', () => {
+    useTerminatorStore.setState({
+      sunrise: [{ webcamId: 11 }] as unknown as WindyWebcam[],
+      sunset: [{ webcamId: 22 }, { webcamId: 33 }] as unknown as WindyWebcam[],
+    });
+
+    render(
+      <PreviewPane
+        view="both"
+        onViewChange={() => {}}
+        panel={PANEL}
+        panelPresetLabel="ktc · 1440×2560"
+        versionName="v1"
+      />
+    );
+
+    expect(capturedPeers.get('sunrise')!.map((w) => w.webcamId)).toEqual([22, 33]);
+    expect(capturedPeers.get('sunset')!.map((w) => w.webcamId)).toEqual([11]);
+  });
+
+  it('still supplies the peer in single-feed view, so one panel looks the same alone', () => {
+    useTerminatorStore.setState({
+      sunrise: [{ webcamId: 11 }] as unknown as WindyWebcam[],
+      sunset: [{ webcamId: 22 }, { webcamId: 33 }] as unknown as WindyWebcam[],
+    });
+
+    render(
+      <PreviewPane
+        view="sunrise"
+        onViewChange={() => {}}
+        panel={PANEL}
+        panelPresetLabel="ktc · 1440×2560"
+        versionName="v1"
+      />
+    );
+
+    expect(capturedPeers.get('sunrise')!.map((w) => w.webcamId)).toEqual([22, 33]);
   });
 
   it("renders one stage for view='sunset'", () => {

--- a/app/studio/PreviewPane.tsx
+++ b/app/studio/PreviewPane.tsx
@@ -66,6 +66,12 @@ export function PreviewPane({
     return feed === 'sunrise' ? liveSunrise : liveSunset;
   };
 
+  // Handed to each panel even in single-feed view: the point of the shared
+  // scale is that one screen looks the same whether or not you happen to be
+  // previewing its twin beside it.
+  const peerOf = (feed: 'sunrise' | 'sunset') =>
+    webcamsFor(feed === 'sunrise' ? 'sunset' : 'sunrise');
+
   return (
     <div
       style={{
@@ -209,6 +215,7 @@ export function PreviewPane({
                   width={panel.width}
                   height={panel.height}
                   feed={feed}
+                  peerWebcams={peerOf(feed)}
                   search=""
                   settings={settings}
                   at={at}

--- a/docs/solutions/2026-09-02-per-panel-normalization-breaks-two-screens.md
+++ b/docs/solutions/2026-09-02-per-panel-normalization-breaks-two-screens.md
@@ -1,0 +1,59 @@
+# Per-panel normalization makes two screens incomparable
+
+**Date:** 2026-09-02
+**Area:** kiosk / mosaic v2 composition
+
+## The trap
+
+The kiosk is two physical panels showing one thing: how good the sunrise is on
+the left, the sunset on the right. Both read the same settings namespace, so
+`floorPx` and `ceilingPx` were provably identical. Composition still made the
+two screens disagree about what a size means, in two independent places.
+
+**Rank-based sizing.** `percentileAmongPassers` ranked each feed's passers
+among themselves. The best tile on a panel always landed at exactly the
+ceiling and the worst passer at exactly the floor, whatever the scores were.
+A panel of mediocre frames still promoted one of them to full size, and a
+panel of brilliant frames still floored one. Height meant "rank on my own
+screen," which is a fact about the pool, not about the sky.
+
+**Per-panel overflow scale.** `compose` shrank the whole composition to fit
+its own viewport, independently per feed. Forty sunset tiles rendered near
+0.6 while twelve sunrise tiles stayed at 1.0, so a sunrise *floor* tile came
+out physically larger than a sunset *ceiling* tile — the exact inversion of
+the thing the size was supposed to communicate.
+
+Neither shows up in a single-panel test, or in any test of one feed. Both are
+obvious the moment the two panels sit side by side in `/studio`'s "both" view.
+
+## The rule
+
+**When two surfaces display the same quantity, every step from signal to
+pixel must be a function of the signal alone — never of the pool the surface
+happens to hold.** Any per-surface normalization (percentile, min-max,
+fit-to-container) silently rescales the axis and destroys comparability
+between surfaces, even when every configured number is identical.
+
+The two fixes mirror the two breaks:
+
+1. **Absolute sizing.** `linear` and `easeIn` map score onto the
+   floor-to-ceiling range through an explicit score window (`scoreFloor`,
+   `scoreCeiling` — see `app/components/mosaic/v2/engine/sizing.ts`). Same
+   score, same height, on either panel. `percentileAmongPassers` survives as
+   an option, and is the one curve that cannot agree across two panels.
+2. **One shared overflow scale.** `compose` takes the peer feed's pool and
+   adopts the tighter of the two required scales, behind the `sharedScale`
+   dial. Each surface hands the other's pool down as `peerWebcams`; the peer
+   pool is loaded for measurement and never drawn.
+
+## The tradeoff worth stating
+
+Absolute sizing means a dull night looks dull — nothing reaches the ceiling
+when nothing deserves it. That is the honest reading and the reason to want
+it. Rank-based sizing hid a dull night by always filling the panel, which is
+why it looked good and meant nothing.
+
+The shared scale costs the roomier panel some slack: it shrinks below what it
+needs so both panels use one ruler. It also costs each screen a preview fetch
+per peer camera, which on the kiosk are frames the twin window is already
+loading into the same HTTP cache.


### PR DESCRIPTION
## The problem

The kiosk is two panels showing one thing: how good the sunrise is on the left, the sunset on the right. Both read the same settings namespace, so `floorPx` and `ceilingPx` were provably identical numbers. Composition still made the two screens disagree about what a size means, in two independent places.

**Rank-based sizing.** `percentileAmongPassers` ranked each feed's passers among themselves. The best tile on a panel always landed at exactly the ceiling and the worst passer at exactly the floor, whatever the scores were. A panel of mediocre frames still promoted one to full size; a panel of brilliant frames still floored one. Height meant rank within one pool, not quality.

**Per-panel overflow scale.** `compose` shrank each composition to fit its own viewport independently. Twenty-one sunset tiles ran near 0.6 while four sunrise tiles stayed at 1.0, so a sunrise *floor* tile came out physically larger than a sunset *ceiling* tile. That is the exact inversion of what the size was supposed to communicate.

Neither shows up in a single-panel test. Both are obvious the moment the panels sit side by side in `/studio`'s "both" view.

## The change

Both fixes are dials, defaulted on, in the `sizing` section:

| Dial | Default | Effect |
|---|---|---|
| `scoreFloor` | 0 | Score that renders at floor height |
| `scoreCeiling` | 1 | Score that renders at ceiling height |
| `sharedScale` | on | One shrink factor across both panels |

- `linear` and `easeIn` now read score through that explicit window, and the `curve` default moves from `percentileAmongPassers` to `linear`. Same score, same height, either panel. The rank-based curve stays as the comparison case, and is the one curve that cannot agree across two panels.
- `compose` takes the peer feed's pool and adopts the tighter of the two required scales. Each surface hands the other's pool down as the new `peerWebcams` prop. The peer pool is measured, never drawn, and a surface showing one panel alone can omit it.

## Scope and risk

**v2 only.** v1 is frozen and has no dial surface, so porting would mean writing the fix twice into code slated for deletion. The registry still pins v1 as the default, so this reaches the glass only when the shared `activeVersion` setting is promoted to v2. Merging the code changes nothing on the screens by itself.

## Tradeoffs, stated

- Absolute sizing means a dull night looks dull. Nothing reaches the ceiling when nothing deserves it. That is the honest reading and the reason to want it.
- The shared scale costs the roomier panel some slack: it shrinks below what it needs so both panels use one ruler. With four sunrise cameras against twenty-one sunset, sunrise is usually the panel giving up room.
- The scale is still a global multiplier, so absolute height is preserved as an *upper* bound rather than a constant. Crowding only ever shrinks tiles below their configured size; it never grows them past it. The cross-panel guarantee holds at a moment in time, not across time.
- Each panel now loads the peer feed's previews to measure them. Against the measured pool sizes (4 sunrise, 21 sunset on 2026-09-02) that is negligible, and both kiosk windows share one browser cache. If the pool ever grew large, the fix is to read aspect ratio from the `images.sizes` metadata already in the payload rather than to tune caching.

## Verification

- `npm run test` — 1,267 passing
- `npm run lint` — clean
- `npm run build` — succeeds
- New coverage: the absolute score window (identical height across different pools, window mapping, clamping, degenerate window, easeIn on the windowed value, rank-based curve unaffected) and the shared scale (panels land on the same scale, the crowded panel is unchanged, a floor tile matches across panels, the knob disables it, an absent or empty peer is a no-op, drops still happen when the shared scale is not enough).

Lesson written up in `docs/solutions/2026-09-02-per-panel-normalization-breaks-two-screens.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mixyhu11Y9f85vcMwYaoVD
