### PR TITLE
docs(workflow): sibling worktree per feature; main checkout is the merge desk

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,37 +4,61 @@ Next.js app behind the sunrise/sunset map: web UI, snapshot ingest, ML rating
 pipeline, kiosk, AR placement portal. The camera-side firmware is a separate
 repo (`../sunset-cam-firmware`); wire spec is `docs/device-protocol.md`.
 
-## Branches: plain branches in the main checkout — no worktrees
+## Branches: one sibling worktree per feature — the main checkout is the merge desk
 
-Work here happens on **ordinary branches in the single main checkout**
-(`git checkout -b feat/...`). Do **not** create `.claude/worktrees/` checkouts —
-the extra folder reads as a separate repo and files stop appearing at their
-normal paths. (The sibling firmware repo uses the opposite convention; don't
-carry it over.)
+Every feature gets its own **git worktree in a sibling directory** and its own
+cmux workspace. The main checkout (`~/GitHub/the-sunset-webcam-map`) stays on
+`main`: it is where PRs merge, migrations apply, and `ml/artifacts/` lives.
+Nobody edits app code there.
 
-If the checkout is mid-work on another branch, **ask before switching.**
+```bash
+scripts/wt.sh new feat/mosaic-v4   # worktree + node_modules symlink + env copies + cmux workspace
+scripts/wt.sh ls
+scripts/wt.sh rm feat/mosaic-v4    # after the PR merges (refuses if dirty or unpushed)
+```
 
-Verify the branch before any commit — Jesse merges PRs in parallel and the
-working branch can shift mid-task.
+Worktrees live at `~/GitHub/the-sunset-webcam-map.worktrees/<branch-slug>/`,
+**beside** the repo, never inside it. The old `.claude/worktrees/` layout inside
+the checkout is what made a worktree read as a second repo; don't recreate it.
+(The firmware repo still uses that nested layout. Don't carry either
+convention across.)
 
-### Multi-session coordination (proven 2026-08-30)
+Inside a worktree, `next dev` picks a free port on its own, `node_modules` is a
+symlink to the main checkout's, and `.env.local` / `.vercel/` are copied at
+creation. Caveats (adding a dependency, stacked branches):
+`docs/solutions/developer-experience/git-worktrees-for-js-and-python-repos.md`.
 
-Several Claude sessions share this one checkout. The protocol:
+Still true in every worktree:
 
-1. **Message peer sessions directly** (`ListAgents` + `SendMessage`) to
-   negotiate the checkout, hand off work, or report a bug in their lane —
-   don't work around each other silently.
-2. **Leave the checkout on `main` when you go idle.** Whoever takes it,
-   returns it.
-3. **Push branches immediately** so the checkout is never the only copy of
-   anyone's work; that's what makes switching safe.
-4. **Lanes:** model/measurement work (training, evals, the STATE doc) and
+- **Verify the branch in the same command as any commit.** Worktrees make a
+  wrong-branch commit rare, not impossible.
+- **Stage explicit paths**, never `git add -A`.
+- **Push as soon as a commit exists** and land small increments the same day.
+  Long-lived branches orphan fixes:
+  `docs/solutions/best-practices/integrate-frequently-dont-let-branches-sprawl.md`.
+- **Remove the worktree when the PR merges.** `git worktree list` should read
+  like the list of open PRs.
+
+### Multi-session coordination
+
+Sessions no longer share a working tree, so there is nothing to negotiate
+about the checkout. What remains:
+
+1. **Lanes:** model/measurement work (training, evals, the STATE doc) and
    display work (mosaic, kiosk) run in separate sessions. Shared helpers
-   (`app/lib/modelReadout.ts`, the mosaic's `qualitySignal`) get a
-   heads-up message to the other lane when they change.
-5. **`docs/superpowers/plans/2026-08-29-two-scale-model-STATE.md` is the
+   (`app/lib/modelReadout.ts`, the mosaic's `qualitySignal`) get a heads-up
+   message (`ListAgents` + `SendMessage`) to the other lane when they change.
+2. **The ML lane is the one exception that still works in the main checkout.**
+   `ml/artifacts/` is 3 GB of mostly untracked data mixed with tracked files,
+   so it can't be symlinked into a worktree. An ML session branches in the
+   main checkout, and the old rules apply to it alone: ask before switching,
+   return the checkout to `main` when idle, message before touching a tracked
+   file there.
+3. **`docs/superpowers/plans/2026-08-29-two-scale-model-STATE.md` is the
    cross-session source of truth** for the model program — read it first,
    update it on the way out.
+4. **Cap active writing lanes at three.** Jesse merges every PR; more open
+   worktrees than that means work outrunning review. Close idle sessions.
 
 ## Commands
 

--- a/scripts/wt.sh
+++ b/scripts/wt.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# One sibling worktree per feature. See CLAUDE.md "Branches".
+#
+#   scripts/wt.sh new <branch> [base]   create worktree + node_modules symlink
+#                                       + env/.vercel copies + cmux workspace
+#   scripts/wt.sh rm  <branch>          remove the worktree (branch is kept)
+#   scripts/wt.sh ls                    list worktrees
+#
+# Worktrees live BESIDE the repo, never inside it:
+#   ~/GitHub/the-sunset-webcam-map.worktrees/<branch-with-slashes-as-dashes>/
+set -euo pipefail
+
+ROOT=$(git -C "$(dirname "$0")/.." rev-parse --show-toplevel)
+WT_DIR="${ROOT}.worktrees"
+
+slug_of() { printf '%s' "$1" | tr '/' '-'; }
+
+cmd=${1:-}
+case "$cmd" in
+  new)
+    branch=${2:-}
+    [ -n "$branch" ] || { echo "usage: scripts/wt.sh new <branch> [base]" >&2; exit 1; }
+    base=${3:-origin/main}
+    path="$WT_DIR/$(slug_of "$branch")"
+    [ ! -e "$path" ] || { echo "already exists: $path" >&2; exit 1; }
+    mkdir -p "$WT_DIR"
+    git -C "$ROOT" fetch -q origin
+
+    if git -C "$ROOT" show-ref --verify -q "refs/heads/$branch"; then
+      git -C "$ROOT" worktree add "$path" "$branch"
+    elif git -C "$ROOT" show-ref --verify -q "refs/remotes/origin/$branch"; then
+      git -C "$ROOT" worktree add --track -b "$branch" "$path" "origin/$branch"
+    else
+      git -C "$ROOT" worktree add -b "$branch" "$path" "$base"
+    fi
+
+    # Shared deps: a new dependency installs into the shared node_modules,
+    # which is fine — package.json/lock changes stay on the branch.
+    ln -s "$ROOT/node_modules" "$path/node_modules"
+    for f in .env.local .env.production.local .env.vercel; do
+      [ -f "$ROOT/$f" ] && cp "$ROOT/$f" "$path/$f"
+    done
+    [ -d "$ROOT/.vercel" ] && cp -R "$ROOT/.vercel" "$path/.vercel"
+
+    if [ -n "${CMUX_SOCKET_PATH:-}" ] && command -v cmux >/dev/null; then
+      cmux new-workspace --cwd "$path" >/dev/null
+      cmux rename-workspace "$branch" >/dev/null || true
+    fi
+    echo "$path"
+    ;;
+  rm)
+    branch=${2:-}
+    [ -n "$branch" ] || { echo "usage: scripts/wt.sh rm <branch>" >&2; exit 1; }
+    path="$WT_DIR/$(slug_of "$branch")"
+    if [ -n "$(git -C "$path" status --porcelain)" ]; then
+      echo "worktree is dirty, not removing: $path" >&2; exit 1
+    fi
+    if ! git -C "$ROOT" branch -r --contains "$branch" >/dev/null 2>&1 || \
+       [ -z "$(git -C "$ROOT" branch -r --contains "$branch" 2>/dev/null)" ]; then
+      echo "branch $branch has commits not on any remote — push first" >&2; exit 1
+    fi
+    git -C "$ROOT" worktree remove "$path"
+    git -C "$ROOT" worktree prune
+    echo "removed $path (branch $branch kept; delete it after the PR merges)"
+    ;;
+  ls)
+    git -C "$ROOT" worktree list
+    ;;
+  *)
+    sed -n '2,10p' "$0" >&2; exit 1
+    ;;
+esac

--- a/scripts/wt.sh
+++ b/scripts/wt.sh
@@ -42,9 +42,11 @@ case "$cmd" in
     done
     [ -d "$ROOT/.vercel" ] && cp -R "$ROOT/.vercel" "$path/.vercel"
 
+    # cmux prints "OK workspace:N"; rename by ref — a bare rename-workspace
+    # hits whichever workspace is focused, i.e. the one you ran this from.
     if [ -n "${CMUX_SOCKET_PATH:-}" ] && command -v cmux >/dev/null; then
-      cmux new-workspace --cwd "$path" >/dev/null
-      cmux rename-workspace "$branch" >/dev/null || true
+      ws=$(CMUX_QUIET=1 cmux new-workspace --cwd "$path" | awk '{print $2}')
+      [ -n "$ws" ] && CMUX_QUIET=1 cmux rename-workspace --workspace "$ws" "$branch" >/dev/null
     fi
     echo "$path"
     ;;


### PR DESCRIPTION
## Why

Seven live sessions and seven cmux workspaces were pointed at one checkout sitting on `main` with zero worktrees. Only one session can have edits on disk at a time; the rest wait. Every rule in the old coordination protocol (message the holder, leave it on `main`, push immediately, verify the branch inside the commit command) was a workaround for that, and it still produced two regressions in the last week (stolen files 2026-08-28, stray doc stub 2026-09-03).

The worktree ban was aimed at the nested `.claude/worktrees/` layout, which reads as a second repo inside the checkout. A sibling worktree per cmux workspace has neither problem: inside that workspace, paths are the normal paths.

## What changes

- **CLAUDE.md**: one sibling worktree per feature at `~/GitHub/the-sunset-webcam-map.worktrees/<branch-slug>/`; the main checkout stays on `main` as the merge desk. Coordination protocol rewritten: lanes + shared-helper heads-up survive, checkout negotiation goes away. ML lane is the documented exception (stays in the main checkout, because `ml/artifacts/` mixes 453 tracked files with 3 GB untracked and cannot be symlinked). Writing lanes capped at three.
- **scripts/wt.sh**: `new <branch>` (worktree + `node_modules` symlink + `.env*`/`.vercel` copies + cmux workspace), `rm <branch>` (refuses if dirty or unpushed), `ls`.

Builds on the existing `docs/solutions/developer-experience/git-worktrees-for-js-and-python-repos.md`, which already prescribed the symlink approach.

## Not in this PR

- Migrating the currently open sessions. Each finishes its current task in the main checkout under the old rules, then its next task starts in a worktree.
- Removing the stale `.claude/worktrees/feat-custom-cam-visibility/` remnant (a `docs/` dir, not a registered worktree). Safe to `rm -rf` any time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0182cVmrt2Yxs7EctLzMwhhN
