### PR TITLE
Motion layer for the mosaic, and a horizontal axis that stops depending on its neighbours

### DIFF
--- a/app/components/mosaic/v2/MosaicCanvas.test.tsx
+++ b/app/components/mosaic/v2/MosaicCanvas.test.tsx
@@ -1,17 +1,18 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, afterEach } from 'vitest';
 import { render } from '@testing-library/react';
 import { MosaicCanvas } from './MosaicCanvas';
 import type { Layout } from './engine/types';
+import type { MotionConfig } from './motion';
 import type { WindyWebcam } from '@/app/lib/types';
 
 const webcam = { webcamId: 1, title: 'c' } as WindyWebcam;
 
-const layout = (): Layout => ({
+const layout = (x = 10): Layout => ({
   tiles: [
     {
       id: 1, lat: 0, lng: 0, srcWidth: 400, srcHeight: 300,
       passes: true, score: 0.5, sunAltitudeDeg: -13,
-      width: 100, height: 75, pinnedToFloor: false, x: 10, y: 20,
+      width: 100, height: 75, pinnedToFloor: false, x, y: 20,
     },
   ],
   dropped: [],
@@ -19,33 +20,144 @@ const layout = (): Layout => ({
   viewport: { width: 300, height: 500 },
 });
 
-const byId = () =>
-  new Map([[1, { img: {} as HTMLImageElement, webcam }]]);
+const byId = (img: HTMLImageElement) => new Map([[1, { img, webcam }]]);
+
+const CUT: MotionConfig = {
+  mode: 'cut', order: 'none', durationMs: 900, staggerMs: 0, waveGridMs: 0,
+};
+
+/**
+ * Drives the render loop synchronously, capped so a still-animating component
+ * cannot spin the test forever. Returns the frame count so a test can assert
+ * the loop parked itself.
+ */
+function stubRaf(maxFrames = 4) {
+  let n = 0;
+  let total = 0;
+  vi.stubGlobal('requestAnimationFrame', (cb: FrameRequestCallback) => {
+    if (n >= maxFrames) return 0;
+    n += 1;
+    total += 1;
+    cb(1000 + total * 16);
+    return n;
+  });
+  vi.stubGlobal('cancelAnimationFrame', () => {});
+  return {
+    count: () => total,
+    /** Hand the loop a fresh budget, e.g. after a rerender. */
+    reset: () => { n = 0; },
+  };
+}
+
+function stubContext(over: Partial<CanvasRenderingContext2D> = {}) {
+  const ctx = {
+    resetTransform: vi.fn(), setTransform: vi.fn(), fillRect: vi.fn(),
+    drawImage: vi.fn(), imageSmoothingEnabled: false, imageSmoothingQuality: '',
+    fillStyle: '', globalAlpha: 1, ...over,
+  } as unknown as CanvasRenderingContext2D;
+  vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockReturnValue(ctx);
+  return ctx;
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
 
 describe('MosaicCanvas', () => {
   it('draws every placed tile at its position', () => {
-    const drawImage = vi.fn();
-    vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockReturnValue({
-      resetTransform: vi.fn(), setTransform: vi.fn(), fillRect: vi.fn(),
-      drawImage, imageSmoothingEnabled: false, imageSmoothingQuality: '',
-      fillStyle: '',
-    } as unknown as CanvasRenderingContext2D);
+    stubRaf();
+    const ctx = stubContext();
+    const img = {} as HTMLImageElement;
 
-    render(<MosaicCanvas layout={layout()} byId={byId()} width={300} height={500} />);
-    expect(drawImage).toHaveBeenCalledWith(expect.anything(), 10, 20, 100, 75);
-    vi.restoreAllMocks();
+    render(
+      <MosaicCanvas
+        layout={layout()} byId={byId(img)} width={300} height={500}
+        motion={CUT} crossfadeMs={0} panelSlot={0}
+      />
+    );
+    expect(ctx.drawImage).toHaveBeenCalledWith(img, 10, 20, 100, 75);
   });
 
   it('never reads pixels back — the canvas is tainted by design', () => {
+    stubRaf();
     const getImageData = vi.fn();
-    vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockReturnValue({
-      resetTransform: vi.fn(), setTransform: vi.fn(), fillRect: vi.fn(),
-      drawImage: vi.fn(), getImageData, imageSmoothingEnabled: false,
-      imageSmoothingQuality: '', fillStyle: '',
-    } as unknown as CanvasRenderingContext2D);
+    stubContext({ getImageData } as Partial<CanvasRenderingContext2D>);
 
-    render(<MosaicCanvas layout={layout()} byId={byId()} width={300} height={500} />);
+    render(
+      <MosaicCanvas
+        layout={layout()} byId={byId({} as HTMLImageElement)} width={300} height={500}
+        motion={CUT} crossfadeMs={0} panelSlot={0}
+      />
+    );
     expect(getImageData).not.toHaveBeenCalled();
-    vi.restoreAllMocks();
+  });
+
+  it('parks the render loop once nothing is moving', () => {
+    // A kiosk sitting on a still composition must not hold a rAF loop open.
+    const raf = stubRaf();
+    stubContext();
+
+    render(
+      <MosaicCanvas
+        layout={layout()} byId={byId({} as HTMLImageElement)} width={300} height={500}
+        motion={CUT} crossfadeMs={0} panelSlot={0}
+      />
+    );
+    expect(raf.count()).toBe(1);
+  });
+
+  it('keeps drawing the old frame underneath while a new one fades up', () => {
+    stubRaf();
+    const ctx = stubContext();
+    const oldImg = { id: 'old' } as unknown as HTMLImageElement;
+    const newImg = { id: 'new' } as unknown as HTMLImageElement;
+
+    const { rerender } = render(
+      <MosaicCanvas
+        layout={layout()} byId={byId(oldImg)} width={300} height={500}
+        motion={CUT} crossfadeMs={800} panelSlot={0}
+      />
+    );
+    (ctx.drawImage as ReturnType<typeof vi.fn>).mockClear();
+
+    // Same camera, new preview: the tile must not pop straight to the new one.
+    rerender(
+      <MosaicCanvas
+        layout={layout()} byId={byId(newImg)} width={300} height={500}
+        motion={CUT} crossfadeMs={800} panelSlot={0}
+      />
+    );
+
+    const drawn = (ctx.drawImage as ReturnType<typeof vi.fn>).mock.calls.map((c) => c[0]);
+    expect(drawn).toContain(oldImg);
+    expect(drawn).toContain(newImg);
+  });
+
+  it('moves a tile toward its new place instead of jumping there', () => {
+    const raf = stubRaf(2);
+    const ctx = stubContext();
+    const img = {} as HTMLImageElement;
+    const tween: MotionConfig = { ...CUT, mode: 'tween', durationMs: 5_000 };
+
+    const { rerender } = render(
+      <MosaicCanvas
+        layout={layout(0)} byId={byId(img)} width={300} height={500}
+        motion={tween} crossfadeMs={0} panelSlot={0}
+      />
+    );
+    (ctx.drawImage as ReturnType<typeof vi.fn>).mockClear();
+    raf.reset();
+
+    rerender(
+      <MosaicCanvas
+        layout={layout(250)} byId={byId(img)} width={300} height={500}
+        motion={tween} crossfadeMs={0} panelSlot={0}
+      />
+    );
+
+    const xs = (ctx.drawImage as ReturnType<typeof vi.fn>).mock.calls.map((c) => c[1]);
+    expect(xs.length).toBeGreaterThan(0);
+    expect(Math.max(...xs)).toBeLessThan(250);
   });
 });

--- a/app/components/mosaic/v2/MosaicCanvas.tsx
+++ b/app/components/mosaic/v2/MosaicCanvas.tsx
@@ -3,6 +3,13 @@
 import { useEffect, useRef } from 'react';
 import type { WindyWebcam } from '@/app/lib/types';
 import type { Layout } from './engine/types';
+import {
+  commit,
+  createMotionState,
+  isSettled,
+  sample,
+  type MotionConfig,
+} from './motion';
 
 interface HitRect {
   x: number;
@@ -13,58 +20,162 @@ interface HitRect {
 }
 
 /**
- * Draws the composed layout. dpr-scaled, black backdrop, drawImage only —
- * frames come from a host with no CORS headers, so the canvas is tainted and
- * reading pixels back would throw. Click hit-testing uses rects captured at
- * draw time rather than the canvas itself.
+ * Draws the composed layout through the motion layer. dpr-scaled, black
+ * backdrop, drawImage only — frames come from a host with no CORS headers, so
+ * the canvas is tainted and reading pixels back would throw. Click hit-testing
+ * uses rects captured at draw time rather than the canvas itself.
+ *
+ * The render loop parks itself whenever every track has settled and no frame
+ * is mid-crossfade, so a kiosk sitting on a still composition costs nothing.
+ * In `cut` mode that is every frame but the one after a commit, which is
+ * exactly what this component did before the motion layer existed.
  */
 export function MosaicCanvas({
   layout,
   byId,
   width,
   height,
+  motion,
+  crossfadeMs,
+  panelSlot,
   onSelect,
 }: {
   layout: Layout;
   byId: Map<number, { img: HTMLImageElement; webcam: WindyWebcam }>;
   width: number;
   height: number;
+  motion: MotionConfig;
+  crossfadeMs: number;
+  panelSlot: 0 | 1;
   onSelect?: (webcam: WindyWebcam) => void;
 }) {
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
   const hitRectsRef = useRef<HitRect[]>([]);
+  const stateRef = useRef(createMotionState());
+  const rafRef = useRef<number | null>(null);
+  const lastTimeRef = useRef(0);
+  // Per-tile image crossfade. Geometry lives in the motion layer; which frame
+  // is drawn into that geometry is this component's business.
+  const fadesRef = useRef(
+    new Map<number, { prev: HTMLImageElement | null; current: HTMLImageElement; startedAt: number }>()
+  );
+  // Latest props, read inside the loop without restarting it.
+  const propsRef = useRef({ layout, byId, width, height, motion, crossfadeMs, panelSlot });
+  propsRef.current = { layout, byId, width, height, motion, crossfadeMs, panelSlot };
 
+  // Size the backing store. Separate from the loop so a resize does not
+  // discard motion state.
   useEffect(() => {
     const canvas = canvasRef.current;
     if (!canvas) return;
-
     const dpr = typeof window !== 'undefined' ? window.devicePixelRatio || 1 : 1;
     canvas.width = Math.floor(width * dpr);
     canvas.height = Math.floor(height * dpr);
     canvas.style.width = `${width}px`;
     canvas.style.height = `${height}px`;
-
     const ctx = canvas.getContext('2d');
     if (!ctx) return;
-
     ctx.resetTransform?.();
     ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
     ctx.imageSmoothingEnabled = true;
     ctx.imageSmoothingQuality = 'high';
-    ctx.fillStyle = '#000000';
-    ctx.fillRect(0, 0, width, height);
+  }, [width, height]);
 
-    const hits: HitRect[] = [];
-    for (const tile of layout.tiles) {
-      const entry = byId.get(tile.id);
-      if (!entry) continue;
-      ctx.drawImage(entry.img, tile.x, tile.y, tile.width, tile.height);
-      hits.push({
-        x: tile.x, y: tile.y, w: tile.width, h: tile.height, webcam: entry.webcam,
-      });
+  useEffect(() => {
+    const draw = (now: number) => {
+      rafRef.current = null;
+      const canvas = canvasRef.current;
+      if (!canvas) return;
+      const ctx = canvas.getContext('2d');
+      if (!ctx) return;
+
+      const p = propsRef.current;
+      const dt = lastTimeRef.current === 0 ? 16 : now - lastTimeRef.current;
+      lastTimeRef.current = now;
+
+      const frames = sample(stateRef.current, now, dt, p.motion);
+
+      ctx.fillStyle = '#000000';
+      ctx.fillRect(0, 0, p.width, p.height);
+
+      const hits: HitRect[] = [];
+      for (const frame of frames) {
+        const entry = p.byId.get(frame.id);
+        const fade = fadesRef.current.get(frame.id);
+        const image = entry?.img ?? fade?.current;
+        if (!image) continue;
+
+        const base = Math.max(0, Math.min(1, frame.opacity));
+        // A tile whose frame just changed shows the old one underneath until
+        // the new one has faded up over it.
+        if (fade?.prev) {
+          const t = p.crossfadeMs <= 0 ? 1 : (now - fade.startedAt) / p.crossfadeMs;
+          if (t >= 1) {
+            fade.prev = null;
+          } else {
+            ctx.globalAlpha = base;
+            ctx.drawImage(fade.prev, frame.x, frame.y, frame.width, frame.height);
+            ctx.globalAlpha = base * Math.max(0, t);
+          }
+        } else {
+          ctx.globalAlpha = base;
+        }
+
+        ctx.drawImage(image, frame.x, frame.y, frame.width, frame.height);
+        ctx.globalAlpha = 1;
+
+        if (entry) {
+          hits.push({
+            x: frame.x, y: frame.y, w: frame.width, h: frame.height, webcam: entry.webcam,
+          });
+        }
+      }
+      hitRectsRef.current = hits;
+
+      const fading = [...fadesRef.current.values()].some(
+        (f) => f.prev && now - f.startedAt < p.crossfadeMs
+      );
+      if (!isSettled(stateRef.current, p.motion, now) || fading) {
+        rafRef.current = requestAnimationFrame(draw);
+      }
+    };
+
+    const p = propsRef.current;
+    const now = typeof performance !== 'undefined' ? performance.now() : Date.now();
+
+    // Note which tiles arrived with a different frame than they had before,
+    // then hand the new geometry to the motion layer.
+    for (const [id, entry] of p.byId) {
+      const fade = fadesRef.current.get(id);
+      if (!fade) {
+        fadesRef.current.set(id, { prev: null, current: entry.img, startedAt: now });
+      } else if (fade.current !== entry.img) {
+        fade.prev = fade.current;
+        fade.current = entry.img;
+        fade.startedAt = now;
+      }
     }
-    hitRectsRef.current = hits;
-  }, [layout, byId, width, height]);
+    for (const id of [...fadesRef.current.keys()]) {
+      if (!p.byId.has(id)) fadesRef.current.delete(id);
+    }
+
+    commit(
+      stateRef.current,
+      layout.tiles.map((t) => ({
+        id: t.id, x: t.x, y: t.y, width: t.width, height: t.height, lat: t.lat,
+      })),
+      p.motion,
+      now,
+      { panelWidth: p.width, panelSlot: p.panelSlot }
+    );
+
+    if (rafRef.current === null) rafRef.current = requestAnimationFrame(draw);
+
+    return () => {
+      if (rafRef.current !== null) cancelAnimationFrame(rafRef.current);
+      rafRef.current = null;
+    };
+  }, [layout, byId, width, height, motion, crossfadeMs, panelSlot]);
 
   const handleClick = (event: React.MouseEvent<HTMLCanvasElement>) => {
     if (!onSelect) return;

--- a/app/components/mosaic/v2/engine/compose.ts
+++ b/app/components/mosaic/v2/engine/compose.ts
@@ -1,5 +1,5 @@
 import { placeBands } from './bands';
-import { altitudeRange, placeRowHorizontally } from './horizontalPlace';
+import { ALTITUDE_WINDOW, placeRowHorizontally } from './horizontalPlace';
 import { MIN_COMPOSITION_SCALE, scaleTiles } from './overflow';
 import { formRows } from './rows';
 import { sizeTiles } from './sizing';
@@ -158,9 +158,10 @@ export function compose(
     placement = arrange(sized, viewport, cfg);
   }
 
-  const altRange = altitudeRange(sized);
+  // Fixed, not derived from `sized`. `sized` is post-drop, so a pool-relative
+  // range let an overflow event rescale X for every surviving tile too.
   const placed = placement.rows.flatMap((row) =>
-    placeRowHorizontally(row, viewport.width, cfg, feed, altRange)
+    placeRowHorizontally(row, viewport.width, cfg, feed, ALTITUDE_WINDOW)
   );
 
   return {

--- a/app/components/mosaic/v2/engine/horizontalPlace.test.ts
+++ b/app/components/mosaic/v2/engine/horizontalPlace.test.ts
@@ -1,6 +1,14 @@
 import { describe, it, expect } from 'vitest';
-import { altitudeToUnit, altitudeRange, placeRowHorizontally } from './horizontalPlace';
+import {
+  altitudeToUnit,
+  ALTITUDE_WINDOW,
+  placeRowHorizontally,
+} from './horizontalPlace';
 import type { PlacedRow, SizedTile, V2Config } from './types';
+import {
+  SEARCH_RADIUS_DEG,
+  TERMINATOR_SUN_ALTITUDE_DEG,
+} from '@/app/lib/masterConfig';
 
 const cfg = (over: Partial<V2Config> = {}): V2Config => ({
   qualitySource: 'auto', gateThreshold: 0.55, failedCamPolicy: 'showAtFloor', maxTiles: 0,
@@ -38,14 +46,27 @@ describe('altitudeToUnit — direction per feed', () => {
   });
 });
 
-describe('altitudeRange', () => {
-  it('spans the pool, ignoring nulls', () => {
-    expect(altitudeRange([{ sunAltitudeDeg: -5 }, { sunAltitudeDeg: null }, { sunAltitudeDeg: -20 }]))
-      .toEqual({ min: -20, max: -5 });
+describe('altitudeToUnit — clamping', () => {
+  it('clamps a sun outside the window to the edge, never past it', () => {
+    // The widening rings sweep near +2.75 and -28.75, both outside the window.
+    // They belong at an edge; they must not compute a position off the panel.
+    expect(altitudeToUnit(2.75, -24, -2, 'sunset')).toBe(0);
+    expect(altitudeToUnit(-28.75, -24, -2, 'sunset')).toBe(1);
+    expect(altitudeToUnit(2.75, -24, -2, 'sunrise')).toBe(1);
+    expect(altitudeToUnit(-28.75, -24, -2, 'sunrise')).toBe(0);
   });
+});
 
-  it('is null when nothing has an altitude', () => {
-    expect(altitudeRange([{ sunAltitudeDeg: null }])).toBeNull();
+describe('ALTITUDE_WINDOW', () => {
+  it('is the pool definition, not a number of its own', () => {
+    // Decision 6a chose solar altitude partly for "no pool-relative
+    // normalization, no dependence on pool membership". The window is
+    // therefore the ring the pool is gathered around, plus the radius it is
+    // gathered within, so it tracks when either constant moves.
+    expect(ALTITUDE_WINDOW).toEqual({
+      min: TERMINATOR_SUN_ALTITUDE_DEG - SEARCH_RADIUS_DEG,
+      max: TERMINATOR_SUN_ALTITUDE_DEG + SEARCH_RADIUS_DEG,
+    });
   });
 });
 

--- a/app/components/mosaic/v2/engine/horizontalPlace.ts
+++ b/app/components/mosaic/v2/engine/horizontalPlace.ts
@@ -1,4 +1,31 @@
-import type { PlacedRow, PlacedTile, SizedTile, V2Config } from './types';
+import {
+  SEARCH_RADIUS_DEG,
+  TERMINATOR_SUN_ALTITUDE_DEG,
+} from '@/app/lib/masterConfig';
+import type { PlacedRow, PlacedTile, V2Config } from './types';
+
+/**
+ * The window that turns a sun altitude into a horizontal position.
+ *
+ * It is the pool's own definition: the terminator ring the sweep gathers
+ * around, plus the radius it gathers within. Decision 6a chose solar altitude
+ * over true longitude partly for "no pool-relative normalization, no
+ * dependence on pool membership", and deriving min/max from the tiles in hand
+ * gave away exactly that property — one camera entering or leaving rescaled
+ * every tile on the panel, and the two panels normalised independently, so
+ * sunrise and sunset were not even on the same ruler.
+ *
+ * Altitudes outside the window clamp to an edge rather than widening it. The
+ * escalation rings near +2.75 and -28.75 only sweep when a feed falls under
+ * the camera floor; widening the window to cover them would squeeze every
+ * ordinary night into the middle of the panel for a case that rarely fires.
+ * A golden-hour camera pinned to the day edge is also simply true: it is the
+ * shallowest into twilight of anything on the wall.
+ */
+export const ALTITUDE_WINDOW = {
+  min: TERMINATOR_SUN_ALTITUDE_DEG - SEARCH_RADIUS_DEG,
+  max: TERMINATOR_SUN_ALTITUDE_DEG + SEARCH_RADIUS_DEG,
+} as const;
 
 /**
  * Solar altitude to a horizontal unit position, 0 = west edge, 1 = east.
@@ -17,18 +44,9 @@ export function altitudeToUnit(
 ): number {
   const span = max - min;
   if (span <= 0) return 0.5;
-  const unit = (altDeg - min) / span;
+  const raw = (altDeg - min) / span;
+  const unit = raw < 0 ? 0 : raw > 1 ? 1 : raw;
   return feed === 'sunrise' ? unit : 1 - unit;
-}
-
-export function altitudeRange(
-  tiles: { sunAltitudeDeg: number | null }[]
-): { min: number; max: number } | null {
-  const known = tiles
-    .map((t) => t.sunAltitudeDeg)
-    .filter((a): a is number => a !== null && Number.isFinite(a));
-  if (known.length === 0) return null;
-  return { min: Math.min(...known), max: Math.max(...known) };
 }
 
 /** Shoulder-to-shoulder packing in west-to-east order, honouring rowAlign. */

--- a/app/components/mosaic/v2/index.tsx
+++ b/app/components/mosaic/v2/index.tsx
@@ -9,7 +9,7 @@ import { FeedLabel } from './overlays/FeedLabel';
 import { ModelReadout } from './overlays/ModelReadout';
 import { SetupOverlay } from './overlays/SetupOverlay';
 import { TileRatings } from './overlays/TileRatings';
-import { V2_SETTINGS_SCHEMA, configFromSettings } from './settingsSchema';
+import { V2_SETTINGS_SCHEMA, configFromSettings, motionFromSettings } from './settingsSchema';
 import { useLoadedTiles } from './useLoadedTiles';
 
 /** Stable identity: a fresh [] each render would re-run the loader effect. */
@@ -32,11 +32,12 @@ export function MosaicV2({
   settings,
   at,
 }: MosaicProps) {
-  const { cfg, modelsMode } = useMemo(() => {
+  const { cfg, motion, crossfadeMs, modelsMode } = useMemo(() => {
     const params = new URLSearchParams(search);
     const merged = mergeSettings(V2_SETTINGS_SCHEMA, settings);
     return {
       cfg: configFromSettings(merged),
+      ...motionFromSettings(merged),
       modelsMode: params.has('models')
         ? params.get('models') === '1'
         : merged.showModelReadout === true,
@@ -62,6 +63,9 @@ export function MosaicV2({
         byId={byId}
         width={width}
         height={height}
+        motion={motion}
+        crossfadeMs={crossfadeMs}
+        panelSlot={feed === 'sunrise' ? 0 : 1}
         onSelect={onSelect}
       />
       {cfg.showFeedLabel && <FeedLabel feed={feed} />}

--- a/app/components/mosaic/v2/motion.test.ts
+++ b/app/components/mosaic/v2/motion.test.ts
@@ -1,0 +1,221 @@
+import { describe, it, expect } from 'vitest';
+import {
+  createMotionState,
+  commit,
+  sample,
+  staggerKeys,
+  isSettled,
+  type MotionConfig,
+  type MotionTarget,
+} from './motion';
+
+const CFG: MotionConfig = {
+  mode: 'tween',
+  order: 'none',
+  durationMs: 1000,
+  staggerMs: 0,
+  waveGridMs: 0,
+};
+
+const cfg = (over: Partial<MotionConfig> = {}): MotionConfig => ({ ...CFG, ...over });
+
+const target = (id: number, over: Partial<MotionTarget> = {}): MotionTarget => ({
+  id,
+  x: 0,
+  y: 0,
+  width: 100,
+  height: 75,
+  lat: 45,
+  ...over,
+});
+
+const CTX = { panelWidth: 1080, panelSlot: 0 as const };
+
+const byId = <T extends { id: number }>(frames: T[]) =>
+  new Map(frames.map((f) => [f.id, f] as const));
+
+describe('motion — tween', () => {
+  it('starts a new tile transparent and inset, then settles on the target', () => {
+    const s = createMotionState();
+    commit(s, [target(1, { x: 200, y: 100 })], cfg(), 0, CTX);
+
+    const first = sample(s, 0, 16, cfg())[0];
+    expect(first.opacity).toBe(0);
+    expect(first.width).toBeLessThan(100);
+
+    const settled = sample(s, 1000, 16, cfg())[0];
+    expect(settled).toMatchObject({ x: 200, y: 100, width: 100, height: 75 });
+    expect(settled.opacity).toBe(1);
+  });
+
+  it('travels between two layouts rather than jumping', () => {
+    const s = createMotionState();
+    commit(s, [target(1, { x: 0 })], cfg(), 0, CTX);
+    sample(s, 1000, 16, cfg());
+
+    commit(s, [target(1, { x: 400 })], cfg(), 1000, CTX);
+    const mid = sample(s, 1500, 16, cfg())[0];
+    expect(mid.x).toBeGreaterThan(0);
+    expect(mid.x).toBeLessThan(400);
+
+    const end = sample(s, 2000, 16, cfg())[0];
+    expect(end.x).toBe(400);
+  });
+
+  it('fades a dropped tile out and then forgets it', () => {
+    const s = createMotionState();
+    commit(s, [target(1), target(2, { x: 200 })], cfg(), 0, CTX);
+    sample(s, 1000, 16, cfg());
+
+    commit(s, [target(1)], cfg(), 1000, CTX);
+    const mid = byId(sample(s, 1400, 16, cfg()));
+    expect(mid.has(2)).toBe(true);
+
+    const after = byId(sample(s, 2000, 16, cfg()));
+    expect(after.has(2)).toBe(false);
+    expect(after.has(1)).toBe(true);
+  });
+});
+
+describe('motion — cut', () => {
+  it('lands on the target with no travel, matching the old canvas', () => {
+    const s = createMotionState();
+    commit(s, [target(1, { x: 300 })], cfg({ mode: 'cut' }), 0, CTX);
+    const f = sample(s, 0, 16, cfg({ mode: 'cut' }))[0];
+    expect(f).toMatchObject({ x: 300, width: 100, opacity: 1 });
+  });
+});
+
+describe('motion — drift', () => {
+  it('closes most of the gap in one time constant and never overshoots', () => {
+    const s = createMotionState();
+    const c = cfg({ mode: 'drift', durationMs: 1000 });
+    commit(s, [target(1, { x: 0 })], c, 0, CTX);
+    sample(s, 0, 1000, c); // settle the entry
+
+    commit(s, [target(1, { x: 1000 })], c, 0, CTX);
+    const step = sample(s, 100, 100, c)[0];
+    expect(step.x).toBeGreaterThan(0);
+    expect(step.x).toBeLessThan(1000);
+
+    const later = sample(s, 1000, 900, c)[0];
+    expect(later.x).toBeGreaterThan(900);
+    expect(later.x).toBeLessThanOrEqual(1000);
+  });
+
+  it('moves imperceptibly over one frame when the time constant is long', () => {
+    const s = createMotionState();
+    const c = cfg({ mode: 'drift', durationMs: 30_000 });
+    commit(s, [target(1, { x: 0 })], c, 0, CTX);
+    sample(s, 0, 60_000, c);
+
+    commit(s, [target(1, { x: 200 })], c, 0, CTX);
+    const oneFrame = sample(s, 16, 16, c)[0];
+    expect(oneFrame.x).toBeLessThan(1);
+  });
+});
+
+describe('staggerKeys', () => {
+  it('gives every tile the same key when ordering is off', () => {
+    const keys = staggerKeys(
+      [target(1, { lat: 60 }), target(2, { lat: 10 })],
+      createMotionState(),
+      'none',
+      CTX
+    );
+    expect([...keys.values()]).toEqual([0, 0]);
+  });
+
+  it('leads with the northernmost tile for latitude ordering', () => {
+    const keys = staggerKeys(
+      [target(1, { lat: 60 }), target(2, { lat: 10 })],
+      createMotionState(),
+      'latitude',
+      CTX
+    );
+    expect(keys.get(1)).toBe(0);
+    expect(keys.get(2)).toBe(1);
+  });
+
+  it('spans a sweep across both panels rather than restarting on each', () => {
+    // The sunrise panel owns the first half of the wave, the sunset panel the
+    // second. Without this the wall runs two waves side by side.
+    const sunrise = staggerKeys(
+      [target(1, { x: 0, width: 0 }), target(2, { x: 1080, width: 0 })],
+      createMotionState(),
+      'sweep',
+      { panelWidth: 1080, panelSlot: 0 }
+    );
+    const sunset = staggerKeys(
+      [target(3, { x: 0, width: 0 }), target(4, { x: 1080, width: 0 })],
+      createMotionState(),
+      'sweep',
+      { panelWidth: 1080, panelSlot: 1 }
+    );
+    expect(sunrise.get(1)).toBe(0);
+    expect(sunrise.get(2)).toBe(0.5);
+    expect(sunset.get(3)).toBe(0.5);
+    expect(sunset.get(4)).toBe(1);
+  });
+
+  it('leads with the furthest traveller for magnitude ordering', () => {
+    const s = createMotionState();
+    commit(s, [target(1, { x: 0 }), target(2, { x: 0 })], cfg(), 0, CTX);
+    sample(s, 1000, 16, cfg());
+
+    const keys = staggerKeys(
+      [target(1, { x: 10 }), target(2, { x: 500 })],
+      s,
+      'magnitude',
+      CTX
+    );
+    expect(keys.get(2)).toBe(0);
+    expect(keys.get(1)).toBeGreaterThan(0);
+  });
+});
+
+describe('sweep phase', () => {
+  it('rounds the wave start onto a shared grid so both panels stay in step', () => {
+    // Two panels commit 300ms apart. Quantised to a 1000ms grid they still
+    // start the same wave, which is what keeps the wall reading as one motion.
+    const a = createMotionState();
+    const b = createMotionState();
+    const c = cfg({ order: 'sweep', staggerMs: 0, waveGridMs: 1000 });
+
+    commit(a, [target(1, { x: 0, width: 0 })], c, 1200, { panelWidth: 1080, panelSlot: 0 });
+    commit(b, [target(2, { x: 0, width: 0 })], c, 1500, { panelWidth: 1080, panelSlot: 1 });
+
+    // Neither has begun at t=1900; both are underway at t=2100.
+    expect(sample(a, 1900, 16, c)[0].opacity).toBe(0);
+    expect(sample(b, 1900, 16, c)[0].opacity).toBe(0);
+    expect(sample(a, 2100, 16, c)[0].opacity).toBeGreaterThan(0);
+    expect(sample(b, 2100, 16, c)[0].opacity).toBeGreaterThan(0);
+  });
+
+  it('spreads start times across the stagger span', () => {
+    const s = createMotionState();
+    const c = cfg({ order: 'sweep', staggerMs: 2000, waveGridMs: 0 });
+    commit(
+      s,
+      [target(1, { x: 0, width: 0 }), target(2, { x: 1080, width: 0 })],
+      c,
+      0,
+      { panelWidth: 1080, panelSlot: 0 }
+    );
+    // Tile 1 has key 0 and is already moving; tile 2 has key 0.5, so its start
+    // is 1000ms out and it has not begun.
+    const frames = byId(sample(s, 500, 16, c));
+    expect(frames.get(1)!.opacity).toBeGreaterThan(0);
+    expect(frames.get(2)!.opacity).toBe(0);
+  });
+});
+
+describe('isSettled', () => {
+  it('reports unsettled mid-tween and settled after it', () => {
+    const s = createMotionState();
+    commit(s, [target(1)], cfg(), 0, CTX);
+    expect(isSettled(s, cfg(), 500)).toBe(false);
+    sample(s, 1000, 16, cfg());
+    expect(isSettled(s, cfg(), 1000)).toBe(true);
+  });
+});

--- a/app/components/mosaic/v2/motion.ts
+++ b/app/components/mosaic/v2/motion.ts
@@ -1,0 +1,295 @@
+/**
+ * The motion layer: geometry only.
+ *
+ * `compose()` stays a pure function from tiles to a target layout. This module
+ * holds the part that layout has never had — memory. Each tile keeps a track
+ * keyed by webcamId, and a track's current pose chases its target pose over
+ * time instead of snapping to it.
+ *
+ * Image crossfades live in the canvas, not here. A track knows where a tile is
+ * and how opaque it is; which frame is drawn into it is the canvas's business.
+ */
+
+export type MotionMode = 'cut' | 'tween' | 'drift';
+export type StaggerOrder = 'none' | 'latitude' | 'sweep' | 'magnitude';
+
+export interface MotionConfig {
+  mode: MotionMode;
+  order: StaggerOrder;
+  /** Tween travel time, or the drift time constant. */
+  durationMs: number;
+  /** Total spread between the first tile to move and the last. */
+  staggerMs: number;
+  /**
+   * Sweep phase quantum. The two panels are separate pages that commit at
+   * different moments, so a sweep starting at "now" would run twice, out of
+   * step. Rounding the start up to a shared grid puts both panels on the same
+   * wave without either knowing the other exists.
+   */
+  waveGridMs: number;
+}
+
+export interface MotionTarget {
+  id: number;
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  lat: number;
+}
+
+export interface MotionFrame {
+  id: number;
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  opacity: number;
+}
+
+interface Pose {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  opacity: number;
+}
+
+interface Track {
+  id: number;
+  current: Pose;
+  from: Pose;
+  to: Pose;
+  startAt: number;
+  exiting: boolean;
+}
+
+export interface MotionState {
+  tracks: Map<number, Track>;
+}
+
+export interface CommitContext {
+  /** Panel width in CSS px, used to place a tile along the sweep. */
+  panelWidth: number;
+  /** 0 for the sunrise panel, 1 for the sunset panel. */
+  panelSlot: 0 | 1;
+}
+
+/** A tile enters and leaves at this fraction of its full size. */
+const ENTRY_INSET = 0.06;
+
+export function createMotionState(): MotionState {
+  return { tracks: new Map() };
+}
+
+function poseOf(t: MotionTarget, opacity: number): Pose {
+  return { x: t.x, y: t.y, width: t.width, height: t.height, opacity };
+}
+
+function inset(p: Pose, opacity: number): Pose {
+  return {
+    x: p.x + p.width * ENTRY_INSET * 0.5,
+    y: p.y + p.height * ENTRY_INSET * 0.5,
+    width: p.width * (1 - ENTRY_INSET),
+    height: p.height * (1 - ENTRY_INSET),
+    opacity,
+  };
+}
+
+/**
+ * A delay weight in [0,1] per tile. 0 moves first, 1 moves last.
+ *
+ * `sweep` is the only ordering that says something true about the world: the
+ * terminator really does travel across the wall, and the two panels really are
+ * two ends of one line, so the key spans both panels rather than restarting on
+ * each. `latitude` and `magnitude` are arbitrary by comparison — kept because
+ * they are worth looking at, not because they mean anything.
+ */
+export function staggerKeys(
+  targets: MotionTarget[],
+  state: MotionState,
+  order: StaggerOrder,
+  ctx: CommitContext
+): Map<number, number> {
+  const keys = new Map<number, number>();
+  if (targets.length === 0) return keys;
+
+  if (order === 'none') {
+    for (const t of targets) keys.set(t.id, 0);
+    return keys;
+  }
+
+  if (order === 'latitude') {
+    const lats = targets.map((t) => t.lat);
+    const north = Math.max(...lats);
+    const south = Math.min(...lats);
+    const span = north - south;
+    for (const t of targets) {
+      keys.set(t.id, span === 0 ? 0 : (north - t.lat) / span);
+    }
+    return keys;
+  }
+
+  if (order === 'sweep') {
+    for (const t of targets) {
+      const local = ctx.panelWidth === 0 ? 0 : (t.x + t.width / 2) / ctx.panelWidth;
+      const clamped = local < 0 ? 0 : local > 1 ? 1 : local;
+      keys.set(t.id, (ctx.panelSlot + clamped) / 2);
+    }
+    return keys;
+  }
+
+  // magnitude: whichever tile has furthest to travel leads.
+  let widest = 0;
+  const deltas = new Map<number, number>();
+  for (const t of targets) {
+    const track = state.tracks.get(t.id);
+    const d = track
+      ? Math.hypot(t.x - track.current.x, t.y - track.current.y) +
+        Math.abs(t.width - track.current.width)
+      : Infinity;
+    const finite = Number.isFinite(d) ? d : 0;
+    deltas.set(t.id, finite);
+    if (finite > widest) widest = finite;
+  }
+  for (const t of targets) {
+    keys.set(t.id, widest === 0 ? 0 : 1 - (deltas.get(t.id) as number) / widest);
+  }
+  return keys;
+}
+
+/** Point every track at a new layout. Does not move anything; `sample` does. */
+export function commit(
+  state: MotionState,
+  targets: MotionTarget[],
+  cfg: MotionConfig,
+  now: number,
+  ctx: CommitContext
+): void {
+  const keys = staggerKeys(targets, state, cfg.order, ctx);
+  const waveStart =
+    cfg.order === 'sweep' && cfg.waveGridMs > 0
+      ? Math.ceil(now / cfg.waveGridMs) * cfg.waveGridMs
+      : now;
+
+  const seen = new Set<number>();
+
+  for (const t of targets) {
+    seen.add(t.id);
+    let track = state.tracks.get(t.id);
+    if (!track) {
+      const arrival = poseOf(t, 1);
+      track = {
+        id: t.id,
+        current: inset(arrival, 0),
+        from: inset(arrival, 0),
+        to: arrival,
+        startAt: waveStart,
+        exiting: false,
+      };
+      state.tracks.set(t.id, track);
+    }
+    track.from = { ...track.current };
+    track.to = poseOf(t, 1);
+    track.startAt = waveStart + cfg.staggerMs * (keys.get(t.id) ?? 0);
+    track.exiting = false;
+  }
+
+  for (const track of state.tracks.values()) {
+    if (seen.has(track.id) || track.exiting) continue;
+    track.from = { ...track.current };
+    track.to = inset(track.current, 0);
+    track.startAt = now;
+    track.exiting = true;
+  }
+}
+
+function easeInOutCubic(t: number): number {
+  return t < 0.5 ? 4 * t * t * t : 1 - Math.pow(-2 * t + 2, 3) / 2;
+}
+
+function lerp(a: number, b: number, t: number): number {
+  return a + (b - a) * t;
+}
+
+/**
+ * Advance every track and return what to draw, nearest-to-settled first.
+ * Exiting tracks are dropped once they have faded out.
+ */
+export function sample(
+  state: MotionState,
+  now: number,
+  dtMs: number,
+  cfg: MotionConfig
+): MotionFrame[] {
+  const frames: MotionFrame[] = [];
+  const finished: number[] = [];
+
+  for (const track of state.tracks.values()) {
+    const { from, to, current } = track;
+
+    if (cfg.mode === 'cut') {
+      Object.assign(current, to);
+    } else if (cfg.mode === 'drift' && !track.exiting) {
+      // Exponential chase: reaches 99.9% of the way in durationMs. A long time
+      // constant turns the 60s poll steps into movement too slow to catch.
+      const tau = Math.max(16, cfg.durationMs);
+      const k = 1 - Math.pow(0.001, Math.max(0, dtMs) / tau);
+      current.x = lerp(current.x, to.x, k);
+      current.y = lerp(current.y, to.y, k);
+      current.width = lerp(current.width, to.width, k);
+      current.height = lerp(current.height, to.height, k);
+      current.opacity = lerp(current.opacity, to.opacity, k);
+    } else {
+      const span = Math.max(1, cfg.durationMs);
+      const raw = (now - track.startAt) / span;
+      const p = raw < 0 ? 0 : raw > 1 ? 1 : raw;
+      const e = easeInOutCubic(p);
+      current.x = lerp(from.x, to.x, e);
+      current.y = lerp(from.y, to.y, e);
+      current.width = lerp(from.width, to.width, e);
+      current.height = lerp(from.height, to.height, e);
+      current.opacity = lerp(from.opacity, to.opacity, e);
+    }
+
+    if (track.exiting && current.opacity < 0.02) {
+      finished.push(track.id);
+      continue;
+    }
+
+    frames.push({
+      id: track.id,
+      x: current.x,
+      y: current.y,
+      width: current.width,
+      height: current.height,
+      opacity: current.opacity,
+    });
+  }
+
+  for (const id of finished) state.tracks.delete(id);
+  return frames;
+}
+
+/** True while any track still has somewhere to be. */
+export function isSettled(state: MotionState, cfg: MotionConfig, now: number): boolean {
+  // cut lands on the target the moment it is sampled, so one draw is always
+  // enough — which is what keeps the render loop parked on a still wall.
+  if (cfg.mode === 'cut') return true;
+  for (const track of state.tracks.values()) {
+    if (cfg.mode === 'drift') {
+      const { current, to } = track;
+      if (
+        Math.abs(current.x - to.x) > 0.25 ||
+        Math.abs(current.y - to.y) > 0.25 ||
+        Math.abs(current.width - to.width) > 0.25 ||
+        Math.abs(current.opacity - to.opacity) > 0.01
+      ) {
+        return false;
+      }
+    } else if (now < track.startAt + cfg.durationMs) {
+      return false;
+    }
+  }
+  return true;
+}

--- a/app/components/mosaic/v2/settingsSchema.test.ts
+++ b/app/components/mosaic/v2/settingsSchema.test.ts
@@ -11,6 +11,8 @@ describe('V2_SETTINGS_SCHEMA', () => {
       'strategy', 'bandCount', 'horizontalAnchor', 'rowAlign',
       'geographicFidelity', 'tileGapPx', 'latNorth', 'latSouth',
       'showFeedLabel', 'showTileRatings', 'showModelReadout',
+      'motionMode', 'motionOrder', 'motionDurationMs', 'motionStaggerMs',
+      'crossfadeMs', 'waveGridMs',
     ]) {
       expect(keys).toContain(key);
     }
@@ -24,7 +26,7 @@ describe('V2_SETTINGS_SCHEMA', () => {
   it('groups knobs into rail sections', () => {
     const sections = new Set(V2_SETTINGS_SCHEMA.map((k) => k.section));
     expect(sections).toEqual(
-      new Set(['signal', 'visibility', 'sizing', 'arrangement', 'overlays'])
+      new Set(['signal', 'visibility', 'sizing', 'arrangement', 'overlays', 'motion'])
     );
   });
 

--- a/app/components/mosaic/v2/settingsSchema.ts
+++ b/app/components/mosaic/v2/settingsSchema.ts
@@ -126,7 +126,7 @@ export const V2_SETTINGS_SCHEMA: SettingsSchema = [
   },
   {
     key: 'motionMode', kind: 'enum',
-    options: ['cut', 'tween', 'drift'] as const, default: 'cut',
+    options: ['cut', 'tween', 'drift'] as const, default: 'drift',
     label: 'motion', section: 'motion',
     description: 'cut snaps to each new composition, which is what the wall did before this section existed. tween travels between them. drift never arrives — it chases the composition continuously, so the wall is always moving and never jumps.',
   },
@@ -137,7 +137,7 @@ export const V2_SETTINGS_SCHEMA: SettingsSchema = [
     description: 'Which tile moves first. sweep runs one wave across both panels in the direction the terminator travels, so the wall reads as the world turning; latitude and magnitude are arbitrary orderings kept for comparison. Needs a stagger span to have any effect.',
   },
   {
-    key: 'motionDurationMs', kind: 'number', min: 0, max: 60_000, step: 100, default: 900,
+    key: 'motionDurationMs', kind: 'number', min: 0, max: 60_000, step: 100, default: 30_000,
     label: 'travel (ms)', section: 'motion',
     description: 'How long a tile takes to reach its new place. In drift mode this is the time constant instead: the wall closes 99.9% of the gap in this long, so a big number is what makes the movement too slow to catch.',
   },
@@ -147,7 +147,7 @@ export const V2_SETTINGS_SCHEMA: SettingsSchema = [
     description: 'Spread between the first tile to move and the last. 0 moves everything at once.',
   },
   {
-    key: 'crossfadeMs', kind: 'number', min: 0, max: 8_000, step: 100, default: 0,
+    key: 'crossfadeMs', kind: 'number', min: 0, max: 8_000, step: 100, default: 1_500,
     label: 'frame crossfade (ms)', section: 'motion',
     description: 'How long a newly published frame takes to fade up over the one it replaces. Independent of tile movement: a camera publishes roughly every ten minutes, whenever it likes.',
   },

--- a/app/components/mosaic/v2/settingsSchema.ts
+++ b/app/components/mosaic/v2/settingsSchema.ts
@@ -1,5 +1,6 @@
 import type { SettingsSchema, SettingsValues } from '@/app/lib/settings/schema';
 import type { V2Config } from './engine/types';
+import type { MotionConfig } from './motion';
 
 /**
  * Every v2 composition knob. Defaults here ARE what the engine does with no
@@ -123,6 +124,38 @@ export const V2_SETTINGS_SCHEMA: SettingsSchema = [
     label: 'model readout', section: 'overlays',
     description: 'What each model head said about each frame.',
   },
+  {
+    key: 'motionMode', kind: 'enum',
+    options: ['cut', 'tween', 'drift'] as const, default: 'cut',
+    label: 'motion', section: 'motion',
+    description: 'cut snaps to each new composition, which is what the wall did before this section existed. tween travels between them. drift never arrives — it chases the composition continuously, so the wall is always moving and never jumps.',
+  },
+  {
+    key: 'motionOrder', kind: 'enum',
+    options: ['none', 'latitude', 'sweep', 'magnitude'] as const, default: 'none',
+    label: 'stagger order', section: 'motion',
+    description: 'Which tile moves first. sweep runs one wave across both panels in the direction the terminator travels, so the wall reads as the world turning; latitude and magnitude are arbitrary orderings kept for comparison. Needs a stagger span to have any effect.',
+  },
+  {
+    key: 'motionDurationMs', kind: 'number', min: 0, max: 60_000, step: 100, default: 900,
+    label: 'travel (ms)', section: 'motion',
+    description: 'How long a tile takes to reach its new place. In drift mode this is the time constant instead: the wall closes 99.9% of the gap in this long, so a big number is what makes the movement too slow to catch.',
+  },
+  {
+    key: 'motionStaggerMs', kind: 'number', min: 0, max: 20_000, step: 100, default: 0,
+    label: 'stagger span (ms)', section: 'motion',
+    description: 'Spread between the first tile to move and the last. 0 moves everything at once.',
+  },
+  {
+    key: 'crossfadeMs', kind: 'number', min: 0, max: 8_000, step: 100, default: 0,
+    label: 'frame crossfade (ms)', section: 'motion',
+    description: 'How long a newly published frame takes to fade up over the one it replaces. Independent of tile movement: a camera publishes roughly every ten minutes, whenever it likes.',
+  },
+  {
+    key: 'waveGridMs', kind: 'number', min: 0, max: 5_000, step: 250, default: 1_000,
+    label: 'wave phase grid (ms)', section: 'motion',
+    description: 'The two panels are separate pages that commit at different moments. Rounding a sweep\'s start up to this shared grid puts both on the same wave with no messaging between them. Only used by the sweep ordering.',
+  },
 ] as const;
 
 /** Merged dial values to the engine's config shape. */
@@ -150,5 +183,25 @@ export function configFromSettings(values: SettingsValues): V2Config {
     showTileRatings: values.showTileRatings as boolean,
     overlayScale: values.overlayScale as number,
     showModelReadout: values.showModelReadout as boolean,
+  };
+}
+
+/**
+ * The motion dials, kept out of V2Config on purpose: the composition engine
+ * decides where a tile belongs and has no business knowing how it gets there.
+ */
+export function motionFromSettings(values: SettingsValues): {
+  motion: MotionConfig;
+  crossfadeMs: number;
+} {
+  return {
+    motion: {
+      mode: values.motionMode as MotionConfig['mode'],
+      order: values.motionOrder as MotionConfig['order'],
+      durationMs: values.motionDurationMs as number,
+      staggerMs: values.motionStaggerMs as number,
+      waveGridMs: values.waveGridMs as number,
+    },
+    crossfadeMs: values.crossfadeMs as number,
   };
 }

--- a/app/components/mosaic/v2/useLoadedTiles.test.ts
+++ b/app/components/mosaic/v2/useLoadedTiles.test.ts
@@ -132,4 +132,41 @@ describe('useLoadedTiles', () => {
 
     expect(result.current).toBe(first);
   });
+
+  it('holds the last good batch on screen while the next one loads', async () => {
+    // The pool refetches every 60s and hands us a fresh array. Clearing tiles
+    // at the start of the new cycle paints the canvas black until the images
+    // resolve, so the wall blinks once a minute. Hold the previous batch.
+    const { result, rerender } = renderHook(
+      ({ cams }) => useLoadedTiles(cams, opts),
+      { initialProps: { cams: [cam(1, 'https://x/a.jpg')] } }
+    );
+    await waitFor(() => expect(created).toHaveLength(1));
+    created[0].onload?.();
+    await waitFor(() => expect(result.current.tiles).toHaveLength(1));
+
+    rerender({ cams: [cam(1, 'https://x/a.jpg')] }); // same camera, new array
+
+    await waitFor(() => expect(result.current.loading).toBe(true));
+    expect(result.current.tiles).toHaveLength(1);
+    expect(result.current.byId.get(1)).toBeDefined();
+  });
+
+  it('replaces the held batch once the new one settles', async () => {
+    const { result, rerender } = renderHook(
+      ({ cams }) => useLoadedTiles(cams, opts),
+      { initialProps: { cams: [cam(1, 'https://x/a.jpg')] } }
+    );
+    await waitFor(() => expect(created).toHaveLength(1));
+    created[0].onload?.();
+    await waitFor(() => expect(result.current.tiles).toHaveLength(1));
+
+    rerender({ cams: [cam(2, 'https://x/b.jpg')] });
+    await waitFor(() => expect(created).toHaveLength(2));
+    created[1].onload?.();
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.tiles.map((t) => t.id)).toEqual([2]);
+    expect(result.current.byId.get(1)).toBeUndefined();
+  });
 });

--- a/app/components/mosaic/v2/useLoadedTiles.ts
+++ b/app/components/mosaic/v2/useLoadedTiles.ts
@@ -67,7 +67,16 @@ export function useLoadedTiles(
       };
     }
 
-    setResult({ tiles: [], byId: new Map(), skipped: noPreviewCount, loading: true });
+    // Hold the last good batch while this one loads. Clearing here paints the
+    // canvas black for as long as the images take, and the pool refetches
+    // every 60s, so the wall blinked once a minute. The held tiles are at most
+    // one cycle stale; the swap below is atomic.
+    setResult((prev) => ({
+      tiles: prev.tiles,
+      byId: prev.byId,
+      skipped: prev.skipped,
+      loading: true,
+    }));
 
     const moment = momentOf(at);
     let settled = 0;


### PR DESCRIPTION
Three commits. The first two stand on their own; the third turns the result on.

## The wall stopped blinking

`useLoadedTiles` cleared its state at the start of every load cycle, so the
canvas painted solid black until the images resolved. The pool refetches every
60s, so the wall blinked once a minute. It now holds the last good batch and
swaps atomically when the next one settles. This is the one change here that
alters behaviour whether or not anybody touches a dial.

## Tiles have somewhere to be, and take time getting there

`compose()` stays a pure function from tiles to a target layout. `motion.ts`
adds the part layout never had, which is memory: a track per webcamId whose
current pose chases its target pose. `MosaicCanvas` draws from that each frame
instead of drawing the layout directly, and parks its render loop the moment
everything settles, so a still wall costs the kiosk nothing.

Image crossfades live in the canvas rather than in the motion layer. A track
knows where a tile is; which frame is drawn into it is the canvas's business.

Six dials land in the v2 schema as a new `motion` section, so they appear on
the studio surface with no further wiring.

## The horizontal axis was measuring the wrong thing

Decision 6a chose solar altitude over true longitude for X, and one of the
stated reasons it won was "no pool-relative normalization, no dependence on
pool membership". The implementation then derived min and max from the tiles
in hand, giving away exactly that property.

The consequences were larger than they look:

- One camera entering or leaving rescaled every tile on the panel, so a tile
  moved when nothing about its own place had changed. That is what stops the
  wall reading as a map rather than a screensaver.
- The range came from `sized`, which is post-drop, so an overflow event
  rescaled every survivor too.
- Each panel normalised over its own tiles, so sunrise and sunset were not on
  the same ruler.

The window is now the pool's own definition: `TERMINATOR_SUN_ALTITUDE_DEG` plus
or minus `SEARCH_RADIUS_DEG`. No new constant, and it tracks by itself when
either moves, as the radius did on 2026-09-02. Altitudes outside it clamp to an
edge rather than widening it — the escalation rings near +2.75 and −28.75 only
sweep under the camera floor, and covering them would squeeze every ordinary
night into the middle of the panel for a case that rarely fires.

Found by session -45 reading `compose.ts` against the spec.

## Defaults

`drift` at a 30s time constant, and frames fading up over 1.5s. Stagger stays
off; it only earns its place on a discrete rearrangement, and with the axis
pinned there is not much left to rearrange.

## Verified

- 1353 tests pass, lint clean, production build succeeds.
- Ran locally against the live pool of 124 cameras and instrumented the canvas
  rather than trusting the code. The render loop draws, converges, and parks;
  the next 60s poll wakes it for 1408 frames, over which the leading tile
  travels from x=354.052 to x=354.084.

That last number is the honest headline. With the axis pinned, geometry motion
between polls is now measured in hundredths of a pixel — invisible, which is
the intent, but it means what you will actually see on the glass is the frame
crossfades, not movement. Worth knowing before looking for something dramatic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EDsk5975cWKCVbN1kdLqBe
