### PR TITLE
feat(studio): scrollable, resizable dial rail with description tooltips

### DIFF
--- a/app/studio/StudioClient.tsx
+++ b/app/studio/StudioClient.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useLoadTerminatorWebcams } from '@/app/store/useLoadTerminatorWebcams';
 import { useTerminatorStore } from '@/app/store/useTerminatorStore';
 import { PreviewPane, type FeedView } from './PreviewPane';
@@ -17,6 +17,12 @@ import { countGatePasses, resolveGate } from '@/app/components/mosaic/gate';
 import { PANEL_PRESETS, DEFAULT_PANEL_PRESET } from '@/app/kiosk/panelPreview';
 import { poolFor } from './previewPool';
 import { restoreSceneDials } from './restoreSceneDials';
+import {
+  RAIL_WIDTH_DEFAULT,
+  clampRailWidth,
+  readStoredRailWidth,
+  writeStoredRailWidth,
+} from './railWidth';
 
 /**
  * `/studio` chrome: left rail (dial controls, Task 11) + preview + a bottom
@@ -31,8 +37,60 @@ const railBg = '#10141d';
 const railBorder = '#1d2432';
 const stripBg = '#0e1119';
 const stripBorder = '#1d2432';
+const handleHover = '#4a90d9';
 const pillBg = 'rgba(16,20,29,.85)';
 const pillBorder = '#232a38';
+
+/**
+ * Rail width, dragged from the rail's right edge and remembered per browser.
+ * Starts at the default on the server and swaps in the stored width after
+ * mount so SSR and the first client paint agree.
+ */
+function useRailWidth() {
+  const [railWidth, setRailWidth] = useState(RAIL_WIDTH_DEFAULT);
+  const [resizing, setResizing] = useState(false);
+  const dragRef = useRef<{ startX: number; startWidth: number } | null>(null);
+
+  useEffect(() => {
+    setRailWidth(readStoredRailWidth());
+  }, []);
+
+  const startResize = useCallback(
+    (e: React.PointerEvent<HTMLDivElement>) => {
+      e.preventDefault();
+      dragRef.current = { startX: e.clientX, startWidth: railWidth };
+      setResizing(true);
+    },
+    [railWidth]
+  );
+
+  useEffect(() => {
+    if (!resizing) return;
+    const onMove = (e: PointerEvent) => {
+      const drag = dragRef.current;
+      if (!drag) return;
+      setRailWidth(clampRailWidth(drag.startWidth + (e.clientX - drag.startX)));
+    };
+    const onUp = () => {
+      dragRef.current = null;
+      setResizing(false);
+      setRailWidth((w) => {
+        writeStoredRailWidth(w);
+        return w;
+      });
+    };
+    window.addEventListener('pointermove', onMove);
+    window.addEventListener('pointerup', onUp);
+    window.addEventListener('pointercancel', onUp);
+    return () => {
+      window.removeEventListener('pointermove', onMove);
+      window.removeEventListener('pointerup', onUp);
+      window.removeEventListener('pointercancel', onUp);
+    };
+  }, [resizing]);
+
+  return { railWidth, startResize, resizing };
+}
 
 export function StudioClient() {
   const [sceneSource, setSceneSource] = useState<SceneSource>({ kind: 'live' });
@@ -46,6 +104,7 @@ export function StudioClient() {
   const sunsetWebcams = useTerminatorStore((t) => t.sunset);
 
   const [railCollapsed, setRailCollapsed] = useState(false);
+  const { railWidth, startResize, resizing } = useRailWidth();
   const [view, setView] = useState<FeedView>('both');
 
   const sharedSettings = settingsApi.effective('shared');
@@ -95,7 +154,7 @@ export function StudioClient() {
     <div
       style={{
         display: 'grid',
-        gridTemplateColumns: railCollapsed ? '1fr' : '320px 1fr',
+        gridTemplateColumns: railCollapsed ? '1fr' : `${railWidth}px 1fr`,
         gridTemplateRows: '1fr 28px',
         height: '100vh',
         width: '100%',
@@ -114,6 +173,9 @@ export function StudioClient() {
             overflow: 'hidden',
             padding: 16,
             boxSizing: 'border-box',
+            position: 'relative',
+            // Reading the rail while dragging its edge shouldn't select text.
+            userSelect: resizing ? 'none' : undefined,
           }}
         >
           <StudioRail
@@ -126,6 +188,23 @@ export function StudioClient() {
                 onRevert={settingsApi.revert}
               />
             }
+          />
+          <div
+            role="separator"
+            aria-orientation="vertical"
+            aria-label="resize dials"
+            title="drag to widen the dials"
+            onPointerDown={startResize}
+            style={{
+              position: 'absolute',
+              top: 0,
+              right: 0,
+              width: 6,
+              height: '100%',
+              cursor: 'col-resize',
+              background: resizing ? handleHover : 'transparent',
+              zIndex: 1,
+            }}
           />
         </aside>
       )}

--- a/app/studio/StudioRail.tsx
+++ b/app/studio/StudioRail.tsx
@@ -35,8 +35,8 @@ const DUSK_THEME = {
     vivid1: '#5aa3ec',
     folderTextColor: '#b7c0d1',
     folderWidgetColor: '#8b95a7',
-    toolTipBackground: '#1a2130',
-    toolTipText: '#d7dce6',
+    toolTipBackground: '#2b3650',
+    toolTipText: '#f1f4f9',
   },
   radii: { xs: '2px', sm: '3px', lg: '6px' },
 };
@@ -49,6 +49,7 @@ function prettify(section: string): string {
 type LevaControl = {
   value: KnobValue;
   label: string;
+  hint: string;
   min?: number;
   max?: number;
   step?: number;
@@ -66,6 +67,7 @@ function controlsForSpec(
     controls[key] = {
       value: ctrl.value,
       label: ctrl.label,
+      hint: ctrl.hint,
       ...(ctrl.min !== undefined ? { min: ctrl.min } : {}),
       ...(ctrl.max !== undefined ? { max: ctrl.max } : {}),
       ...(ctrl.step !== undefined ? { step: ctrl.step } : {}),
@@ -228,6 +230,7 @@ export function StudioRail({
         </label>
         <select
           id="studio-version-select"
+          title={activeVersionKnob?.description}
           value={activeVersion}
           onChange={(e) => api.setKnob(SHARED_NAMESPACE, 'activeVersion', e.target.value)}
           style={{
@@ -257,7 +260,28 @@ export function StudioRail({
         )}
       </div>
 
-      <div style={{ flex: 1, minHeight: 0, position: 'relative' }}>
+      {/* The dial list is taller than the viewport for v3; scroll it here
+          rather than letting the aside clip it. Leva's hint tooltips are
+          fixed-positioned, so the scroll box does not cut them off. */}
+      <div
+        id="studio-rail-dials"
+        style={{ flex: 1, minHeight: 0, position: 'relative', overflowY: 'auto' }}
+      >
+        {/* Leva's hint tooltip is capped at 260px and 11px type, sized for a
+            word or two; the knob descriptions are full sentences. Radix's
+            popper wrapper is the one stable hook. */}
+        <style>{`
+          #studio-rail-dials [data-radix-popper-content-wrapper] {
+            z-index: 20 !important;
+            opacity: 1 !important; /* a leva folder rule dims it to 0.4 */
+          }
+          #studio-rail-dials [data-radix-popper-content-wrapper] > div > div {
+            max-width: 340px;
+            font-size: 12px;
+            line-height: 1.45;
+            padding: 8px 10px;
+          }
+        `}</style>
         <LevaPanel store={store} theme={DUSK_THEME} fill flat titleBar={false} />
       </div>
     </div>

--- a/app/studio/levaConfig.test.ts
+++ b/app/studio/levaConfig.test.ts
@@ -102,3 +102,15 @@ describe('buildFolderSpecs', () => {
     expect(buildFolderSpecs([], {}, [])).toEqual([]);
   });
 });
+
+describe('buildFolderSpecs hints', () => {
+  it('carries each knob description through as the control hint', () => {
+    const specs = buildFolderSpecs(SCHEMA, { floorPx: 100, cullOverflow: true, panelPreset: 'dell' }, []);
+    const sizing = specs.find((s) => s.section === 'sizing')!;
+    const arrangement = specs.find((s) => s.section === 'arrangement')!;
+
+    expect(sizing.controls.floorPx.hint).toBe('Minimum tile size');
+    expect(sizing.controls.panelPreset.hint).toBe('Panel size');
+    expect(arrangement.controls.cullOverflow.hint).toBe('Remove tiles that overflow the viewport');
+  });
+});

--- a/app/studio/levaConfig.ts
+++ b/app/studio/levaConfig.ts
@@ -14,6 +14,7 @@ export interface LevaFolderSpec {
     {
       value: KnobValue;
       label: string; // '● floorPx' when the knob differs from live, else 'floorPx'
+      hint: string; // knob.description — leva renders it as a hover tooltip on the label
       min?: number;
       max?: number;
       step?: number; // number knobs
@@ -44,6 +45,7 @@ export function buildFolderSpecs(
       spec.controls[knob.key] = {
         value,
         label,
+        hint: knob.description,
         min: knob.min,
         max: knob.max,
         step: knob.step,
@@ -52,10 +54,11 @@ export function buildFolderSpecs(
       spec.controls[knob.key] = {
         value,
         label,
+        hint: knob.description,
         options: knob.options,
       };
     } else {
-      spec.controls[knob.key] = { value, label };
+      spec.controls[knob.key] = { value, label, hint: knob.description };
     }
   }
 

--- a/app/studio/railWidth.test.ts
+++ b/app/studio/railWidth.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  clampRailWidth,
+  RAIL_WIDTH_DEFAULT,
+  RAIL_WIDTH_MAX,
+  RAIL_WIDTH_MIN,
+  RAIL_WIDTH_STORAGE_KEY,
+  readStoredRailWidth,
+  writeStoredRailWidth,
+} from './railWidth';
+
+describe('clampRailWidth', () => {
+  it('passes through widths inside the range', () => {
+    expect(clampRailWidth(400)).toBe(400);
+  });
+
+  it('pins to the min and max', () => {
+    expect(clampRailWidth(RAIL_WIDTH_MIN - 50)).toBe(RAIL_WIDTH_MIN);
+    expect(clampRailWidth(RAIL_WIDTH_MAX + 500)).toBe(RAIL_WIDTH_MAX);
+  });
+
+  it('falls back to the default for non-finite input', () => {
+    expect(clampRailWidth(Number.NaN)).toBe(RAIL_WIDTH_DEFAULT);
+    expect(clampRailWidth(Number.POSITIVE_INFINITY)).toBe(RAIL_WIDTH_DEFAULT);
+  });
+
+  it('rounds to whole pixels', () => {
+    expect(clampRailWidth(400.6)).toBe(401);
+  });
+});
+
+describe('stored rail width', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it('returns the default when nothing is stored', () => {
+    expect(readStoredRailWidth()).toBe(RAIL_WIDTH_DEFAULT);
+  });
+
+  it('round-trips a written width', () => {
+    writeStoredRailWidth(480);
+    expect(window.localStorage.getItem(RAIL_WIDTH_STORAGE_KEY)).toBe('480');
+    expect(readStoredRailWidth()).toBe(480);
+  });
+
+  it('clamps garbage and out-of-range stored values', () => {
+    window.localStorage.setItem(RAIL_WIDTH_STORAGE_KEY, 'wide');
+    expect(readStoredRailWidth()).toBe(RAIL_WIDTH_DEFAULT);
+    window.localStorage.setItem(RAIL_WIDTH_STORAGE_KEY, '9999');
+    expect(readStoredRailWidth()).toBe(RAIL_WIDTH_MAX);
+  });
+});

--- a/app/studio/railWidth.ts
+++ b/app/studio/railWidth.ts
@@ -1,0 +1,35 @@
+/**
+ * Width of the /studio dial rail. Pure helpers (clamp + storage) live here
+ * so they're unit-testable without rendering the grid; StudioClient owns
+ * the drag handle and the React state.
+ *
+ * 360 (not leva's 320 default) so the label column beside a 160px control
+ * fits the longest dial names without ellipsis at the default width.
+ */
+export const RAIL_WIDTH_DEFAULT = 360;
+export const RAIL_WIDTH_MIN = 280;
+export const RAIL_WIDTH_MAX = 640;
+export const RAIL_WIDTH_STORAGE_KEY = 'studio.railWidth';
+
+export function clampRailWidth(width: number): number {
+  if (!Number.isFinite(width)) return RAIL_WIDTH_DEFAULT;
+  return Math.round(Math.min(RAIL_WIDTH_MAX, Math.max(RAIL_WIDTH_MIN, width)));
+}
+
+export function readStoredRailWidth(): number {
+  try {
+    const raw = window.localStorage.getItem(RAIL_WIDTH_STORAGE_KEY);
+    if (raw === null) return RAIL_WIDTH_DEFAULT;
+    return clampRailWidth(Number(raw));
+  } catch {
+    return RAIL_WIDTH_DEFAULT;
+  }
+}
+
+export function writeStoredRailWidth(width: number): void {
+  try {
+    window.localStorage.setItem(RAIL_WIDTH_STORAGE_KEY, String(clampRailWidth(width)));
+  } catch {
+    // Storage unavailable (private mode, quota): the width just won't persist.
+  }
+}


### PR DESCRIPTION
## What

The `/studio` sidebar cut off everything below the fold and truncated dial names, with no way to learn what a dial did. This PR makes the rail:

- **Scrollable** — the leva wrapper scrolls, so every folder and dial is reachable.
- **Explained** — hovering any dial label shows its schema `description` as a tooltip (leva `hint`). Leva's stock tooltip is tiny, dim, and narrow; the rail overrides it to 340px / 12px / opaque via Radix's stable `data-radix-popper-content-wrapper` attribute. The version select gets its description as a `title`.
- **Resizable** — defaults to 360px so labels fit, with a drag handle on the right edge (280–640px), remembered in `localStorage` under `studio.railWidth`.

## Verified

- `npx vitest run app/studio` — 13 files / 114 tests pass (new: hint passthrough, width clamp + storage).
- ESLint clean; tsc clean for touched files.
- Browser check at 1400×800 and 1400×520: rail scrolls with visible scrollbar, drag persists (562 stored), tooltip renders opaque above folder chrome and wraps long descriptions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F27w6Csj9mYQvgWXQhasrc
