### PR TITLE
Mosaic v3: ship 8 x 240 as the band defaults

### DIFF
--- a/app/components/mosaic/v3/engine/realPool.test.ts
+++ b/app/components/mosaic/v3/engine/realPool.test.ts
@@ -95,18 +95,20 @@ describe('the real pool, on the real axis', () => {
   it('records how dense the default dials actually leave the wall', () => {
     // Not a correctness property — a measurement, pinned so a tuning change
     // is visible rather than silent. On the live capture the sunset panel
-    // draws 5 of 42 and evicts 37, because the pool clusters hard in BOTH
+    // draws 8 of 42 and evicts 34, because the pool clusters hard in BOTH
     // latitude and altitude: every camera is near the terminator by
     // construction, and 38 of the 42 fail the gate and sit at the identical
     // floor size, so they land on top of each other.
     //
-    // Eviction is behaving as specified. Whether 5 tiles is the wall Jesse
-    // wants is a dial question for the glass — bandCount, floorPx, tileGapPx
-    // — not an engine question. Update these numbers when the dials move.
+    // Eviction is behaving as specified. The defaults moved once already:
+    // 13 x 480 drew 5 / evicted 37 here and showed 1 of the 4 real sunsets;
+    // 8 x 240 (decided 2026-09-03) shows 3 of 4. Update these numbers when
+    // the dials move again.
     const layout = compose(sunset, viewport, cfg, 'sunset');
-    expect(layout.tiles.length).toBe(5);
-    expect(layout.evicted.length).toBe(37);
-    expect(compose(sunrise, viewport, cfg, 'sunrise').tiles.length).toBe(10);
+    expect(layout.tiles.length).toBe(8);
+    expect(layout.evicted.length).toBe(34);
+    expect(layout.tiles.filter((t) => t.passes).length).toBe(3);
+    expect(compose(sunrise, viewport, cfg, 'sunrise').tiles.length).toBe(9);
   });
 
   it('keeps every drawn tile inside the panel horizontally', () => {

--- a/app/components/mosaic/v3/settingsSchema.test.ts
+++ b/app/components/mosaic/v3/settingsSchema.test.ts
@@ -66,7 +66,11 @@ describe('V3_SETTINGS_SCHEMA', () => {
     const byKey = Object.fromEntries(V3_SETTINGS_SCHEMA.map((k) => [k.key, k.default]));
     expect(byKey.failedCamPolicy).toBe('showAtFloor');
     expect(byKey.floorPx).toBe(100);
-    expect(byKey.ceilingPx).toBe(480);
+    // Decided 2026-09-03 on the live-capture fixture: 8 x 240 keeps
+    // bandCount * ceilingPx at the dell panel height (1920), the relation
+    // that keeps the wall whole. 13 x 480 showed 1 of 4 real sunsets.
+    expect(byKey.ceilingPx).toBe(240);
+    expect(byKey.bandCount).toBe(8);
     // Spec §5.4: a starting guess, not a measurement — but the guess is
     // written down, so a silent drift from it shows up here.
     expect(byKey.hysteresisMargin).toBe(0.05);
@@ -92,7 +96,7 @@ describe('configFromSettings', () => {
     const cfg = configFromSettings(schemaDefaults(V3_SETTINGS_SCHEMA));
     expect(cfg.gateThreshold).toBe(0.55);
     expect(cfg.maxTiles).toBe(0);
-    expect(cfg.bandCount).toBe(13);
+    expect(cfg.bandCount).toBe(8);
     expect(cfg.axisDayEdgeDeg).toBe(-2);
   });
 

--- a/app/components/mosaic/v3/settingsSchema.ts
+++ b/app/components/mosaic/v3/settingsSchema.ts
@@ -36,9 +36,9 @@ export const V3_SETTINGS_SCHEMA: SettingsSchema = [
     description: 'Height of the smallest tile. Gate-failers pin to exactly this.',
   },
   {
-    key: 'ceilingPx', kind: 'number', min: 50, max: 1200, step: 10, default: 480,
+    key: 'ceilingPx', kind: 'number', min: 50, max: 1200, step: 10, default: 240,
     label: 'ceiling (px)', section: 'sizing',
-    description: 'Height of the best-scoring gate-passer.',
+    description: 'Height of the best-scoring gate-passer. Bound to band count: the wall only renders whole when bandCount * ceilingPx <= panel height (8 * 240 = 1920, the dell panel). Past that, a tall tile in an end band overhangs and the whole wall shrinks.',
   },
   {
     key: 'curve', kind: 'enum',
@@ -62,9 +62,9 @@ export const V3_SETTINGS_SCHEMA: SettingsSchema = [
     description: 'Shrink both panels by the same amount, taken from whichever is more crowded. Off, each panel shrinks to its own tile count and a sunrise floor tile can outgrow a sunset ceiling tile.',
   },
   {
-    key: 'bandCount', kind: 'number', min: 2, max: 40, step: 1, default: 13,
+    key: 'bandCount', kind: 'number', min: 2, max: 40, step: 1, default: 8,
     label: 'band count', section: 'arrangement',
-    description: 'Number of fixed latitude strips. They never move: a band is the same pixels holding one camera or forty. 13 over the default window is one band per 10 degrees.',
+    description: 'Number of fixed latitude strips. They never move: a band is the same pixels holding one camera or forty. 8 over the default window is one band per 16 degrees. More bands with a smaller ceiling shows more of the pool, smaller; keep bandCount * ceilingPx at or under the panel height (decided 2026-09-03 on the live-capture fixture: 13 x 480 showed 1 of 4 real sunsets, 8 x 240 shows 3).',
   },
   {
     key: 'bandGrid', kind: 'enum', options: ['full', 'inset'] as const, default: 'full',

--- a/docs/superpowers/plans/2026-09-02-mosaic-v3-band-paradigm.md
+++ b/docs/superpowers/plans/2026-09-02-mosaic-v3-band-paradigm.md
@@ -2404,6 +2404,12 @@ smaller ceiling shows more of the pool, smaller.** `8 x 240` and `13 x 148`
 both surface 3 of the 4 real sunsets instead of 1. Which one is right is a
 question about the wall, so it stays Jesse's.
 
+**Decided 2026-09-03: `8 x 240` ships as the v3 defaults.** Jesse's call,
+from the side-by-side: the same 3 of 4 as `13 x 148`, but the ceiling stays
+2.4x the floor so the best sunset is still visibly the best thing on the
+wall. `realPool.test.ts` now pins 8 drawn / 34 evicted / 3 passers on the
+sunset panel and 9 on sunrise.
+
 ### Compare them yourself
 
 ```


### PR DESCRIPTION
## What changes

Two v3 defaults: `bandCount` 13 → 8 and `ceilingPx` 480 → 240. Nothing else in the engine moves. `DEFAULT_MOSAIC_VERSION` stays v1.

## Why

v3 holds bands fixed and resolves overlap by eviction, never by nudging. A tile may be taller than its band, so the wall only renders whole when `bandCount * ceilingPx <= panel height`. The shipped 13 × 480 = 6240 was 3.25× the 1920 px dell panel: the best sunset spilled across three bands and evicted its neighbours.

Measured on the live-capture fixture (sunset panel, 42 cameras, 4 pass the gate):

| bands | ceiling | product | real sunsets shown | drawn |
|---|---|---|---|---|
| 13 | 480 | 6240 | 1 of 4 | 5 |
| **8** | **240** | **1920** | **3 of 4** | **8** |
| 13 | 148 | 1924 | 3 of 4 | 11 |

8 × 240 was Jesse's pick from the side-by-side: the same coverage as 13 × 148, but the ceiling stays 2.4× the floor so the best sunset is still visibly the best thing on the wall. Comparison page: https://claude.ai/code/artifact/09fb308b-455b-4538-a899-a3c303fc6caa

## Tests

`realPool.test.ts` re-pins at the new defaults (sunset 8 drawn / 34 evicted, sunrise 9) and now also asserts 3 passers drawn, so the next dial move shows up in the number that matters. Schema test pins both defaults. 665 tests green across mosaic, studio, settings, kiosk; `npm run build` green.

## Not done here

Still v3, not a v4: a registry version is a different engine, and a v4 would be byte-identical except these two numbers. Comparing dial sets is what URL overrides and saved scenes with restore-dials are for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018qPFnPNnUPC73snZPDmDbF
