### PR TITLE
Terminator pool coverage, phase 1: the switch, the telemetry, and the geometry record

### DIFF
--- a/app/api/cron/update-cameras/lib/dailyDigest.test.ts
+++ b/app/api/cron/update-cameras/lib/dailyDigest.test.ts
@@ -233,7 +233,9 @@ function summaryWithDayRing(): SweepDigestSummary {
     sunsetThinTicks: 12,
     escalationBoxes: 2880,
     escalationMs: 960_000,
-    rings: [ringStat(0), ringStat(15.75)],
+    // Desc by offset_deg, like getSweepDigestSummary's real ORDER BY — a
+    // base-first fixture here would mask the i===0 ring-labeling bug (M4).
+    rings: [ringStat(15.75), ringStat(0)],
   };
 }
 
@@ -286,7 +288,7 @@ describe('formatSweepLine', () => {
     expect(formatSweepLine(null)).toBe('');
   });
 
-  it('collapses a quiet day to one clause', () => {
+  it('prints only the summary and efficiency lines on a quiet day', () => {
     const html = formatSweepLine(quiet);
     expect(html).toContain('no feed fell under the floor');
     expect(html).toContain('2,976');
@@ -301,6 +303,37 @@ describe('formatSweepLine', () => {
     expect(formatSweepLine(summaryWithDayRing())).toContain('-24° to +14°');
   });
 
+  it('shows a partial-escalation ring share against the base ring\'s ticks, not just the full-day hull', () => {
+    // Base ran all 96 ticks; the day-side ring ran only 12 of them. The span
+    // alone would print the same "-24° to +14°" as a day where +15.75 ran
+    // every tick, which over-claims how much of the day it actually covered.
+    const html = formatSweepLine({
+      ...quiet,
+      escalatedTicks: 12,
+      sunsetThinTicks: 12,
+      escalationBoxes: 180,
+      rings: [
+        quiet.rings[0], // base, ringsSwept: 96
+        {
+          offsetDeg: 15.75,
+          ringsSwept: 12,
+          boxesAttempted: 180,
+          boxesEmpty: 20,
+          boxesFailed: 0,
+          newWebcams: 45,
+          framesScored: 40,
+          framesGatePassed: 4,
+          elapsedMs: 60_000,
+        },
+      ],
+    });
+    expect(html).toContain('12/96 ticks');
+  });
+
+  it('prints no ticks-share parenthetical on a base-only day', () => {
+    expect(formatSweepLine(summaryBaseOnly())).not.toContain('ticks)');
+  });
+
   it('prints the widening bill as seconds and frames, not just boxes', () => {
     const html = formatSweepLine(summaryWithDayRing());
     expect(html).toContain('Widening cost');
@@ -312,7 +345,7 @@ describe('formatSweepLine', () => {
     // gate-passed frame as the base ring is the one to narrow or drop, and
     // that ratio is invisible in any total.
     const html = formatSweepLine(summaryWithDayRing());
-    expect(html).toContain('per gate-passed');
+    expect(html).toContain('Per gate-passed');
   });
 
   it('says nothing about widening cost when nothing escalated', () => {

--- a/app/api/cron/update-cameras/lib/dailyDigest.test.ts
+++ b/app/api/cron/update-cameras/lib/dailyDigest.test.ts
@@ -11,7 +11,9 @@ import {
   sendDailyUsageDigest,
   formatCalibrationLine,
   formatSweepLine,
+  sweptAltitudeSpan,
 } from './dailyDigest';
+import type { SweepDigestSummary, SweepRingStats } from './sweepStats';
 
 const NOW = new Date('2026-08-03T00:20:00Z');
 const SUNSET = 'noisy-leaf-96391119';
@@ -189,6 +191,69 @@ describe('formatCalibrationLine', () => {
   });
 });
 
+/** `ringStat(offsetDeg)`: a plausible ring, base by default at offset 0. */
+function ringStat(offsetDeg: number): SweepRingStats {
+  const isBase = offsetDeg === 0;
+  return {
+    offsetDeg,
+    ringsSwept: 96,
+    boxesAttempted: isBase ? 2976 : 2880,
+    boxesEmpty: isBase ? 300 : 200,
+    boxesFailed: 0,
+    newWebcams: isBase ? 400 : 45,
+    framesScored: isBase ? 380 : 40,
+    framesGatePassed: isBase ? 130 : 4,
+    elapsedMs: isBase ? 1_152_000 : 960_000,
+  };
+}
+
+/** A day where only the base ring ran. */
+function summaryBaseOnly(): SweepDigestSummary {
+  return {
+    ticks: 96,
+    escalatedTicks: 0,
+    budgetExhaustedTicks: 0,
+    sunriseThinTicks: 0,
+    sunsetThinTicks: 0,
+    sunriseShortTicks: 0,
+    sunsetShortTicks: 0,
+    baseBoxes: 2976,
+    escalationBoxes: 0,
+    baseMs: 1_152_000,
+    escalationMs: 0,
+    rings: [ringStat(0)],
+  };
+}
+
+/** A day where the base ring plus one day-side (+15.75°) ring both ran. */
+function summaryWithDayRing(): SweepDigestSummary {
+  return {
+    ...summaryBaseOnly(),
+    escalatedTicks: 12,
+    sunsetThinTicks: 12,
+    escalationBoxes: 2880,
+    escalationMs: 960_000,
+    rings: [ringStat(0), ringStat(15.75)],
+  };
+}
+
+describe('sweptAltitudeSpan', () => {
+  it('is the base ring alone when nothing escalated', () => {
+    expect(sweptAltitudeSpan([ringStat(0)])).toEqual({ min: -24, max: -2 });
+  });
+
+  it('reaches golden hour once the day-side ring ran', () => {
+    expect(sweptAltitudeSpan([ringStat(0), ringStat(15.75)])).toEqual({
+      min: -24,
+      max: 13.75,
+    });
+  });
+
+  it('is null when no ring ran', () => {
+    expect(sweptAltitudeSpan([])).toBeNull();
+  });
+});
+
 describe('formatSweepLine', () => {
   const quiet = {
     ticks: 96,
@@ -200,15 +265,19 @@ describe('formatSweepLine', () => {
     sunsetShortTicks: 0,
     baseBoxes: 2976,
     escalationBoxes: 0,
+    baseMs: 1_152_000,
+    escalationMs: 0,
     rings: [
       {
         offsetDeg: 0,
         ringsSwept: 96,
         boxesAttempted: 2976,
         boxesEmpty: 300,
+        boxesFailed: 0,
         newWebcams: 400,
         framesScored: 380,
         framesGatePassed: 130,
+        elapsedMs: 1_152_000,
       },
     ],
   };
@@ -221,8 +290,40 @@ describe('formatSweepLine', () => {
     const html = formatSweepLine(quiet);
     expect(html).toContain('no feed fell under the floor');
     expect(html).toContain('2,976');
-    // Nothing was widened, so there is no cost and no per-ring comparison.
-    expect(html).not.toContain('gate-passed');
+    // Nothing was widened, so there is no widening bill and no per-ring
+    // comparison table. (The per-gate-passed cost line still prints — that
+    // question doesn't require widening to have an answer.)
+    expect(html).not.toContain('Widening cost');
+    expect(html).not.toContain('Rings:');
+  });
+
+  it('prints the swept altitude span in degrees, not ring offsets', () => {
+    expect(formatSweepLine(summaryWithDayRing())).toContain('-24° to +14°');
+  });
+
+  it('prints the widening bill as seconds and frames, not just boxes', () => {
+    const html = formatSweepLine(summaryWithDayRing());
+    expect(html).toContain('Widening cost');
+    expect(html).toContain('16.0 min/day sweeping');
+  });
+
+  it('prints what each ring cost per sunset it delivered', () => {
+    // The lever question. A ring that costs twice as many boxes per
+    // gate-passed frame as the base ring is the one to narrow or drop, and
+    // that ratio is invisible in any total.
+    const html = formatSweepLine(summaryWithDayRing());
+    expect(html).toContain('per gate-passed');
+  });
+
+  it('says nothing about widening cost when nothing escalated', () => {
+    expect(formatSweepLine(summaryBaseOnly())).not.toContain('Widening cost');
+  });
+
+  it('reports failed boxes apart from empty ones, and only when there are any', () => {
+    expect(formatSweepLine(summaryBaseOnly())).not.toContain('boxes failed');
+    const withFailures = summaryBaseOnly();
+    withFailures.rings[0].boxesFailed = 12;
+    expect(formatSweepLine(withFailures)).toContain('12 boxes failed');
   });
 
   it('names the thin feed, the escalation cost, and its share of the baseline', () => {
@@ -254,9 +355,11 @@ describe('formatSweepLine', () => {
           ringsSwept: 12,
           boxesAttempted: 180,
           boxesEmpty: 20,
+          boxesFailed: 0,
           newWebcams: 45,
           framesScored: 40,
           framesGatePassed: 4,
+          elapsedMs: 60_000,
         },
       ],
     });

--- a/app/api/cron/update-cameras/lib/dailyDigest.ts
+++ b/app/api/cron/update-cameras/lib/dailyDigest.ts
@@ -3,12 +3,18 @@ import {
   getCalibrationDigestSummary,
   type CalibrationDigestSummary,
 } from './dbOperations';
-import { getSweepDigestSummary, type SweepDigestSummary } from './sweepStats';
+import {
+  getSweepDigestSummary,
+  type SweepDigestSummary,
+  type SweepRingStats,
+} from './sweepStats';
+import { coverageSpan } from './sweepGeometry';
 import { deriveDailyDeltas } from '@/app/components/Ops/opsMath';
 import type { ProviderUsageRow, CostEventRow } from '@/app/lib/opsTypes';
 import {
   NEON_COST_PER_CU_HOUR,
   DIGEST_LOOKBACK_DAYS,
+  TERMINATOR_SUN_ALTITUDE_DEG,
 } from '@/app/lib/masterConfig';
 
 const SUNSET_PROJECT = 'noisy-leaf-96391119';
@@ -55,6 +61,34 @@ const count = (n: number) => n.toLocaleString('en-US');
 function ringLabel(offsetDeg: number): string {
   if (offsetDeg === 0) return 'base';
   return `${offsetDeg > 0 ? '+' : ''}${offsetDeg}°`;
+}
+
+/**
+ * The solar-altitude span yesterday's rings actually gathered from.
+ *
+ * The digest already prints ring offsets, which say where a ring sits
+ * relative to the base ring and nothing about where the sun was. The useful
+ * form is the resulting altitude band, because that is what can be read
+ * against the measured quality curve: good frames peak at 0 to +6 degrees,
+ * and a span whose day edge is -2 never touches it.
+ *
+ * Shares its arithmetic with sweepGeometry's coverageSpan, which answers the
+ * same question about a tick rather than about yesterday.
+ */
+export function sweptAltitudeSpan(
+  rings: SweepRingStats[],
+): { min: number; max: number } | null {
+  if (rings.length === 0) return null;
+  return coverageSpan(
+    rings.map((r) => TERMINATOR_SUN_ALTITUDE_DEG + r.offsetDeg),
+  );
+}
+
+/** `-24° to +14°`. Rounded outward, so the printed band never overstates. */
+function formatSpan(span: { min: number; max: number }): string {
+  const lo = Math.floor(span.min);
+  const hi = Math.ceil(span.max);
+  return `${lo}° to ${hi > 0 ? '+' : ''}${hi}°`;
 }
 
 /**
@@ -108,15 +142,60 @@ export function formatSweepLine(summary: SweepDigestSummary | null): string {
       : `${count(totalBoxes)} boxes`,
   );
 
+  const span = sweptAltitudeSpan(s.rings);
+  if (span) parts.push(`swept ${formatSpan(span)} solar altitude`);
+
   if (s.budgetExhaustedTicks > 0) {
     parts.push(`${s.budgetExhaustedTicks} ticks hit the sweep budget`);
   }
-  // Empty conflates "no cameras there" with "the call failed". Rising empty
-  // against flat discovery is the signature of a Windy quota ceiling, which
-  // is why it rides in the summary line rather than waiting for a dashboard.
+  // Empty and failed are different facts and the digest keeps them apart.
+  // Empty is ocean. Failed is a non-OK response, and a RISING failed count
+  // is the only thing in this line that can mean a Windy ceiling; the empty
+  // share never could, because it used to contain the failures.
+  const failedBoxes = s.rings.reduce((sum, r) => sum + r.boxesFailed, 0);
   parts.push(`${pct(emptyBoxes, totalBoxes)}% of boxes empty`);
+  if (failedBoxes > 0) {
+    parts.push(`<b>${count(failedBoxes)} boxes failed</b>`);
+  }
 
   const lines = [`Widening: ${parts.join(' · ')}`];
+
+  // The bill, in the units that actually have one.
+  //
+  // Not dollars, deliberately. Windy publishes no price, no rate limit and no
+  // quota headers (measured 2026-09-02, see the camera-refresh cost spec), so
+  // multiplying boxes by a rate would mean inventing the rate. What widening
+  // provably consumes is function wall-clock and scoring work, and both are
+  // measured here.
+  if (s.escalationMs > 0) {
+    const escalationMin = s.escalationMs / 60_000;
+    const escalationFrames = s.rings
+      .filter((r) => r.offsetDeg !== 0)
+      .reduce((sum, r) => sum + r.framesScored, 0);
+    lines.push(
+      `Widening cost: ${escalationMin.toFixed(1)} min/day sweeping ` +
+        `(+${pct(s.escalationMs, s.baseMs)}% on base) · ` +
+        `${count(escalationFrames)} extra frames scored`,
+    );
+  }
+
+  // Cost per result, per ring. The lever line.
+  //
+  // Totals cannot say which ring to narrow or drop; a ratio can. A ring
+  // buying gate-passed frames at several times the base ring's box cost is
+  // the one to change, and that stays true whether the bill went up or down.
+  // Rings with no gate-passed frames print as "none", not as a division by
+  // zero dressed up as a large number.
+  const efficiency = s.rings.map((r) => {
+    if (r.framesGatePassed === 0) return `${ringLabel(r.offsetDeg)} none`;
+    const boxesEach = Math.round(r.boxesAttempted / r.framesGatePassed);
+    const secondsEach = r.elapsedMs / r.framesGatePassed / 1000;
+    return (
+      `${ringLabel(r.offsetDeg)} ${count(boxesEach)} boxes` +
+      ` + ${secondsEach.toFixed(1)}s`
+    );
+  });
+  lines.push(`per gate-passed frame: ${efficiency.join(' · ')}`);
 
   if (s.rings.length > 1) {
     const ringClauses = s.rings.map((r, i) => {

--- a/app/api/cron/update-cameras/lib/dailyDigest.ts
+++ b/app/api/cron/update-cameras/lib/dailyDigest.ts
@@ -84,7 +84,10 @@ export function sweptAltitudeSpan(
   );
 }
 
-/** `-24° to +14°`. Rounded outward, so the printed band never overstates. */
+/**
+ * `-24° to +14°`. Rounded outward to whole degrees; the printed band may
+ * overstate by under 1° and never understates.
+ */
 function formatSpan(span: { min: number; max: number }): string {
   const lo = Math.floor(span.min);
   const hi = Math.ceil(span.max);
@@ -143,7 +146,26 @@ export function formatSweepLine(summary: SweepDigestSummary | null): string {
   );
 
   const span = sweptAltitudeSpan(s.rings);
-  if (span) parts.push(`swept ${formatSpan(span)} solar altitude`);
+  if (span) {
+    // The span alone over-claims on a partial-escalation day: one ring that
+    // ran a single tick prints the same band as one that ran all day. The
+    // parenthetical says how many of the base ring's ticks each other ring
+    // actually shared, against the base ring's ringsSwept.
+    const base = s.rings.find((r) => r.offsetDeg === 0);
+    const shares = base
+      ? s.rings
+          .filter((r) => r.offsetDeg !== 0)
+          .map(
+            (r) => `${ringLabel(r.offsetDeg)} on ${r.ringsSwept}/${base.ringsSwept} ticks`,
+          )
+          .join(', ')
+      : '';
+    parts.push(
+      shares
+        ? `swept ${formatSpan(span)} solar altitude (${shares})`
+        : `swept ${formatSpan(span)} solar altitude`,
+    );
+  }
 
   if (s.budgetExhaustedTicks > 0) {
     parts.push(`${s.budgetExhaustedTicks} ticks hit the sweep budget`);
@@ -167,6 +189,10 @@ export function formatSweepLine(summary: SweepDigestSummary | null): string {
   // multiplying boxes by a rate would mean inventing the rate. What widening
   // provably consumes is function wall-clock and scoring work, and both are
   // measured here.
+  // Rows written before the timing migration have elapsed_ms = 0 alongside a
+  // non-zero escalationBoxes, so this gate silently omits the Widening cost
+  // line for those days. Acceptable: it only means pre-migration days don't
+  // get the section, not that they print a wrong number.
   if (s.escalationMs > 0) {
     const escalationMin = s.escalationMs / 60_000;
     const escalationFrames = s.rings
@@ -195,14 +221,14 @@ export function formatSweepLine(summary: SweepDigestSummary | null): string {
       ` + ${secondsEach.toFixed(1)}s`
     );
   });
-  lines.push(`per gate-passed frame: ${efficiency.join(' · ')}`);
+  lines.push(`Per gate-passed frame: ${efficiency.join(' · ')}`);
 
   if (s.rings.length > 1) {
-    const ringClauses = s.rings.map((r, i) => {
+    const ringClauses = s.rings.map((r) => {
       const rate =
         r.framesScored > 0
           ? `${r.framesGatePassed}/${r.framesScored}${
-              i === 0 ? ' gate-passed' : ''
+              r.offsetDeg === 0 ? ' gate-passed' : ''
             } (${pct(r.framesGatePassed, r.framesScored)}%)`
           : `${count(r.newWebcams)} new, unscored`;
       return `${ringLabel(r.offsetDeg)} ${rate}`;

--- a/app/api/cron/update-cameras/lib/sweepGeometry.test.ts
+++ b/app/api/cron/update-cameras/lib/sweepGeometry.test.ts
@@ -1,0 +1,69 @@
+// @vitest-environment node
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const sqlMock = vi.fn();
+vi.mock('@/app/lib/db', () => ({
+  sql: (strings: TemplateStringsArray, ...values: unknown[]) =>
+    sqlMock(strings, ...values),
+}));
+
+import { coverageSpan, sweepGeometry, upsertSweepGeometry } from './sweepGeometry';
+
+beforeEach(() => {
+  sqlMock.mockReset();
+});
+
+describe('coverageSpan', () => {
+  it('widens a single ring altitude by the search radius on both sides', () => {
+    expect(coverageSpan([-13])).toEqual({ min: -24, max: -2 });
+  });
+
+  it('spans from the night-most floor to the day-most ceiling', () => {
+    expect(coverageSpan([-13, 2.75])).toEqual({ min: -24, max: 13.75 });
+  });
+});
+
+describe('sweepGeometry', () => {
+  it('records the base ring alone when nothing is forced', () => {
+    const g = sweepGeometry([]);
+    expect(g.baseAltitudeDeg).toBe(-13);
+    expect(g.searchRadiusDeg).toBe(11);
+    expect(g.forcedOffsetsDeg).toBe('');
+    expect(g.coverageMinDeg).toBe(-24);
+    expect(g.coverageMaxDeg).toBe(-2);
+  });
+
+  it('widens the recorded coverage to golden hour when the day ring is forced', () => {
+    // This is the number the whole measurement is about: the guaranteed pool
+    // has to contain 0 to +6 degrees, where 19.7% of frames are good, versus
+    // 1.0% at the base ring.
+    const g = sweepGeometry([15.75]);
+    expect(g.coverageMinDeg).toBe(-24);
+    expect(g.coverageMaxDeg).toBe(13.75);
+  });
+
+  it('gives different configurations different signatures', () => {
+    expect(sweepGeometry([]).signature).not.toBe(sweepGeometry([15.75]).signature);
+  });
+
+  it('gives the same configuration the same signature every tick', () => {
+    expect(sweepGeometry([15.75]).signature).toBe(sweepGeometry([15.75]).signature);
+  });
+});
+
+describe('upsertSweepGeometry', () => {
+  it('never throws when the table is missing', async () => {
+    // Same non-fatal contract as upsertSweepStats: a deploy that lands before
+    // the migration is applied must not fail the tick.
+    sqlMock.mockRejectedValue(new Error('relation "daily_sweep_geometry" does not exist'));
+    await expect(
+      upsertSweepGeometry(new Date('2026-09-05T00:10:00Z'), sweepGeometry([]))
+    ).resolves.toBeUndefined();
+  });
+
+  it('writes under the UTC date', async () => {
+    sqlMock.mockResolvedValue([]);
+    await upsertSweepGeometry(new Date('2026-09-05T00:10:00Z'), sweepGeometry([]));
+    expect(sqlMock.mock.calls[0]).toContain('2026-09-05');
+  });
+});

--- a/app/api/cron/update-cameras/lib/sweepGeometry.ts
+++ b/app/api/cron/update-cameras/lib/sweepGeometry.ts
@@ -1,0 +1,117 @@
+import { sql } from '@/app/lib/db';
+import {
+  TERMINATOR_SUN_ALTITUDE_DEG,
+  SEARCH_RADIUS_DEG,
+  TERMINATOR_WIDEN_OFFSETS_DEG,
+} from '@/app/lib/masterConfig';
+
+/**
+ * The ring angles a tick actually ran with.
+ *
+ * Stored beside the counters because offset_deg alone is not a fact about the
+ * sky. +15.75 means +2.75 degrees of solar altitude only while the base ring
+ * is at -13, and this configuration is expected to move. Without this record,
+ * comparing a day of counters against a day from before a change silently
+ * compares two different experiments.
+ */
+export interface SweepGeometry {
+  signature: string;
+  baseAltitudeDeg: number;
+  searchRadiusDeg: number;
+  widenOffsetsDeg: string;
+  forcedOffsetsDeg: string;
+  /**
+   * The span the sweep was GUARANTEED to gather from: the base ring plus
+   * whatever was forced on this tick.
+   *
+   * Distinct from TERMINATOR_POOL_COVERAGE_DEG, which is the display's
+   * compile-time contract and only moves when a ring becomes unconditional.
+   * This one is the measurement record: during a bounded measurement window
+   * the runtime flag widens what the sweep really gathers while the display
+   * contract deliberately stays put, and this column is the only place that
+   * difference is written down.
+   */
+  coverageMinDeg: number;
+  coverageMaxDeg: number;
+}
+
+const fmt = (offsets: readonly number[]) => [...offsets].join(',');
+
+/**
+ * The solar-altitude span a set of ring altitudes gathers from.
+ *
+ * Shared so the two questions that need it cannot drift apart: this module
+ * asks "what was the pool guaranteed to hold on this tick", and the digest
+ * asks "what did yesterday's rings actually cover". Same arithmetic, two
+ * inputs. (masterConfig's TERMINATOR_POOL_COVERAGE_DEG is a third thing —
+ * the display contract, moved by hand — and cannot call this, because masterConfig is
+ * imported by client code and this module imports the database.)
+ *
+ * A true union rather than a hull: the widest gap between consecutive ring
+ * altitudes (15.75) is under one band's width (2 x SEARCH_RADIUS_DEG = 22),
+ * so there is no hole for min/max to paper over.
+ */
+export function coverageSpan(
+  ringAltitudesDeg: number[],
+): { min: number; max: number } {
+  return {
+    min: Math.min(...ringAltitudesDeg) - SEARCH_RADIUS_DEG,
+    max: Math.max(...ringAltitudesDeg) + SEARCH_RADIUS_DEG,
+  };
+}
+
+export function sweepGeometry(forcedOffsets: readonly number[]): SweepGeometry {
+  const guaranteed = [0, ...forcedOffsets];
+  const { min: coverageMinDeg, max: coverageMaxDeg } = coverageSpan(
+    guaranteed.map((o) => TERMINATOR_SUN_ALTITUDE_DEG + o),
+  );
+  const widenOffsetsDeg = fmt(TERMINATOR_WIDEN_OFFSETS_DEG);
+  const forcedOffsetsDeg = fmt(forcedOffsets);
+  return {
+    signature:
+      `base${TERMINATOR_SUN_ALTITUDE_DEG}` +
+      `_r${SEARCH_RADIUS_DEG}` +
+      `_off${widenOffsetsDeg}` +
+      `_forced${forcedOffsetsDeg}`,
+    baseAltitudeDeg: TERMINATOR_SUN_ALTITUDE_DEG,
+    searchRadiusDeg: SEARCH_RADIUS_DEG,
+    widenOffsetsDeg,
+    forcedOffsetsDeg,
+    coverageMinDeg,
+    coverageMaxDeg,
+  };
+}
+
+/**
+ * Add one tick to today's row for this geometry.
+ *
+ * `ticks` accumulates, everything else is fixed by the signature, so a
+ * configuration change mid-day makes a second row rather than corrupting the
+ * first. Non-fatal by contract, like every other telemetry write in this
+ * directory: a missing table means a quiet warning, never a failed tick.
+ */
+export async function upsertSweepGeometry(
+  now: Date,
+  geometry: SweepGeometry,
+): Promise<void> {
+  const date = now.toISOString().slice(0, 10);
+  try {
+    await sql`
+      insert into daily_sweep_geometry (
+        date, signature, base_altitude_deg, search_radius_deg,
+        widen_offsets_deg, forced_offsets_deg,
+        coverage_min_deg, coverage_max_deg, ticks, updated_at
+      ) values (
+        ${date}, ${geometry.signature}, ${geometry.baseAltitudeDeg},
+        ${geometry.searchRadiusDeg}, ${geometry.widenOffsetsDeg},
+        ${geometry.forcedOffsetsDeg}, ${geometry.coverageMinDeg},
+        ${geometry.coverageMaxDeg}, 1, now()
+      )
+      on conflict (date, signature) do update set
+        ticks = daily_sweep_geometry.ticks + 1,
+        updated_at = now()
+    `;
+  } catch (error) {
+    console.warn('[sweepGeometry] persist failed:', error);
+  }
+}

--- a/app/api/cron/update-cameras/lib/sweepStats.test.ts
+++ b/app/api/cron/update-cameras/lib/sweepStats.test.ts
@@ -34,6 +34,7 @@ const healthy: SweepTelemetry = {
       failedByStatus: {},
       newWebcams: 3,
       newWebcamIds: [101, 102, 103],
+      elapsedMs: 8_000,
     },
   ],
   counts: { sunrise: 18, sunset: 21 },
@@ -54,6 +55,7 @@ const escalated: SweepTelemetry = {
       failedByStatus: {},
       newWebcams: 3,
       newWebcamIds: [101, 102, 103],
+      elapsedMs: 8_000,
     },
     {
       offsetDeg: 15.75,
@@ -64,6 +66,7 @@ const escalated: SweepTelemetry = {
       failedByStatus: {},
       newWebcams: 2,
       newWebcamIds: [201, 202],
+      elapsedMs: 5_000,
     },
   ],
   counts: { sunrise: 18, sunset: 17 },
@@ -166,6 +169,18 @@ describe('computeSweepTickStats', () => {
     expect(stats.rings[0].boxesFailed).toBe(3);
     expect(stats.rings[0].boxesEmpty).toBe(healthy.rings[0].empty);
   });
+
+  it('splits sweep milliseconds into base and escalation', async () => {
+    const stats = computeSweepTickStats({ telemetry: escalated, floor: 15 });
+    expect(stats.baseMs).toBe(8_000);
+    expect(stats.escalationMs).toBe(5_000);
+  });
+
+  it('reports no escalation milliseconds on a base-only tick', async () => {
+    const stats = computeSweepTickStats({ telemetry: healthy, floor: 15 });
+    expect(stats.baseMs).toBe(8_000);
+    expect(stats.escalationMs).toBe(0);
+  });
 });
 
 describe('upsertSweepStats', () => {
@@ -179,11 +194,16 @@ describe('upsertSweepStats', () => {
     const [tickCall, ...ringCalls] = sqlMock.mock.calls;
     expect(tickCall[0].join('?')).toContain('daily_sunset_stats');
     expect(tickCall).toContain('2026-09-03');
+    expect(tickCall).toContain(stats.baseMs);
+    expect(tickCall).toContain(stats.escalationMs);
     for (const call of ringCalls) {
       expect(call[0].join('?')).toContain('daily_sweep_ring_stats');
       expect(call).toContain('2026-09-03');
     }
     expect(ringCalls.some((c) => c.includes(15.75))).toBe(true);
+    expect(
+      ringCalls.some((c) => stats.rings.some((r) => c.includes(r.elapsedMs))),
+    ).toBe(true);
   });
 
   it('never throws when the tables are missing', async () => {
@@ -244,5 +264,32 @@ describe('getSweepDigestSummary', () => {
       throw new Error('no such table');
     });
     expect(await getSweepDigestSummary()).toBeNull();
+  });
+
+  it('reads the timing columns back for the digest', async () => {
+    sqlMock
+      .mockResolvedValueOnce([
+        {
+          sweep_ticks: 96, sweep_escalated_ticks: 96,
+          sweep_budget_exhausted_ticks: 3,
+          sweep_sunrise_thin_ticks: 0, sweep_sunset_thin_ticks: 0,
+          sweep_sunrise_short_ticks: 0, sweep_sunset_short_ticks: 0,
+          sweep_base_boxes: 2976, sweep_escalation_boxes: 2880,
+          sweep_base_ms: '1152000', sweep_escalation_ms: '960000',
+        },
+      ])
+      .mockResolvedValueOnce([
+        {
+          offset_deg: '0', rings_swept: 96, boxes_attempted: 2976,
+          boxes_empty: 400, boxes_failed: 0, new_webcams: 300, frames_scored: 200,
+          frames_gate_passed: 40, elapsed_ms: '1152000',
+        },
+      ]);
+    const summary = await getSweepDigestSummary();
+    // BIGINT arrives from the Neon driver as a string, like every NUMERIC in
+    // this codebase. Unwrapped, every downstream comparison silently
+    // concatenates instead of adding.
+    expect(summary?.escalationMs).toBe(960_000);
+    expect(summary?.rings[0].elapsedMs).toBe(1_152_000);
   });
 });

--- a/app/api/cron/update-cameras/lib/sweepStats.test.ts
+++ b/app/api/cron/update-cameras/lib/sweepStats.test.ts
@@ -30,6 +30,8 @@ const healthy: SweepTelemetry = {
       feedsSwept: ['sunrise', 'sunset'],
       attempted: 31,
       empty: 4,
+      failed: 0,
+      failedByStatus: {},
       newWebcams: 3,
       newWebcamIds: [101, 102, 103],
     },
@@ -48,6 +50,8 @@ const escalated: SweepTelemetry = {
       feedsSwept: ['sunrise', 'sunset'],
       attempted: 31,
       empty: 4,
+      failed: 0,
+      failedByStatus: {},
       newWebcams: 3,
       newWebcamIds: [101, 102, 103],
     },
@@ -56,6 +60,8 @@ const escalated: SweepTelemetry = {
       feedsSwept: ['sunset'],
       attempted: 15,
       empty: 2,
+      failed: 0,
+      failedByStatus: {},
       newWebcams: 2,
       newWebcamIds: [201, 202],
     },
@@ -149,6 +155,16 @@ describe('computeSweepTickStats', () => {
   it('leaves gate counts at zero when no scoring outcomes are supplied', () => {
     const s = computeSweepTickStats({ telemetry: escalated, floor: 15 });
     expect(s.rings.every((r) => r.framesScored === 0)).toBe(true);
+  });
+
+  it('accumulates failed boxes per ring', async () => {
+    const withFailures: SweepTelemetry = {
+      ...healthy,
+      rings: [{ ...healthy.rings[0], failed: 3, failedByStatus: { '400': 3 } }],
+    };
+    const stats = computeSweepTickStats({ telemetry: withFailures, floor: 15 });
+    expect(stats.rings[0].boxesFailed).toBe(3);
+    expect(stats.rings[0].boxesEmpty).toBe(healthy.rings[0].empty);
   });
 });
 

--- a/app/api/cron/update-cameras/lib/sweepStats.ts
+++ b/app/api/cron/update-cameras/lib/sweepStats.ts
@@ -14,6 +14,7 @@ export interface SweepRingStats {
   ringsSwept: number;
   boxesAttempted: number;
   boxesEmpty: number;
+  boxesFailed: number;
   newWebcams: number;
   framesScored: number;
   framesGatePassed: number;
@@ -82,6 +83,7 @@ export function computeSweepTickStats(input: {
       ringsSwept: 0,
       boxesAttempted: 0,
       boxesEmpty: 0,
+      boxesFailed: 0,
       newWebcams: 0,
       framesScored: 0,
       framesGatePassed: 0,
@@ -89,6 +91,7 @@ export function computeSweepTickStats(input: {
     acc.ringsSwept += 1;
     acc.boxesAttempted += ring.attempted;
     acc.boxesEmpty += ring.empty;
+    acc.boxesFailed += ring.failed;
     acc.newWebcams += ring.newWebcams;
     byOffset.set(ring.offsetDeg, acc);
   }
@@ -177,12 +180,12 @@ export async function upsertSweepStats(
       await sql`
         insert into daily_sweep_ring_stats (
           date, offset_deg,
-          rings_swept, boxes_attempted, boxes_empty,
+          rings_swept, boxes_attempted, boxes_empty, boxes_failed,
           new_webcams, frames_scored, frames_gate_passed,
           updated_at
         ) values (
           ${date}, ${ring.offsetDeg},
-          ${ring.ringsSwept}, ${ring.boxesAttempted}, ${ring.boxesEmpty},
+          ${ring.ringsSwept}, ${ring.boxesAttempted}, ${ring.boxesEmpty}, ${ring.boxesFailed},
           ${ring.newWebcams}, ${ring.framesScored}, ${ring.framesGatePassed},
           now()
         )
@@ -191,6 +194,7 @@ export async function upsertSweepStats(
           boxes_attempted =
             daily_sweep_ring_stats.boxes_attempted + excluded.boxes_attempted,
           boxes_empty = daily_sweep_ring_stats.boxes_empty + excluded.boxes_empty,
+          boxes_failed = daily_sweep_ring_stats.boxes_failed + excluded.boxes_failed,
           new_webcams = daily_sweep_ring_stats.new_webcams + excluded.new_webcams,
           frames_scored =
             daily_sweep_ring_stats.frames_scored + excluded.frames_scored,
@@ -241,7 +245,7 @@ export async function getSweepDigestSummary(): Promise<SweepDigestSummary | null
 
     const ringRows = (await sql`
       select
-        offset_deg, rings_swept, boxes_attempted, boxes_empty,
+        offset_deg, rings_swept, boxes_attempted, boxes_empty, boxes_failed,
         new_webcams, frames_scored, frames_gate_passed
       from daily_sweep_ring_stats
       where date = CURRENT_DATE - 1
@@ -265,6 +269,7 @@ export async function getSweepDigestSummary(): Promise<SweepDigestSummary | null
         ringsSwept: Number(r.rings_swept),
         boxesAttempted: Number(r.boxes_attempted),
         boxesEmpty: Number(r.boxes_empty),
+        boxesFailed: Number(r.boxes_failed),
         newWebcams: Number(r.new_webcams),
         framesScored: Number(r.frames_scored),
         framesGatePassed: Number(r.frames_gate_passed),

--- a/app/api/cron/update-cameras/lib/sweepStats.ts
+++ b/app/api/cron/update-cameras/lib/sweepStats.ts
@@ -18,6 +18,7 @@ export interface SweepRingStats {
   newWebcams: number;
   framesScored: number;
   framesGatePassed: number;
+  elapsedMs: number;
 }
 
 /**
@@ -38,6 +39,10 @@ export interface SweepTickStats {
   baseBoxes: number;
   /** Windy boxes attributable to widening — the bill this feature adds. */
   escalationBoxes: number;
+  /** Wall clock the base ring spent, summed over the tick. */
+  baseMs: number;
+  /** Wall clock widening added. Boxes are free at Windy; seconds are not. */
+  escalationMs: number;
   rings: SweepRingStats[];
 }
 
@@ -87,12 +92,14 @@ export function computeSweepTickStats(input: {
       newWebcams: 0,
       framesScored: 0,
       framesGatePassed: 0,
+      elapsedMs: 0,
     };
     acc.ringsSwept += 1;
     acc.boxesAttempted += ring.attempted;
     acc.boxesEmpty += ring.empty;
     acc.boxesFailed += ring.failed;
     acc.newWebcams += ring.newWebcams;
+    acc.elapsedMs += ring.elapsedMs;
     byOffset.set(ring.offsetDeg, acc);
   }
   for (const [offsetDeg, gate] of gateByOffset ?? []) {
@@ -112,6 +119,8 @@ export function computeSweepTickStats(input: {
     sunsetShortTicks: short('sunset'),
     baseBoxes: base?.attempted ?? 0,
     escalationBoxes: escalation.reduce((sum, r) => sum + r.attempted, 0),
+    baseMs: base?.elapsedMs ?? 0,
+    escalationMs: escalation.reduce((sum, r) => sum + r.elapsedMs, 0),
     rings: [...byOffset.values()],
   };
 }
@@ -146,6 +155,7 @@ export async function upsertSweepStats(
         sweep_sunrise_thin_ticks, sweep_sunset_thin_ticks,
         sweep_sunrise_short_ticks, sweep_sunset_short_ticks,
         sweep_base_boxes, sweep_escalation_boxes,
+        sweep_base_ms, sweep_escalation_ms,
         updated_at
       ) values (
         ${date}, ${modelVersion},
@@ -153,6 +163,7 @@ export async function upsertSweepStats(
         ${stats.sunriseThinTicks}, ${stats.sunsetThinTicks},
         ${stats.sunriseShortTicks}, ${stats.sunsetShortTicks},
         ${stats.baseBoxes}, ${stats.escalationBoxes},
+        ${stats.baseMs}, ${stats.escalationMs},
         now()
       )
       on conflict (date) do update set
@@ -173,6 +184,9 @@ export async function upsertSweepStats(
         sweep_base_boxes = daily_sunset_stats.sweep_base_boxes + excluded.sweep_base_boxes,
         sweep_escalation_boxes =
           daily_sunset_stats.sweep_escalation_boxes + excluded.sweep_escalation_boxes,
+        sweep_base_ms = daily_sunset_stats.sweep_base_ms + excluded.sweep_base_ms,
+        sweep_escalation_ms =
+          daily_sunset_stats.sweep_escalation_ms + excluded.sweep_escalation_ms,
         updated_at = now()
     `;
 
@@ -181,12 +195,12 @@ export async function upsertSweepStats(
         insert into daily_sweep_ring_stats (
           date, offset_deg,
           rings_swept, boxes_attempted, boxes_empty, boxes_failed,
-          new_webcams, frames_scored, frames_gate_passed,
+          new_webcams, frames_scored, frames_gate_passed, elapsed_ms,
           updated_at
         ) values (
           ${date}, ${ring.offsetDeg},
           ${ring.ringsSwept}, ${ring.boxesAttempted}, ${ring.boxesEmpty}, ${ring.boxesFailed},
-          ${ring.newWebcams}, ${ring.framesScored}, ${ring.framesGatePassed},
+          ${ring.newWebcams}, ${ring.framesScored}, ${ring.framesGatePassed}, ${ring.elapsedMs},
           now()
         )
         on conflict (date, offset_deg) do update set
@@ -200,6 +214,7 @@ export async function upsertSweepStats(
             daily_sweep_ring_stats.frames_scored + excluded.frames_scored,
           frames_gate_passed =
             daily_sweep_ring_stats.frames_gate_passed + excluded.frames_gate_passed,
+          elapsed_ms = daily_sweep_ring_stats.elapsed_ms + excluded.elapsed_ms,
           updated_at = now()
       `;
     }
@@ -218,6 +233,8 @@ export interface SweepDigestSummary {
   sunsetShortTicks: number;
   baseBoxes: number;
   escalationBoxes: number;
+  baseMs: number;
+  escalationMs: number;
   rings: SweepRingStats[];
 }
 
@@ -236,7 +253,8 @@ export async function getSweepDigestSummary(): Promise<SweepDigestSummary | null
         sweep_ticks, sweep_escalated_ticks, sweep_budget_exhausted_ticks,
         sweep_sunrise_thin_ticks, sweep_sunset_thin_ticks,
         sweep_sunrise_short_ticks, sweep_sunset_short_ticks,
-        sweep_base_boxes, sweep_escalation_boxes
+        sweep_base_boxes, sweep_escalation_boxes,
+        sweep_base_ms, sweep_escalation_ms
       from daily_sunset_stats
       where date = CURRENT_DATE - 1
     `) as Record<string, number | string>[];
@@ -246,7 +264,7 @@ export async function getSweepDigestSummary(): Promise<SweepDigestSummary | null
     const ringRows = (await sql`
       select
         offset_deg, rings_swept, boxes_attempted, boxes_empty, boxes_failed,
-        new_webcams, frames_scored, frames_gate_passed
+        new_webcams, frames_scored, frames_gate_passed, elapsed_ms
       from daily_sweep_ring_stats
       where date = CURRENT_DATE - 1
       order by offset_deg desc
@@ -262,6 +280,8 @@ export async function getSweepDigestSummary(): Promise<SweepDigestSummary | null
       sunsetShortTicks: Number(row.sweep_sunset_short_ticks),
       baseBoxes: Number(row.sweep_base_boxes),
       escalationBoxes: Number(row.sweep_escalation_boxes),
+      baseMs: Number(row.sweep_base_ms),
+      escalationMs: Number(row.sweep_escalation_ms),
       // offset_deg is NUMERIC, which the Neon driver hands back as a string.
       // Number() here or every downstream comparison against 15.75 misses.
       rings: ringRows.map((r) => ({
@@ -273,6 +293,7 @@ export async function getSweepDigestSummary(): Promise<SweepDigestSummary | null
         newWebcams: Number(r.new_webcams),
         framesScored: Number(r.frames_scored),
         framesGatePassed: Number(r.frames_gate_passed),
+        elapsedMs: Number(r.elapsed_ms),
       })),
     };
   } catch (error) {

--- a/app/api/cron/update-cameras/lib/terminatorSweep.test.ts
+++ b/app/api/cron/update-cameras/lib/terminatorSweep.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { feedsBelowFloor, sweepWithEscalation } from './terminatorSweep';
 import type { Location, WindyWebcam } from '@/app/lib/types';
 
@@ -339,5 +339,27 @@ describe('sweepWithEscalation', () => {
     expect(res.telemetry.rings[0].failed).toBe(1);
     expect(res.telemetry.rings[0].failedByStatus).toEqual({ '400': 1 });
     expect(res.telemetry.rings[0].empty).toBe(1);
+  });
+
+  it('times each ring separately', async () => {
+    let clock = 1_000;
+    const nowSpy = vi.spyOn(Date, 'now').mockImplementation(() => clock);
+    try {
+      const res = await sweepWithEscalation({
+        buildRing: ring,
+        fetchCoords: async (coords) => {
+          clock += 5_000; // each ring takes 5s of wall clock
+          return { webcams: [], attempted: coords.length, empty: 0, failed: 0, failedByStatus: {} };
+        },
+        classify,
+        floor: 2,
+        offsets: [15.75],
+        hasBudget: () => true,
+        forcedOffsets: [15.75],
+      });
+      expect(res.telemetry.rings.map((r) => r.elapsedMs)).toEqual([5_000, 5_000]);
+    } finally {
+      nowSpy.mockRestore();
+    }
   });
 });

--- a/app/api/cron/update-cameras/lib/terminatorSweep.test.ts
+++ b/app/api/cron/update-cameras/lib/terminatorSweep.test.ts
@@ -197,4 +197,127 @@ describe('sweepWithEscalation', () => {
       'sunrise', 'sunset',
     ]);
   });
+
+  it('sweeps a forced ring even when both feeds clear the floor', async () => {
+    const seen: Location[][] = [];
+    const res = await sweepWithEscalation({
+      buildRing: ring,
+      fetchCoords: stubFetcher(
+        { 0: [cam(1), cam(2), cam(3), cam(4)], 15.75: [cam(5), cam(6)] },
+        seen
+      ),
+      classify,
+      floor: 2,
+      offsets: [15.75, -15.75],
+      hasBudget: () => true,
+      forcedOffsets: [15.75],
+    });
+    expect(res.telemetry.rings.map((r) => r.offsetDeg)).toEqual([0, 15.75]);
+    expect(res.telemetry.thinAfterBase).toEqual([]);
+  });
+
+  it('sweeps BOTH feeds on a forced ring, not just a thin one', async () => {
+    // A forced ring exists to widen coverage, not to rescue a feed. Sweeping
+    // only the thin half would leave one panel without the golden-hour
+    // cameras the whole measurement is about -- and with no feed thin at all,
+    // "the thin half" is empty and the ring would fetch nothing.
+    const seen: Location[][] = [];
+    await sweepWithEscalation({
+      buildRing: ring,
+      fetchCoords: stubFetcher(
+        { 0: [cam(1), cam(2), cam(3), cam(4)], 15.75: [cam(5), cam(6)] },
+        seen
+      ),
+      classify,
+      floor: 2,
+      offsets: [15.75],
+      hasBudget: () => true,
+      forcedOffsets: [15.75],
+    });
+    // ring() puts sunrise at lng 1 and sunset at lng 2 for each offset.
+    expect(seen[1]).toEqual([
+      { lat: 15.75, lng: 1 },
+      { lat: 15.75, lng: 2 },
+    ]);
+  });
+
+  it('still sacrifices a forced ring when the budget is gone', async () => {
+    // Spec §8: budget exhaustion sacrifices escalation rings first. The
+    // scoring loop needs the remaining tick more than the pool needs cameras,
+    // and forcing a ring must not buy its way past that.
+    const res = await sweepWithEscalation({
+      buildRing: ring,
+      fetchCoords: stubFetcher({ 0: [cam(1), cam(2), cam(3), cam(4)] }),
+      classify,
+      floor: 2,
+      offsets: [15.75],
+      hasBudget: () => false,
+      forcedOffsets: [15.75],
+    });
+    expect(res.telemetry.rings.map((r) => r.offsetDeg)).toEqual([0]);
+    expect(res.telemetry.budgetExhausted).toBe(true);
+  });
+
+  it('is unchanged from today when no offsets are forced', async () => {
+    // Spec §8: with the switch off, sweep behaviour is what it is today.
+    const healthy = {
+      buildRing: ring,
+      fetchCoords: stubFetcher({ 0: [cam(1), cam(2), cam(3), cam(4)] }),
+      classify,
+      floor: 2,
+      offsets: [15.75, -15.75],
+      hasBudget: () => true,
+    };
+    const withoutField = await sweepWithEscalation(healthy);
+    const withEmptyField = await sweepWithEscalation({
+      ...healthy,
+      forcedOffsets: [],
+    });
+    expect(withoutField.telemetry.rings).toHaveLength(1);
+    expect(withEmptyField.telemetry.rings).toHaveLength(1);
+    expect(withoutField.telemetry.budgetExhausted).toBe(false);
+    expect(withEmptyField.telemetry.budgetExhausted).toBe(false);
+  });
+
+  it('credits a shared camera to the ring that saw it first', async () => {
+    // Spec §8. The day ring's boxes overlap the base ring's (15.75 is under
+    // the 22-degree box span), so the same camera routinely comes back from
+    // both. If the later ring re-claimed it, the day ring's gate-pass rate
+    // would be diluted with base-ring cameras and the one number that
+    // distinguishes "widening adds sunsets" from "widening adds cameras the
+    // gate floors" would stop meaning anything.
+    const res = await sweepWithEscalation({
+      buildRing: ring,
+      fetchCoords: stubFetcher({
+        0: [cam(1), cam(2), cam(3), cam(4)],
+        15.75: [cam(2), cam(4), cam(6)], // 2 and 4 already seen by base
+      }),
+      classify,
+      floor: 2,
+      offsets: [15.75],
+      hasBudget: () => true,
+      forcedOffsets: [15.75],
+    });
+    expect(res.telemetry.rings[0].newWebcamIds).toEqual([1, 2, 3, 4]);
+    expect(res.telemetry.rings[1].newWebcamIds).toEqual([6]);
+    expect(res.telemetry.rings[1].newWebcams).toBe(1);
+  });
+
+  it('still escalates on a thin feed while a later ring is forced', async () => {
+    // Forcing must ADD a trigger, never replace the floor-based one.
+    const res = await sweepWithEscalation({
+      buildRing: ring,
+      fetchCoords: stubFetcher({
+        0: [cam(2), cam(4)], // sunset only; sunrise is thin
+        15.75: [cam(1), cam(3)],
+      }),
+      classify,
+      floor: 2,
+      offsets: [15.75],
+      hasBudget: () => true,
+      forcedOffsets: [15.75],
+    });
+    expect(res.telemetry.thinAfterBase).toEqual(['sunrise']);
+    expect(res.telemetry.rings.map((r) => r.offsetDeg)).toEqual([0, 15.75]);
+  });
 });

--- a/app/api/cron/update-cameras/lib/terminatorSweep.test.ts
+++ b/app/api/cron/update-cameras/lib/terminatorSweep.test.ts
@@ -16,7 +16,7 @@ function stubFetcher(perRing: Record<number, WindyWebcam[]>, seen: Location[][] 
     seen.push(coords);
     const offset = coords[0]?.lat ?? 0;
     const webcams = perRing[offset] ?? [];
-    return { webcams, attempted: coords.length, empty: 0 };
+    return { webcams, attempted: coords.length, empty: 0, failed: 0, failedByStatus: {} };
   };
 }
 
@@ -319,5 +319,25 @@ describe('sweepWithEscalation', () => {
     });
     expect(res.telemetry.thinAfterBase).toEqual(['sunrise']);
     expect(res.telemetry.rings.map((r) => r.offsetDeg)).toEqual([0, 15.75]);
+  });
+
+  it('carries failed boxes per ring, apart from empty ones', async () => {
+    const res = await sweepWithEscalation({
+      buildRing: ring,
+      fetchCoords: async (coords) => ({
+        webcams: [],
+        attempted: coords.length,
+        empty: 1,
+        failed: 1,
+        failedByStatus: { '400': 1 },
+      }),
+      classify,
+      floor: 2,
+      offsets: [],
+      hasBudget: () => true,
+    });
+    expect(res.telemetry.rings[0].failed).toBe(1);
+    expect(res.telemetry.rings[0].failedByStatus).toEqual({ '400': 1 });
+    expect(res.telemetry.rings[0].empty).toBe(1);
   });
 });

--- a/app/api/cron/update-cameras/lib/terminatorSweep.ts
+++ b/app/api/cron/update-cameras/lib/terminatorSweep.ts
@@ -13,6 +13,9 @@ export interface RingTelemetry {
   feedsSwept: Feed[];
   attempted: number;
   empty: number;
+  /** Boxes whose request came back non-OK. Not ocean; see CoordFetchResult. */
+  failed: number;
+  failedByStatus: Record<string, number>;
   /** Cameras this ring contributed that no earlier ring had seen. */
   newWebcams: number;
   /**
@@ -139,6 +142,8 @@ export async function sweepWithEscalation(
       feedsSwept: feeds,
       attempted: res.attempted,
       empty: res.empty,
+      failed: res.failed,
+      failedByStatus: res.failedByStatus,
       newWebcams: byId.size - before,
       newWebcamIds,
     });

--- a/app/api/cron/update-cameras/lib/terminatorSweep.ts
+++ b/app/api/cron/update-cameras/lib/terminatorSweep.ts
@@ -29,6 +29,16 @@ export interface RingTelemetry {
    * the cheap scalar for logs and dashboards.
    */
   newWebcamIds: number[];
+  /**
+   * Wall clock this ring spent, in milliseconds.
+   *
+   * The only unit-bearing cost signal the sweep produces. Windy publishes no
+   * per-call price, no rate limit and no quota headers, so a box count cannot
+   * be turned into money; function seconds can. It also says how close a ring
+   * came to TERMINATOR_SWEEP_BUDGET_MS, which the budget-exhausted flag only
+   * reports after the fact.
+   */
+  elapsedMs: number;
 }
 
 export interface SweepTelemetry {
@@ -129,7 +139,9 @@ export async function sweepWithEscalation(
       coords.push(...ring.sunsetCoords);
     }
     const before = byId.size;
+    const startedAt = Date.now();
     const res = await opts.fetchCoords(coords);
+    const elapsedMs = Date.now() - startedAt;
     // Record the ids this ring is first to see, before inserting them, so the
     // delta is against every EARLIER ring rather than against this one.
     const newWebcamIds: number[] = [];
@@ -146,6 +158,7 @@ export async function sweepWithEscalation(
       failedByStatus: res.failedByStatus,
       newWebcams: byId.size - before,
       newWebcamIds,
+      elapsedMs,
     });
   };
 

--- a/app/api/cron/update-cameras/lib/terminatorSweep.ts
+++ b/app/api/cron/update-cameras/lib/terminatorSweep.ts
@@ -60,6 +60,19 @@ export interface SweepOptions {
   ) => { sunrise: WindyWebcam[]; sunset: WindyWebcam[] };
   floor: number;
   offsets: readonly number[];
+  /**
+   * Offsets to sweep on every tick regardless of the camera floor, both feeds.
+   *
+   * The floor-based trigger asks "is a panel too empty to look at". This asks
+   * a different question: "does the pool reach the altitudes where sunsets
+   * actually happen". Good frames peak at 0 to +6 degrees solar altitude and
+   * the base ring at -13 never sees them, so the day-side ring is worth
+   * paying for even when nothing is thin. Additive to the floor trigger,
+   * never a replacement for it.
+   *
+   * Empty or absent means today's behaviour exactly.
+   */
+  forcedOffsets?: readonly number[];
   hasBudget: () => boolean;
 }
 
@@ -154,13 +167,21 @@ export async function sweepWithEscalation(
   const thinAfterBase = feedsBelowFloor(counts, opts.floor);
 
   for (const offsetDeg of opts.offsets) {
+    const forced = opts.forcedOffsets?.includes(offsetDeg) ?? false;
     const thin = feedsBelowFloor(counts, opts.floor);
-    if (thin.length === 0) break;
+    // Forced rings sweep both feeds; floor-triggered rings sweep only the
+    // thin half, which is what halves the cost of the common case.
+    const feeds: Feed[] = forced ? [...FEEDS] : thin;
+    // `continue`, not `break`. With no forced offsets the two are observably
+    // identical -- feedsBelowFloor is pure, counts have not changed, and
+    // neither path pushes a ring or sets budgetExhausted -- but `break` would
+    // skip a forced offset that sat after a non-forced one in the list.
+    if (feeds.length === 0) continue;
     if (!opts.hasBudget()) {
       budgetExhausted = true;
       break;
     }
-    await sweep(offsetDeg, thin);
+    await sweep(offsetDeg, feeds);
     counts = currentCounts();
   }
 

--- a/app/api/cron/update-cameras/lib/windyApi.test.ts
+++ b/app/api/cron/update-cameras/lib/windyApi.test.ts
@@ -45,19 +45,42 @@ describe('fetchCoordsCounted', () => {
   });
   afterEach(() => vi.unstubAllGlobals());
 
-  it('reports how many boxes were tried and how many came back empty', async () => {
+  it('counts a non-OK response as failed, not as empty', async () => {
+    // Two of the three boxes 400. Before this field existed they were
+    // scored as empty ocean, which is why the empty share could never tell a
+    // quota from the Pacific.
     const res = await fetchCoordsCounted(
       [{ lat: 0, lng: 99 }, { lat: 0, lng: 5 }, { lat: 0, lng: 20 }],
       5,
       0
     );
     expect(res.attempted).toBe(3);
-    expect(res.empty).toBe(2);
+    expect(res.failed).toBe(2);
+    expect(res.failedByStatus).toEqual({ '400': 2 });
+    expect(res.empty).toBe(0);
     expect(res.webcams).toHaveLength(1);
+  });
+
+  it('counts a 200 with no cameras as empty', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      json: async () => [],
+    })));
+    const res = await fetchCoordsCounted([{ lat: 0, lng: 5 }], 5, 0);
+    expect(res.empty).toBe(1);
+    expect(res.failed).toBe(0);
+    expect(res.failedByStatus).toEqual({});
   });
 
   it('is a no-op on an empty coordinate list', async () => {
     const res = await fetchCoordsCounted([], 5, 0);
-    expect(res).toEqual({ webcams: [], attempted: 0, empty: 0 });
+    expect(res).toEqual({
+      webcams: [],
+      attempted: 0,
+      empty: 0,
+      failed: 0,
+      failedByStatus: {},
+    });
   });
 });

--- a/app/api/cron/update-cameras/lib/windyApi.test.ts
+++ b/app/api/cron/update-cameras/lib/windyApi.test.ts
@@ -38,7 +38,7 @@ describe('fetchCoordsCounted', () => {
     vi.stubGlobal('fetch', vi.fn(async (url: string) => {
       // Boxes centred on lng 99 answer with one webcam; everything else 400s.
       if (url.includes('westLon=88')) {
-        return { ok: true, json: async () => [{ webcamId: 1, location: {} }] };
+        return { ok: true, status: 200, json: async () => [{ webcamId: 1, location: {} }] };
       }
       return { ok: false, status: 400, statusText: 'Bad Request' };
     }));

--- a/app/api/cron/update-cameras/lib/windyApi.ts
+++ b/app/api/cron/update-cameras/lib/windyApi.ts
@@ -40,12 +40,27 @@ export function boundingBox(loc: Location, radiusDeg: number): BoundingBox {
 }
 
 /**
+ * One box's answer, with the status that produced it.
+ *
+ * `ok: false` with an empty list is a failed request. `ok: true` with an
+ * empty list is a box with no cameras in it. Until this type existed the two
+ * were indistinguishable downstream, which made every "empty box" count a
+ * mix of ocean and rejected calls.
+ */
+export interface BoxFetchResult {
+  webcams: WindyWebcam[];
+  /** HTTP status of the response. */
+  status: number;
+  ok: boolean;
+}
+
+/**
  * Fetch webcams from Windy API for a given location
  */
 export async function fetchWebcamsFor(
   loc: Location,
   delayMs = 0
-): Promise<WindyWebcam[]> {
+): Promise<BoxFetchResult> {
   // Add delay to avoid rate limiting
   if (delayMs > 0) {
     await new Promise((resolve) => setTimeout(resolve, delayMs));
@@ -77,14 +92,14 @@ export async function fetchWebcamsFor(
     console.error(
       `❌ API error for ${loc.lat},${loc.lng}: ${res.status} ${res.statusText}`
     );
-    return [] as WindyWebcam[];
+    return { webcams: [], status: res.status, ok: false };
   }
 
   const data: WindyWebcam[] = await res.json();
   console.log(
     `📹 Found ${data.length} webcams at ${loc.lat},${loc.lng}`
   );
-  return data ?? [];
+  return { webcams: data ?? [], status: res.status, ok: true };
 }
 
 /**
@@ -106,8 +121,8 @@ export async function fetchWebcamsInBatches(
   coords: Location[],
   batchSize = 5,
   delayBetweenBatches = 1000
-): Promise<WindyWebcam[][]> {
-  const batches: WindyWebcam[][] = [];
+): Promise<BoxFetchResult[]> {
+  const batches: BoxFetchResult[] = [];
 
   for (let i = 0; i < coords.length; i += batchSize) {
     const batch = coords.slice(i, i + batchSize);
@@ -151,14 +166,16 @@ export interface CoordFetchResult {
   webcams: WindyWebcam[];
   /** Boxes we sent to Windy. */
   attempted: number;
-  /**
-   * Boxes that returned nothing. Conflates "no cameras there" with "the call
-   * failed", because `fetchWebcamsFor` swallows non-OK responses. That
-   * conflation is the point: a rising `empty` count against a flat camera
-   * count is the signature of an API wall, which is the thing we need to be
-   * able to see.
-   */
+  /** Boxes that answered 200 with no cameras. Ocean, or nearly. */
   empty: number;
+  /**
+   * Boxes whose request came back non-OK. Counted apart from `empty` because
+   * a quota ceiling and the Pacific look identical in an empty count and
+   * nothing like each other here.
+   */
+  failed: number;
+  /** `failed`, split by HTTP status: `{ "400": 3 }`. */
+  failedByStatus: Record<string, number>;
 }
 
 /**
@@ -170,16 +187,31 @@ export async function fetchCoordsCounted(
   batchSize = 5,
   delayMs = 1000
 ): Promise<CoordFetchResult> {
-  if (coords.length === 0) return { webcams: [], attempted: 0, empty: 0 };
+  if (coords.length === 0) {
+    return { webcams: [], attempted: 0, empty: 0, failed: 0, failedByStatus: {} };
+  }
   // One entry per COORDINATE, not per batch: fetchWebcamsInBatches spreads
   // each batch's results back in, so the array is 1:1 with `coords`. That
-  // invariant is what makes `attempted` and `empty` correct, and the old
-  // `batches` name hid it.
+  // invariant is what makes `attempted`, `empty` and `failed` correct.
   const perCoord = await fetchWebcamsInBatches(coords, batchSize, delayMs);
+  let empty = 0;
+  let failed = 0;
+  const failedByStatus: Record<string, number> = {};
+  for (const box of perCoord) {
+    if (!box.ok) {
+      failed += 1;
+      const key = String(box.status);
+      failedByStatus[key] = (failedByStatus[key] ?? 0) + 1;
+    } else if (box.webcams.length === 0) {
+      empty += 1;
+    }
+  }
   return {
-    webcams: perCoord.flat(),
+    webcams: perCoord.flatMap((box) => box.webcams),
     attempted: coords.length,
-    empty: perCoord.filter((r) => r.length === 0).length,
+    empty,
+    failed,
+    failedByStatus,
   };
 }
 

--- a/app/api/cron/update-cameras/route.test.ts
+++ b/app/api/cron/update-cameras/route.test.ts
@@ -26,6 +26,7 @@ const uploadToFirebaseMock = vi.fn(() => ({
   path: 'snapshots/0/test.jpg',
 }));
 const insertWindyDisagreementSnapshotMock = vi.fn(() => 999);
+const isFlagEnabledMock = vi.fn();
 
 vi.mock('@/app/lib/terminatorPayload', () => ({
   fetchTerminatorWebcams: () => fetchTerminatorWebcamsMock(),
@@ -93,6 +94,10 @@ vi.mock('./lib/providerUsage', () => ({
 // real module -- and with it @/app/lib/db, which calls neon() at import time
 // and throws without DATABASE_URL. Nothing in this file uses sql directly.
 vi.mock('@/app/lib/db', () => ({ sql: vi.fn() }));
+vi.mock('@/app/lib/runtimeFlags', () => ({
+  SWEEP_FORCE_DAY_RING: 'sweep_force_day_ring',
+  isFlagEnabled: () => isFlagEnabledMock(),
+}));
 
 const upsertSweepStatsMock = vi.fn();
 // Only the write is stubbed. computeSweepTickStats and ringOffsetByWebcamId
@@ -192,6 +197,7 @@ beforeEach(() => {
     path: 'snapshots/0/test.jpg',
   });
   insertWindyDisagreementSnapshotMock.mockReset().mockReturnValue(999);
+  isFlagEnabledMock.mockReset().mockResolvedValue(false);
   toggles.high = false;
   toggles.all = false;
   toggles.trickleRate = 0;
@@ -550,6 +556,23 @@ describe('GET /api/cron/update-cameras', () => {
     const res = await GET(makeReq());
     expect(res.status).toBe(200);
     expect((await res.json()).digest).toEqual({ skipped: 'send-failed' });
+  });
+
+  it('sweeps only the base ring while the switch is off', async () => {
+    const res = await GET(makeReq());
+    const body = await res.json();
+    expect(body.forcedDayRing).toBe(false);
+    expect(body.sweep.rings).toHaveLength(1);
+  });
+
+  it('sweeps the day-side ring on a healthy tick when the switch is on', async () => {
+    isFlagEnabledMock.mockResolvedValue(true);
+    const res = await GET(makeReq());
+    const body = await res.json();
+    expect(body.forcedDayRing).toBe(true);
+    expect(body.sweep.rings.map((r: { offsetDeg: number }) => r.offsetDeg))
+      .toEqual([0, 15.75]);
+    expect(body.sweep.rings[1].feedsSwept).toEqual(['sunrise', 'sunset']);
   });
 
   describe('terminator sweep telemetry', () => {

--- a/app/api/cron/update-cameras/route.test.ts
+++ b/app/api/cron/update-cameras/route.test.ts
@@ -108,6 +108,21 @@ vi.mock('./lib/sweepStats', async (importOriginal) => ({
   ...(await importOriginal<typeof import('./lib/sweepStats')>()),
   upsertSweepStats: (...a: unknown[]) => upsertSweepStatsMock(...a),
 }));
+const upsertSweepGeometryMock = vi.fn();
+// Only the write is stubbed. sweepGeometry stays real (it reads only
+// masterConfig constants, no DB) so the assertion below checks REAL output —
+// a regression that drops forcedOffsets from the geometry record would
+// otherwise break no test.
+vi.mock('./lib/sweepGeometry', async () => {
+  const actual =
+    await vi.importActual<typeof import('./lib/sweepGeometry')>(
+      './lib/sweepGeometry',
+    );
+  return {
+    ...actual,
+    upsertSweepGeometry: (...a: unknown[]) => upsertSweepGeometryMock(...a),
+  };
+});
 const sendDailyUsageDigestMock = vi.fn();
 vi.mock('./lib/dailyDigest', () => ({
   sendDailyUsageDigest: (...a: unknown[]) => sendDailyUsageDigestMock(...a),
@@ -188,6 +203,7 @@ beforeEach(() => {
   captureProviderUsageDailyMock.mockReset().mockResolvedValue({ captured: 0 });
   sendDailyUsageDigestMock.mockReset().mockResolvedValue({ sent: true });
   upsertSweepStatsMock.mockReset().mockResolvedValue(undefined);
+  upsertSweepGeometryMock.mockReset().mockResolvedValue(undefined);
   setCachedMock.mockReset().mockResolvedValue(undefined);
   markKioskTickRanMock.mockReset().mockResolvedValue(undefined);
   fetchTerminatorWebcamsMock.mockReset().mockResolvedValue([]);
@@ -565,6 +581,10 @@ describe('GET /api/cron/update-cameras', () => {
     const body = await res.json();
     expect(body.forcedDayRing).toBe(false);
     expect(body.sweep.rings).toHaveLength(1);
+    expect(upsertSweepGeometryMock).toHaveBeenCalledTimes(1);
+    expect(upsertSweepGeometryMock.mock.calls[0][1]).toMatchObject({
+      forcedOffsetsDeg: '',
+    });
   });
 
   it('sweeps the day-side ring on a healthy tick when the switch is on', async () => {
@@ -575,6 +595,10 @@ describe('GET /api/cron/update-cameras', () => {
     expect(body.sweep.rings.map((r: { offsetDeg: number }) => r.offsetDeg))
       .toEqual([0, 15.75]);
     expect(body.sweep.rings[1].feedsSwept).toEqual(['sunrise', 'sunset']);
+    expect(upsertSweepGeometryMock).toHaveBeenCalledTimes(1);
+    expect(upsertSweepGeometryMock.mock.calls[0][1]).toMatchObject({
+      forcedOffsetsDeg: '15.75',
+    });
   });
 
   describe('terminator sweep telemetry', () => {

--- a/app/api/cron/update-cameras/route.test.ts
+++ b/app/api/cron/update-cameras/route.test.ts
@@ -46,7 +46,7 @@ vi.mock('./lib/windyApi', () => ({
   // list short-circuits to zero webcams without calling the batch fetcher.
   fetchCoordsCounted: async (coords: unknown[], ...rest: unknown[]) => {
     if (!Array.isArray(coords) || coords.length === 0) {
-      return { webcams: [], attempted: 0, empty: 0 };
+      return { webcams: [], attempted: 0, empty: 0, failed: 0, failedByStatus: {} };
     }
     const batches = (await fetchBatchesMock(coords, ...rest)) as Array<
       Array<{ webcamId: number | string; [k: string]: unknown }>
@@ -55,6 +55,8 @@ vi.mock('./lib/windyApi', () => ({
       webcams: batches.flat(),
       attempted: coords.length,
       empty: batches.filter((b) => b.length === 0).length,
+      failed: 0,
+      failedByStatus: {},
     };
   },
 }));

--- a/app/api/cron/update-cameras/route.ts
+++ b/app/api/cron/update-cameras/route.ts
@@ -18,6 +18,7 @@ import { createTerminatorQueryRing } from '@/app/components/Map/lib/terminatorRi
 import {
   TERMINATOR_CAMERA_FLOOR,
   TERMINATOR_WIDEN_OFFSETS_DEG,
+  TERMINATOR_DAY_SIDE_OFFSETS_DEG,
   TERMINATOR_SWEEP_BUDGET_MS,
   TICK_DEADLINE_MS,
   TERMINATOR_PRECISION_DEG,
@@ -31,6 +32,7 @@ import {
   AI_SNAPSHOT_MIN_RATING_THRESHOLD,
   ARCHIVE_BACKFILL_ENABLED,
 } from '@/app/lib/masterConfig';
+import { isFlagEnabled, SWEEP_FORCE_DAY_RING } from '@/app/lib/runtimeFlags';
 import { classifyCustomCamerasForTick } from './lib/customClassification';
 import { verifyCronAuth } from './lib/auth';
 import { dedupeCoords, fetchCoordsCounted } from './lib/windyApi';
@@ -88,6 +90,12 @@ export async function GET(req: Request) {
   const now = new Date();
   const { raHours, gmstHours } = subsolarPoint(now);
 
+  // Read per tick, so the operator can bring the spending back down without a
+  // redeploy. Fails closed inside isFlagEnabled: an unreachable database
+  // gives today's behaviour, never extra cost.
+  const forcedDayRing = await isFlagEnabled(SWEEP_FORCE_DAY_RING);
+  const forcedOffsets = forcedDayRing ? TERMINATOR_DAY_SIDE_OFFSETS_DEG : [];
+
   const tickStartedAt = Date.now();
   const sweep = await sweepWithEscalation({
     buildRing: (offsetDeg) => {
@@ -113,6 +121,12 @@ export async function GET(req: Request) {
     classify: classifyWebcamsByPhase,
     floor: TERMINATOR_CAMERA_FLOOR,
     offsets: TERMINATOR_WIDEN_OFFSETS_DEG,
+    // Phase 1 of the pool-coverage spec: force the golden-hour ring so the
+    // pool reaches 0 to +6 degrees, where good frames actually are, instead
+    // of only the -24 to -2 band the base ring covers. Roughly doubles Windy
+    // boxes per tick, which is the cost the measurement window exists to
+    // price.
+    forcedOffsets,
     // Escalation rings are the first thing sacrificed on a slow tick: the
     // scoring loop below needs the remaining budget more than the pool needs
     // extra cameras. See TERMINATOR_SWEEP_BUDGET_MS for the cutoff rationale.
@@ -123,7 +137,10 @@ export async function GET(req: Request) {
   const sunsetCoords = sweep.coords.sunsetCoords;
   const windyAll = sweep.webcams.filter((w) => w.location);
 
-  console.log('🛰️ terminator sweep:', JSON.stringify(sweep.telemetry));
+  console.log(
+    '🛰️ terminator sweep:',
+    JSON.stringify({ forcedDayRing, ...sweep.telemetry }),
+  );
 
   // Ring attribution for the detection-gate comparison. Each camera is
   // credited to the ring that first saw it this tick, so the digest can print
@@ -501,5 +518,6 @@ export async function GET(req: Request) {
     providerUsage,
     digest,
     sweep: sweep.telemetry,
+    forcedDayRing,
   });
 }

--- a/app/api/cron/update-cameras/route.ts
+++ b/app/api/cron/update-cameras/route.ts
@@ -91,13 +91,14 @@ export async function GET(req: Request) {
   const now = new Date();
   const { raHours, gmstHours } = subsolarPoint(now);
 
+  const tickStartedAt = Date.now();
+
   // Read per tick, so the operator can bring the spending back down without a
   // redeploy. Fails closed inside isFlagEnabled: an unreachable database
   // gives today's behaviour, never extra cost.
   const forcedDayRing = await isFlagEnabled(SWEEP_FORCE_DAY_RING);
   const forcedOffsets = forcedDayRing ? TERMINATOR_DAY_SIDE_OFFSETS_DEG : [];
 
-  const tickStartedAt = Date.now();
   const sweep = await sweepWithEscalation({
     buildRing: (offsetDeg) => {
       const r = createTerminatorQueryRing(

--- a/app/api/cron/update-cameras/route.ts
+++ b/app/api/cron/update-cameras/route.ts
@@ -44,6 +44,7 @@ import {
   upsertSweepStats,
   type RingGateCounts,
 } from './lib/sweepStats';
+import { sweepGeometry, upsertSweepGeometry } from './lib/sweepGeometry';
 import {
   upsertWebcams,
   getWebcamIdMap,
@@ -481,6 +482,11 @@ export async function GET(req: Request) {
     gateByOffset,
   });
   await upsertSweepStats(new Date(), sweepStats, tickStats.modelVersion);
+
+  // The angles behind the counters just written. Recorded every tick rather
+  // than on change, because nothing watches for a change -- masterConfig.ts
+  // edits arrive by deploy and the flag flips outside the app entirely.
+  await upsertSweepGeometry(new Date(), sweepGeometry(forcedOffsets));
 
   // Once per UTC day, snapshot Neon usage counters for the Ops tab. Never
   // allowed to fail the tick.

--- a/app/lib/masterConfig.test.ts
+++ b/app/lib/masterConfig.test.ts
@@ -3,6 +3,8 @@ import {
   SEARCH_RADIUS_DEG,
   TERMINATOR_CAMERA_FLOOR,
   TERMINATOR_WIDEN_OFFSETS_DEG,
+  TERMINATOR_SUN_ALTITUDE_DEG,
+  TERMINATOR_DAY_SIDE_OFFSETS_DEG,
   TERMINATOR_SWEEP_BUDGET_MS,
   TICK_DEADLINE_MS,
   YOUTUBE_MAX_LOCATION_RADIUS_KM,
@@ -74,5 +76,20 @@ describe('YOUTUBE_MAX_LOCATION_RADIUS_KM', () => {
     const sentKm = Math.min(rawKm, YOUTUBE_MAX_LOCATION_RADIUS_KM);
     expect(sentKm).toBeLessThanOrEqual(YOUTUBE_MAX_LOCATION_RADIUS_KM);
     expect(sentKm).toBe(Math.min(rawKm, 1000));
+  });
+});
+
+describe('TERMINATOR_DAY_SIDE_OFFSETS_DEG', () => {
+  it('is the golden-hour ring, and only it', () => {
+    // Positive offset moves the ring toward day. The night-side ring lands
+    // near -28.75, where the detection gate floors the frames anyway, so
+    // forcing it would buy cost without sunsets.
+    expect(TERMINATOR_DAY_SIDE_OFFSETS_DEG).toEqual([15.75]);
+  });
+
+  it('puts its ring inside the measured quality peak', () => {
+    const altitude = TERMINATOR_SUN_ALTITUDE_DEG + TERMINATOR_DAY_SIDE_OFFSETS_DEG[0];
+    expect(altitude).toBeGreaterThan(0);
+    expect(altitude).toBeLessThan(6);
   });
 });

--- a/app/lib/masterConfig.ts
+++ b/app/lib/masterConfig.ts
@@ -50,6 +50,14 @@ export const TERMINATOR_CAMERA_FLOOR = 15;
 // live measurement of a new offset.
 export const TERMINATOR_WIDEN_OFFSETS_DEG = [15.75, -15.75] as const;
 
+// The escalation offsets that move the ring toward day. Positive offset
+// shrinks the ring radius, so positive is day. Named rather than indexed
+// because "the day-side ring" is the concept the forced-sweep switch acts on,
+// and TERMINATOR_WIDEN_OFFSETS_DEG[0] would silently mean something else if
+// the array were ever reordered.
+export const TERMINATOR_DAY_SIDE_OFFSETS_DEG = TERMINATOR_WIDEN_OFFSETS_DEG
+  .filter((offset) => offset > 0);
+
 // Wall-clock budget for the whole terminator sweep (base ring + any
 // escalation rings), in milliseconds. The scoring loop that follows needs
 // the remaining tick more than the pool needs extra cameras, so escalation

--- a/app/lib/runtimeFlags.test.ts
+++ b/app/lib/runtimeFlags.test.ts
@@ -1,0 +1,46 @@
+// @vitest-environment node
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const sqlMock = vi.fn();
+vi.mock('@/app/lib/db', () => ({
+  sql: (strings: TemplateStringsArray, ...values: unknown[]) =>
+    sqlMock(strings, ...values),
+}));
+
+import { isFlagEnabled, SWEEP_FORCE_DAY_RING } from './runtimeFlags';
+
+// Braces, not a concise arrow: mockReset() returns the mock, and Vitest treats
+// a value returned from a hook as a teardown callback.
+beforeEach(() => {
+  sqlMock.mockReset();
+});
+
+describe('isFlagEnabled', () => {
+  it('is true when the row says enabled', async () => {
+    sqlMock.mockResolvedValue([{ enabled: true }]);
+    await expect(isFlagEnabled(SWEEP_FORCE_DAY_RING)).resolves.toBe(true);
+  });
+
+  it('is false when the row says disabled', async () => {
+    sqlMock.mockResolvedValue([{ enabled: false }]);
+    await expect(isFlagEnabled(SWEEP_FORCE_DAY_RING)).resolves.toBe(false);
+  });
+
+  it('is false when the row does not exist', async () => {
+    sqlMock.mockResolvedValue([]);
+    await expect(isFlagEnabled(SWEEP_FORCE_DAY_RING)).resolves.toBe(false);
+  });
+
+  it('fails closed when the table is missing or the read throws', async () => {
+    // A flag that fails OPEN would spend money on an unreachable database,
+    // which is the one failure mode the operator's cost condition rules out.
+    // This also covers the deploy window before the migration is applied.
+    sqlMock.mockRejectedValue(new Error('relation "runtime_flags" does not exist'));
+    await expect(isFlagEnabled(SWEEP_FORCE_DAY_RING)).resolves.toBe(false);
+  });
+
+  it('does not treat a truthy non-boolean as enabled', async () => {
+    sqlMock.mockResolvedValue([{ enabled: 'false' }]);
+    await expect(isFlagEnabled(SWEEP_FORCE_DAY_RING)).resolves.toBe(false);
+  });
+});

--- a/app/lib/runtimeFlags.ts
+++ b/app/lib/runtimeFlags.ts
@@ -1,0 +1,40 @@
+import 'server-only';
+import { sql } from '@/app/lib/db';
+
+/**
+ * Booleans the cron reads at tick time.
+ *
+ * The point is reversibility without a redeploy: env vars in this project
+ * bake in when the deploy is built, so an env-var kill-switch cannot bring
+ * spending down until someone redeploys. A row can be flipped in seconds --
+ * see scripts/set-runtime-flag.mjs -- and the next tick honours it.
+ */
+
+/**
+ * Sweep the day-side escalation ring every tick, both feeds, regardless of
+ * TERMINATOR_CAMERA_FLOOR. Roughly doubles Windy boxes per tick. Off by
+ * default; phase 1 of the pool-coverage spec turns it on for a bounded
+ * measurement window.
+ */
+export const SWEEP_FORCE_DAY_RING = 'sweep_force_day_ring';
+
+/**
+ * Read one flag. Fails CLOSED: any error, missing row, or non-boolean value
+ * reads as off.
+ *
+ * Failing closed is the whole safety property. This flag gates spending, and
+ * an unreachable database must not be able to turn spending on. It also means
+ * a deploy that lands before the migration is applied behaves exactly like
+ * today rather than throwing inside the cron.
+ */
+export async function isFlagEnabled(key: string): Promise<boolean> {
+  try {
+    const rows = (await sql`
+      SELECT enabled FROM runtime_flags WHERE key = ${key}
+    `) as unknown as { enabled: boolean }[];
+    return rows[0]?.enabled === true;
+  } catch (error) {
+    console.warn('[runtimeFlags] read failed, treating as off:', key, error);
+    return false;
+  }
+}

--- a/database/migrations/20260902_runtime_flags.sql
+++ b/database/migrations/20260902_runtime_flags.sql
@@ -1,0 +1,32 @@
+-- runtime_flags: booleans the cron reads at tick time (spec:
+-- docs/superpowers/specs/2026-09-02-terminator-pool-coverage-design.md §4).
+--
+-- Deliberately NOT env vars. Env vars in this project bake in at deploy time,
+-- so bringing spending back down through one would need a `vercel redeploy`.
+-- The operator's condition on approving this spend was a switch that works
+-- without a code change or a redeploy, and a table row is that switch.
+--
+-- Kept separate from kiosk_settings: that table is display dials, sanitized
+-- against a versioned settings schema and copied studio -> live by the Deploy
+-- button. An ops kill-switch has none of those semantics and must not inherit
+-- them -- in particular it must never be copied by a profile deploy.
+--
+-- Forward-only, idempotent. Apply via:
+--   node scripts/apply-migration.mjs database/migrations/20260902_runtime_flags.sql --apply
+
+CREATE TABLE IF NOT EXISTS runtime_flags (
+  key        TEXT PRIMARY KEY,
+  enabled    BOOLEAN NOT NULL DEFAULT false,
+  note       TEXT,
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- Seeded OFF. Phase 1 flips it by hand for a bounded window; see
+-- scripts/set-runtime-flag.mjs.
+INSERT INTO runtime_flags (key, enabled, note)
+VALUES (
+  'sweep_force_day_ring',
+  false,
+  'Sweep the +15.75 day-side ring every tick regardless of TERMINATOR_CAMERA_FLOOR. Roughly doubles Windy boxes per tick.'
+)
+ON CONFLICT (key) DO NOTHING;

--- a/database/migrations/20260902_sweep_geometry.sql
+++ b/database/migrations/20260902_sweep_geometry.sql
@@ -1,0 +1,35 @@
+-- daily_sweep_geometry: the ring angles behind each day's sweep counters.
+--
+-- daily_sweep_ring_stats keys on offset_deg, which is meaningless on its own:
+-- +15.75 is +2.75 degrees of solar altitude only while the base ring sits at
+-- -13. The pool-coverage work expects the base altitude, the radius and the
+-- offset set to move more than once, so every historical row needs the
+-- geometry that produced it stored beside it rather than inferred from
+-- whatever masterConfig.ts happens to say later.
+--
+-- One row per (date, signature). A configuration change mid-day writes a
+-- SECOND row for that date rather than overwriting the first, so the
+-- transition is visible instead of averaged away -- which is exactly the
+-- moment the record exists for.
+--
+-- Forward-only, idempotent. Apply via:
+--   node scripts/apply-migration.mjs database/migrations/20260902_sweep_geometry.sql --apply
+
+CREATE TABLE IF NOT EXISTS daily_sweep_geometry (
+  date               DATE NOT NULL,        -- UTC date, matches daily_sunset_stats
+  -- Stable label for one configuration, e.g.
+  -- 'base-13_r11_off15.75,-15.75_forced15.75'. Comparing signatures across
+  -- days is how a change is spotted without diffing six columns.
+  signature          TEXT NOT NULL,
+  base_altitude_deg  NUMERIC(6,2) NOT NULL,
+  search_radius_deg  NUMERIC(6,2) NOT NULL,
+  widen_offsets_deg  TEXT NOT NULL,        -- every offset the sweep MAY run
+  forced_offsets_deg TEXT NOT NULL,        -- offsets it ran unconditionally
+  -- The resulting solar-altitude span, stored rather than derived so it
+  -- survives a change to the derivation itself.
+  coverage_min_deg   NUMERIC(6,2) NOT NULL,
+  coverage_max_deg   NUMERIC(6,2) NOT NULL,
+  ticks              INTEGER NOT NULL DEFAULT 0,
+  updated_at         TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  PRIMARY KEY (date, signature)
+);

--- a/database/migrations/20260902_sweep_timing.sql
+++ b/database/migrations/20260902_sweep_timing.sql
@@ -1,0 +1,24 @@
+-- Sweep timing: the one cost signal with a unit.
+--
+-- The sweep telemetry already answers "how many boxes" and "did the frames
+-- pass the gate". It cannot answer "what did widening cost", because Windy
+-- publishes no price, no rate limit and no quota headers -- a box count is
+-- not money. Function wall-clock is, and it is also what actually runs out
+-- against TERMINATOR_SWEEP_BUDGET_MS.
+--
+-- BIGINT: a day of ticks summing tens of seconds each stays far inside
+-- INTEGER, but these are additive counters with no natural ceiling and the
+-- cost of the wider type here is nil.
+--
+-- Forward-only, idempotent. Apply via:
+--   node scripts/apply-migration.mjs database/migrations/20260902_sweep_timing.sql --apply
+
+ALTER TABLE daily_sunset_stats
+  -- Wall clock the base ring spent, summed over today's ticks.
+  ADD COLUMN IF NOT EXISTS sweep_base_ms       BIGINT NOT NULL DEFAULT 0,
+  -- Wall clock widening added, summed over today's ticks. Read against
+  -- sweep_base_ms, this is the widening's marginal compute cost.
+  ADD COLUMN IF NOT EXISTS sweep_escalation_ms BIGINT NOT NULL DEFAULT 0;
+
+ALTER TABLE daily_sweep_ring_stats
+  ADD COLUMN IF NOT EXISTS elapsed_ms BIGINT NOT NULL DEFAULT 0;

--- a/database/migrations/20260903_sweep_failed_boxes.sql
+++ b/database/migrations/20260903_sweep_failed_boxes.sql
@@ -1,0 +1,14 @@
+-- Failed boxes, counted apart from empty ones.
+--
+-- boxes_empty conflated "no cameras there" with "the call failed", because
+-- fetchWebcamsFor returned [] on any non-OK response. Measured 2026-09-03:
+-- 2,250 Windy errors in 24h, all 400, on boxes touching the poles and the
+-- antimeridian, every one recorded as ocean. That made the empty share
+-- useless as a quota signal at any sample size. This column is the
+-- disambiguation. boxes_empty now means 200-with-nothing only.
+--
+-- Forward-only, idempotent. Apply via:
+--   node scripts/apply-migration.mjs database/migrations/20260903_sweep_failed_boxes.sql --apply
+
+ALTER TABLE daily_sweep_ring_stats
+  ADD COLUMN IF NOT EXISTS boxes_failed INTEGER NOT NULL DEFAULT 0;

--- a/docs/superpowers/plans/2026-09-02-terminator-pool-coverage-phase1.md
+++ b/docs/superpowers/plans/2026-09-02-terminator-pool-coverage-phase1.md
@@ -1699,26 +1699,76 @@ there is nothing to compare against, and the whole window is wasted.
 A first baseline was already captured on 2026-09-02/03 and is in the SDD
 ledger; re-run these to extend it to the day of the flip.
 
-- [ ] **Step 1b: Gate on the empty-box share before flipping**
+- [x] **Step 1b: RESOLVED 2026-09-03. The empty-box alarm was not a quota
+  ceiling.**
 
-Compute `boxes_empty / boxes_attempted` from `daily_sweep_ring_stats`, and
-**compare like with like**. The first capture appeared to show a jump, 26.9%
-on 2026-09-02 against 38.8% on 2026-09-03, which the sweep-telemetry
-migration would name as "the signature of an undiscovered Windy quota
-ceiling."
+Settled by direct observation, not by waiting for a third day. Recorded in
+full because the reasoning matters more than the verdict: the gate as
+originally written could not have answered the question it asked.
 
-That comparison was invalid and the alarm is probably false. Both rows were
-partial days covering different UTC hours: 09-02 ran from the merge at 17:56Z
-to midnight, 09-03 from midnight to 06:27Z. The terminator crosses far more
-ocean in the early-UTC window, so empty boxes and cameras-found move together
-for purely geographic reasons. `new_webcams` per tick fell from 113.8 to 98.4
-across the same pair, which fits geography as well as it fits a ceiling.
+**The original alarm.** The first capture appeared to show a jump in
+`boxes_empty / boxes_attempted`, 26.9% on 2026-09-02 against 38.8% on
+2026-09-03, while `new_webcams` per tick fell from 113.8 to 98.4. The
+sweep-telemetry migration names exactly that shape as "the signature of an
+undiscovered Windy quota ceiling."
 
-**Compare one full UTC day against another full UTC day, or the same UTC
-hours on two dates.** Never two partial days. If the share is genuinely
-climbing on a like-for-like comparison across three days, do not flip: a
-pre-existing ceiling is a bigger finding than the widening question, and
-doubling the call rate into it would confound both.
+**Why more days would not have settled it.** `boxes_empty` cannot separate
+the two hypotheses at any sample size. `fetchWebcamsFor` returns an empty
+array on every non-OK response (`app/api/cron/update-cameras/lib/windyApi.ts`,
+the `if (!res.ok)` branch), so a throttled call and an open-ocean box
+increment the same counter by one. No number of additional days
+un-conflates a conflated metric. The status codes were the missing
+instrument, and they were already in the Vercel function logs the whole time.
+
+**What the evidence showed.** Three independent checks, all agreeing:
+
+- **Status codes.** Every non-OK Windy response in the sampled production
+  logs is `400 Bad Request`. Zero 429, zero 403, zero 5xx. A quota ceiling
+  presents as 429 or 403.
+- **Live probe at the full production call rate.** Six boxes, all 200.
+  Camera-dense land boxes returned 26, 30, 17 and 11 cameras; ocean controls
+  returned 0. An exhausted quota would have flattened the land boxes too.
+- **The failures are geographic, not volumetric.** They cluster on boxes
+  touching the antimeridian and the poles, an unbiased recent sample of 2,400
+  box attempts contained zero of them, and replaying the exact coordinates
+  that failed in production returns 200.
+
+The partial-day reading therefore stands, now with a mechanism rather than a
+guess. 09-02 ran from the merge at 17:56Z to midnight and 09-03 from midnight
+to 06:27Z. The terminator crosses far more ocean in the early-UTC window, so
+empty boxes and cameras-found move together for purely geographic reasons.
+
+**A defect in this step as originally written.** It prescribed comparing "the
+same UTC hours on two dates." That is not executable.
+`daily_sweep_ring_stats` is keyed `(date, offset_deg)` with no hour column,
+so hour-matching against stored data is impossible. Whole UTC day against
+whole UTC day is the only comparison the schema supports, and the first
+complete day is 2026-09-03.
+
+**The gate that replaces it.** Do not gate on the empty-box share, which is
+ambiguous by construction. Gate on the status codes:
+
+```bash
+vercel logs --environment production --no-branch --since 24h \
+  --limit 500 --query "API error" --json \
+  | grep -oE 'API error for [-0-9.,]+: [0-9]+'
+```
+
+Any 429 or 403 means a real ceiling, and a real ceiling is a bigger finding
+than the widening question: do not flip, because doubling the call rate into
+it would confound both. All-400 means edge-of-world box rejection, which is
+a separate bug and not a reason to hold the window.
+
+**A second, unrelated bug this surfaced.** Boxes near the antimeridian and
+the poles are intermittently rejected with 400 and then silently scored as
+empty ocean. It does not block the measurement window. It does mean a small
+standing overstatement in every `boxes_empty` figure.
+
+**Carry into Task 5.** While the sweep telemetry is already open, split the
+counter: count non-OK responses separately from genuinely empty boxes, and
+carry the status code. It is a small change across `windyApi.ts`, the sweep,
+and one migration column, and it turns this gate from an inference into an
+observation permanently.
 
 - [ ] **Step 2: Log the change on the cost timeline**
 

--- a/docs/superpowers/plans/2026-09-02-terminator-pool-coverage-phase1.md
+++ b/docs/superpowers/plans/2026-09-02-terminator-pool-coverage-phase1.md
@@ -1,0 +1,1889 @@
+# Terminator Pool Coverage — Phase 1 (Measurement) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Turn the day-side escalation ring on behind a runtime switch for a
+bounded window, and come out knowing three things: what the pool costs per
+sunset it actually delivers, which lever moves that ratio, and exactly what
+geometry produced every number.
+
+**Architecture:** Four seams. A `runtime_flags` row the cron reads at tick time
+(not an env var, so it flips without a redeploy). A `forcedOffsets` option on
+`sweepWithEscalation` that makes a named ring sweep both feeds regardless of
+`TERMINATOR_CAMERA_FLOOR`. Per-ring wall-clock added to the existing sweep
+telemetry, which is the only marginal-cost signal the feature does not already
+carry. And a per-day geometry record, so the ring angles behind any historical
+row stay readable after the configuration has moved on. Phase 1 changes no
+default behaviour: with the flag off, the sweep is what it is today.
+
+**Tech Stack:** Next.js App Router, TypeScript, Vitest, Neon Postgres over the
+`@neondatabase/serverless` HTTP driver, Resend for the digest email.
+
+**Spec:** `docs/superpowers/specs/2026-09-02-terminator-pool-coverage-design.md`
+
+**Sibling spec (boundary only):**
+`docs/superpowers/specs/2026-09-02-mosaic-v3-band-paradigm-design.md` §8.
+Task 1 is what that spec's §6 test reads. Nothing else here touches display.
+
+---
+
+## Global Constraints
+
+- **Plain branches in the main checkout.** `git checkout -b ...`. Never create
+  `.claude/worktrees/`. If the checkout is mid-work on another branch, ask
+  before switching.
+- **Verify the branch before every commit.** `git rev-parse --abbrev-ref HEAD`.
+  PRs are merged in parallel sessions and the working branch can shift
+  mid-task. If it is not the expected branch, stop and say so.
+- **Never `git add -A` or `git add .`.** Several sessions share this one
+  checkout; a broad add stages another session's files. Stage explicit paths,
+  exactly the ones the task's **Files** block names.
+- **Push the branch as soon as the first task commits**, so the checkout is
+  never the only copy.
+- **Migrations are forward-only and idempotent**, applied by hand. There is no
+  separate dev database: every env file here points at the same Neon endpoint,
+  so applying a migration is a production schema change. Dry-run first:
+  `node scripts/apply-migration.mjs <file>.sql` then `--apply`.
+- **`NUMERIC` and `BIGINT` come back from the Neon driver as strings.** Wrap
+  every numeric read in `Number()`. This has already bitten `offset_deg`.
+- **Telemetry is never worth failing a cron tick over.** Every new read or
+  write in the cron path catches its own errors and degrades to a safe
+  default.
+- **The flag fails closed.** An unreadable flag means off, which means no extra
+  spend.
+- **Run `npm run test` before every commit**, not just the one new file.
+
+---
+
+## Cost posture — the actual target
+
+The operator has approved this spend, with a band and a deliverable.
+
+| | per day | per month |
+| --- | --- | --- |
+| Where the bill sits now (measured 2026-09-03) | $0.64 | ~$19 |
+| Where it used to sit, and the ceiling | $2.60–3.30 | $80–100 |
+
+There is a second ceiling that is not financial. Windy publishes no rate limit
+and no quota headers, and the sibling cost spec names ~22,300 calls/day as the
+likely point of discovering one. Breaching it empties the panels, which is
+worse than any bill in the band above. Task 8 therefore aborts on box volume
+as well as on dollars, and box volume is the faster signal.
+
+**Anywhere between those two rows is acceptable.** Above the top row is a
+problem, and Task 8 aborts on it rather than finishing the window.
+
+Two consequences for this plan, both differing from the spec's §4 and §7:
+
+**The bill may be visible after the fact.** The spec reads as though the digest
+must ship before the spending starts. It does not. The measurement window can
+open as soon as the switch exists, and the digest lines can land while it runs.
+Task 8 does not wait on an email.
+
+**Granularity is the real deliverable, not the total.** Knowing the bill went up
+is worth little. Knowing *which ring bought how many gate-passed frames per
+box, per second of sweep* is what says which lever to pull. Every cost number
+in this plan is therefore reported per ring and divided by results, never as a
+tick-level or day-level lump.
+
+**The geometry must be recorded, not remembered.** The operator expects this
+configuration to expand and contract more than once. A row saying "offset 15.75
+scored 40 of 200" is uninterpretable a month later if the base altitude has
+moved in between, because 15.75 will have meant a different sun angle. Task 6
+records the angles themselves alongside the counters, so that every historical
+number stays readable through the next change. This is a requirement, not a
+nicety.
+
+---
+
+## The boundary constant is NOT this plan's to write
+
+Settled with the Plan A session on 2026-09-02, reversing an earlier reading of
+mine. Recorded here because the plan originally said the opposite.
+
+Plan A §6 specifies a test asserting the display window **covers** the range
+the sweep gathers. That is window ⊇ coverage. An earlier draft of this plan
+assumed the reverse and proposed
+`TERMINATOR_POOL_COVERAGE_DEG = { min: -39.75, max: 13.75 }`, the union over
+every ring that exists in config. Against the actual test direction that value
+fails on day one, because Plan A §6 also fixes the default window at −24 and
+−2.
+
+The measurement settles it. `sweep_escalated_ticks` is **0** on both
+2026-09-02 and 2026-09-03: escalation has never fired in production. "The
+range the sweep gathers" is therefore the base ring alone, −24° to −2°, and a
+constant claiming −39.75 to +13.75 would describe rings nobody sweeps.
+
+**The rule, and it is a tripwire.** The constant tracks what the sweep
+actually gathers under the current configuration. It moves in the same commit
+that makes a ring unconditional. That coupling is the point: turning a ring on
+breaks Plan A's window test, and the break is the reminder to move the axis
+dials with it.
+
+Consequences for this plan:
+
+- **Task 1 does not create the constant.** The Plan A session already
+  committed one on `feat/mosaic-v3-band-paradigm` and is renaming it to
+  `TERMINATOR_POOL_COVERAGE_DEG` with value `{ min: -24, max: -2 }`. Do not
+  add a second one to `main`. Task 1 adds only
+  `TERMINATOR_DAY_SIDE_OFFSETS_DEG`, which Plan A does not read.
+- **Phase 1 does not move it.** The forced-ring switch is runtime; the
+  constant is compile-time. During the measurement window the sweep really
+  will gather −24° to +13.75° while the constant still says −24° to −2°. That
+  is deliberate: a bounded measurement must not move the display contract.
+  The honest record of what was actually swept lives in Task 6's
+  `daily_sweep_geometry`, stamped per day.
+- **Moving it is phase 2's first act**, alongside the axis dials.
+
+One caveat to keep in the constant's comment rather than paper over:
+escalation is unobserved, not impossible. It fires when a feed drops under
+`TERMINATOR_CAMERA_FLOOR`. When it does, the pool briefly reaches +13.75° and
+those cameras clamp to the panel's day edge, which is the behaviour
+`horizontalPlace.ts` already documents and defends.
+
+On dollars in the digest: Windy publishes no price, no rate limit and no quota
+headers, measured 2026-09-02 and recorded in
+`docs/superpowers/specs/2026-09-02-camera-refresh-cost-design.md`. That spec
+also names the two numbers nobody has measured, the update-cameras function's
+wall-clock duration and the cron's share of Neon compute. Task 8 measures both,
+because the day-over-day Neon delta across the window gives the second one
+directly. Until then the digest reports the physical bill, which is boxes,
+sweep seconds and frames, all divided by gate-passed frames.
+
+---
+
+## File Structure
+
+| File | Responsibility |
+| --- | --- |
+| `app/lib/masterConfig.ts` | **Modify.** Adds `TERMINATOR_DAY_SIDE_OFFSETS_DEG` only. The boundary constant belongs to the Plan A branch. |
+| `app/lib/masterConfig.test.ts` | **Modify.** Pins the day-side offset and its ring altitude. |
+| `database/migrations/20260902_runtime_flags.sql` | **Create.** The `runtime_flags` table plus the one seeded row, off. |
+| `app/lib/runtimeFlags.ts` | **Create.** One read function, fails closed. The only consumer of `runtime_flags`. |
+| `app/lib/runtimeFlags.test.ts` | **Create.** |
+| `scripts/set-runtime-flag.mjs` | **Create.** How the switch flips without a redeploy. Dry by default. |
+| `app/api/cron/update-cameras/lib/terminatorSweep.ts` | **Modify.** `forcedOffsets` option; per-ring `elapsedMs`. |
+| `app/api/cron/update-cameras/lib/terminatorSweep.test.ts` | **Modify.** |
+| `app/api/cron/update-cameras/route.ts` | **Modify.** Reads the flag, passes `forcedOffsets`, records the geometry, surfaces both in the response. |
+| `database/migrations/20260902_sweep_timing.sql` | **Create.** Millisecond columns on the two existing sweep tables. |
+| `database/migrations/20260902_sweep_geometry.sql` | **Create.** `daily_sweep_geometry`: which angles produced a day's rows. |
+| `app/api/cron/update-cameras/lib/sweepGeometry.ts` | **Create.** Signature, coverage span, and the daily upsert. |
+| `app/api/cron/update-cameras/lib/sweepGeometry.test.ts` | **Create.** |
+| `app/api/cron/update-cameras/lib/sweepStats.ts` | **Modify.** Rolls `elapsedMs` into tick stats, persists it, reads it back for the digest. |
+| `app/api/cron/update-cameras/lib/sweepStats.test.ts` | **Modify.** |
+| `app/api/cron/update-cameras/lib/dailyDigest.ts` | **Modify.** Altitude-span clause, the widening bill, and cost per gate-passed frame per ring. |
+| `app/api/cron/update-cameras/lib/dailyDigest.test.ts` | **Modify.** |
+| `docs/superpowers/plans/2026-09-02-terminator-pool-coverage-phase1-REPORT.md` | **Create in Task 8.** The measurement answer phase 2 is decided from. |
+
+Tasks 1 through 7 are code and need the checkout. Task 8 needs it barely at
+all: a flag flip, a daily cost glance, and three SQL reads.
+
+---
+
+## Task 1: Name the day-side ring
+
+Small and pure config. First because Task 4 cannot proceed without it, and it
+costs about two minutes of the shared checkout.
+
+**Read "The boundary constant is NOT this plan's to write" above before
+starting.** Do **not** add `TERMINATOR_POOL_COVERAGE_DEG`. Another session
+owns it and has already committed it on its own branch; a second definition
+here collides on merge.
+
+**Files:**
+- Modify: `app/lib/masterConfig.ts` (after `TERMINATOR_WIDEN_OFFSETS_DEG`, around line 51)
+- Test: `app/lib/masterConfig.test.ts`
+
+**Interfaces:**
+- Consumes: `TERMINATOR_SUN_ALTITUDE_DEG`, `TERMINATOR_WIDEN_OFFSETS_DEG` —
+  both already in this file.
+- Produces:
+  - `TERMINATOR_DAY_SIDE_OFFSETS_DEG: readonly number[]` — used by Tasks 4 and 6.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `app/lib/masterConfig.test.ts`:
+
+```ts
+describe('TERMINATOR_DAY_SIDE_OFFSETS_DEG', () => {
+  it('is the golden-hour ring, and only it', () => {
+    // Positive offset moves the ring toward day. The night-side ring lands
+    // near -28.75, where the detection gate floors the frames anyway, so
+    // forcing it would buy cost without sunsets.
+    expect(TERMINATOR_DAY_SIDE_OFFSETS_DEG).toEqual([15.75]);
+  });
+
+  it('puts its ring inside the measured quality peak', () => {
+    const altitude = TERMINATOR_SUN_ALTITUDE_DEG + TERMINATOR_DAY_SIDE_OFFSETS_DEG[0];
+    expect(altitude).toBeGreaterThan(0);
+    expect(altitude).toBeLessThan(6);
+  });
+});
+```
+
+Extend the existing import at the top of the file to add
+`TERMINATOR_SUN_ALTITUDE_DEG` and `TERMINATOR_DAY_SIDE_OFFSETS_DEG`.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run app/lib/masterConfig.test.ts`
+Expected: FAIL — `TERMINATOR_DAY_SIDE_OFFSETS_DEG` is not exported.
+
+- [ ] **Step 3: Write the implementation**
+
+In `app/lib/masterConfig.ts`, immediately after the
+`TERMINATOR_WIDEN_OFFSETS_DEG` export:
+
+```ts
+// The escalation offsets that move the ring toward day. Positive offset
+// shrinks the ring radius, so positive is day. Named rather than indexed
+// because "the day-side ring" is the concept the forced-sweep switch acts on,
+// and TERMINATOR_WIDEN_OFFSETS_DEG[0] would silently mean something else if
+// the array were ever reordered.
+export const TERMINATOR_DAY_SIDE_OFFSETS_DEG = TERMINATOR_WIDEN_OFFSETS_DEG
+  .filter((offset) => offset > 0);
+```
+
+Nothing else. `TERMINATOR_POOL_COVERAGE_DEG` belongs to the Plan A branch;
+see the boundary section above.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx vitest run app/lib/masterConfig.test.ts`
+Expected: PASS, all cases.
+
+- [ ] **Step 5: Confirm branch, then commit**
+
+```bash
+git rev-parse --abbrev-ref HEAD
+git add app/lib/masterConfig.ts app/lib/masterConfig.test.ts
+git commit -m "feat(config): name the day-side widening offset"
+git push -u origin HEAD
+```
+
+- [ ] **Step 6: Confirm you did not touch the boundary constant**
+
+Run: `git show --stat HEAD` and `grep -n POOL_COVERAGE app/lib/masterConfig.ts`
+Expected: the grep finds nothing on this branch. If it finds something, the
+Plan A branch has merged in the meantime; leave that definition exactly as it
+is and do not modify or duplicate it.
+
+---
+
+## Task 2: The runtime switch
+
+A stored flag, not an env var. Env vars bake in at deploy time here, so an
+env-var switch would need `vercel redeploy` to bring spending back down, which
+fails the spec §4 condition outright.
+
+**Files:**
+- Create: `database/migrations/20260902_runtime_flags.sql`
+- Create: `app/lib/runtimeFlags.ts`
+- Create: `app/lib/runtimeFlags.test.ts`
+- Create: `scripts/set-runtime-flag.mjs`
+
+**Interfaces:**
+- Consumes: `sql` from `@/app/lib/db`.
+- Produces:
+  - `SWEEP_FORCE_DAY_RING: 'sweep_force_day_ring'` — the flag key.
+  - `isFlagEnabled(key: string): Promise<boolean>` — used by Task 4.
+
+- [ ] **Step 1: Write the migration**
+
+Create `database/migrations/20260902_runtime_flags.sql`:
+
+```sql
+-- runtime_flags: booleans the cron reads at tick time (spec:
+-- docs/superpowers/specs/2026-09-02-terminator-pool-coverage-design.md §4).
+--
+-- Deliberately NOT env vars. Env vars in this project bake in at deploy time,
+-- so bringing spending back down through one would need a `vercel redeploy`.
+-- The operator's condition on approving this spend was a switch that works
+-- without a code change or a redeploy, and a table row is that switch.
+--
+-- Kept separate from kiosk_settings: that table is display dials, sanitized
+-- against a versioned settings schema and copied studio -> live by the Deploy
+-- button. An ops kill-switch has none of those semantics and must not inherit
+-- them -- in particular it must never be copied by a profile deploy.
+--
+-- Forward-only, idempotent. Apply via:
+--   node scripts/apply-migration.mjs database/migrations/20260902_runtime_flags.sql --apply
+
+CREATE TABLE IF NOT EXISTS runtime_flags (
+  key        TEXT PRIMARY KEY,
+  enabled    BOOLEAN NOT NULL DEFAULT false,
+  note       TEXT,
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- Seeded OFF. Phase 1 flips it by hand for a bounded window; see
+-- scripts/set-runtime-flag.mjs.
+INSERT INTO runtime_flags (key, enabled, note)
+VALUES (
+  'sweep_force_day_ring',
+  false,
+  'Sweep the +15.75 day-side ring every tick regardless of TERMINATOR_CAMERA_FLOOR. Roughly doubles Windy boxes per tick.'
+)
+ON CONFLICT (key) DO NOTHING;
+```
+
+- [ ] **Step 2: Write the failing test**
+
+Create `app/lib/runtimeFlags.test.ts`:
+
+```ts
+// @vitest-environment node
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const sqlMock = vi.fn();
+vi.mock('@/app/lib/db', () => ({
+  sql: (strings: TemplateStringsArray, ...values: unknown[]) =>
+    sqlMock(strings, ...values),
+}));
+
+import { isFlagEnabled, SWEEP_FORCE_DAY_RING } from './runtimeFlags';
+
+// Braces, not a concise arrow: mockReset() returns the mock, and Vitest treats
+// a value returned from a hook as a teardown callback.
+beforeEach(() => {
+  sqlMock.mockReset();
+});
+
+describe('isFlagEnabled', () => {
+  it('is true when the row says enabled', async () => {
+    sqlMock.mockResolvedValue([{ enabled: true }]);
+    await expect(isFlagEnabled(SWEEP_FORCE_DAY_RING)).resolves.toBe(true);
+  });
+
+  it('is false when the row says disabled', async () => {
+    sqlMock.mockResolvedValue([{ enabled: false }]);
+    await expect(isFlagEnabled(SWEEP_FORCE_DAY_RING)).resolves.toBe(false);
+  });
+
+  it('is false when the row does not exist', async () => {
+    sqlMock.mockResolvedValue([]);
+    await expect(isFlagEnabled(SWEEP_FORCE_DAY_RING)).resolves.toBe(false);
+  });
+
+  it('fails closed when the table is missing or the read throws', async () => {
+    // A flag that fails OPEN would spend money on an unreachable database,
+    // which is the one failure mode the operator's cost condition rules out.
+    // This also covers the deploy window before the migration is applied.
+    sqlMock.mockRejectedValue(new Error('relation "runtime_flags" does not exist'));
+    await expect(isFlagEnabled(SWEEP_FORCE_DAY_RING)).resolves.toBe(false);
+  });
+
+  it('does not treat a truthy non-boolean as enabled', async () => {
+    sqlMock.mockResolvedValue([{ enabled: 'false' }]);
+    await expect(isFlagEnabled(SWEEP_FORCE_DAY_RING)).resolves.toBe(false);
+  });
+});
+```
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `npx vitest run app/lib/runtimeFlags.test.ts`
+Expected: FAIL — cannot resolve `./runtimeFlags`.
+
+- [ ] **Step 4: Write the implementation**
+
+Create `app/lib/runtimeFlags.ts`:
+
+```ts
+import 'server-only';
+import { sql } from '@/app/lib/db';
+
+/**
+ * Booleans the cron reads at tick time.
+ *
+ * The point is reversibility without a redeploy: env vars in this project
+ * bake in when the deploy is built, so an env-var kill-switch cannot bring
+ * spending down until someone redeploys. A row can be flipped in seconds --
+ * see scripts/set-runtime-flag.mjs -- and the next tick honours it.
+ */
+
+/**
+ * Sweep the day-side escalation ring every tick, both feeds, regardless of
+ * TERMINATOR_CAMERA_FLOOR. Roughly doubles Windy boxes per tick. Off by
+ * default; phase 1 of the pool-coverage spec turns it on for a bounded
+ * measurement window.
+ */
+export const SWEEP_FORCE_DAY_RING = 'sweep_force_day_ring';
+
+/**
+ * Read one flag. Fails CLOSED: any error, missing row, or non-boolean value
+ * reads as off.
+ *
+ * Failing closed is the whole safety property. This flag gates spending, and
+ * an unreachable database must not be able to turn spending on. It also means
+ * a deploy that lands before the migration is applied behaves exactly like
+ * today rather than throwing inside the cron.
+ */
+export async function isFlagEnabled(key: string): Promise<boolean> {
+  try {
+    const rows = (await sql`
+      SELECT enabled FROM runtime_flags WHERE key = ${key}
+    `) as unknown as { enabled: boolean }[];
+    return rows[0]?.enabled === true;
+  } catch (error) {
+    console.warn('[runtimeFlags] read failed, treating as off:', key, error);
+    return false;
+  }
+}
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `npx vitest run app/lib/runtimeFlags.test.ts`
+Expected: PASS, five cases.
+
+- [ ] **Step 6: Write the flip script**
+
+Create `scripts/set-runtime-flag.mjs`:
+
+```js
+// scripts/set-runtime-flag.mjs
+//
+// Flips a runtime_flags row. This is the switch the pool-coverage spec's cost
+// condition asks for: it takes effect on the next cron tick, with no code
+// change and no redeploy.
+//
+// Dry by default, matching apply-migration.mjs and the backfill scripts.
+// Every env file here points at the SAME Neon endpoint, so every --apply run
+// is a production change.
+//
+//   node scripts/set-runtime-flag.mjs                              # list
+//   node scripts/set-runtime-flag.mjs sweep_force_day_ring on
+//   node scripts/set-runtime-flag.mjs sweep_force_day_ring on --apply
+import { neon } from '@neondatabase/serverless';
+import { readFileSync } from 'node:fs';
+
+function loadDatabaseUrl() {
+  if (process.env.DATABASE_URL) return process.env.DATABASE_URL;
+  const env = readFileSync('.env.local', 'utf8');
+  const line = env.split('\n').find((l) => l.startsWith('DATABASE_URL='));
+  if (!line) throw new Error('DATABASE_URL not found in env or .env.local');
+  return line.slice('DATABASE_URL='.length).replace(/^"|"$/g, '');
+}
+
+const sql = neon(loadDatabaseUrl());
+const [key, state] = process.argv.slice(2).filter((a) => !a.startsWith('--'));
+const apply = process.argv.includes('--apply');
+
+const rows = await sql`SELECT key, enabled, note, updated_at FROM runtime_flags ORDER BY key`;
+console.log('current flags:');
+for (const r of rows) console.log(`  ${r.key} = ${r.enabled}  (${r.updated_at.toISOString?.() ?? r.updated_at})`);
+
+if (!key) process.exit(0);
+
+if (state !== 'on' && state !== 'off') {
+  console.error('usage: node scripts/set-runtime-flag.mjs <key> <on|off> [--apply]');
+  process.exit(1);
+}
+if (!rows.some((r) => r.key === key)) {
+  console.error(`no such flag: ${key}. Apply the migration that seeds it first.`);
+  process.exit(1);
+}
+
+const enabled = state === 'on';
+if (!apply) {
+  console.log(`\nDRY RUN. Would set ${key} = ${enabled}. Re-run with --apply.`);
+  process.exit(0);
+}
+await sql`UPDATE runtime_flags SET enabled = ${enabled}, updated_at = now() WHERE key = ${key}`;
+console.log(`\n${key} = ${enabled}. Takes effect on the next cron tick.`);
+```
+
+- [ ] **Step 7: Dry-run the migration, then apply it**
+
+```bash
+node scripts/apply-migration.mjs database/migrations/20260902_runtime_flags.sql
+```
+Expected: prints two statements, the CREATE TABLE and the INSERT. Then:
+
+```bash
+node scripts/apply-migration.mjs database/migrations/20260902_runtime_flags.sql --apply
+node scripts/set-runtime-flag.mjs
+```
+Expected: `sweep_force_day_ring = false`.
+
+Do not turn it on. Task 8 owns the flip.
+
+- [ ] **Step 8: Confirm branch, then commit**
+
+```bash
+git rev-parse --abbrev-ref HEAD
+git add database/migrations/20260902_runtime_flags.sql app/lib/runtimeFlags.ts \
+        app/lib/runtimeFlags.test.ts scripts/set-runtime-flag.mjs
+git commit -m "feat(ops): a runtime flag the cron reads at tick time"
+```
+
+---
+
+## Task 3: Forced offsets in the sweep
+
+**Files:**
+- Modify: `app/api/cron/update-cameras/lib/terminatorSweep.ts` (the `SweepOptions` interface, and the escalation loop near the end of `sweepWithEscalation`)
+- Test: `app/api/cron/update-cameras/lib/terminatorSweep.test.ts`
+
+**Interfaces:**
+- Consumes: nothing from earlier tasks.
+- Produces: `SweepOptions.forcedOffsets?: readonly number[]` — consumed by Task 4.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append inside the existing `describe('sweepWithEscalation', ...)` block in
+`app/api/cron/update-cameras/lib/terminatorSweep.test.ts`. The `cam`, `ring`,
+`stubFetcher` and `classify` helpers are already defined at the top of that
+file; do not redefine them.
+
+```ts
+  it('sweeps a forced ring even when both feeds clear the floor', async () => {
+    const seen: Location[][] = [];
+    const res = await sweepWithEscalation({
+      buildRing: ring,
+      fetchCoords: stubFetcher(
+        { 0: [cam(1), cam(2), cam(3), cam(4)], 15.75: [cam(5), cam(6)] },
+        seen
+      ),
+      classify,
+      floor: 2,
+      offsets: [15.75, -15.75],
+      hasBudget: () => true,
+      forcedOffsets: [15.75],
+    });
+    expect(res.telemetry.rings.map((r) => r.offsetDeg)).toEqual([0, 15.75]);
+    expect(res.telemetry.thinAfterBase).toEqual([]);
+  });
+
+  it('sweeps BOTH feeds on a forced ring, not just a thin one', async () => {
+    // A forced ring exists to widen coverage, not to rescue a feed. Sweeping
+    // only the thin half would leave one panel without the golden-hour
+    // cameras the whole measurement is about -- and with no feed thin at all,
+    // "the thin half" is empty and the ring would fetch nothing.
+    const seen: Location[][] = [];
+    await sweepWithEscalation({
+      buildRing: ring,
+      fetchCoords: stubFetcher(
+        { 0: [cam(1), cam(2), cam(3), cam(4)], 15.75: [cam(5), cam(6)] },
+        seen
+      ),
+      classify,
+      floor: 2,
+      offsets: [15.75],
+      hasBudget: () => true,
+      forcedOffsets: [15.75],
+    });
+    // ring() puts sunrise at lng 1 and sunset at lng 2 for each offset.
+    expect(seen[1]).toEqual([
+      { lat: 15.75, lng: 1 },
+      { lat: 15.75, lng: 2 },
+    ]);
+  });
+
+  it('still sacrifices a forced ring when the budget is gone', async () => {
+    // Spec §8: budget exhaustion sacrifices escalation rings first. The
+    // scoring loop needs the remaining tick more than the pool needs cameras,
+    // and forcing a ring must not buy its way past that.
+    const res = await sweepWithEscalation({
+      buildRing: ring,
+      fetchCoords: stubFetcher({ 0: [cam(1), cam(2), cam(3), cam(4)] }),
+      classify,
+      floor: 2,
+      offsets: [15.75],
+      hasBudget: () => false,
+      forcedOffsets: [15.75],
+    });
+    expect(res.telemetry.rings.map((r) => r.offsetDeg)).toEqual([0]);
+    expect(res.telemetry.budgetExhausted).toBe(true);
+  });
+
+  it('is unchanged from today when no offsets are forced', async () => {
+    // Spec §8: with the switch off, sweep behaviour is what it is today.
+    const healthy = {
+      buildRing: ring,
+      fetchCoords: stubFetcher({ 0: [cam(1), cam(2), cam(3), cam(4)] }),
+      classify,
+      floor: 2,
+      offsets: [15.75, -15.75],
+      hasBudget: () => true,
+    };
+    const withoutField = await sweepWithEscalation(healthy);
+    const withEmptyField = await sweepWithEscalation({
+      ...healthy,
+      forcedOffsets: [],
+    });
+    expect(withoutField.telemetry.rings).toHaveLength(1);
+    expect(withEmptyField.telemetry.rings).toHaveLength(1);
+    expect(withoutField.telemetry.budgetExhausted).toBe(false);
+    expect(withEmptyField.telemetry.budgetExhausted).toBe(false);
+  });
+
+  it('credits a shared camera to the ring that saw it first', async () => {
+    // Spec §8. The day ring's boxes overlap the base ring's (15.75 is under
+    // the 22-degree box span), so the same camera routinely comes back from
+    // both. If the later ring re-claimed it, the day ring's gate-pass rate
+    // would be diluted with base-ring cameras and the one number that
+    // distinguishes "widening adds sunsets" from "widening adds cameras the
+    // gate floors" would stop meaning anything.
+    const res = await sweepWithEscalation({
+      buildRing: ring,
+      fetchCoords: stubFetcher({
+        0: [cam(1), cam(2), cam(3), cam(4)],
+        15.75: [cam(2), cam(4), cam(6)], // 2 and 4 already seen by base
+      }),
+      classify,
+      floor: 2,
+      offsets: [15.75],
+      hasBudget: () => true,
+      forcedOffsets: [15.75],
+    });
+    expect(res.telemetry.rings[0].newWebcamIds).toEqual([1, 2, 3, 4]);
+    expect(res.telemetry.rings[1].newWebcamIds).toEqual([6]);
+    expect(res.telemetry.rings[1].newWebcams).toBe(1);
+  });
+
+  it('still escalates on a thin feed while a later ring is forced', async () => {
+    // Forcing must ADD a trigger, never replace the floor-based one.
+    const res = await sweepWithEscalation({
+      buildRing: ring,
+      fetchCoords: stubFetcher({
+        0: [cam(2), cam(4)], // sunset only; sunrise is thin
+        15.75: [cam(1), cam(3)],
+      }),
+      classify,
+      floor: 2,
+      offsets: [15.75],
+      hasBudget: () => true,
+      forcedOffsets: [15.75],
+    });
+    expect(res.telemetry.thinAfterBase).toEqual(['sunrise']);
+    expect(res.telemetry.rings.map((r) => r.offsetDeg)).toEqual([0, 15.75]);
+  });
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npx vitest run app/api/cron/update-cameras/lib/terminatorSweep.test.ts`
+Expected: FAIL — TypeScript rejects `forcedOffsets`, and the forced rings do
+not run.
+
+- [ ] **Step 3: Add the option to `SweepOptions`**
+
+In `app/api/cron/update-cameras/lib/terminatorSweep.ts`, add to the
+`SweepOptions` interface, after `offsets`:
+
+```ts
+  /**
+   * Offsets to sweep on every tick regardless of the camera floor, both feeds.
+   *
+   * The floor-based trigger asks "is a panel too empty to look at". This asks
+   * a different question: "does the pool reach the altitudes where sunsets
+   * actually happen". Good frames peak at 0 to +6 degrees solar altitude and
+   * the base ring at -13 never sees them, so the day-side ring is worth
+   * paying for even when nothing is thin. Additive to the floor trigger,
+   * never a replacement for it.
+   *
+   * Empty or absent means today's behaviour exactly.
+   */
+  forcedOffsets?: readonly number[];
+```
+
+- [ ] **Step 4: Change the escalation loop**
+
+Replace the `for (const offsetDeg of opts.offsets)` loop in
+`sweepWithEscalation` with:
+
+```ts
+  for (const offsetDeg of opts.offsets) {
+    const forced = opts.forcedOffsets?.includes(offsetDeg) ?? false;
+    const thin = feedsBelowFloor(counts, opts.floor);
+    // Forced rings sweep both feeds; floor-triggered rings sweep only the
+    // thin half, which is what halves the cost of the common case.
+    const feeds: Feed[] = forced ? [...FEEDS] : thin;
+    // `continue`, not `break`. With no forced offsets the two are observably
+    // identical -- feedsBelowFloor is pure, counts have not changed, and
+    // neither path pushes a ring or sets budgetExhausted -- but `break` would
+    // skip a forced offset that sat after a non-forced one in the list.
+    if (feeds.length === 0) continue;
+    if (!opts.hasBudget()) {
+      budgetExhausted = true;
+      break;
+    }
+    await sweep(offsetDeg, feeds);
+    counts = currentCounts();
+  }
+```
+
+- [ ] **Step 5: Run the tests**
+
+Run: `npx vitest run app/api/cron/update-cameras/lib/terminatorSweep.test.ts`
+Expected: PASS, including every pre-existing case.
+
+- [ ] **Step 6: Confirm branch, then commit**
+
+```bash
+git rev-parse --abbrev-ref HEAD
+git add app/api/cron/update-cameras/lib/terminatorSweep.ts \
+        app/api/cron/update-cameras/lib/terminatorSweep.test.ts
+git commit -m "feat(cron): let a named ring sweep regardless of the camera floor"
+```
+
+---
+
+## Task 4: Wire the switch into the cron
+
+**Files:**
+- Modify: `app/api/cron/update-cameras/route.ts` (imports at the top; the `sweepWithEscalation` call around line 89; the log line at 126; the `NextResponse.json` at 492)
+- Test: `app/api/cron/update-cameras/route.test.ts`
+
+**Interfaces:**
+- Consumes: `isFlagEnabled`, `SWEEP_FORCE_DAY_RING` (Task 2);
+  `TERMINATOR_DAY_SIDE_OFFSETS_DEG` (Task 1); `forcedOffsets` (Task 3).
+- Produces: a `forcedDayRing: boolean` field on the cron's JSON response, so
+  the switch is smoke-testable from outside without reading the database. Also
+  a local `forcedOffsets` value that Task 6 reuses for the geometry record.
+
+- [ ] **Step 1: Add the flag mock to the route test harness**
+
+`route.test.ts` mocks every module the route imports and drives a real `GET`
+via `makeReq()`. Follow that pattern exactly. Add a mock declaration beside
+the others near the top of the file:
+
+```ts
+const isFlagEnabledMock = vi.fn();
+```
+
+and a `vi.mock` beside the existing ones:
+
+```ts
+vi.mock('@/app/lib/runtimeFlags', () => ({
+  SWEEP_FORCE_DAY_RING: 'sweep_force_day_ring',
+  isFlagEnabled: () => isFlagEnabledMock(),
+}));
+```
+
+and a reset in the existing `beforeEach`, defaulting the flag OFF so every
+pre-existing test keeps today's behaviour:
+
+```ts
+  isFlagEnabledMock.mockReset().mockResolvedValue(false);
+```
+
+- [ ] **Step 2: Write the failing tests**
+
+Add inside `describe('GET /api/cron/update-cameras', ...)`. The
+`HEALTHY_CLASSIFY_RESULT` fixture already puts both feeds exactly at
+`TERMINATOR_CAMERA_FLOOR`, so nothing is thin and the only reason a second
+ring can run is the switch.
+
+```ts
+  it('sweeps only the base ring while the switch is off', async () => {
+    const res = await GET(makeReq());
+    const body = await res.json();
+    expect(body.forcedDayRing).toBe(false);
+    expect(body.sweep.rings).toHaveLength(1);
+  });
+
+  it('sweeps the day-side ring on a healthy tick when the switch is on', async () => {
+    isFlagEnabledMock.mockResolvedValue(true);
+    const res = await GET(makeReq());
+    const body = await res.json();
+    expect(body.forcedDayRing).toBe(true);
+    expect(body.sweep.rings.map((r: { offsetDeg: number }) => r.offsetDeg))
+      .toEqual([0, 15.75]);
+    expect(body.sweep.rings[1].feedsSwept).toEqual(['sunrise', 'sunset']);
+  });
+```
+
+- [ ] **Step 3: Run them to verify they fail**
+
+Run: `npx vitest run app/api/cron/update-cameras/route.test.ts`
+Expected: FAIL — `forcedDayRing` is `undefined`.
+
+- [ ] **Step 4: Wire it in**
+
+Add to the `@/app/lib/masterConfig` import block:
+
+```ts
+  TERMINATOR_DAY_SIDE_OFFSETS_DEG,
+```
+
+Add a new import beside the other `@/app/lib` imports:
+
+```ts
+import { isFlagEnabled, SWEEP_FORCE_DAY_RING } from '@/app/lib/runtimeFlags';
+```
+
+Immediately before `const tickStartedAt = Date.now();`:
+
+```ts
+  // Read per tick, so the operator can bring the spending back down without a
+  // redeploy. Fails closed inside isFlagEnabled: an unreachable database
+  // gives today's behaviour, never extra cost.
+  const forcedDayRing = await isFlagEnabled(SWEEP_FORCE_DAY_RING);
+  const forcedOffsets = forcedDayRing ? TERMINATOR_DAY_SIDE_OFFSETS_DEG : [];
+```
+
+In the `sweepWithEscalation` options object, after `offsets:`:
+
+```ts
+    // Phase 1 of the pool-coverage spec: force the golden-hour ring so the
+    // pool reaches 0 to +6 degrees, where good frames actually are, instead
+    // of only the -24 to -2 band the base ring covers. Roughly doubles Windy
+    // boxes per tick, which is the cost the measurement window exists to
+    // price.
+    forcedOffsets,
+```
+
+Change the log line at 126 to carry the switch:
+
+```ts
+  console.log(
+    '🛰️ terminator sweep:',
+    JSON.stringify({ forcedDayRing, ...sweep.telemetry }),
+  );
+```
+
+Add to the `NextResponse.json({ ... })` object, next to `sweep`:
+
+```ts
+    forcedDayRing,
+```
+
+- [ ] **Step 5: Run the whole suite**
+
+Run: `npm run test`
+Expected: PASS. Then `npm run lint` and `npm run build`, both clean.
+
+- [ ] **Step 6: Confirm branch, then commit**
+
+```bash
+git rev-parse --abbrev-ref HEAD
+git add app/api/cron/update-cameras/route.ts app/api/cron/update-cameras/route.test.ts
+git commit -m "feat(cron): honour the forced-day-ring switch per tick"
+```
+
+---
+
+## Task 5: Per-ring wall-clock, captured and persisted
+
+Capture and persistence are one task, not two. Adding a required `elapsedMs`
+to `SweepRingStats` immediately breaks `getSweepDigestSummary`'s typecheck,
+which only the persistence half repairs, so there is no point between them
+where the branch is green and a reviewer could accept one half alone.
+
+
+Spec §7 step 2 says extend `SweepRingStats` only if a field is genuinely
+missing. Boxes, gate-pass rates, new cameras and budget exhaustion are all
+there. Elapsed time is not, and it is the one quantity that turns "how much
+did widening cost" into something with a unit. Boxes are free at Windy;
+function seconds are not.
+
+**Files:**
+- Modify: `app/api/cron/update-cameras/lib/terminatorSweep.ts` (`RingTelemetry`, and the `sweep` closure)
+- Modify: `app/api/cron/update-cameras/lib/sweepStats.ts` (`SweepRingStats`, `SweepTickStats`, `SweepDigestSummary`, `computeSweepTickStats`)
+- Test: `app/api/cron/update-cameras/lib/terminatorSweep.test.ts`, `app/api/cron/update-cameras/lib/sweepStats.test.ts`
+
+**Interfaces:**
+- Produces:
+  - `RingTelemetry.elapsedMs: number` (required, not optional).
+  - `SweepRingStats.elapsedMs: number`.
+  - `SweepTickStats.baseMs: number`, `SweepTickStats.escalationMs: number`.
+  - The same two fields on `SweepDigestSummary`.
+
+- [ ] **Step 1: Write the failing tests**
+
+In `terminatorSweep.test.ts`, inside `describe('sweepWithEscalation', ...)`:
+
+```ts
+  it('times each ring separately', async () => {
+    let clock = 1_000;
+    const nowSpy = vi.spyOn(Date, 'now').mockImplementation(() => clock);
+    try {
+      const res = await sweepWithEscalation({
+        buildRing: ring,
+        fetchCoords: async (coords) => {
+          clock += 5_000; // each ring takes 5s of wall clock
+          return { webcams: [], attempted: coords.length, empty: 0 };
+        },
+        classify,
+        floor: 2,
+        offsets: [15.75],
+        hasBudget: () => true,
+        forcedOffsets: [15.75],
+      });
+      expect(res.telemetry.rings.map((r) => r.elapsedMs)).toEqual([5_000, 5_000]);
+    } finally {
+      nowSpy.mockRestore();
+    }
+  });
+```
+
+Add `vi` to the vitest import at the top of that file.
+
+In `sweepStats.test.ts`, add `elapsedMs` to every `RingTelemetry` object in the
+`healthy` and `escalated` fixtures (`elapsedMs: 8_000` on base rings,
+`elapsedMs: 5_000` on escalation rings), then add:
+
+```ts
+  it('splits sweep milliseconds into base and escalation', async () => {
+    const stats = computeSweepTickStats({ telemetry: escalated, floor: 15 });
+    expect(stats.baseMs).toBe(8_000);
+    expect(stats.escalationMs).toBe(5_000);
+  });
+
+  it('reports no escalation milliseconds on a base-only tick', async () => {
+    const stats = computeSweepTickStats({ telemetry: healthy, floor: 15 });
+    expect(stats.baseMs).toBe(8_000);
+    expect(stats.escalationMs).toBe(0);
+  });
+```
+
+- [ ] **Step 2: Run them to verify they fail**
+
+Run: `npx vitest run app/api/cron/update-cameras/lib/terminatorSweep.test.ts app/api/cron/update-cameras/lib/sweepStats.test.ts`
+Expected: FAIL — `elapsedMs` is not a property of `RingTelemetry`, and
+`baseMs` is undefined.
+
+- [ ] **Step 3: Time the rings**
+
+In `terminatorSweep.ts`, add to `RingTelemetry` after `newWebcamIds`:
+
+```ts
+  /**
+   * Wall clock this ring spent, in milliseconds.
+   *
+   * The only unit-bearing cost signal the sweep produces. Windy publishes no
+   * per-call price, no rate limit and no quota headers, so a box count cannot
+   * be turned into money; function seconds can. It also says how close a ring
+   * came to TERMINATOR_SWEEP_BUDGET_MS, which the budget-exhausted flag only
+   * reports after the fact.
+   */
+  elapsedMs: number;
+```
+
+In the `sweep` closure, the existing body reads:
+
+```ts
+    const before = byId.size;
+    const res = await opts.fetchCoords(coords);
+```
+
+Change to:
+
+```ts
+    const before = byId.size;
+    const startedAt = Date.now();
+    const res = await opts.fetchCoords(coords);
+    const elapsedMs = Date.now() - startedAt;
+```
+
+and add `elapsedMs,` to the `rings.push({ ... })` object.
+
+- [ ] **Step 4: Roll it into the tick stats**
+
+In `sweepStats.ts`, add to `SweepRingStats` after `framesGatePassed`:
+
+```ts
+  elapsedMs: number;
+```
+
+Add to `SweepTickStats`, after `escalationBoxes`:
+
+```ts
+  /** Wall clock the base ring spent, summed over the tick. */
+  baseMs: number;
+  /** Wall clock widening added. Boxes are free at Windy; seconds are not. */
+  escalationMs: number;
+```
+
+Add the same two fields to `SweepDigestSummary`.
+
+In `computeSweepTickStats`, add `elapsedMs: 0` to the per-offset accumulator
+default, add `acc.elapsedMs += ring.elapsedMs;` beside
+`acc.boxesAttempted += ring.attempted;`, and add to the returned object beside
+`escalationBoxes`:
+
+```ts
+    baseMs: base?.elapsedMs ?? 0,
+    escalationMs: escalation.reduce((sum, r) => sum + r.elapsedMs, 0),
+```
+
+Do **not** run the suite yet and do **not** commit here. Adding a required
+field to `SweepRingStats` and `SweepDigestSummary` leaves
+`getSweepDigestSummary` failing to typecheck until Step 8 fills the new
+fields in, so this task only builds green once the persistence half lands.
+That is why the two halves are one task.
+
+- [ ] **Step 5: Write the migration**
+
+Create `database/migrations/20260902_sweep_timing.sql`:
+
+```sql
+-- Sweep timing: the one cost signal with a unit.
+--
+-- The sweep telemetry already answers "how many boxes" and "did the frames
+-- pass the gate". It cannot answer "what did widening cost", because Windy
+-- publishes no price, no rate limit and no quota headers -- a box count is
+-- not money. Function wall-clock is, and it is also what actually runs out
+-- against TERMINATOR_SWEEP_BUDGET_MS.
+--
+-- BIGINT: a day of ticks summing tens of seconds each stays far inside
+-- INTEGER, but these are additive counters with no natural ceiling and the
+-- cost of the wider type here is nil.
+--
+-- Forward-only, idempotent. Apply via:
+--   node scripts/apply-migration.mjs database/migrations/20260902_sweep_timing.sql --apply
+
+ALTER TABLE daily_sunset_stats
+  -- Wall clock the base ring spent, summed over today's ticks.
+  ADD COLUMN IF NOT EXISTS sweep_base_ms       BIGINT NOT NULL DEFAULT 0,
+  -- Wall clock widening added, summed over today's ticks. Read against
+  -- sweep_base_ms, this is the widening's marginal compute cost.
+  ADD COLUMN IF NOT EXISTS sweep_escalation_ms BIGINT NOT NULL DEFAULT 0;
+
+ALTER TABLE daily_sweep_ring_stats
+  ADD COLUMN IF NOT EXISTS elapsed_ms BIGINT NOT NULL DEFAULT 0;
+```
+
+- [ ] **Step 2: Write the failing test**
+
+In `sweepStats.test.ts`, extend whichever existing test asserts the
+`upsertSweepStats` bind values so it also expects the two new millisecond
+values, and add:
+
+```ts
+  it('reads the timing columns back for the digest', async () => {
+    sqlMock
+      .mockResolvedValueOnce([
+        {
+          sweep_ticks: 96, sweep_escalated_ticks: 96,
+          sweep_budget_exhausted_ticks: 3,
+          sweep_sunrise_thin_ticks: 0, sweep_sunset_thin_ticks: 0,
+          sweep_sunrise_short_ticks: 0, sweep_sunset_short_ticks: 0,
+          sweep_base_boxes: 2976, sweep_escalation_boxes: 2880,
+          sweep_base_ms: '1152000', sweep_escalation_ms: '960000',
+        },
+      ])
+      .mockResolvedValueOnce([
+        {
+          offset_deg: '0', rings_swept: 96, boxes_attempted: 2976,
+          boxes_empty: 400, new_webcams: 300, frames_scored: 200,
+          frames_gate_passed: 40, elapsed_ms: '1152000',
+        },
+      ]);
+    const summary = await getSweepDigestSummary();
+    // BIGINT arrives from the Neon driver as a string, like every NUMERIC in
+    // this codebase. Unwrapped, every downstream comparison silently
+    // concatenates instead of adding.
+    expect(summary?.escalationMs).toBe(960_000);
+    expect(summary?.rings[0].elapsedMs).toBe(1_152_000);
+  });
+```
+
+- [ ] **Step 7: Run it to verify it fails**
+
+Run: `npx vitest run app/api/cron/update-cameras/lib/sweepStats.test.ts`
+Expected: FAIL — `escalationMs` is `undefined`.
+
+- [ ] **Step 8: Persist and read back**
+
+In `upsertSweepStats`, add `sweep_base_ms, sweep_escalation_ms` to the
+`daily_sunset_stats` column list, `${stats.baseMs}, ${stats.escalationMs}` to
+the values, and to the `do update set` clause:
+
+```sql
+        sweep_base_ms = daily_sunset_stats.sweep_base_ms + excluded.sweep_base_ms,
+        sweep_escalation_ms =
+          daily_sunset_stats.sweep_escalation_ms + excluded.sweep_escalation_ms,
+```
+
+In the ring insert, add `elapsed_ms` to the column list, `${ring.elapsedMs}`
+to the values, and to the update clause:
+
+```sql
+          elapsed_ms = daily_sweep_ring_stats.elapsed_ms + excluded.elapsed_ms,
+```
+
+In `getSweepDigestSummary`, add `sweep_base_ms, sweep_escalation_ms` to the
+first select and `elapsed_ms` to the ring select, then map:
+
+```ts
+      baseMs: Number(row.sweep_base_ms),
+      escalationMs: Number(row.sweep_escalation_ms),
+```
+and inside the ring mapper:
+```ts
+        elapsedMs: Number(r.elapsed_ms),
+```
+
+- [ ] **Step 9: Run the tests, now including the whole suite**
+
+Run: `npx vitest run app/api/cron/update-cameras/lib/`
+Expected: PASS. Then `npm run test`. If any fixture elsewhere constructs a
+`RingTelemetry` or a `SweepRingStats`, TypeScript will name the file; add
+`elapsedMs` there too.
+
+- [ ] **Step 10: Dry-run the migration, then apply it**
+
+```bash
+node scripts/apply-migration.mjs database/migrations/20260902_sweep_timing.sql
+node scripts/apply-migration.mjs database/migrations/20260902_sweep_timing.sql --apply
+```
+
+- [ ] **Step 11: Confirm branch, then commit**
+
+Both halves in one commit: the type change and the code that satisfies it.
+
+```bash
+git rev-parse --abbrev-ref HEAD
+git add app/api/cron/update-cameras/lib/terminatorSweep.ts \
+        app/api/cron/update-cameras/lib/terminatorSweep.test.ts \
+        app/api/cron/update-cameras/lib/sweepStats.ts \
+        app/api/cron/update-cameras/lib/sweepStats.test.ts \
+        database/migrations/20260902_sweep_timing.sql
+git commit -m "feat(cron): time each sweep ring and persist it, base split from widening"
+```
+
+---
+
+## Task 6: Record which angles produced the numbers
+
+The configuration is expected to expand and contract more than once. Without
+this task, a row saying `offset_deg = 15.75, frames_gate_passed = 40` becomes
+uninterpretable as soon as `TERMINATOR_SUN_ALTITUDE_DEG` or
+`SEARCH_RADIUS_DEG` moves, because the same offset will then mean a different
+sun angle. The counters must carry their own geometry.
+
+Recorded automatically rather than written down by hand, because a record that
+depends on someone remembering to log a change is the record that will be
+missing on the day it matters.
+
+**Files:**
+- Create: `database/migrations/20260902_sweep_geometry.sql`
+- Create: `app/api/cron/update-cameras/lib/sweepGeometry.ts`
+- Create: `app/api/cron/update-cameras/lib/sweepGeometry.test.ts`
+- Modify: `app/api/cron/update-cameras/route.ts` (beside the existing `upsertSweepStats` call, around line 465)
+
+**Interfaces:**
+- Consumes: `TERMINATOR_SUN_ALTITUDE_DEG`, `SEARCH_RADIUS_DEG`,
+  `TERMINATOR_WIDEN_OFFSETS_DEG` (existing config); the `forcedOffsets` local
+  from Task 4.
+- Produces:
+  - `coverageSpan(ringAltitudesDeg: number[]): { min: number; max: number }`
+    — also imported by Task 7's digest, so the two span calculations cannot
+    drift apart.
+  - `sweepGeometry(forcedOffsets: readonly number[]): SweepGeometry`
+  - `upsertSweepGeometry(now: Date, geometry: SweepGeometry): Promise<void>`
+
+- [ ] **Step 1: Write the migration**
+
+Create `database/migrations/20260902_sweep_geometry.sql`:
+
+```sql
+-- daily_sweep_geometry: the ring angles behind each day's sweep counters.
+--
+-- daily_sweep_ring_stats keys on offset_deg, which is meaningless on its own:
+-- +15.75 is +2.75 degrees of solar altitude only while the base ring sits at
+-- -13. The pool-coverage work expects the base altitude, the radius and the
+-- offset set to move more than once, so every historical row needs the
+-- geometry that produced it stored beside it rather than inferred from
+-- whatever masterConfig.ts happens to say later.
+--
+-- One row per (date, signature). A configuration change mid-day writes a
+-- SECOND row for that date rather than overwriting the first, so the
+-- transition is visible instead of averaged away -- which is exactly the
+-- moment the record exists for.
+--
+-- Forward-only, idempotent. Apply via:
+--   node scripts/apply-migration.mjs database/migrations/20260902_sweep_geometry.sql --apply
+
+CREATE TABLE IF NOT EXISTS daily_sweep_geometry (
+  date               DATE NOT NULL,        -- UTC date, matches daily_sunset_stats
+  -- Stable label for one configuration, e.g.
+  -- 'base-13_r11_off15.75,-15.75_forced15.75'. Comparing signatures across
+  -- days is how a change is spotted without diffing six columns.
+  signature          TEXT NOT NULL,
+  base_altitude_deg  NUMERIC(6,2) NOT NULL,
+  search_radius_deg  NUMERIC(6,2) NOT NULL,
+  widen_offsets_deg  TEXT NOT NULL,        -- every offset the sweep MAY run
+  forced_offsets_deg TEXT NOT NULL,        -- offsets it ran unconditionally
+  -- The resulting solar-altitude span, stored rather than derived so it
+  -- survives a change to the derivation itself.
+  coverage_min_deg   NUMERIC(6,2) NOT NULL,
+  coverage_max_deg   NUMERIC(6,2) NOT NULL,
+  ticks              INTEGER NOT NULL DEFAULT 0,
+  updated_at         TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  PRIMARY KEY (date, signature)
+);
+```
+
+- [ ] **Step 2: Write the failing test**
+
+Create `app/api/cron/update-cameras/lib/sweepGeometry.test.ts`:
+
+```ts
+// @vitest-environment node
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const sqlMock = vi.fn();
+vi.mock('@/app/lib/db', () => ({
+  sql: (strings: TemplateStringsArray, ...values: unknown[]) =>
+    sqlMock(strings, ...values),
+}));
+
+import { coverageSpan, sweepGeometry, upsertSweepGeometry } from './sweepGeometry';
+
+beforeEach(() => {
+  sqlMock.mockReset();
+});
+
+describe('coverageSpan', () => {
+  it('widens a single ring altitude by the search radius on both sides', () => {
+    expect(coverageSpan([-13])).toEqual({ min: -24, max: -2 });
+  });
+
+  it('spans from the night-most floor to the day-most ceiling', () => {
+    expect(coverageSpan([-13, 2.75])).toEqual({ min: -24, max: 13.75 });
+  });
+});
+
+describe('sweepGeometry', () => {
+  it('records the base ring alone when nothing is forced', () => {
+    const g = sweepGeometry([]);
+    expect(g.baseAltitudeDeg).toBe(-13);
+    expect(g.searchRadiusDeg).toBe(11);
+    expect(g.forcedOffsetsDeg).toBe('');
+    expect(g.coverageMinDeg).toBe(-24);
+    expect(g.coverageMaxDeg).toBe(-2);
+  });
+
+  it('widens the recorded coverage to golden hour when the day ring is forced', () => {
+    // This is the number the whole measurement is about: the guaranteed pool
+    // has to contain 0 to +6 degrees, where 19.7% of frames are good, versus
+    // 1.0% at the base ring.
+    const g = sweepGeometry([15.75]);
+    expect(g.coverageMinDeg).toBe(-24);
+    expect(g.coverageMaxDeg).toBe(13.75);
+  });
+
+  it('gives different configurations different signatures', () => {
+    expect(sweepGeometry([]).signature).not.toBe(sweepGeometry([15.75]).signature);
+  });
+
+  it('gives the same configuration the same signature every tick', () => {
+    expect(sweepGeometry([15.75]).signature).toBe(sweepGeometry([15.75]).signature);
+  });
+});
+
+describe('upsertSweepGeometry', () => {
+  it('never throws when the table is missing', async () => {
+    // Same non-fatal contract as upsertSweepStats: a deploy that lands before
+    // the migration is applied must not fail the tick.
+    sqlMock.mockRejectedValue(new Error('relation "daily_sweep_geometry" does not exist'));
+    await expect(
+      upsertSweepGeometry(new Date('2026-09-05T00:10:00Z'), sweepGeometry([]))
+    ).resolves.toBeUndefined();
+  });
+
+  it('writes under the UTC date', async () => {
+    sqlMock.mockResolvedValue([]);
+    await upsertSweepGeometry(new Date('2026-09-05T00:10:00Z'), sweepGeometry([]));
+    expect(sqlMock.mock.calls[0]).toContain('2026-09-05');
+  });
+});
+```
+
+- [ ] **Step 3: Run it to verify it fails**
+
+Run: `npx vitest run app/api/cron/update-cameras/lib/sweepGeometry.test.ts`
+Expected: FAIL — cannot resolve `./sweepGeometry`.
+
+- [ ] **Step 4: Write the implementation**
+
+Create `app/api/cron/update-cameras/lib/sweepGeometry.ts`:
+
+```ts
+import { sql } from '@/app/lib/db';
+import {
+  TERMINATOR_SUN_ALTITUDE_DEG,
+  SEARCH_RADIUS_DEG,
+  TERMINATOR_WIDEN_OFFSETS_DEG,
+} from '@/app/lib/masterConfig';
+
+/**
+ * The ring angles a tick actually ran with.
+ *
+ * Stored beside the counters because offset_deg alone is not a fact about the
+ * sky. +15.75 means +2.75 degrees of solar altitude only while the base ring
+ * is at -13, and this configuration is expected to move. Without this record,
+ * comparing a day of counters against a day from before a change silently
+ * compares two different experiments.
+ */
+export interface SweepGeometry {
+  signature: string;
+  baseAltitudeDeg: number;
+  searchRadiusDeg: number;
+  widenOffsetsDeg: string;
+  forcedOffsetsDeg: string;
+  /**
+   * The span the sweep was GUARANTEED to gather from: the base ring plus
+   * whatever was forced on this tick.
+   *
+   * Distinct from TERMINATOR_POOL_COVERAGE_DEG, which is the display's
+   * compile-time contract and only moves when a ring becomes unconditional.
+   * This one is the measurement record: during a bounded measurement window
+   * the runtime flag widens what the sweep really gathers while the display
+   * contract deliberately stays put, and this column is the only place that
+   * difference is written down.
+   */
+  coverageMinDeg: number;
+  coverageMaxDeg: number;
+}
+
+const fmt = (offsets: readonly number[]) => [...offsets].join(',');
+
+/**
+ * The solar-altitude span a set of ring altitudes gathers from.
+ *
+ * Shared so the two questions that need it cannot drift apart: this module
+ * asks "what was the pool guaranteed to hold on this tick", and the digest
+ * asks "what did yesterday's rings actually cover". Same arithmetic, two
+ * inputs. (masterConfig's TERMINATOR_POOL_COVERAGE_DEG is a third thing —
+ * the display contract, moved by hand — and cannot call this, because masterConfig is
+ * imported by client code and this module imports the database.)
+ *
+ * A true union rather than a hull: the widest gap between consecutive ring
+ * altitudes (15.75) is under one band's width (2 x SEARCH_RADIUS_DEG = 22),
+ * so there is no hole for min/max to paper over.
+ */
+export function coverageSpan(
+  ringAltitudesDeg: number[],
+): { min: number; max: number } {
+  return {
+    min: Math.min(...ringAltitudesDeg) - SEARCH_RADIUS_DEG,
+    max: Math.max(...ringAltitudesDeg) + SEARCH_RADIUS_DEG,
+  };
+}
+
+export function sweepGeometry(forcedOffsets: readonly number[]): SweepGeometry {
+  const guaranteed = [0, ...forcedOffsets];
+  const { min: coverageMinDeg, max: coverageMaxDeg } = coverageSpan(
+    guaranteed.map((o) => TERMINATOR_SUN_ALTITUDE_DEG + o),
+  );
+  const widenOffsetsDeg = fmt(TERMINATOR_WIDEN_OFFSETS_DEG);
+  const forcedOffsetsDeg = fmt(forcedOffsets);
+  return {
+    signature:
+      `base${TERMINATOR_SUN_ALTITUDE_DEG}` +
+      `_r${SEARCH_RADIUS_DEG}` +
+      `_off${widenOffsetsDeg}` +
+      `_forced${forcedOffsetsDeg}`,
+    baseAltitudeDeg: TERMINATOR_SUN_ALTITUDE_DEG,
+    searchRadiusDeg: SEARCH_RADIUS_DEG,
+    widenOffsetsDeg,
+    forcedOffsetsDeg,
+    coverageMinDeg,
+    coverageMaxDeg,
+  };
+}
+
+/**
+ * Add one tick to today's row for this geometry.
+ *
+ * `ticks` accumulates, everything else is fixed by the signature, so a
+ * configuration change mid-day makes a second row rather than corrupting the
+ * first. Non-fatal by contract, like every other telemetry write in this
+ * directory: a missing table means a quiet warning, never a failed tick.
+ */
+export async function upsertSweepGeometry(
+  now: Date,
+  geometry: SweepGeometry,
+): Promise<void> {
+  const date = now.toISOString().slice(0, 10);
+  try {
+    await sql`
+      insert into daily_sweep_geometry (
+        date, signature, base_altitude_deg, search_radius_deg,
+        widen_offsets_deg, forced_offsets_deg,
+        coverage_min_deg, coverage_max_deg, ticks, updated_at
+      ) values (
+        ${date}, ${geometry.signature}, ${geometry.baseAltitudeDeg},
+        ${geometry.searchRadiusDeg}, ${geometry.widenOffsetsDeg},
+        ${geometry.forcedOffsetsDeg}, ${geometry.coverageMinDeg},
+        ${geometry.coverageMaxDeg}, 1, now()
+      )
+      on conflict (date, signature) do update set
+        ticks = daily_sweep_geometry.ticks + 1,
+        updated_at = now()
+    `;
+  } catch (error) {
+    console.warn('[sweepGeometry] persist failed:', error);
+  }
+}
+```
+
+- [ ] **Step 5: Run the tests**
+
+Run: `npx vitest run app/api/cron/update-cameras/lib/sweepGeometry.test.ts`
+Expected: PASS, six cases.
+
+- [ ] **Step 6: Call it from the cron**
+
+In `route.ts`, add the import beside the `sweepStats` one:
+
+```ts
+import { sweepGeometry, upsertSweepGeometry } from './lib/sweepGeometry';
+```
+
+and directly after the existing `await upsertSweepStats(...)` call:
+
+```ts
+  // The angles behind the counters just written. Recorded every tick rather
+  // than on change, because nothing watches for a change -- masterConfig.ts
+  // edits arrive by deploy and the flag flips outside the app entirely.
+  await upsertSweepGeometry(new Date(), sweepGeometry(forcedOffsets));
+```
+
+- [ ] **Step 7: Run the whole suite, then apply the migration**
+
+Run: `npm run test`
+Expected: PASS.
+
+```bash
+node scripts/apply-migration.mjs database/migrations/20260902_sweep_geometry.sql
+node scripts/apply-migration.mjs database/migrations/20260902_sweep_geometry.sql --apply
+```
+
+- [ ] **Step 8: Confirm branch, then commit**
+
+```bash
+git rev-parse --abbrev-ref HEAD
+git add database/migrations/20260902_sweep_geometry.sql \
+        app/api/cron/update-cameras/lib/sweepGeometry.ts \
+        app/api/cron/update-cameras/lib/sweepGeometry.test.ts \
+        app/api/cron/update-cameras/route.ts
+git commit -m "feat(cron): record the ring angles behind each day's counters"
+```
+
+---
+
+## Task 7: The digest lines
+
+Spec §5, plus the operator's ask for granularity. Three additions. The existing
+per-ring gate-pass clause stays where it is: it is the only thing that
+separates widening that adds sunsets from widening that adds cameras the gate
+floors.
+
+**Files:**
+- Modify: `app/api/cron/update-cameras/lib/dailyDigest.ts` (`formatSweepLine`, around lines 78–135)
+- Test: `app/api/cron/update-cameras/lib/dailyDigest.test.ts`
+
+**Interfaces:**
+- Consumes: `SweepDigestSummary` with `baseMs`, `escalationMs`,
+  `rings[].elapsedMs` (Task 5); `TERMINATOR_SUN_ALTITUDE_DEG`,
+  `SEARCH_RADIUS_DEG` (existing config).
+- Produces: `sweptAltitudeSpan(rings): { min: number; max: number } | null`,
+  exported for its own test.
+
+- [ ] **Step 1: Write the failing tests**
+
+In `dailyDigest.test.ts`:
+
+```ts
+describe('sweptAltitudeSpan', () => {
+  it('is the base ring alone when nothing escalated', () => {
+    expect(sweptAltitudeSpan([ringStat(0)])).toEqual({ min: -24, max: -2 });
+  });
+
+  it('reaches golden hour once the day-side ring ran', () => {
+    expect(sweptAltitudeSpan([ringStat(0), ringStat(15.75)])).toEqual({
+      min: -24,
+      max: 13.75,
+    });
+  });
+
+  it('is null when no ring ran', () => {
+    expect(sweptAltitudeSpan([])).toBeNull();
+  });
+});
+
+describe('formatSweepLine', () => {
+  it('prints the swept altitude span in degrees, not ring offsets', () => {
+    expect(formatSweepLine(summaryWithDayRing())).toContain('-24° to +14°');
+  });
+
+  it('prints the widening bill as seconds and frames, not just boxes', () => {
+    const html = formatSweepLine(summaryWithDayRing());
+    expect(html).toContain('Widening cost');
+    expect(html).toContain('16.0 min/day sweeping');
+  });
+
+  it('prints what each ring cost per sunset it delivered', () => {
+    // The lever question. A ring that costs twice as many boxes per
+    // gate-passed frame as the base ring is the one to narrow or drop, and
+    // that ratio is invisible in any total.
+    const html = formatSweepLine(summaryWithDayRing());
+    expect(html).toContain('per gate-passed');
+  });
+
+  it('says nothing about widening cost when nothing escalated', () => {
+    expect(formatSweepLine(summaryBaseOnly())).not.toContain('Widening cost');
+  });
+});
+```
+
+Write `ringStat(offsetDeg)`, `summaryWithDayRing()` and `summaryBaseOnly()` as
+local helpers in the test file, following the existing fixture style. Give
+`summaryWithDayRing()` `escalationMs: 960_000` (16 minutes),
+`escalationBoxes: 2880` against `baseBoxes: 2976`, and both rings non-zero
+`framesScored` and `framesGatePassed` so the per-ring ratio is computable.
+
+- [ ] **Step 2: Run them to verify they fail**
+
+Run: `npx vitest run app/api/cron/update-cameras/lib/dailyDigest.test.ts`
+Expected: FAIL — `sweptAltitudeSpan` is not exported.
+
+- [ ] **Step 3: Add the span helper**
+
+In `dailyDigest.ts`, extend the `@/app/lib/masterConfig` import with
+`TERMINATOR_SUN_ALTITUDE_DEG`, import `SweepRingStats` alongside the existing
+`SweepDigestSummary` import, add `import { coverageSpan } from './sweepGeometry';`,
+then add above `formatSweepLine`:
+
+```ts
+/**
+ * The solar-altitude span yesterday's rings actually gathered from.
+ *
+ * The digest already prints ring offsets, which say where a ring sits
+ * relative to the base ring and nothing about where the sun was. The useful
+ * form is the resulting altitude band, because that is what can be read
+ * against the measured quality curve: good frames peak at 0 to +6 degrees,
+ * and a span whose day edge is -2 never touches it.
+ *
+ * Shares its arithmetic with sweepGeometry's coverageSpan, which answers the
+ * same question about a tick rather than about yesterday.
+ */
+export function sweptAltitudeSpan(
+  rings: SweepRingStats[],
+): { min: number; max: number } | null {
+  if (rings.length === 0) return null;
+  return coverageSpan(
+    rings.map((r) => TERMINATOR_SUN_ALTITUDE_DEG + r.offsetDeg),
+  );
+}
+
+/** `-24° to +14°`. Rounded outward, so the printed band never overstates. */
+function formatSpan(span: { min: number; max: number }): string {
+  const lo = Math.floor(span.min);
+  const hi = Math.ceil(span.max);
+  return `${lo}° to ${hi > 0 ? '+' : ''}${hi}°`;
+}
+```
+
+- [ ] **Step 4: Add the three clauses to `formatSweepLine`**
+
+After the existing `parts.push(...)` for boxes:
+
+```ts
+  const span = sweptAltitudeSpan(s.rings);
+  if (span) parts.push(`swept ${formatSpan(span)} solar altitude`);
+```
+
+After `const lines = [\`Widening: ${parts.join(' · ')}\`];` and before the
+`if (s.rings.length > 1)` block:
+
+```ts
+  // The bill, in the units that actually have one.
+  //
+  // Not dollars, deliberately. Windy publishes no price, no rate limit and no
+  // quota headers (measured 2026-09-02, see the camera-refresh cost spec), so
+  // multiplying boxes by a rate would mean inventing the rate. What widening
+  // provably consumes is function wall-clock and scoring work, and both are
+  // measured here.
+  if (s.escalationMs > 0) {
+    const escalationMin = s.escalationMs / 60_000;
+    const escalationFrames = s.rings
+      .filter((r) => r.offsetDeg !== 0)
+      .reduce((sum, r) => sum + r.framesScored, 0);
+    lines.push(
+      `Widening cost: ${escalationMin.toFixed(1)} min/day sweeping ` +
+        `(+${pct(s.escalationMs, s.baseMs)}% on base) · ` +
+        `${count(escalationFrames)} extra frames scored`,
+    );
+  }
+
+  // Cost per result, per ring. The lever line.
+  //
+  // Totals cannot say which ring to narrow or drop; a ratio can. A ring
+  // buying gate-passed frames at several times the base ring's box cost is
+  // the one to change, and that stays true whether the bill went up or down.
+  // Rings with no gate-passed frames print as "none", not as a division by
+  // zero dressed up as a large number.
+  const efficiency = s.rings.map((r) => {
+    if (r.framesGatePassed === 0) return `${ringLabel(r.offsetDeg)} none`;
+    const boxesEach = Math.round(r.boxesAttempted / r.framesGatePassed);
+    const secondsEach = r.elapsedMs / r.framesGatePassed / 1000;
+    return (
+      `${ringLabel(r.offsetDeg)} ${count(boxesEach)} boxes` +
+      ` + ${secondsEach.toFixed(1)}s`
+    );
+  });
+  lines.push(`Per gate-passed frame: ${efficiency.join(' · ')}`);
+```
+
+- [ ] **Step 5: Run the tests**
+
+Run: `npx vitest run app/api/cron/update-cameras/lib/dailyDigest.test.ts`
+Expected: PASS.
+
+- [ ] **Step 6: Run the whole suite, lint, build**
+
+Run: `npm run test && npm run lint && npm run build`
+Expected: all clean. Do not proceed to Task 8 on a red suite.
+
+- [ ] **Step 7: Confirm branch, then commit and open the PR**
+
+```bash
+git rev-parse --abbrev-ref HEAD
+git add app/api/cron/update-cameras/lib/dailyDigest.ts \
+        app/api/cron/update-cameras/lib/dailyDigest.test.ts
+git commit -m "feat(digest): swept altitude span, the widening bill, and cost per sunset"
+git push
+```
+
+Open the PR. Body must state: the switch defaults off, sweep behaviour is
+unchanged until it is flipped, all three migrations are already applied, and
+the measurement window has not started.
+
+---
+
+## Task 8: The bounded measurement window
+
+No checkout needed beyond reading. This is the task that spends money.
+
+- [ ] **Step 1: Capture the baseline before spending anything**
+
+The sweep landed in production on 2026-09-02 (PR #112), so there are already
+rows. Confirm they are real, because every write in this path swallows its own
+errors and an unapplied migration looks exactly like a quiet day.
+
+```bash
+node scripts/set-runtime-flag.mjs
+```
+Expected: `sweep_force_day_ring = false`.
+
+Then read the last four days. Write the query to a file first, then run it
+however you normally reach Neon:
+
+```sql
+SELECT date, sweep_ticks, sweep_escalated_ticks, sweep_budget_exhausted_ticks,
+       sweep_base_boxes, sweep_escalation_boxes,
+       sweep_base_ms, sweep_escalation_ms
+FROM daily_sunset_stats
+WHERE date >= CURRENT_DATE - 4 ORDER BY date;
+```
+
+Also capture the Neon side, which is where the dollars actually are:
+
+```sql
+SELECT day, project_id, compute_time_s
+FROM provider_usage_daily
+WHERE day >= CURRENT_DATE - 8 ORDER BY day;
+```
+
+**Record both in the report before flipping anything.** Without a baseline
+there is nothing to compare against, and the whole window is wasted.
+
+A first baseline was already captured on 2026-09-02/03 and is in the SDD
+ledger; re-run these to extend it to the day of the flip.
+
+- [ ] **Step 1b: Gate on the empty-box share before flipping**
+
+Compute `boxes_empty / boxes_attempted` per day from
+`daily_sweep_ring_stats`. The captured baseline shows it rising: 27% on
+2026-09-02 and 38% on 2026-09-03, while `new_webcams` fell from 40,042 to
+37,198. The sweep-telemetry migration names exactly that pattern as "the
+signature of an undiscovered Windy quota ceiling."
+
+Two days is not a trend, but it is the wrong direction in which to double
+call volume. **If the share is still climbing across three consecutive days,
+do not flip.** Report that instead: a pre-existing ceiling problem is a bigger
+finding than the widening question, and doubling the call rate into it would
+confound both.
+
+- [ ] **Step 2: Log the change on the cost timeline**
+
+`cost_events` is what annotates the Ops chart and rides in the digest. It is
+the existing record of "what we changed and when", and this change belongs on
+it beside the June and July entries. Write the row to a file, then apply it:
+
+```sql
+INSERT INTO cost_events (occurred_on, sha, description)
+VALUES (CURRENT_DATE, NULL,
+  'sweep_force_day_ring ON: day-side ring (+15.75, ~+2.75 deg solar altitude) forced on both feeds every tick; pool -24..-2 becomes -24..+14');
+```
+
+Add the matching OFF row on the day of Step 5. Two rows, not one, so the
+window has both edges on the chart.
+
+- [ ] **Step 3: Flip the switch**
+
+```bash
+node scripts/set-runtime-flag.mjs sweep_force_day_ring on
+node scripts/set-runtime-flag.mjs sweep_force_day_ring on --apply
+```
+
+Verify on the next tick:
+
+```bash
+curl -s -H "Authorization: Bearer $CRON_SECRET" \
+  https://<prod-host>/api/cron/update-cameras | jq '.forcedDayRing, .sweep.rings'
+```
+Expected: `true`, and two ring entries, offsets `0` and `15.75`, the second
+with `feedsSwept: ["sunrise","sunset"]`.
+
+If `CRON_SECRET` is not pullable, read `forcedDayRing` from the Vercel function
+logs instead: it is in the `🛰️ terminator sweep:` line.
+
+**Expected magnitude, measured 2026-09-02/03, not assumed.** The base ring is
+exactly 30.0 boxes per tick. The tick rate is **not** the cron's 96/day:
+`/api/kiosk/tick` re-invokes this same handler in-process whenever a gallery
+screen is visible, throttled near one per minute by a Redis lock. Measured
+sweep ticks were 352 and 365 per day, giving ~10,700 boxes/day. A forced day
+ring on both feeds roughly doubles per-tick boxes.
+
+| | measured baseline | forced, at observed tick rate | forced, screens on all day |
+| --- | --- | --- | --- |
+| ticks/day | 352–365 | 352–365 | up to ~1,536 |
+| boxes/day | ~10,700 | ~21,400 | ~92,000 |
+
+**The right-hand column is the risk.** The camera-refresh cost spec names
+22,300 calls/day as the most likely way to discover a Windy rate limit, and
+says discovering it makes panels *blanker* — the outcome this feature exists
+to prevent. Windy publishes no quota headers, so there is no warning before
+the wall. Cost here scales with **kiosk uptime**, not with the cron schedule,
+and a show is exactly when screens run all day.
+
+A half-ring takes roughly 5–7 seconds, so a full forced ring adds 10–14
+seconds to a base sweep of similar length, against a 25-second budget.
+**Budget exhaustion becoming common is a finding, not a bug.** It is spec §3
+question 2 answering itself, and the strongest argument for a narrower offset
+in phase 2.
+
+- [ ] **Step 4: Check the cost daily, and abort if it breaches**
+
+Once a day, not once at the end. Read the digest email, or:
+
+```bash
+node scripts/usage-report.mjs
+```
+
+Two indicators, and the leading one matters more.
+
+**Leading — Windy boxes per day.** Visible within hours, and it is the one
+that can break the product rather than the budget. Read it as
+`sweep_base_boxes + sweep_escalation_boxes` for today.
+
+| reading | action |
+| --- | --- |
+| under 18,000/day | continue |
+| 18,000–22,000/day | continue, check twice daily, and watch the empty-box share |
+| above 22,000/day, or empty-box share rising while `new_webcams` falls | **turn the switch off immediately.** That pair is the documented signature of a Windy quota ceiling, and the failure mode empties the panels |
+
+**Lagging — dollars per day**, from the digest or `node scripts/usage-report.mjs`.
+
+| reading | action |
+| --- | --- |
+| up to $2.60/day | continue, inside the approved band |
+| $2.60–3.30/day | continue but note it; top of the band |
+| above $3.30/day sustained for two days | turn the switch off, then finish the report from what was collected |
+
+The band is the operator's: the bill sits near $0.64/day now (measured
+2026-09-03: 3.92 CU-hr sunset + 0.67 CU-hr nwac at $0.14/CU-hr) and used to
+sit at $80–100/month. Anywhere between is acceptable; above the old rate is
+not.
+
+- [ ] **Step 5: Run for three full UTC days, then stop**
+
+Three, because the digest reads `CURRENT_DATE - 1` and the terminator's land
+coverage varies day to day.
+
+```bash
+node scripts/set-runtime-flag.mjs sweep_force_day_ring off --apply
+```
+
+Then add the OFF row to `cost_events`, matching Step 2.
+
+Turn it off even if the numbers look good. Phase 2 turns it back on
+deliberately, from a decision, with a chosen configuration.
+
+- [ ] **Step 6: Answer the three questions in a report**
+
+Create `docs/superpowers/plans/2026-09-02-terminator-pool-coverage-phase1-REPORT.md`.
+Open it with the geometry table, because everything else is only readable
+through it:
+
+```sql
+SELECT date, signature, base_altitude_deg, search_radius_deg,
+       forced_offsets_deg, coverage_min_deg, coverage_max_deg, ticks
+FROM daily_sweep_geometry ORDER BY date, signature;
+```
+
+State plainly what the pool covered before and what it covered during: −24° to
+−2° becoming −24° to +14°. Then one section per spec §3 question.
+
+1. **Yield that survives scoring.** From `daily_sweep_ring_stats`:
+   `frames_gate_passed / frames_scored` for `offset_deg = 15.75` against
+   `offset_deg = 0`. The failure mode is self-concealing — a ring that adds
+   cameras the gate then floors reads as success in both the escalation count
+   and the new-camera count — so this ratio is the answer and `new_webcams` is
+   not. Say whether the day ring's rate is comparable to base, materially
+   worse, or too small a sample to call.
+2. **Sweep budget.** `sweep_budget_exhausted_ticks / sweep_ticks`, plus
+   `sweep_base_ms + sweep_escalation_ms` per tick against the 25,000 ms budget
+   and the 50,000 ms tick deadline. Report the per-tick mean and the worst day.
+3. **Cost, and the levers.** This is the section the operator actually needs.
+   - `sweep_escalation_boxes` against the ~2,980/day baseline, and
+     `sweep_escalation_ms` as minutes per day.
+   - **Boxes per gate-passed frame and sweep-seconds per gate-passed frame,
+     per ring.** The whole point: a ring costing several times the base ring's
+     rate per delivered sunset is the one to narrow or drop.
+   - **The Neon delta.** `provider_usage_daily` compute across the forced days
+     against the baseline days. This measures the cron's share of Neon compute
+     directly, which is one of the two numbers the camera-refresh cost spec
+     names as missing, and it is what turns every ratio above into dollars.
+   - **The function's wall-clock duration** from the Vercel function logs,
+     distribution and not just mean. That is the other missing number.
+
+Close with an explicit recommendation among the three phase-2 options in spec
+§7 step 4: always-on, conditional, or a narrower offset. Recommend, do not
+enumerate. If a narrower offset looks right, name the offset and say what it
+would put the ring altitude at, because the next person will otherwise have to
+redo the arithmetic.
+
+- [ ] **Step 7: Commit the report and leave the checkout on main**
+
+```bash
+git rev-parse --abbrev-ref HEAD
+git add docs/superpowers/plans/2026-09-02-terminator-pool-coverage-phase1-REPORT.md
+git commit -m "docs(sweep): phase 1 measurement results"
+git checkout main
+```
+
+Several sessions share this checkout. Whoever takes it, returns it.
+
+---
+
+## What phase 2 is, and why it is not in this plan
+
+Spec §7 steps 4–6. Phase 2 chooses always-on, conditional, or a narrower
+offset; it does not need a new coverage constant (Task 1 shipped one that is
+correct for any ring set); and it converts the per-ring ratios into dollars
+using the Neon delta and function duration Task 8 measures.
+
+It is deliberately not written here. The spec says the final choice is
+deferred until the measurement reports, and a task list that pre-commits to one
+of three outcomes would be a plan pretending to be a measurement. Write the
+phase 2 plan when the report exists.

--- a/docs/superpowers/plans/2026-09-02-terminator-pool-coverage-phase1.md
+++ b/docs/superpowers/plans/2026-09-02-terminator-pool-coverage-phase1.md
@@ -1701,17 +1701,24 @@ ledger; re-run these to extend it to the day of the flip.
 
 - [ ] **Step 1b: Gate on the empty-box share before flipping**
 
-Compute `boxes_empty / boxes_attempted` per day from
-`daily_sweep_ring_stats`. The captured baseline shows it rising: 27% on
-2026-09-02 and 38% on 2026-09-03, while `new_webcams` fell from 40,042 to
-37,198. The sweep-telemetry migration names exactly that pattern as "the
-signature of an undiscovered Windy quota ceiling."
+Compute `boxes_empty / boxes_attempted` from `daily_sweep_ring_stats`, and
+**compare like with like**. The first capture appeared to show a jump, 26.9%
+on 2026-09-02 against 38.8% on 2026-09-03, which the sweep-telemetry
+migration would name as "the signature of an undiscovered Windy quota
+ceiling."
 
-Two days is not a trend, but it is the wrong direction in which to double
-call volume. **If the share is still climbing across three consecutive days,
-do not flip.** Report that instead: a pre-existing ceiling problem is a bigger
-finding than the widening question, and doubling the call rate into it would
-confound both.
+That comparison was invalid and the alarm is probably false. Both rows were
+partial days covering different UTC hours: 09-02 ran from the merge at 17:56Z
+to midnight, 09-03 from midnight to 06:27Z. The terminator crosses far more
+ocean in the early-UTC window, so empty boxes and cameras-found move together
+for purely geographic reasons. `new_webcams` per tick fell from 113.8 to 98.4
+across the same pair, which fits geography as well as it fits a ceiling.
+
+**Compare one full UTC day against another full UTC day, or the same UTC
+hours on two dates.** Never two partial days. If the share is genuinely
+climbing on a like-for-like comparison across three days, do not flip: a
+pre-existing ceiling is a bigger finding than the widening question, and
+doubling the call rate into it would confound both.
 
 - [ ] **Step 2: Log the change on the cost timeline**
 
@@ -1747,24 +1754,39 @@ with `feedsSwept: ["sunrise","sunset"]`.
 If `CRON_SECRET` is not pullable, read `forcedDayRing` from the Vercel function
 logs instead: it is in the `🛰️ terminator sweep:` line.
 
-**Expected magnitude, measured 2026-09-02/03, not assumed.** The base ring is
+**STOP. Do not flip the switch without the operator's explicit go-ahead on
+the numbers below.** The plan was written against an assumed baseline that
+the measurement disproved, and the gap is large enough to change the
+decision.
+
+**Expected magnitude, measured 2026-09-03, not assumed.** The base ring is
 exactly 30.0 boxes per tick. The tick rate is **not** the cron's 96/day:
 `/api/kiosk/tick` re-invokes this same handler in-process whenever a gallery
-screen is visible, throttled near one per minute by a Redis lock. Measured
-sweep ticks were 352 and 365 per day, giving ~10,700 boxes/day. A forced day
-ring on both feeds roughly doubles per-tick boxes.
+screen is visible, throttled to about one per minute by a Redis lock.
+Measured at 06:27Z on 2026-09-03: 388 ticks in 387 minutes, which is 1.003
+ticks per minute sustained. The kiosk is polling continuously.
 
-| | measured baseline | forced, at observed tick rate | forced, screens on all day |
-| --- | --- | --- | --- |
-| ticks/day | 352–365 | 352–365 | up to ~1,536 |
-| boxes/day | ~10,700 | ~21,400 | ~92,000 |
+| | per full day at the current rate |
+| --- | --- |
+| ticks, cron alone | 96 |
+| ticks, actual | ~1,444 |
+| kiosk share of sweep volume | 93% |
+| Windy boxes, switch OFF | ~43,300 |
+| Windy boxes, day ring forced | ~86,600 |
+| Windy risk point named by the camera-refresh spec | 22,300 |
 
-**The right-hand column is the risk.** The camera-refresh cost spec names
-22,300 calls/day as the most likely way to discover a Windy rate limit, and
-says discovering it makes panels *blanker* — the outcome this feature exists
-to prevent. Windy publishes no quota headers, so there is no warning before
-the wall. Cost here scales with **kiosk uptime**, not with the cron schedule,
-and a show is exactly when screens run all day.
+**Production already runs at roughly twice the stated risk point with this
+feature switched off.** Forcing the day ring would take it to nearly four
+times. The camera-refresh spec says discovering a Windy rate limit makes
+panels *blanker*, which is the outcome this feature exists to prevent, and
+Windy publishes no quota headers so there is no warning before the wall.
+
+**The dominant cost lever is not the ring configuration.** It is the kiosk
+poll cadence in `app/api/kiosk/tick/route.ts` and `KIOSK_TICK_LOCK_TTL_MS`.
+A full camera sweep runs every minute to score frames, which is fifteen times
+the cron's own rate. Any conversation about what this feature costs should
+start there, not with the offsets. That is a finding for the operator, and it
+is out of scope for this plan to change.
 
 A half-ring takes roughly 5–7 seconds, so a full forced ring adds 10–14
 seconds to a base sweep of similar length, against a 25-second budget.
@@ -1786,11 +1808,15 @@ Two indicators, and the leading one matters more.
 that can break the product rather than the budget. Read it as
 `sweep_base_boxes + sweep_escalation_boxes` for today.
 
+Absolute thresholds are useless here: the measured baseline is already about
+43,300/day, twice the spec's stated risk point. Judge the *change* instead,
+and judge it against whether Windy is still answering.
+
 | reading | action |
 | --- | --- |
-| under 18,000/day | continue |
-| 18,000–22,000/day | continue, check twice daily, and watch the empty-box share |
-| above 22,000/day, or empty-box share rising while `new_webcams` falls | **turn the switch off immediately.** That pair is the documented signature of a Windy quota ceiling, and the failure mode empties the panels |
+| boxes/day under 2x the like-for-like baseline **and** empty share flat | continue |
+| empty share up more than 5 points on a like-for-like comparison | check twice daily; this is the first thing a ceiling would move |
+| empty share climbing while `new_webcams` per tick falls, on a like-for-like comparison | **turn the switch off immediately.** That pair is the documented ceiling signature and its failure mode empties the panels |
 
 **Lagging — dollars per day**, from the digest or `node scripts/usage-report.mjs`.
 

--- a/docs/superpowers/plans/2026-09-02-terminator-pool-coverage-phase1.md
+++ b/docs/superpowers/plans/2026-09-02-terminator-pool-coverage-phase1.md
@@ -67,18 +67,18 @@ The operator has approved this spend, with a band and a deliverable.
 There is a second ceiling that is not financial. Windy publishes no rate limit
 and no quota headers, and the sibling cost spec names ~22,300 calls/day as the
 likely point of discovering one. Breaching it empties the panels, which is
-worse than any bill in the band above. Task 8 therefore aborts on box volume
+worse than any bill in the band above. Task 9 therefore aborts on box volume
 as well as on dollars, and box volume is the faster signal.
 
 **Anywhere between those two rows is acceptable.** Above the top row is a
-problem, and Task 8 aborts on it rather than finishing the window.
+problem, and Task 9 aborts on it rather than finishing the window.
 
 Two consequences for this plan, both differing from the spec's §4 and §7:
 
 **The bill may be visible after the fact.** The spec reads as though the digest
 must ship before the spending starts. It does not. The measurement window can
 open as soon as the switch exists, and the digest lines can land while it runs.
-Task 8 does not wait on an email.
+Task 9 does not wait on an email.
 
 **Granularity is the real deliverable, not the total.** Knowing the bill went up
 is worth little. Knowing *which ring bought how many gate-passed frames per
@@ -89,7 +89,7 @@ tick-level or day-level lump.
 **The geometry must be recorded, not remembered.** The operator expects this
 configuration to expand and contract more than once. A row saying "offset 15.75
 scored 40 of 200" is uninterpretable a month later if the base altitude has
-moved in between, because 15.75 will have meant a different sun angle. Task 6
+moved in between, because 15.75 will have meant a different sun angle. Task 7
 records the angles themselves alongside the counters, so that every historical
 number stays readable through the next change. This is a requirement, not a
 nicety.
@@ -131,7 +131,7 @@ Consequences for this plan:
   constant is compile-time. During the measurement window the sweep really
   will gather −24° to +13.75° while the constant still says −24° to −2°. That
   is deliberate: a bounded measurement must not move the display contract.
-  The honest record of what was actually swept lives in Task 6's
+  The honest record of what was actually swept lives in Task 7's
   `daily_sweep_geometry`, stamped per day.
 - **Moving it is phase 2's first act**, alongside the axis dials.
 
@@ -145,7 +145,7 @@ On dollars in the digest: Windy publishes no price, no rate limit and no quota
 headers, measured 2026-09-02 and recorded in
 `docs/superpowers/specs/2026-09-02-camera-refresh-cost-design.md`. That spec
 also names the two numbers nobody has measured, the update-cameras function's
-wall-clock duration and the cron's share of Neon compute. Task 8 measures both,
+wall-clock duration and the cron's share of Neon compute. Task 9 measures both,
 because the day-over-day Neon delta across the window gives the second one
 directly. Until then the digest reports the physical bill, which is boxes,
 sweep seconds and frames, all divided by gate-passed frames.
@@ -173,9 +173,9 @@ sweep seconds and frames, all divided by gate-passed frames.
 | `app/api/cron/update-cameras/lib/sweepStats.test.ts` | **Modify.** |
 | `app/api/cron/update-cameras/lib/dailyDigest.ts` | **Modify.** Altitude-span clause, the widening bill, and cost per gate-passed frame per ring. |
 | `app/api/cron/update-cameras/lib/dailyDigest.test.ts` | **Modify.** |
-| `docs/superpowers/plans/2026-09-02-terminator-pool-coverage-phase1-REPORT.md` | **Create in Task 8.** The measurement answer phase 2 is decided from. |
+| `docs/superpowers/plans/2026-09-02-terminator-pool-coverage-phase1-REPORT.md` | **Create in Task 9.** The measurement answer phase 2 is decided from. |
 
-Tasks 1 through 7 are code and need the checkout. Task 8 needs it barely at
+Tasks 1 through 8 are code and need the checkout. Task 9 needs it barely at
 all: a flag flip, a daily cost glance, and three SQL reads.
 
 ---
@@ -198,7 +198,7 @@ here collides on merge.
 - Consumes: `TERMINATOR_SUN_ALTITUDE_DEG`, `TERMINATOR_WIDEN_OFFSETS_DEG` —
   both already in this file.
 - Produces:
-  - `TERMINATOR_DAY_SIDE_OFFSETS_DEG: readonly number[]` — used by Tasks 4 and 6.
+  - `TERMINATOR_DAY_SIDE_OFFSETS_DEG: readonly number[]` — used by Tasks 4 and 7.
 
 - [ ] **Step 1: Write the failing test**
 
@@ -507,7 +507,7 @@ node scripts/set-runtime-flag.mjs
 ```
 Expected: `sweep_force_day_ring = false`.
 
-Do not turn it on. Task 8 owns the flip.
+Do not turn it on. Task 9 owns the flip.
 
 - [ ] **Step 8: Confirm branch, then commit**
 
@@ -742,7 +742,7 @@ git commit -m "feat(cron): let a named ring sweep regardless of the camera floor
   `TERMINATOR_DAY_SIDE_OFFSETS_DEG` (Task 1); `forcedOffsets` (Task 3).
 - Produces: a `forcedDayRing: boolean` field on the cron's JSON response, so
   the switch is smoke-testable from outside without reading the database. Also
-  a local `forcedOffsets` value that Task 6 reuses for the geometry record.
+  a local `forcedOffsets` value that Task 7 reuses for the geometry record.
 
 - [ ] **Step 1: Add the flag mock to the route test harness**
 
@@ -866,7 +866,342 @@ git commit -m "feat(cron): honour the forced-day-ring switch per tick"
 
 ---
 
-## Task 5: Per-ring wall-clock, captured and persisted
+## Task 5: Count failed boxes apart from empty ones
+
+Contributed by a peer session's investigation (2026-09-03) and accepted into
+this plan. Today `fetchWebcamsFor` returns `[]` on any non-OK response, so a
+throttled or rejected call and an open-ocean box increment the same
+`empty` counter. That is why the empty-box share could never have answered
+the quota question at any sample size: the metric is conflated by
+construction. The status codes are the instrument, and they are thrown away
+three functions deep. This task carries them up.
+
+Production evidence for why it is worth a task: 2,250 Windy errors in one
+24-hour window, all `400`, clustered on boxes touching the poles and the
+antimeridian, every one of them recorded as empty ocean. Every `boxes_empty`
+figure in the telemetry so far is overstated by that amount.
+
+Deliberately NOT changed here: a thrown `fetch` still propagates and fails
+the tick, exactly as today. This task changes what a non-OK *response*
+records, not what an exception does.
+
+**Files:**
+- Modify: `app/api/cron/update-cameras/lib/windyApi.ts` (`fetchWebcamsFor`, `fetchWebcamsInBatches`, `CoordFetchResult`, `fetchCoordsCounted`)
+- Modify: `app/api/cron/update-cameras/lib/terminatorSweep.ts` (`RingTelemetry`, the `sweep` closure)
+- Modify: `app/api/cron/update-cameras/lib/sweepStats.ts` (`SweepRingStats`, `computeSweepTickStats`, `upsertSweepStats`, `getSweepDigestSummary`)
+- Create: `database/migrations/20260903_sweep_failed_boxes.sql`
+- Test: `app/api/cron/update-cameras/lib/windyApi.test.ts`
+- Test: `app/api/cron/update-cameras/lib/terminatorSweep.test.ts` (fixtures only)
+- Test: `app/api/cron/update-cameras/lib/sweepStats.test.ts`
+- Test: `app/api/cron/update-cameras/route.test.ts` (the `fetchCoordsCounted` mock only)
+
+**Interfaces:**
+- Consumes: nothing from earlier tasks.
+- Produces:
+  - `BoxFetchResult { webcams: WindyWebcam[]; status: number; ok: boolean }`
+    — the per-box return of `fetchWebcamsFor`.
+  - `CoordFetchResult.failed: number` and
+    `CoordFetchResult.failedByStatus: Record<string, number>`.
+  - `RingTelemetry.failed: number` and `RingTelemetry.failedByStatus`.
+  - `SweepRingStats.boxesFailed: number`, persisted as
+    `daily_sweep_ring_stats.boxes_failed`. Read by Task 8's digest.
+
+- [ ] **Step 1: Change the existing Windy test so it stops asserting the conflation**
+
+In `app/api/cron/update-cameras/lib/windyApi.test.ts`, the
+`describe('fetchCoordsCounted', ...)` block stubs `fetch` so that boxes
+centred on lng 99 answer with one webcam and everything else returns
+`400`. Its first test currently asserts those two 400s as `empty: 2`. That
+assertion is the bug this task removes. Replace the two existing tests in
+that block with:
+
+```ts
+  it('counts a non-OK response as failed, not as empty', async () => {
+    // Two of the three boxes 400. Before this field existed they were
+    // scored as empty ocean, which is why the empty share could never tell a
+    // quota from the Pacific.
+    const res = await fetchCoordsCounted(
+      [{ lat: 0, lng: 99 }, { lat: 0, lng: 5 }, { lat: 0, lng: 20 }],
+      5,
+      0
+    );
+    expect(res.attempted).toBe(3);
+    expect(res.failed).toBe(2);
+    expect(res.failedByStatus).toEqual({ '400': 2 });
+    expect(res.empty).toBe(0);
+    expect(res.webcams).toHaveLength(1);
+  });
+
+  it('counts a 200 with no cameras as empty', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      json: async () => [],
+    })));
+    const res = await fetchCoordsCounted([{ lat: 0, lng: 5 }], 5, 0);
+    expect(res.empty).toBe(1);
+    expect(res.failed).toBe(0);
+    expect(res.failedByStatus).toEqual({});
+  });
+
+  it('is a no-op on an empty coordinate list', async () => {
+    const res = await fetchCoordsCounted([], 5, 0);
+    expect(res).toEqual({
+      webcams: [],
+      attempted: 0,
+      empty: 0,
+      failed: 0,
+      failedByStatus: {},
+    });
+  });
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `npx vitest run app/api/cron/update-cameras/lib/windyApi.test.ts`
+Expected: FAIL — `res.failed` is `undefined`, and `res.empty` is `2`.
+
+- [ ] **Step 3: Carry the status out of `fetchWebcamsFor`**
+
+In `windyApi.ts`, add above `fetchWebcamsFor`:
+
+```ts
+/**
+ * One box's answer, with the status that produced it.
+ *
+ * `ok: false` with an empty list is a failed request. `ok: true` with an
+ * empty list is a box with no cameras in it. Until this type existed the two
+ * were indistinguishable downstream, which made every "empty box" count a
+ * mix of ocean and rejected calls.
+ */
+export interface BoxFetchResult {
+  webcams: WindyWebcam[];
+  /** HTTP status of the response. */
+  status: number;
+  ok: boolean;
+}
+```
+
+Change `fetchWebcamsFor`'s signature to `Promise<BoxFetchResult>`. Replace the
+`if (!res.ok)` branch's `return [] as WindyWebcam[];` with:
+
+```ts
+    return { webcams: [], status: res.status, ok: false };
+```
+
+and the final `return data ?? [];` with:
+
+```ts
+  return { webcams: data ?? [], status: res.status, ok: true };
+```
+
+Leave the `console.error` line exactly as it is: the Vercel log query in
+Task 9 greps for that text.
+
+- [ ] **Step 4: Thread it through the batcher and the counter**
+
+`fetchWebcamsInBatches` returns `Promise<WindyWebcam[][]>` today. Change the
+return type to `Promise<BoxFetchResult[]>` and the local `batches` to
+`BoxFetchResult[]`. The body needs no other change: it already pushes each
+`fetchWebcamsFor` result through one-to-one.
+
+In `CoordFetchResult`, replace the `empty` doc comment and add two fields:
+
+```ts
+  /** Boxes that answered 200 with no cameras. Ocean, or nearly. */
+  empty: number;
+  /**
+   * Boxes whose request came back non-OK. Counted apart from `empty` because
+   * a quota ceiling and the Pacific look identical in an empty count and
+   * nothing like each other here.
+   */
+  failed: number;
+  /** `failed`, split by HTTP status: `{ "400": 3 }`. */
+  failedByStatus: Record<string, number>;
+```
+
+Rewrite the body of `fetchCoordsCounted` after the early return:
+
+```ts
+  if (coords.length === 0) {
+    return { webcams: [], attempted: 0, empty: 0, failed: 0, failedByStatus: {} };
+  }
+  // One entry per COORDINATE, not per batch: fetchWebcamsInBatches spreads
+  // each batch's results back in, so the array is 1:1 with `coords`. That
+  // invariant is what makes `attempted`, `empty` and `failed` correct.
+  const perCoord = await fetchWebcamsInBatches(coords, batchSize, delayMs);
+  let empty = 0;
+  let failed = 0;
+  const failedByStatus: Record<string, number> = {};
+  for (const box of perCoord) {
+    if (!box.ok) {
+      failed += 1;
+      const key = String(box.status);
+      failedByStatus[key] = (failedByStatus[key] ?? 0) + 1;
+    } else if (box.webcams.length === 0) {
+      empty += 1;
+    }
+  }
+  return {
+    webcams: perCoord.flatMap((box) => box.webcams),
+    attempted: coords.length,
+    empty,
+    failed,
+    failedByStatus,
+  };
+```
+
+- [ ] **Step 5: Run the Windy tests**
+
+Run: `npx vitest run app/api/cron/update-cameras/lib/windyApi.test.ts`
+Expected: PASS, three cases.
+
+- [ ] **Step 6: Carry it into the ring telemetry**
+
+In `terminatorSweep.ts`, add to `RingTelemetry` after `empty`:
+
+```ts
+  /** Boxes whose request came back non-OK. Not ocean; see CoordFetchResult. */
+  failed: number;
+  failedByStatus: Record<string, number>;
+```
+
+In the `sweep` closure's `rings.push({ ... })`, add after `empty: res.empty,`:
+
+```ts
+      failed: res.failed,
+      failedByStatus: res.failedByStatus,
+```
+
+In `terminatorSweep.test.ts`, the `stubFetcher` helper at the top returns
+`{ webcams, attempted: coords.length, empty: 0 }`. Add `failed: 0,
+failedByStatus: {}` to that object. Any test with an inline `fetchCoords`
+(there is one in the timing test if Task 6 has already landed; otherwise
+none) gets the same two fields. Then add inside
+`describe('sweepWithEscalation', ...)`:
+
+```ts
+  it('carries failed boxes per ring, apart from empty ones', async () => {
+    const res = await sweepWithEscalation({
+      buildRing: ring,
+      fetchCoords: async (coords) => ({
+        webcams: [],
+        attempted: coords.length,
+        empty: 1,
+        failed: 1,
+        failedByStatus: { '400': 1 },
+      }),
+      classify,
+      floor: 2,
+      offsets: [],
+      hasBudget: () => true,
+    });
+    expect(res.telemetry.rings[0].failed).toBe(1);
+    expect(res.telemetry.rings[0].failedByStatus).toEqual({ '400': 1 });
+    expect(res.telemetry.rings[0].empty).toBe(1);
+  });
+```
+
+- [ ] **Step 7: Carry it into the daily stats**
+
+In `sweepStats.ts`, add to `SweepRingStats` after `boxesEmpty`:
+
+```ts
+  boxesFailed: number;
+```
+
+In `computeSweepTickStats`, add `boxesFailed: 0` to the per-offset
+accumulator default and `acc.boxesFailed += ring.failed;` beside
+`acc.boxesEmpty += ring.empty;`.
+
+In `upsertSweepStats`'s ring insert, add `boxes_failed` to the column list,
+`${ring.boxesFailed}` to the values, and to the update clause:
+
+```sql
+          boxes_failed = daily_sweep_ring_stats.boxes_failed + excluded.boxes_failed,
+```
+
+In `getSweepDigestSummary`, add `boxes_failed` to the ring select and
+`boxesFailed: Number(r.boxes_failed),` to the ring mapper.
+
+In `sweepStats.test.ts`, add `failed: 0, failedByStatus: {}` to every
+`RingTelemetry` object in the `healthy` and `escalated` fixtures, and add:
+
+```ts
+  it('accumulates failed boxes per ring', async () => {
+    const withFailures: SweepTelemetry = {
+      ...healthy,
+      rings: [{ ...healthy.rings[0], failed: 3, failedByStatus: { '400': 3 } }],
+    };
+    const stats = computeSweepTickStats({ telemetry: withFailures, floor: 15 });
+    expect(stats.rings[0].boxesFailed).toBe(3);
+    expect(stats.rings[0].boxesEmpty).toBe(healthy.rings[0].empty);
+  });
+```
+
+- [ ] **Step 8: Update the route test's mock**
+
+`route.test.ts` mocks `./lib/windyApi` and reimplements `fetchCoordsCounted`
+over a `fetchBatchesMock`. Its return object is
+`{ webcams, attempted, empty }`. Add `failed: 0, failedByStatus: {}` to that
+return so the real `sweep` closure, which now reads `res.failed`, does not
+record `undefined`. Do not change anything else in that file.
+
+- [ ] **Step 9: Write the migration**
+
+Create `database/migrations/20260903_sweep_failed_boxes.sql`:
+
+```sql
+-- Failed boxes, counted apart from empty ones.
+--
+-- boxes_empty conflated "no cameras there" with "the call failed", because
+-- fetchWebcamsFor returned [] on any non-OK response. Measured 2026-09-03:
+-- 2,250 Windy errors in 24h, all 400, on boxes touching the poles and the
+-- antimeridian, every one recorded as ocean. That made the empty share
+-- useless as a quota signal at any sample size. This column is the
+-- disambiguation. boxes_empty now means 200-with-nothing only.
+--
+-- Forward-only, idempotent. Apply via:
+--   node scripts/apply-migration.mjs database/migrations/20260903_sweep_failed_boxes.sql --apply
+
+ALTER TABLE daily_sweep_ring_stats
+  ADD COLUMN IF NOT EXISTS boxes_failed INTEGER NOT NULL DEFAULT 0;
+```
+
+- [ ] **Step 10: Run the whole suite, lint, build**
+
+Run: `npm run test && npm run lint && npm run build`
+Expected: all clean. If TypeScript names a file constructing a
+`CoordFetchResult`, `BoxFetchResult` or `RingTelemetry` you did not touch,
+add the new fields there too.
+
+- [ ] **Step 11: Dry-run the migration and STOP**
+
+```bash
+node scripts/apply-migration.mjs database/migrations/20260903_sweep_failed_boxes.sql
+```
+
+Paste the printed statement into your report. Do not pass `--apply`; the
+controller applies it.
+
+- [ ] **Step 12: Confirm branch, then commit**
+
+```bash
+git rev-parse --abbrev-ref HEAD
+git add app/api/cron/update-cameras/lib/windyApi.ts \
+        app/api/cron/update-cameras/lib/windyApi.test.ts \
+        app/api/cron/update-cameras/lib/terminatorSweep.ts \
+        app/api/cron/update-cameras/lib/terminatorSweep.test.ts \
+        app/api/cron/update-cameras/lib/sweepStats.ts \
+        app/api/cron/update-cameras/lib/sweepStats.test.ts \
+        app/api/cron/update-cameras/route.test.ts \
+        database/migrations/20260903_sweep_failed_boxes.sql
+git commit -m "feat(cron): count failed Windy boxes apart from empty ones"
+```
+
+---
+
+## Task 6: Per-ring wall-clock, captured and persisted
 
 Capture and persistence are one task, not two. Adding a required `elapsedMs`
 to `SweepRingStats` immediately breaks `getSweepDigestSummary`'s typecheck,
@@ -1148,7 +1483,7 @@ git commit -m "feat(cron): time each sweep ring and persist it, base split from 
 
 ---
 
-## Task 6: Record which angles produced the numbers
+## Task 7: Record which angles produced the numbers
 
 The configuration is expected to expand and contract more than once. Without
 this task, a row saying `offset_deg = 15.75, frames_gate_passed = 40` becomes
@@ -1172,7 +1507,7 @@ missing on the day it matters.
   from Task 4.
 - Produces:
   - `coverageSpan(ringAltitudesDeg: number[]): { min: number; max: number }`
-    — also imported by Task 7's digest, so the two span calculations cannot
+    — also imported by Task 8's digest, so the two span calculations cannot
     drift apart.
   - `sweepGeometry(forcedOffsets: readonly number[]): SweepGeometry`
   - `upsertSweepGeometry(now: Date, geometry: SweepGeometry): Promise<void>`
@@ -1469,7 +1804,7 @@ git commit -m "feat(cron): record the ring angles behind each day's counters"
 
 ---
 
-## Task 7: The digest lines
+## Task 8: The digest lines
 
 Spec §5, plus the operator's ask for granularity. Three additions. The existing
 per-ring gate-pass clause stays where it is: it is the only thing that
@@ -1482,7 +1817,7 @@ floors.
 
 **Interfaces:**
 - Consumes: `SweepDigestSummary` with `baseMs`, `escalationMs`,
-  `rings[].elapsedMs` (Task 5); `TERMINATOR_SUN_ALTITUDE_DEG`,
+  `rings[].elapsedMs` (Task 6); `TERMINATOR_SUN_ALTITUDE_DEG`,
   `SEARCH_RADIUS_DEG` (existing config).
 - Produces: `sweptAltitudeSpan(rings): { min: number; max: number } | null`,
   exported for its own test.
@@ -1591,6 +1926,40 @@ After the existing `parts.push(...)` for boxes:
   if (span) parts.push(`swept ${formatSpan(span)} solar altitude`);
 ```
 
+Then replace the existing empty-share clause. It currently reads:
+
+```ts
+  parts.push(`${pct(emptyBoxes, totalBoxes)}% of boxes empty`);
+```
+
+Now that failed boxes are counted apart (Task 5), the digest must not fold
+them back in. Replace it, and its comment, with:
+
+```ts
+  // Empty and failed are different facts and the digest keeps them apart.
+  // Empty is ocean. Failed is a non-OK response, and a RISING failed count
+  // is the only thing in this line that can mean a Windy ceiling; the empty
+  // share never could, because it used to contain the failures.
+  const failedBoxes = s.rings.reduce((sum, r) => sum + r.boxesFailed, 0);
+  parts.push(`${pct(emptyBoxes, totalBoxes)}% of boxes empty`);
+  if (failedBoxes > 0) {
+    parts.push(`<b>${count(failedBoxes)} boxes failed</b>`);
+  }
+```
+
+Add a test for it beside the others in `dailyDigest.test.ts`:
+
+```ts
+  it('reports failed boxes apart from empty ones, and only when there are any', () => {
+    expect(formatSweepLine(summaryBaseOnly())).not.toContain('boxes failed');
+    const withFailures = summaryBaseOnly();
+    withFailures.rings[0].boxesFailed = 12;
+    expect(formatSweepLine(withFailures)).toContain('12 boxes failed');
+  });
+```
+
+Give every ring in the test fixtures a `boxesFailed: 0` field.
+
 After `const lines = [\`Widening: ${parts.join(' · ')}\`];` and before the
 `if (s.rings.length > 1)` block:
 
@@ -1641,7 +2010,7 @@ Expected: PASS.
 - [ ] **Step 6: Run the whole suite, lint, build**
 
 Run: `npm run test && npm run lint && npm run build`
-Expected: all clean. Do not proceed to Task 8 on a red suite.
+Expected: all clean. Do not proceed to Task 9 on a red suite.
 
 - [ ] **Step 7: Confirm branch, then commit and open the PR**
 
@@ -1659,7 +2028,7 @@ the measurement window has not started.
 
 ---
 
-## Task 8: The bounded measurement window
+## Task 9: The bounded measurement window
 
 No checkout needed beyond reading. This is the task that spends money.
 
@@ -1700,7 +2069,7 @@ A first baseline was already captured on 2026-09-02/03 and is in the SDD
 ledger; re-run these to extend it to the day of the flip.
 
 - [x] **Step 1b: RESOLVED 2026-09-03. The empty-box alarm was not a quota
-  ceiling.**
+  ceiling. One watch remains before the flip, below.**
 
 Settled by direct observation, not by waiting for a third day. Recorded in
 full because the reasoning matters more than the verdict: the gate as
@@ -1723,30 +2092,52 @@ instrument, and they were already in the Vercel function logs the whole time.
 **What the evidence showed.** Three independent checks, all agreeing:
 
 - **Status codes.** Every non-OK Windy response in the sampled production
-  logs is `400 Bad Request`. Zero 429, zero 403, zero 5xx. A quota ceiling
-  presents as 429 or 403.
-- **Live probe at the full production call rate.** Six boxes, all 200.
-  Camera-dense land boxes returned 26, 30, 17 and 11 cameras; ocean controls
-  returned 0. An exhausted quota would have flattened the land boxes too.
-- **The failures are geographic, not volumetric.** They cluster on boxes
-  touching the antimeridian and the poles, an unbiased recent sample of 2,400
-  box attempts contained zero of them, and replaying the exact coordinates
-  that failed in production returns 200.
+  logs (the CLI returns at most 500 requests per query, so this is a sample,
+  not the full day) is `400 Bad Request`. Zero 429, zero 403, zero 5xx.
+- **Live probe at the full production call rate, 06:30Z.** Six boxes, all
+  200. Camera-dense land boxes returned 26, 30, 17 and 11 cameras; ocean
+  controls returned 0. An exhausted quota would have flattened the land
+  boxes too.
+- **The failures are geographic, not quota-shaped.** They cluster on boxes
+  touching the antimeridian and the poles, an unbiased sample of 2,400 box
+  attempts at 06:30Z contained zero of them, and replaying the exact
+  coordinates that failed in production returns 200.
 
 The partial-day reading therefore stands, now with a mechanism rather than a
 guess. 09-02 ran from the merge at 17:56Z to midnight and 09-03 from midnight
 to 06:27Z. The terminator crosses far more ocean in the early-UTC window, so
 empty boxes and cameras-found move together for purely geographic reasons.
 
+Windy's own documentation (checked 2026-09-03) publishes no request limit
+and no quota status code. It does distinguish a free tier from a
+professional tier, so an undocumented cap on the free tier remains possible.
+Absence from the docs is not absence of a limit.
+
+**What this does NOT establish.** The Task 9 note below says production
+"already runs at roughly twice the stated risk point." That is a rate, not a
+day. The spec's 22,300 figure was never a measured threshold: it is the
+projected call volume of a hypothetical 2-minute cron cadence, and the spec
+called it "the most likely way to discover a ceiling," meaning if we went
+there we might find one. No full UTC day has yet exceeded it. The
+kiosk-driven rate only began at 17:56Z on 09-02, so 09-02 totalled roughly
+13,000 boxes and 09-03 had reached roughly 12,000 by 06:30Z. At 30 boxes per
+tick and one tick a minute, **2026-09-03 crosses 22,300 at about 12:20Z**,
+the first day ever to do so. A daily quota resetting at midnight UTC would
+bite after that hour and clear at 00Z, and nothing measured so far can see
+it. The rate assumes the kiosk stays visible; the tick route's Redis NX lock
+caps it at one a minute but nothing lowers it while a gallery screen is up.
+
 **A defect in this step as originally written.** It prescribed comparing "the
 same UTC hours on two dates." That is not executable.
 `daily_sweep_ring_stats` is keyed `(date, offset_deg)` with no hour column,
 so hour-matching against stored data is impossible. Whole UTC day against
-whole UTC day is the only comparison the schema supports, and the first
-complete day is 2026-09-03.
+whole UTC day is the only comparison the schema supports, and 2026-09-03 will
+be the first complete day.
 
 **The gate that replaces it.** Do not gate on the empty-box share, which is
-ambiguous by construction. Gate on the status codes:
+ambiguous by construction. Gate on the status codes, and read them **after
+about 14:00Z on 2026-09-03 or later**, so the read covers the first-ever
+crossing of the 22,300 figure:
 
 ```bash
 vercel logs --environment production --no-branch --since 24h \
@@ -1756,15 +2147,26 @@ vercel logs --environment production --no-branch --since 24h \
 
 Any 429 or 403 means a real ceiling, and a real ceiling is a bigger finding
 than the widening question: do not flip, because doubling the call rate into
-it would confound both. All-400 means edge-of-world box rejection, which is
-a separate bug and not a reason to hold the window.
+it would confound both. Also re-run the live land-box probe at that hour: a
+quota that returns 200 with an empty body instead of an error would show as
+land boxes going to zero while ocean boxes stay zero. All-400 with land boxes
+still populated means edge-of-world box rejection, which is the separate bug
+below.
 
 **A second, unrelated bug this surfaced.** Boxes near the antimeridian and
 the poles are intermittently rejected with 400 and then silently scored as
-empty ocean. It does not block the measurement window. It does mean a small
-standing overstatement in every `boxes_empty` figure.
+empty ocean. It is not a quota. Whether its rate rises with call volume is
+unmeasured: the biased sample showed more 400s per sweep after the kiosk
+rate began at 17:56Z, but the unbiased 06:30Z sample at the same rate showed
+none, and the terminator's position relative to the antimeridian differs
+between those hours. The Task 6 counter split settles it. Until then it means
+a small standing overstatement in every `boxes_empty` figure.
 
-**Carry into Task 5.** While the sweep telemetry is already open, split the
+One more consumer of the same key is `app/api/webcams/route.ts`, the
+client-facing map route, which hits the same clusters endpoint and is
+outside every count in this plan.
+
+**Task 5 does this.** While the sweep telemetry is already open, split the
 counter: count non-OK responses separately from genuinely empty boxes, and
 carry the status code. It is a small change across `windyApi.ts`, the sweep,
 and one migration column, and it turns this gate from an inference into an
@@ -1812,24 +2214,36 @@ decision.
 **Expected magnitude, measured 2026-09-03, not assumed.** The base ring is
 exactly 30.0 boxes per tick. The tick rate is **not** the cron's 96/day:
 `/api/kiosk/tick` re-invokes this same handler in-process whenever a gallery
-screen is visible, throttled to about one per minute by a Redis lock.
-Measured at 06:27Z on 2026-09-03: 388 ticks in 387 minutes, which is 1.003
-ticks per minute sustained. The kiosk is polling continuously.
+screen is visible, throttled to at most one per minute by a Redis lock. The
+kiosk is **intermittent**, and the rate swings with it. Measured on
+2026-09-03: 1.0 ticks/min from 00:00Z to 06:45Z, then 0.3/min to 16:00Z, then
+about 1.1/min. An earlier draft of this plan read the first window as
+steady state and projected ~1,444 ticks and ~43,300 boxes per day. That was
+wrong. Whole-day totals so far:
 
-| | per full day at the current rate |
-| --- | --- |
-| ticks, cron alone | 96 |
-| ticks, actual | ~1,444 |
-| kiosk share of sweep volume | 93% |
-| Windy boxes, switch OFF | ~43,300 |
-| Windy boxes, day ring forced | ~86,600 |
-| Windy risk point named by the camera-refresh spec | 22,300 |
+| UTC day | ticks | Windy boxes | note |
+| --- | --- | --- | --- |
+| 2026-09-02 | 352 | 10,560 | telemetry starts 17:56Z, partial |
+| 2026-09-03 to 16:01Z | 570 | 17,745 | first complete day; projected ~24,000 |
 
-**Production already runs at roughly twice the stated risk point with this
-feature switched off.** Forcing the day ring would take it to nearly four
-times. The camera-refresh spec says discovering a Windy rate limit makes
-panels *blanker*, which is the outcome this feature exists to prevent, and
-Windy publishes no quota headers so there is no warning before the wall.
+**No full UTC day has yet crossed the 22,300 figure.** 2026-09-03 is
+projected to be the first, around 18:20Z. That figure was never a measured
+limit: it is the projected volume of a hypothetical 2-minute cron cadence in
+the camera-refresh spec, which called it "the most likely way to discover a
+ceiling." A daily quota resetting at midnight UTC could not have been seen
+by any measurement before that crossing. Read the status-code gate in Step
+1b **after** it.
+
+Forcing the day ring on both feeds roughly doubles boxes per tick. At today's
+mixed rate that is roughly 45,000 to 50,000 a day; with screens on all day it
+is closer to 86,000. The camera-refresh spec says discovering a Windy rate
+limit makes panels *blanker*, which is the outcome this feature exists to
+prevent, and Windy publishes no quota headers so there is no warning before
+the wall.
+
+One more consumer of the same key sits outside every count here:
+`app/api/webcams/route.ts`, the client-facing map route, hits the same
+clusters endpoint. Every boxes-per-day figure in this plan is a floor.
 
 **The dominant cost lever is not the ring configuration.** It is the kiosk
 poll cadence in `app/api/kiosk/tick/route.ts` and `KIOSK_TICK_LOCK_TTL_MS`.
@@ -1908,7 +2322,29 @@ FROM daily_sweep_geometry ORDER BY date, signature;
 ```
 
 State plainly what the pool covered before and what it covered during: −24° to
-−2° becoming −24° to +14°. Then one section per spec §3 question.
+−2° becoming −24° to +14°.
+
+**Open with the natural-escalation baseline, because it already answers the
+spec's first question in direction.** On 2026-09-03 the conditional trigger
+fired for the first time in production: 43 sweeps by 16:01Z, all because the
+sunrise feed went thin, all recovered within budget, all on the +15.75
+day-side ring. From `daily_sweep_ring_stats` at that hour:
+
+| ring | swept | boxes | frames scored | gate passed | pass rate | boxes per pass |
+| --- | --- | --- | --- | --- | --- | --- |
+| +15.75 | 43 | 645 | 157 | 22 | 14.0% | 29.3 |
+| 0 | 570 | 17,100 | 7,065 | 478 | 6.8% | 35.8 |
+
+The day-side ring's frames pass the detection gate at twice the base ring's
+rate, and it is cheaper per gate-passed frame. That is the self-concealing
+failure mode ruled out in direction, on production data, with no switch
+flipped. It is 22 passes from one feed over one two-hour window at the
+eastern-Pacific sunrise edge, so it is a first reading and not a verdict. The
+forced-ring window is therefore partly a replication of this result and
+partly the first measurement of the always-on cost, which the conditional
+trigger (thin half only, ~7% of ticks) cannot estimate. Say both.
+
+Then one section per spec §3 question.
 
 1. **Yield that survives scoring.** From `daily_sweep_ring_stats`:
    `frames_gate_passed / frames_scored` for `offset_deg = 15.75` against
@@ -1957,7 +2393,7 @@ Several sessions share this checkout. Whoever takes it, returns it.
 Spec §7 steps 4–6. Phase 2 chooses always-on, conditional, or a narrower
 offset; it does not need a new coverage constant (Task 1 shipped one that is
 correct for any ring set); and it converts the per-ring ratios into dollars
-using the Neon delta and function duration Task 8 measures.
+using the Neon delta and function duration Task 9 measures.
 
 It is deliberately not written here. The spec says the final choice is
 deferred until the measurement reports, and a task list that pre-commits to one

--- a/scripts/set-runtime-flag.mjs
+++ b/scripts/set-runtime-flag.mjs
@@ -1,0 +1,50 @@
+// scripts/set-runtime-flag.mjs
+//
+// Flips a runtime_flags row. This is the switch the pool-coverage spec's cost
+// condition asks for: it takes effect on the next cron tick, with no code
+// change and no redeploy.
+//
+// Dry by default, matching apply-migration.mjs and the backfill scripts.
+// Every env file here points at the SAME Neon endpoint, so every --apply run
+// is a production change.
+//
+//   node scripts/set-runtime-flag.mjs                              # list
+//   node scripts/set-runtime-flag.mjs sweep_force_day_ring on
+//   node scripts/set-runtime-flag.mjs sweep_force_day_ring on --apply
+import { neon } from '@neondatabase/serverless';
+import { readFileSync } from 'node:fs';
+
+function loadDatabaseUrl() {
+  if (process.env.DATABASE_URL) return process.env.DATABASE_URL;
+  const env = readFileSync('.env.local', 'utf8');
+  const line = env.split('\n').find((l) => l.startsWith('DATABASE_URL='));
+  if (!line) throw new Error('DATABASE_URL not found in env or .env.local');
+  return line.slice('DATABASE_URL='.length).replace(/^"|"$/g, '');
+}
+
+const sql = neon(loadDatabaseUrl());
+const [key, state] = process.argv.slice(2).filter((a) => !a.startsWith('--'));
+const apply = process.argv.includes('--apply');
+
+const rows = await sql`SELECT key, enabled, note, updated_at FROM runtime_flags ORDER BY key`;
+console.log('current flags:');
+for (const r of rows) console.log(`  ${r.key} = ${r.enabled}  (${r.updated_at.toISOString?.() ?? r.updated_at})`);
+
+if (!key) process.exit(0);
+
+if (state !== 'on' && state !== 'off') {
+  console.error('usage: node scripts/set-runtime-flag.mjs <key> <on|off> [--apply]');
+  process.exit(1);
+}
+if (!rows.some((r) => r.key === key)) {
+  console.error(`no such flag: ${key}. Apply the migration that seeds it first.`);
+  process.exit(1);
+}
+
+const enabled = state === 'on';
+if (!apply) {
+  console.log(`\nDRY RUN. Would set ${key} = ${enabled}. Re-run with --apply.`);
+  process.exit(0);
+}
+await sql`UPDATE runtime_flags SET enabled = ${enabled}, updated_at = now() WHERE key = ${key}`;
+console.log(`\n${key} = ${enabled}. Takes effect on the next cron tick.`);


### PR DESCRIPTION
## What this is

Phase 1 of the terminator pool-coverage spec: the instrumentation to measure whether forcing the day-side sweep ring on is worth its cost. **Default behaviour is unchanged.** The switch is off in production, and with it off the sweep runs byte-for-byte what `main` runs today plus additive telemetry.

Spec: `docs/superpowers/specs/2026-09-02-terminator-pool-coverage-design.md`
Plan: `docs/superpowers/plans/2026-09-02-terminator-pool-coverage-phase1.md`

## Why

Good sunsets happen with the sun just above the horizon: 19.7% of frames score ≥ 0.5 at 0° to +2° solar altitude, against 1.0% at the −13° base ring. The pool gathers −24° to −2° and never sees the peak. The existing day-side escalation ring reaches +2.75° but only fires when a feed goes thin.

## What landed

| task | what | files |
|---|---|---|
| 1 | `TERMINATOR_DAY_SIDE_OFFSETS_DEG`, derived not hardcoded | masterConfig |
| 2 | `runtime_flags` table, fail-closed `isFlagEnabled`, dry-by-default flip script | runtimeFlags, migration, scripts |
| 3 | `forcedOffsets` on `sweepWithEscalation`: named rings sweep both feeds every tick | terminatorSweep |
| 4 | cron reads the flag once per tick; response gains `forcedDayRing` | route |
| 5 | failed Windy responses counted apart from empty boxes, status carried up | windyApi, migration |
| 6 | per-ring wall-clock, split base vs escalation, persisted | terminatorSweep, sweepStats, migration |
| 7 | `daily_sweep_geometry`: the ring angles behind each day's counters, written every tick | sweepGeometry, migration |
| 8 | digest: swept altitude span, widening bill, cost per gate-passed frame per ring, failed boxes | dailyDigest |

Four migrations, all additive and idempotent, **already applied** to production. The flag reads `false`.

## The switch

A database row, not an env var, because env vars here bake in at deploy time and the operator's condition was reversibility without a redeploy.

```
node scripts/set-runtime-flag.mjs                              # list
node scripts/set-runtime-flag.mjs sweep_force_day_ring on --apply
node scripts/set-runtime-flag.mjs sweep_force_day_ring off --apply
```

`isFlagEnabled` fails closed: a thrown read, a missing row, a missing table, or a non-boolean all read as off.

## What the measurement already found, before any switch flipped

The conditional trigger fired in production for the first time on 2026-09-03 (sunrise went thin). From `daily_sweep_ring_stats` at 16:01Z:

| ring | swept | frames scored | gate passed | pass rate | boxes per pass |
|---|---|---|---|---|---|
| +15.75 (day) | 43 | 157 | 22 | 14.0% | 29.3 |
| 0 (base) | 570 | 7,065 | 478 | 6.8% | 35.8 |

The day-side ring's frames pass the detection gate at twice the base rate, at fewer boxes per sunset. That is spec §3 question 1 answered in direction on production data. Small sample; the forced window is part replication, part first measurement of always-on cost.

## Two things this branch corrected about the baseline

- **Sweep volume tracks kiosk uptime, not the cron.** `/api/kiosk/tick` re-invokes the cron handler about once a minute while a gallery screen is visible. Measured rate swung between 0.3 and 1.1 ticks/min on 2026-09-03. The cron alone would be 96/day.
- **The empty-box share could never have detected a Windy ceiling.** `fetchWebcamsFor` returned `[]` on any non-OK response, so a rejected call and an ocean box incremented the same counter. 2,250 Windy errors in one 24h window, all `400`, on boxes touching the poles and antimeridian, every one recorded as empty. Task 5 splits them. Credit to a peer session for the log analysis.

## Not in this PR, deliberately

- **The flip.** Task 9 of the plan. Waits on the operator's explicit go against the measured volume, and on the status-code gate being read after the first full UTC day crosses 22,300 calls (projected 2026-09-03 ~18:20Z).
- **`TERMINATOR_POOL_COVERAGE_DEG`.** Lives on `feat/mosaic-v3-band-paradigm` at `{min: -24, max: -2}` by agreement with that session. It moves in the commit that makes a ring unconditional, not before.
- The dollar line in the digest. No per-call price exists; Task 9 measures the two rates it needs.

## Testing

1,405 tests, lint, build all green at head. Every task had a spec-compliance and quality review. A whole-branch review confirmed the flag-off equivalence under an end-to-end trace and returned three Important items, all fixed in the final commit: the flag read moved inside the tick's deadline anchor, the digest's swept-span line now states each ring's share of ticks so a single escalated tick cannot read as a whole day, and the route test now asserts the geometry record is written with the forced offsets it actually ran.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XBzKyhNNTej7y1jRdWjtuu
