### PR TITLE
Say which settings the server refused to store

### DIFF
--- a/app/api/kiosk/settings/route.test.ts
+++ b/app/api/kiosk/settings/route.test.ts
@@ -155,7 +155,47 @@ describe('PATCH /api/kiosk/settings', () => {
     expect(res.status).toBe(200);
     expect(putStudioNamespaceMock).toHaveBeenCalledWith('v1', { floorPx: 800 });
     const body = await res.json();
-    expect(body).toEqual({ revision: 2 });
+    expect(body.revision).toBe(2);
+  });
+
+  it('names a posted key the schema does not know, so an undeployed dial is not swallowed', async () => {
+    requireOwnerMock.mockResolvedValueOnce(null);
+    putStudioNamespaceMock.mockResolvedValueOnce(3);
+
+    const res = await PATCH(
+      reqPatch({ namespace: 'v1', values: { floorPx: 200, motionMode: 'drift' } }),
+    );
+    const body = await res.json();
+    expect(body.dropped).toEqual([{ key: 'motionMode', reason: 'unknown' }]);
+  });
+
+  it('still stores the values that did survive alongside the warning', async () => {
+    requireOwnerMock.mockResolvedValueOnce(null);
+    putStudioNamespaceMock.mockResolvedValueOnce(3);
+
+    await PATCH(reqPatch({ namespace: 'v1', values: { floorPx: 200, motionMode: 'drift' } }));
+    expect(putStudioNamespaceMock).toHaveBeenCalledWith('v1', { floorPx: 200 });
+  });
+
+  it('warns on the server so a dropped key is greppable in the deploy logs', async () => {
+    requireOwnerMock.mockResolvedValueOnce(null);
+    putStudioNamespaceMock.mockResolvedValueOnce(3);
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    await PATCH(reqPatch({ namespace: 'v1', values: { motionMode: 'drift' } }));
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining('motionMode'),
+    );
+    warn.mockRestore();
+  });
+
+  it('omits the warning entirely when every posted key survived', async () => {
+    requireOwnerMock.mockResolvedValueOnce(null);
+    putStudioNamespaceMock.mockResolvedValueOnce(4);
+
+    const res = await PATCH(reqPatch({ namespace: 'v1', values: { floorPx: 200 } }));
+    const body = await res.json();
+    expect(body).toEqual({ revision: 4 });
   });
 
   it('strips defaults: omits values equal to schema defaults', async () => {

--- a/app/api/kiosk/settings/route.ts
+++ b/app/api/kiosk/settings/route.ts
@@ -2,7 +2,7 @@ import { NextResponse } from 'next/server';
 import { requireOwner } from '@/app/lib/owner';
 import { getProfileSettings, putStudioNamespace } from '@/app/lib/settings/store';
 import { getKioskLastPoll } from '@/app/lib/cache';
-import { sanitizeValues, stripDefaults } from '@/app/lib/settings/schema';
+import { droppedKeys, sanitizeValues, stripDefaults } from '@/app/lib/settings/schema';
 import { SHARED_NAMESPACE, SHARED_SCHEMA } from '@/app/lib/settings/sharedSchema';
 import { MOSAIC_SETTINGS_SCHEMAS } from '@/app/components/mosaic/registry';
 
@@ -42,7 +42,20 @@ export async function PATCH(request: Request) {
   if (!schema) {
     return NextResponse.json({ error: `unknown namespace: ${namespace}` }, { status: 400 });
   }
+  // Sanitizing is quiet by design, which is right for a stored blob and wrong
+  // for a live PATCH: a dial posted against a build whose schema predates it
+  // vanishes here, the studio row never moves, and Deploy goes on truthfully
+  // reporting "in sync with glass" about a setting the glass has never heard
+  // of. Name the casualties instead of swallowing them.
+  const dropped = droppedKeys(schema, values);
+  if (dropped.length > 0) {
+    console.warn(
+      `[settings] PATCH ${namespace} dropped ${dropped.length} key(s): ` +
+        dropped.map((d) => `${d.key} (${d.reason})`).join(', ')
+    );
+  }
+
   const deviations = stripDefaults(schema, sanitizeValues(schema, values));
   const revision = await putStudioNamespace(namespace, deviations);
-  return NextResponse.json({ revision });
+  return NextResponse.json(dropped.length > 0 ? { revision, dropped } : { revision });
 }

--- a/app/lib/settings/schema.test.ts
+++ b/app/lib/settings/schema.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import {
-  schemaDefaults, sanitizeValues, stripDefaults, mergeSettings, diffKeys,
+  schemaDefaults, sanitizeValues, stripDefaults, mergeSettings, diffKeys, droppedKeys,
   type SettingsSchema,
 } from './schema';
 
@@ -68,5 +68,25 @@ describe('diffKeys', () => {
   });
   it('treats an explicit default and an absent key as identical', () => {
     expect(diffKeys(SCHEMA, { floorPx: 100 }, {})).toEqual([]);
+  });
+});
+
+describe('droppedKeys', () => {
+  it('flags a key the schema has never heard of, which is what an undeployed dial looks like', () => {
+    expect(droppedKeys(SCHEMA, { floorPx: 140, motionMode: 'drift' })).toEqual([
+      { key: 'motionMode', reason: 'unknown' },
+    ]);
+  });
+  it('flags a known key whose value could not survive sanitizing', () => {
+    expect(droppedKeys(SCHEMA, { activeVersion: 'v9' })).toEqual([
+      { key: 'activeVersion', reason: 'invalid' },
+    ]);
+  });
+  it('says nothing when every posted key survives, clamping included', () => {
+    expect(droppedKeys(SCHEMA, { floorPx: 5000, cullOverflow: false })).toEqual([]);
+  });
+  it('says nothing for input that was never an object', () => {
+    expect(droppedKeys(SCHEMA, null)).toEqual([]);
+    expect(droppedKeys(SCHEMA, [1, 2])).toEqual([]);
   });
 });

--- a/app/lib/settings/schema.ts
+++ b/app/lib/settings/schema.ts
@@ -100,3 +100,28 @@ export function diffKeys(
   }
   return keys;
 }
+
+export type DroppedKey = { key: string; reason: 'unknown' | 'invalid' };
+
+/**
+ * The keys a caller posted that `sanitizeValues` will silently discard.
+ *
+ * Sanitizing is deliberately quiet so a stale stored blob cannot poison a
+ * profile, but that same silence hides the case where a dial is posted
+ * against a build whose schema predates it: the value vanishes, the studio
+ * row never changes, and Deploy goes on truthfully reporting "in sync with
+ * glass" about a setting the glass has never been told. Callers use this to
+ * say so out loud. A clamped number is not dropped — the value survives.
+ */
+export function droppedKeys(schema: SettingsSchema, input: unknown): DroppedKey[] {
+  if (typeof input !== 'object' || input === null || Array.isArray(input)) return [];
+  const raw = input as Record<string, unknown>;
+  const known = new Set(schema.map((knob) => knob.key));
+  const survived = sanitizeValues(schema, input);
+  const out: DroppedKey[] = [];
+  for (const key of Object.keys(raw)) {
+    if (key in survived) continue;
+    out.push({ key, reason: known.has(key) ? 'invalid' : 'unknown' });
+  }
+  return out;
+}

--- a/app/studio/StatusStrip.test.tsx
+++ b/app/studio/StatusStrip.test.tsx
@@ -125,4 +125,45 @@ describe('StatusStrip', () => {
     expect(clearIntervalSpy).toHaveBeenCalled();
     clearIntervalSpy.mockRestore();
   });
+
+  it('names the keys a write could not store, so an undeployed dial is not silent', () => {
+    const now = new Date('2026-08-30T12:00:00Z');
+    vi.setSystemTime(now);
+
+    render(
+      <StatusStrip
+        glassVersion="v2"
+        liveRevision={14}
+        lastPollAt={new Date(now.getTime() - 5_000).toISOString()}
+        deployedAtMs={null}
+        diffCount={0}
+        sunrisePass={{ pass: 1, total: 39 }}
+        sunsetPass={{ pass: 3, total: 42 }}
+        droppedKeys={[{ key: 'motionMode', reason: 'unknown' }]}
+      />
+    );
+
+    expect(screen.getByText(/motionMode/)).toBeInTheDocument();
+  });
+
+  it('says nothing about dropped keys when the last write stored everything', () => {
+    const now = new Date('2026-08-30T12:00:00Z');
+    vi.setSystemTime(now);
+
+    render(
+      <StatusStrip
+        glassVersion="v2"
+        liveRevision={14}
+        lastPollAt={new Date(now.getTime() - 5_000).toISOString()}
+        deployedAtMs={null}
+        diffCount={0}
+        sunrisePass={{ pass: 1, total: 39 }}
+        sunsetPass={{ pass: 3, total: 42 }}
+        droppedKeys={[]}
+      />
+    );
+
+    expect(screen.queryByTestId('status-strip-dropped')).toBeNull();
+  });
+
 });

--- a/app/studio/StatusStrip.tsx
+++ b/app/studio/StatusStrip.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from 'react';
 import { stripState, formatPollAge, type StripKind } from './stripState';
+import type { DroppedKey } from '@/app/lib/settings/schema';
 import { KIOSK_TICK_INTERVAL_MS } from '@/app/lib/masterConfig';
 
 const mono = 'ui-monospace, SFMono-Regular, Menlo, monospace';
@@ -37,6 +38,7 @@ export function StatusStrip({
   diffCount,
   sunrisePass,
   sunsetPass,
+  droppedKeys = [],
 }: {
   glassVersion: string;
   liveRevision: number;
@@ -45,6 +47,7 @@ export function StatusStrip({
   diffCount: number;
   sunrisePass: GatePassCount;
   sunsetPass: GatePassCount;
+  droppedKeys?: DroppedKey[];
 }) {
   const [nowMs, setNowMs] = useState(() => Date.now());
 
@@ -114,6 +117,21 @@ export function StatusStrip({
       <span style={{ color: amber }}>
         ↑{sunrisePass.pass}/{sunrisePass.total} ↓{sunsetPass.pass}/{sunsetPass.total} pass
       </span>
+      {droppedKeys.length > 0 && (
+        <span
+          data-testid="status-strip-dropped"
+          style={{ color: red }}
+          title={
+            'The server stored every other value but discarded these. An ' +
+            '"unknown" key means this build has no such dial, so deploy the ' +
+            'code before setting it; "invalid" means the value itself was ' +
+            'rejected.'
+          }
+        >
+          ⚠ not stored:{' '}
+          {droppedKeys.map((d) => `${d.key} (${d.reason})`).join(', ')}
+        </span>
+      )}
       <span style={{ marginLeft: 'auto' }}>{stateWord}</span>
     </div>
   );

--- a/app/studio/StudioClient.tsx
+++ b/app/studio/StudioClient.tsx
@@ -218,6 +218,7 @@ export function StudioClient() {
           diffCount={settingsApi.diffCount}
           sunrisePass={sunrisePass}
           sunsetPass={sunsetPass}
+          droppedKeys={settingsApi.droppedKeys}
         />
       </div>
     </div>

--- a/app/studio/useStudioSettings.test.tsx
+++ b/app/studio/useStudioSettings.test.tsx
@@ -463,4 +463,81 @@ describe('useStudioSettings', () => {
     const body = JSON.parse(patchCalls[0][1].body as string);
     expect(body).toEqual({ namespace: 'v1', values: { floorPx: 200, padding: 5 } });
   });
+
+  it('surfaces the keys a PATCH dropped, so a dial this build cannot store is visible', async () => {
+    const getResponse = settingsResponse({}, {});
+    fetchMock = vi.fn(async (url: string, init?: RequestInit) => {
+      if (!init || (!init.method && url === '/api/kiosk/settings')) {
+        return { ok: true, json: async () => getResponse };
+      }
+      if (init.method === 'PATCH') {
+        return {
+          ok: true,
+          json: async () => ({
+            revision: 2,
+            dropped: [{ key: 'motionMode', reason: 'unknown' }],
+          }),
+        };
+      }
+      return { ok: true, json: async () => ({}) };
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { result } = renderHook(() => useStudioSettings(), { wrapper });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+
+    act(() => {
+      result.current.setKnob('v1', 'floorPx', 140);
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(500);
+    });
+
+    expect(result.current.droppedKeys).toEqual([
+      { key: 'motionMode', reason: 'unknown' },
+    ]);
+  });
+
+  it('clears a stale dropped-key warning once a later PATCH stores everything', async () => {
+    const getResponse = settingsResponse({}, {});
+    let dropOnNextPatch = true;
+    fetchMock = vi.fn(async (url: string, init?: RequestInit) => {
+      if (!init || (!init.method && url === '/api/kiosk/settings')) {
+        return { ok: true, json: async () => getResponse };
+      }
+      if (init.method === 'PATCH') {
+        const dropped = dropOnNextPatch
+          ? [{ key: 'motionMode', reason: 'unknown' }]
+          : undefined;
+        dropOnNextPatch = false;
+        return { ok: true, json: async () => ({ revision: 2, dropped }) };
+      }
+      return { ok: true, json: async () => ({}) };
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { result } = renderHook(() => useStudioSettings(), { wrapper });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+
+    act(() => {
+      result.current.setKnob('v1', 'floorPx', 140);
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(500);
+    });
+    expect(result.current.droppedKeys).toHaveLength(1);
+
+    act(() => {
+      result.current.setKnob('v1', 'floorPx', 160);
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(500);
+    });
+    expect(result.current.droppedKeys).toEqual([]);
+  });
+
 });

--- a/app/studio/useStudioSettings.ts
+++ b/app/studio/useStudioSettings.ts
@@ -7,6 +7,7 @@ import {
   diffKeys,
   sanitizeValues,
   stripDefaults,
+  type DroppedKey,
   type KnobValue,
   type SettingsSchema,
   type SettingsValues,
@@ -38,6 +39,7 @@ export interface StudioSettingsApi {
   deploy: () => Promise<void>;
   revert: () => Promise<void>;
   deployedAtMs: number | null; // Date.now() at last successful deploy this session
+  droppedKeys: DroppedKey[]; // keys the last PATCH per namespace could not store
 }
 
 function schemaFor(namespace: string): SettingsSchema | null {
@@ -71,6 +73,11 @@ export function useStudioSettings(): StudioSettingsApi {
   const overlayRef = useRef<Record<string, SettingsValues>>({});
   const timers = useRef<Record<string, ReturnType<typeof setTimeout>>>({});
   const [deployedAtMs, setDeployedAtMs] = useState<number | null>(null);
+  // Keyed by namespace so one namespace's clean write cannot clear another's
+  // warning. Each PATCH response replaces its own namespace's entry.
+  const [droppedByNamespace, setDroppedByNamespace] = useState<
+    Record<string, DroppedKey[]>
+  >({});
 
   const flush = useCallback((namespace: string, schema: SettingsSchema) => {
     const values = overlayRef.current[namespace] ?? {};
@@ -82,14 +89,21 @@ export function useStudioSettings(): StudioSettingsApi {
       method: 'PATCH',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(body),
-    }).then((res) => {
+    }).then(async (res) => {
       if (!res.ok) {
         // Leave the optimistic overlay in place — the local edit isn't
         // lost, it just hasn't reached the server. Next successful flush
         // (this namespace's next edit, or a future retry) resends the full
         // deviation set from overlayRef, so nothing needs replaying here.
         console.warn('[studio] settings PATCH failed:', res.status);
+        return res;
       }
+      // A key the server could not store is the one failure this panel used
+      // to hide completely: the dial moves, the row does not, and Deploy
+      // then reports "in sync with glass" about a setting the glass has
+      // never been told. Carry it out to the strip instead.
+      const payload = (await res.json().catch(() => ({}))) as { dropped?: DroppedKey[] };
+      setDroppedByNamespace((prev) => ({ ...prev, [namespace]: payload.dropped ?? [] }));
       return res;
     });
   }, []);
@@ -214,6 +228,11 @@ export function useStudioSettings(): StudioSettingsApi {
     return out;
   }, [studio, live]);
 
+  const droppedKeys = useMemo(
+    () => Object.values(droppedByNamespace).flat(),
+    [droppedByNamespace]
+  );
+
   const diffCount = useMemo(
     () => Object.values(diffByNamespace).reduce((sum, keys) => sum + keys.length, 0),
     [diffByNamespace]
@@ -262,5 +281,6 @@ export function useStudioSettings(): StudioSettingsApi {
     deploy,
     revert,
     deployedAtMs,
+    droppedKeys,
   };
 }


### PR DESCRIPTION
Written by a parallel session; opened here so it can be merged. Verified
independently before opening: 1347 tests pass on this branch.

## The problem

`sanitizeValues` silently discards any key the schema does not recognise. That
is correct behaviour, but the studio said nothing about it, so a write that
stored nothing was indistinguishable from a write that stored fine and had no
visible effect. The failure mode this produces is a long debugging session
against a dial that was never persisted.

It bites hardest exactly when a new dial is being introduced, because the code
that knows the key has to be deployed before any value for it can survive a
write.

## The change

`droppedKeys()` classifies every posted key the server discarded:

- `unknown` — the schema has never heard of it, which is the undeployed-dial case
- `invalid` — the value could not survive sanitising

A clamped number is not counted as dropped, since the value does survive.

The settings PATCH route warns server-side and returns the list.
`useStudioSettings` holds it per namespace, so one namespace's clean write
cannot clear another's warning. The status strip renders it in red beside the
state word.

Concretely, posting `motionMode` against a build that does not know that key now
puts `⚠ not stored: motionMode (unknown)` in the strip instead of nothing.

## Merge before #116

#116 introduces six `motion` dials. If one of those writes ever fails to store,
this is the difference between seeing why and hunting a ghost. The two branches
touch no files in common and merge cleanly into main independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EDsk5975cWKCVbN1kdLqBe
