### PR TITLE
docs(mosaic): specs for the band paradigm (v3) and for pool coverage

### DIFF
--- a/docs/superpowers/specs/2026-09-02-mosaic-v3-band-paradigm-design.md
+++ b/docs/superpowers/specs/2026-09-02-mosaic-v3-band-paradigm-design.md
@@ -1,0 +1,306 @@
+# Mosaic v3 — the band paradigm
+
+**Date:** 2026-09-02
+**Status:** Design approved in conversation. Ready for implementation planning.
+**Parent specs (binding):** `2026-08-30-kiosk-studio-control-and-mosaic-v2-design.md`,
+`2026-09-01-mosaic-v2-phase2-composition-decisions.md`
+**Sibling spec:** `2026-09-02-terminator-pool-coverage-design.md` (Plan B). The two
+meet at one boundary, defined in §8.
+
+---
+
+## 1. What this is
+
+v2 arranges tiles by floating rows whose vertical position is the average
+latitude of whoever happens to share the row. v3 replaces that with **fixed
+bands**: the screen is an abstract map, the vertical axis is quantised into
+strips that never move, and the horizontal axis is perpendicular distance from
+the terminator. Nothing on the wall changes position because of who else is in
+the pool.
+
+v3 ships as a new registry entry alongside v1 and v2. `DEFAULT_MOSAIC_VERSION`
+stays `v1`. All three remain switchable by `?v=` so they can be compared on the
+same glass.
+
+### What v3 cannot do, stated up front
+
+The small-to-large-to-small arc — a camera growing as it approaches the
+terminator and shrinking after — **is not achievable by this spec alone**, and
+implementers should not chase it. See §2. v3 delivers a stable, legible,
+absolutely-positioned wall. The arc needs Plan B.
+
+---
+
+## 2. The measurement that drives this design
+
+Run 2026-09-02 against 46,079 scored snapshots joined to camera coordinates,
+solar altitude computed per frame with SunCalc at capture time.
+
+Share of frames Claude scored at or above 0.5, by the sun's altitude:
+
+| sun altitude | frames | good |
+|---|---|---|
+| −16° to −14° | 2,577 | 1.0% |
+| −12° to −10° | 3,040 | 3.3% |
+| −8° to −6° | 5,862 | 10.8% |
+| −2° to 0° | 1,959 | 14.9% |
+| **0° to +2°** | 1,701 | **19.7%** |
+| **+4° to +6°** | 2,167 | **19.4%** |
+
+Good sunsets happen with the sun just above the horizon. The 4,525 good frames
+come from 679 distinct cameras, the most prolific contributing 3.8% and the top
+ten 22.6%, so this is a property of nature rather than of a few sites.
+
+Reproduce with `node scripts/altitude-quality-report.mjs`.
+
+**Consequence.** The pool gathers within `SEARCH_RADIUS_DEG` (11°) of
+`TERMINATOR_SUN_ALTITUDE_DEG` (−13°), so it holds cameras from −24° to −2° and
+nothing else. On the sunset panel a camera appears at the day edge already past
+its quality peak, and can only shrink. `masterConfig.ts` already records the
+same fact in a comment: the day-side escalation ring reaches golden hour,
+"which the base ring at −13 misses entirely."
+
+### Timestamps are correct — do not "fix" them
+
+`webcam_snapshots.captured_at` is declared `timestamp without time zone`, which
+looks like a bug and is not one. Every hourly offset from −8 to +8 was tested
+against 21,061 Claude-confirmed sunsets, scored by how many land within 8° of
+the horizon:
+
+| offset applied | sunsets near the horizon |
+|---|---|
+| −1 h | 56.8% |
+| **0** | **74.4%** |
+| +1 h | 43.8% |
+
+A sharp peak at zero. Stored local time or mishandled DST could not produce
+that. Nothing in the pipeline applies a zone offset and `webcams.timezone` is
+null for all 21,061 rows, so there is nothing to get wrong. Migrating the
+column to `timestamptz` would turn a working convention into an enforced
+guarantee, but the data is correct today and the migration is **explicitly out
+of scope**, recorded here so the question is not re-opened.
+
+---
+
+## 3. Decisions settled in conversation — do not re-derive
+
+- **West stays on the left.** Tiles travel **left to right** on both panels.
+  The terminator sweeps westward, so relative to a terminator-centred frame the
+  ground moves east, and east is on the right. Right-to-left motion and
+  west-on-the-left cannot both hold; west-on-the-left won.
+- **On the sunset panel** the left edge is the day side and the right edge is
+  deep twilight. **On the sunrise panel** those are reversed, because the day
+  side of the sunrise line is to the east. Both still travel left to right.
+- **Size means quality and nothing else.** No positional term. The
+  small-large-small sequence is meant to emerge from the detector firing during
+  the sunset window, not from geometry.
+- **X is perpendicular angular distance from the terminator.** This is exactly
+  solar altitude, not an approximation: a point with the sun h degrees up sits
+  h degrees on the day side of the terminator circle. v2's axis is already
+  correct on this point and carries over unchanged.
+- **Screen centre is the pool's ring at −13°**, not the geometric terminator at
+  0°. Zero is outside the window today and clamps.
+
+---
+
+## 4. v3 as a registry version
+
+`app/components/mosaic/registry.ts` ships every version side by side and
+resolves one from `?v=`. v3 is added the way the registry's own comment
+prescribes:
+
+- new folder `app/components/mosaic/v3/`, seeded as a copy of v2
+- `MOSAIC_VERSIONS.v3` and `MOSAIC_SETTINGS_SCHEMAS.v3` rows
+- `DEFAULT_MOSAIC_VERSION` unchanged at `v1`
+
+Settings live in v3's own namespace, so v2's dials are untouched and a v2 scene
+still replays as v2. The duplicated engine folder is the intended cost; the
+registry comment prescribes deleting a loser's folder rather than abstracting
+across versions.
+
+**Do not refactor v2's engine into a shared module.** Versions are independent
+by design so they can evolve or be deleted without touching each other.
+
+---
+
+## 5. The band model
+
+### 5.1 Bands fix the vertical axis
+
+The latitude range (`latNorth` 70, `latSouth` −60) is cut into `bandCount`
+equal strips. A camera's band follows from its latitude alone. The strip
+covering 45°N to 50°N is the same pixels tonight and next year, holding one
+camera or forty.
+
+This is the vertical cure for the disease that was fixed on the horizontal axis
+on 2026-09-01. v2 forms rows by greedy width packing over the current pool and
+places each row at its members' mean latitude, so adding one camera changes row
+membership, which changes the means, which moves every row.
+
+Bands are always drawn at their own position. An empty band stays empty; a
+quiet latitude reads as quiet.
+
+### 5.2 Placement is absolute, and nothing is ever shoved
+
+Each tile is placed at:
+
+- **x** from its solar altitude through the axis window (§6), unchanged from v2
+- **y** centred on its band
+- **height** from quality, width from source aspect, unchanged from v2
+
+There is no de-overlap pass. v2's `packByAltitude` pushes colliding tiles
+rightward and then slides the whole row back, which means one arriving camera
+can move every tile in the row and corrupts the axis. **That pass is deleted in
+v3, not adjusted.**
+
+### 5.3 Collisions are resolved by eviction, not by movement
+
+One rule covers both axes. Within a band:
+
+1. Compute every candidate's rectangle at its absolute position.
+2. Sort candidates by **effective quality** descending (§5.4).
+3. Admit in order. Skip any candidate whose rectangle, expanded by
+   `tileGapPx`, intersects a rectangle already admitted.
+4. Skipped candidates are not drawn.
+
+Deterministic, absolute position preserved exactly, and the best sunset always
+wins its neighbourhood. A large tile evicts more neighbours, which is correct:
+it earned the space.
+
+Test the rectangle intersection in **2D**, not horizontally only. A tall tile
+may exceed its band's height, and testing both axes lets bands stay fixed
+without capping tile size. Candidates are drawn from the whole panel's admitted
+set, not the band's, so a tall tile cannot overlap a neighbouring band's tile.
+
+### 5.4 Hysteresis, so near-ties do not trade places
+
+Two cameras with close scores must not swap every poll. Two mechanisms, both
+required:
+
+- **Incumbency bonus.** A tile currently on screen competes with
+  `quality + hysteresisMargin`. A challenger must beat it by that margin.
+- **Minimum dwell.** A tile that has been on screen for less than
+  `minDwellMs` is not evicted at all.
+
+Both become dials. Defaults are a starting guess, not a measurement:
+`hysteresisMargin` 0.05, `minDwellMs` 90,000.
+
+This requires state across compositions, which `compose()` has never had — it
+is pure, and must stay pure. Pass the previous admitted set and a clock reading
+in as arguments; do not reach for module state or a hook inside the engine.
+
+The parent spec listed hysteresis as out of scope for phase 2. This spec brings
+it into scope for v3.
+
+### 5.5 Entering and leaving are crossfades
+
+Admission and eviction are visible events. Reuse v2's `crossfadeMs` so tiles
+fade rather than pop. The motion layer added in PR #116 already parks its
+render loop when settled and that behaviour carries over.
+
+### 5.6 How band eviction composes with global overflow
+
+They are separate stages and must stay separate. Band eviction runs first and
+handles crowding within a band. The existing global overflow stage then handles
+total vertical extent, still applying one uniform scale-down before dropping
+anything, per the parent spec's named reference failure.
+
+`layout.dropped` continues to report **overflow casualties only**. Band
+evictions are a third category and get their own field so the setup overlay can
+tell the operator which mechanism removed a camera.
+
+---
+
+## 6. The axis window becomes its own dials
+
+Today the screen's edges are derived from the cron's constants:
+
+```js
+export const ALTITUDE_WINDOW = {
+  min: TERMINATOR_SUN_ALTITUDE_DEG - SEARCH_RADIUS_DEG,
+  max: TERMINATOR_SUN_ALTITUDE_DEG + SEARCH_RADIUS_DEG,
+};
+```
+
+v3 gives the display two dials, `axisNightEdgeDeg` and `axisDayEdgeDeg`,
+defaulting to the current derived values of −24 and −2.
+
+**The window can only usefully narrow.** A window wider than the pool leaves
+dead space at the edges; a window narrower than the pool clamps the excluded
+cameras into a pile. Narrowing is still worth having, because good frames
+currently crowd into the day-side third of the panel and a tighter window
+spreads them across it.
+
+Decision 6a chose the derived form so the axis would track when the constants
+moved. That property is replaced by a **test** asserting the configured window
+covers the range the sweep actually gathers, rather than by derivation. The
+test must read Plan B's coverage constant, not `SEARCH_RADIUS_DEG` directly.
+
+---
+
+## 7. The centre line overlay
+
+The terminator zone is the organising idea of the whole composition and is
+currently invisible. v3 draws it, under two constraints:
+
+- **Toggleable** from `/studio`, as a dial in the overlays section alongside
+  `showTileRatings` and `showModelReadout`.
+- **Never on the Pi.** A dial alone is insufficient: Deploy copies settings
+  rows to the kiosk, so a dial left on in studio would follow it to the wall.
+
+Follow the `setupMode` precedent. The kiosk routes read `?setup=1` from the URL
+and the Pi's launch script never passes it. The centre line is suppressed
+structurally in `app/kiosk/*/page.tsx` unless an explicit URL parameter is
+present, so no settings row can put it on the glass, and it stays available by
+hand for debugging on the device.
+
+---
+
+## 8. The boundary with Plan B
+
+Plan B changes which solar altitudes the pool contains. The two specs meet at
+exactly one contract:
+
+- **Plan B owns** the altitude range the sweep gathers, and must export it as a
+  named constant describing the union of every ring swept.
+- **Plan A owns** the display window, and must never assume it equals
+  `TERMINATOR_SUN_ALTITUDE_DEG ± SEARCH_RADIUS_DEG`.
+- The test in §6 is the enforcement point.
+
+Neither plan blocks the other. v3 can be built and judged against today's pool;
+it simply will not show the growth half of the arc until B lands.
+
+---
+
+## 9. Testing
+
+The parent spec's bar applies. Specific to v3:
+
+- Band assignment is a pure function of latitude and does not consult the pool.
+- Adding or removing a camera moves **no** other tile. This is the headline
+  property and deserves a direct test on a real scene pool.
+- Eviction is deterministic and order-independent given the same inputs.
+- Hysteresis: a challenger within the margin does not displace an incumbent; a
+  challenger beyond it does, but not before `minDwellMs`.
+- 2D intersection, including a tile taller than its band.
+- The centre line does not render on a kiosk route without the URL parameter,
+  even when its setting is on.
+- The axis window test from §6.
+
+Use the live capture scene (21 sunrise / 42 sunset) as the trustworthy pool.
+Both reconstructed historical scenes sit roughly 7 hours off in local solar
+time and cannot judge anything twilight-dependent — a known, separate,
+unfixed bug recorded in the phase-2 decisions doc.
+
+---
+
+## 10. Out of scope
+
+- Moving `TERMINATOR_SUN_ALTITUDE_DEG` or widening the sweep — Plan B.
+- The `captured_at` type migration (§2).
+- Promoting v3 to `DEFAULT_MOSAIC_VERSION`. That is a decision for the glass
+  after comparing all three.
+- Refactoring shared code out of v1/v2/v3.
+- The reconstructed-scene timestamp skew.
+- The ripple / refresh-head paradigm from the 2026-09-02 motion handoff. It
+  remains designed-but-unbuilt and is not superseded by this spec.

--- a/docs/superpowers/specs/2026-09-02-terminator-pool-coverage-design.md
+++ b/docs/superpowers/specs/2026-09-02-terminator-pool-coverage-design.md
@@ -1,0 +1,199 @@
+# Terminator pool coverage — reaching the altitudes where sunsets actually are
+
+**Date:** 2026-09-02
+**Status:** Design approved in conversation. Phase 1 is measurement, and the
+final choice is deliberately deferred until it reports.
+**Sibling spec:** `2026-09-02-mosaic-v3-band-paradigm-design.md` (Plan A). The
+two meet at one boundary, defined in §6.
+
+---
+
+## 1. The problem, measured
+
+Run 2026-09-02 against 46,079 scored snapshots joined to camera coordinates,
+solar altitude computed per frame with SunCalc at capture time. Share of frames
+Claude scored at or above 0.5:
+
+| sun altitude | frames | good |
+|---|---|---|
+| −16° to −14° | 2,577 | 1.0% |
+| −12° to −10° | 3,040 | 3.3% |
+| −8° to −6° | 5,862 | 10.8% |
+| −2° to 0° | 1,959 | 14.9% |
+| **0° to +2°** | 1,701 | **19.7%** |
+| **+4° to +6°** | 2,167 | **19.4%** |
+
+Good sunsets happen with the sun just above the horizon. The 4,525 good frames
+come from 679 distinct cameras, top camera 3.8%, top ten 22.6%, so this is not
+a few sites skewing the result. Only 55% of them fall inside the −24° to −2°
+window the pool can currently see.
+
+Reproduce with `node scripts/altitude-quality-report.mjs`.
+
+**The base ring sits at −13°, where roughly one frame in a hundred is good.**
+Twenty times better lies at 0° to +6°. The pool gathers within
+`SEARCH_RADIUS_DEG` (11°) of the ring, so it spans −24° to −2° and never sees
+the peak.
+
+`masterConfig.ts` already records the same conclusion in a comment on
+`TERMINATOR_WIDEN_OFFSETS_DEG`: the `+15.75` offset "puts the ring near +2.75
+degrees solar altitude (golden hour, which the base ring at −13 misses
+entirely)."
+
+### Why this matters beyond image quality
+
+The display paradigm in Plan A wants a camera to grow as it approaches its
+sunset and shrink after. That arc has two halves and **the growth half lives at
+altitudes the pool never collects.** On the sunset panel a camera appears at
+the day edge already past its peak and can only shrink. No display change fixes
+this. It is a coverage problem.
+
+---
+
+## 2. Two candidate answers, and why the obvious one is probably wrong
+
+**Move the ring.** Change `TERMINATOR_SUN_ALTITUDE_DEG` from −13 toward day.
+This *shifts* the pool: it buys the day side and sells the night side. At −4
+the pool would span −15° to +7°.
+
+**Sweep two rings.** Keep the base ring and stop gating the existing day-side
+escalation ring behind a camera shortage. This *adds*: the pool becomes the
+union, roughly −24° through +14°, straddling the quality peak on both sides.
+
+**The union is what the paradigm actually needs.** A symmetric arc requires
+both sides of the peak. Moving the ring alone would only relocate where the arc
+gets truncated, and would give up the deep-twilight tail that the wall
+currently shows. Sweeping two rings is also the lower-risk change: it removes
+no camera anyone sees today, and the machinery already exists and was measured
+returning 92 to 100% cameras the base ring had never seen, versus 26 to 35% for
+a 3-degree offset.
+
+There is also a hard empirical wall against moving the base ring, recorded in
+`masterConfig.ts`: "15 doesn't work. 14 is the highest that works," and "−8
+showed too much day time." The constant interacts with Windy's zoom-4 box span
+cap of 22.5°, and `SEARCH_RADIUS_DEG` at 11 is already near that ceiling.
+
+**Recommendation: sweep two rings.** Moving the base ring stays available but
+is not the plan.
+
+---
+
+## 3. Phase 1 — measure before committing
+
+The deciding facts are not in hand. Phase 1 writes no production behaviour
+change; it turns the escalation ring on **behind a flag, for a bounded window**,
+and reads the telemetry that already exists.
+
+Questions phase 1 must answer:
+
+1. **Yield that survives scoring.** How many day-ring cameras does the
+   detection gate actually pass? The failure mode is self-concealing: a ring
+   that adds cameras the gate then floors reads as success in both the
+   escalation count and the new-camera count. `sweepStats.ts` already splits
+   `framesScored` and `framesGatePassed` per ring for exactly this reason.
+2. **Sweep budget.** `TERMINATOR_SWEEP_BUDGET_MS` is 25s inside a tick whose
+   deadline is 50s. How often does an always-escalated sweep exhaust it?
+   `budgetExhaustedTicks` already tracks this.
+3. **Cost.** Windy boxes per day against the ~3,000 baseline, plus the scoring
+   spend on the additional frames. `baseBoxes` and `escalationBoxes` already
+   separate the bill this feature adds.
+
+Do not skip phase 1. Every number in `masterConfig.ts` around this feature is
+annotated as measured or as "chosen against a single observation," and that
+discipline is why the widening work is trustworthy.
+
+---
+
+## 4. Cost posture
+
+The operator has approved spending on this for the show, with two conditions.
+
+- **It must be reversible by a switch**, so spending can be brought back down
+  without a code change or a redeploy. Env vars bake in at deploy time in this
+  project, so a switch that requires `vercel redeploy` to take effect does not
+  satisfy this. Prefer a stored setting the cron reads at tick time.
+- **The bill must be visible in the daily digest.**
+
+For reference, this system was driven from about $60/month to about $0.44/day
+in July 2026. The digest email goes out around 5pm Pacific.
+
+---
+
+## 5. Digest metrics
+
+Most of what was asked for already ships. `formatSweepLine` in
+`dailyDigest.ts` reports per-ring boxes, escalation cost against the base,
+per-ring gate-pass rates, thin-feed counts, and budget exhaustion.
+
+What to add:
+
+- **The altitude range actually swept**, expressed in degrees, so the operator
+  can read at a glance how wide the pool got. Today the digest reports ring
+  offsets; the useful form is the resulting solar-altitude span.
+- **A cost line for the widening**, so the escalation boxes read as money
+  rather than as a count.
+
+Keep the existing per-ring gate-pass clause prominent. It is the only thing
+that distinguishes widening that adds sunsets from widening that adds cameras
+the gate floors.
+
+---
+
+## 6. The boundary with Plan A
+
+- **This spec owns** the altitude range the sweep gathers, and **must export it
+  as a named constant** describing the union of every ring swept. Plan A's
+  display window test reads that constant.
+- **Plan A owns** the display window and must not assume it equals
+  `TERMINATOR_SUN_ALTITUDE_DEG ± SEARCH_RADIUS_DEG`.
+- Widening the pool without Plan A's window dials produces no visible change,
+  because the new day-side cameras clamp to the panel edge. Widening is
+  therefore best judged after Plan A lands, though it can be measured before.
+
+Neither plan blocks the other.
+
+---
+
+## 7. Implementation sketch
+
+Phase 1, measurement:
+
+1. A stored setting the cron reads per tick, defaulting off, that forces the
+   day-side ring regardless of `TERMINATOR_CAMERA_FLOOR`.
+2. Extend `SweepRingStats` only if a needed field is genuinely missing. Check
+   first; most of it is there.
+3. Run for a bounded window and report against §3's three questions.
+
+Phase 2, decision and rollout, only after phase 1 reports:
+
+4. Choose always-on, conditional, or a narrower offset, from the measured
+   yield and cost.
+5. Export the coverage constant for Plan A.
+6. Add the digest lines from §5.
+
+---
+
+## 8. Testing
+
+- The forced-escalation switch is honoured per tick and defaults off.
+- With the switch off, sweep behaviour is byte-for-byte what it is today.
+- Per-ring attribution stays correct when both rings find the same camera:
+  the ring that *first* saw it gets the credit, which is the existing rule.
+- The exported coverage constant matches the rings actually swept, including
+  when the switch is off.
+- Budget exhaustion still sacrifices escalation rings first. The scoring loop
+  needs the remaining tick more than the pool needs extra cameras.
+
+---
+
+## 9. Out of scope
+
+- Every display-side change — Plan A.
+- Moving `TERMINATOR_SUN_ALTITUDE_DEG`. Kept as a documented fallback in §2,
+  not planned work.
+- Raising `SEARCH_RADIUS_DEG`. It is at 11 against a hard Windy ceiling of
+  11.25, verified live 2026-09-02 and guarded by `masterConfig.test.ts`.
+- The `captured_at` column type. Timestamps were verified correct on
+  2026-09-02; see Plan A §2.
+- Camera-level reputation and consistent-false-positive exclusion, still a
+  future workstream from the phase-2 decisions doc.

--- a/scripts/altitude-quality-report.mjs
+++ b/scripts/altitude-quality-report.mjs
@@ -1,0 +1,126 @@
+// scripts/altitude-quality-report.mjs
+// Read-only report: where in the sky the good sunsets actually happen, and
+// whether captured_at can be trusted as UTC.
+//
+// This is the measurement behind the two 2026-09-02 specs
+// (docs/superpowers/specs/2026-09-02-mosaic-v3-band-paradigm-design.md and
+// -terminator-pool-coverage-design.md). Re-run it before acting on either;
+// both rest on the claim that quality peaks near 0 to +6 degrees while the
+// pool's ring sits at -13.
+//
+// Run: node scripts/altitude-quality-report.mjs
+import { neon } from '@neondatabase/serverless';
+import { readFileSync } from 'node:fs';
+import SunCalc from 'suncalc';
+
+// Read the pool constants out of masterConfig rather than copying them: node
+// cannot import the .ts directly, and a hardcoded copy would drift silently
+// the first time the ring moves, which is precisely what Plan B may do.
+function constFromMasterConfig(name) {
+  const src = readFileSync('app/lib/masterConfig.ts', 'utf8');
+  const match = src.match(new RegExp(`export const ${name}\\s*=\\s*(-?\\d+(?:\\.\\d+)?)`));
+  if (!match) throw new Error(`${name} not found in app/lib/masterConfig.ts`);
+  return Number(match[1]);
+}
+
+function loadDatabaseUrl() {
+  if (process.env.DATABASE_URL) return process.env.DATABASE_URL;
+  const env = readFileSync('.env.local', 'utf8');
+  const line = env.split('\n').find((l) => l.startsWith('DATABASE_URL='));
+  if (!line) throw new Error('DATABASE_URL not found in env or .env.local');
+  return line.slice('DATABASE_URL='.length).replace(/^"|"$/g, '');
+}
+
+const sql = neon(loadDatabaseUrl());
+const DEG_PER_RAD = 180 / Math.PI;
+const GOOD = 0.5; // llm_quality is normalized [0,1]; measured max is 0.88
+
+// AT TIME ZONE 'UTC' is doing real work: captured_at is `timestamp without
+// time zone`, so this is where the "these digits are UTC" assumption becomes
+// explicit. The offset sweep below is what verifies it.
+const rows = await sql`
+  SELECT EXTRACT(EPOCH FROM s.captured_at AT TIME ZONE 'UTC') AS epoch,
+         w.lat AS lat, w.lng AS lng, s.webcam_id AS cam,
+         s.llm_quality AS q, s.llm_is_sunset AS sset
+  FROM webcam_snapshots s
+  JOIN webcams w ON w.id = s.webcam_id
+  WHERE s.llm_quality IS NOT NULL
+    AND s.captured_at IS NOT NULL
+    AND w.lat IS NOT NULL AND w.lng IS NOT NULL`;
+
+const altAt = (epoch, lat, lng, offsetHours = 0) =>
+  SunCalc.getPosition(
+    new Date((Number(epoch) + offsetHours * 3600) * 1000),
+    Number(lat),
+    Number(lng)
+  ).altitude * DEG_PER_RAD;
+
+const pts = rows.map((r) => ({
+  alt: altAt(r.epoch, r.lat, r.lng),
+  q: Number(r.q),
+  sset: r.sset,
+  cam: r.cam,
+}));
+console.log(`scored frames with coordinates: ${pts.length}`);
+
+// --- 1. Is captured_at really UTC? -----------------------------------------
+// A stored-local-time or DST bug would flatten this curve, because no single
+// global offset could fix rows from many zones at once. A sharp peak at 0 is
+// the evidence that the naked column type is not hiding a bug.
+const confirmed = rows.filter((r) => r.sset);
+console.log(`\n-- captured_at offset sweep (${confirmed.length} confirmed sunsets) --`);
+console.table(
+  Array.from({ length: 17 }, (_, i) => i - 8).map((off) => {
+    const alts = confirmed.map((r) => altAt(r.epoch, r.lat, r.lng, off));
+    return {
+      offsetHours: off,
+      pctWithin8DegOfHorizon: +(
+        (100 * alts.filter((a) => a >= -8 && a <= 8).length) / alts.length
+      ).toFixed(1),
+    };
+  })
+);
+
+// --- 2. Where do the good frames actually sit? -----------------------------
+console.log('\n-- hit rate by solar altitude, 2-degree bins --');
+const bins = [];
+for (let lo = -20; lo < 12; lo += 2) {
+  const ps = pts.filter((p) => p.alt >= lo && p.alt < lo + 2);
+  if (ps.length < 50) continue;
+  bins.push({
+    altitude: `${lo} to ${lo + 2}`,
+    frames: ps.length,
+    pctGood: +((100 * ps.filter((p) => p.q >= GOOD).length) / ps.length).toFixed(1),
+    meanQuality: +(ps.reduce((a, b) => a + b.q, 0) / ps.length).toFixed(3),
+  });
+}
+console.table(bins);
+
+// --- 3. What the pool's window can and cannot see --------------------------
+const ring = constFromMasterConfig('TERMINATOR_SUN_ALTITUDE_DEG');
+const radius = constFromMasterConfig('SEARCH_RADIUS_DEG');
+const windowMin = ring - radius;
+const windowMax = ring + radius;
+const good = pts.filter((p) => p.q >= GOOD);
+const inWindow = good.filter((p) => p.alt >= windowMin && p.alt <= windowMax);
+const alts = good.map((p) => p.alt).sort((a, b) => a - b);
+const pct = (x) => +alts[Math.floor(alts.length * x)].toFixed(1);
+
+console.log(`\n-- coverage of the ${windowMin} to ${windowMax} degree pool window --`);
+console.log(`good frames (llm_quality >= ${GOOD}): ${good.length}`);
+console.log(`  inside the window: ${((100 * inWindow.length) / good.length).toFixed(1)}%`);
+console.log(
+  `  altitude percentiles: p10 ${pct(0.1)} | p25 ${pct(0.25)} | ` +
+    `median ${pct(0.5)} | p75 ${pct(0.75)} | p90 ${pct(0.9)}`
+);
+
+// Concentration guard: the headline claim is about nature, not about a
+// handful of prolific cameras, so report the share before anyone leans on it.
+const byCam = new Map();
+for (const p of good) byCam.set(p.cam, (byCam.get(p.cam) ?? 0) + 1);
+const shares = [...byCam.values()].sort((a, b) => b - a);
+console.log(
+  `  distinct cameras: ${byCam.size} | top camera ` +
+    `${((100 * shares[0]) / good.length).toFixed(1)}% | top 10 ` +
+    `${((100 * shares.slice(0, 10).reduce((a, b) => a + b, 0)) / good.length).toFixed(1)}%`
+);


### PR DESCRIPTION
Two specs, split from one design conversation, plus the measurement script behind both.

## What was measured

Quality peaks with the sun **just above the horizon**, not at the ring the pool gathers around.

| sun altitude | frames | good (llm_quality ≥ 0.5) |
|---|---|---|
| −16° to −14° | 2,577 | 1.0% |
| −8° to −6° | 5,862 | 10.8% |
| **0° to +2°** | 1,701 | **19.7%** |
| **+4° to +6°** | 2,167 | **19.4%** |

The pool spans −24° to −2°, so it never sees the peak. Only 55% of good frames fall inside it. From 679 distinct cameras, top camera 3.8%, so this is nature rather than a few sites.

**Consequence:** the intended small-to-large-to-small arc, where a camera grows approaching its sunset and shrinks after, cannot happen today. The growth half lives at altitudes the pool never collects.

## The two plans

**Plan A — mosaic v3, the band paradigm.** Fixed latitude bands so vertical position stops depending on pool membership, absolute placement with no de-overlap shoving, and collisions resolved by evicting on quality with hysteresis. Ships as a registry version beside v1 and v2 so all three stay comparable by `?v=`. Includes a toggleable centre line that is structurally suppressed on the kiosk routes so it can never reach the Pi.

**Plan B — pool coverage.** Recommends sweeping the existing day-side ring on every tick rather than moving `TERMINATOR_SUN_ALTITUDE_DEG`, because a symmetric arc needs both sides of the peak and moving the ring would only relocate the truncation. Starts with measurement, since the deciding facts are yield after the detection gate, sweep budget, and cost.

## Timestamps: verified correct, no fix needed

`captured_at` is `timestamp without time zone`, which looks like a bug. It is not. An hourly offset sweep over 21,061 confirmed sunsets peaks sharply at zero.

| offset | sunsets near the horizon |
|---|---|
| −1 h | 56.8% |
| **0** | **74.4%** |
| +1 h | 43.8% |

Nothing applies a zone offset and `webcams.timezone` is null throughout. The `timestamptz` migration is explicitly out of scope.

## Notes

Docs and one read-only script. No production code. `node scripts/altitude-quality-report.mjs` reproduces every number above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tk8pkADGspAfRScpWobEtS
