### PR TITLE
docs(kiosk): pushing an update to the glass + land the reload fix

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,6 +94,14 @@ Why: `docs/solutions/workflow-issues/migrations-need-a-ledger.md`.
 - **Never let an ML fallback masquerade as real model output.** Persist
   `pathTaken`, surface a fallbacks counter.
 
+## The kiosk Pi (the glass)
+
+Settings reach the Pi on their own within a minute of a /studio Deploy. Code
+does not: the Pi's Chromium tabs run the build they loaded until someone
+reloads them. After a kiosk-affecting merge builds, run
+`bash scripts/pi/kiosk-doctor.sh --sync --reload`. The full procedure and the
+failure table: `docs/ops/pushing-an-update-to-the-glass.md`.
+
 ## Data gotchas
 
 - **`ai_rating` is junk** (a removed baseline heuristic). The real quality

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,9 +82,15 @@ boots/config → `snap-now.sh` on the device.
 
 ## Where knowledge lives
 
-`docs/solutions/` holds accumulated lessons; also `docs/ops/`, `docs/ml/`
+`docs/solutions/` holds accumulated lessons, filed by category
+(`integration-issues/`, `best-practices/`, …) with YAML frontmatter — grep
+`module:`, `tags:`, or `problem_type:` to find one. Also `docs/ops/`, `docs/ml/`
 (incl. `rating-rubric.md`), `docs/hardware/`, `docs/plans/`. Check there before
 re-deriving something.
+
+`CONCEPTS.md` at the repo root is the shared domain vocabulary — the display
+chain (Feed, Pool, Gate, Mosaic, Composition, Tile, Glass, Dial) — relevant when
+orienting or naming things.
 
 The repo root has accumulated a lot of loose planning `.md` files — treat
 `docs/` as authoritative over root-level notes.

--- a/CONCEPTS.md
+++ b/CONCEPTS.md
@@ -1,0 +1,103 @@
+# Concepts
+
+Shared domain vocabulary for this project — entities, named processes, and status
+concepts with project-specific meaning. Seeded with core domain vocabulary, then
+accretes as ce-compound and ce-compound-refresh process learnings; direct edits
+are fine. Glossary only, not a spec or catch-all.
+
+## Relationships
+
+A Feed defines a Pool of candidate webcams. The Gate decides which members of
+that Pool are worth showing. A Mosaic arranges the survivors into a Composition
+of Tiles, and the Composition is what appears on the Glass. Dials are the
+positions that steer every step of that chain, and each Mosaic Version
+interprets its own Dials.
+
+## The display chain
+
+### Feed
+One of the two halves of the terminator the project renders — the sunrise side
+or the sunset side — each with its own webcams, its own screen, and its own
+settings.
+
+A Feed is a standing concept, not a time window. Its membership changes
+continuously as the terminator moves, so the same Feed names a different set of
+cameras minute to minute.
+
+### Pool
+The set of webcams currently eligible for a Feed, before any quality judgement
+is applied.
+
+Pool membership is defined by fixed geographic and solar-position bounds, not by
+the cameras that happen to be present. This distinction is load-bearing: a
+display axis derived from the Pool's *definition* stays still, while one derived
+from its *present members* moves every time any camera arrives or leaves.
+
+### Gate
+The pass/fail judgement that decides whether a single webcam's current frame is
+good enough to show.
+
+The Gate is asked per Mosaic Version, because each Version reads a different
+quality signal at a different threshold. A frame that one Version gates in,
+another gates out, so reporting surfaces must ask the Version on the Glass
+rather than assuming one interpretation.
+
+### Mosaic
+The renderer that arranges gated frames into the picture the project exists to
+show.
+*Avoid:* wall
+
+### Mosaic Version
+A named, independently frozen implementation of the Mosaic, shipping alongside
+the others in a single build.
+
+Versions are never edited in place once frozen — a new idea becomes a new
+Version. One is pinned as the default; a surface may select a different one, and
+a live setting can override the pin without a redeploy. Each Version owns its
+own Dials, so a Dial name means nothing without knowing which Version is
+reading it.
+
+### Composition
+One particular arrangement of Tiles that a Mosaic produces at a moment in time,
+given a Pool and a set of Dial positions.
+
+The Composition is a target, not a drawing. Motion settings determine whether
+the picture snaps to each new Composition, travels to it, or chases it
+continuously without ever arriving.
+
+### Tile
+One webcam's frame as placed in a Composition, with its size and position
+carrying meaning rather than being arbitrary layout.
+
+A Tile's size encodes how good its frame is judged to be, and its position
+encodes where on Earth the camera sits.
+
+### Glass
+The physical display surface a Composition actually reaches — the kiosk
+screens, as opposed to a preview, a test, or the deployed code.
+
+The distinction matters because code can be merged and deployed while the Glass
+still shows something older, and because settings can be deployed without the
+code that reads them. "On the Glass" always means verified at the surface, never
+inferred from an upstream step succeeding.
+
+### Dial
+A single named, operator-adjustable setting that steers composition or motion,
+tunable live without a deploy.
+
+Dials are namespaced per Mosaic Version. A Dial only takes effect once the code
+that reads it is on the Glass, so introducing a new Dial requires shipping the
+code first and moving the Dial second.
+
+### Kiosk
+The always-on installation that renders the Feeds unattended — both the routes
+that draw them and the dedicated hardware that displays them.
+
+## Flagged ambiguities
+
+- "Wall" is used informally for the Mosaic and for the Composition it is
+  currently showing. Prefer Mosaic for the renderer and Composition for the
+  arrangement.
+- "Glass" and "Composition" are adjacent but not interchangeable: the
+  Composition is what was computed, the Glass is where it was confirmed to have
+  landed.

--- a/docs/ops/pushing-an-update-to-the-glass.md
+++ b/docs/ops/pushing-an-update-to-the-glass.md
@@ -1,0 +1,109 @@
+# Pushing an update to the glass
+
+"The glass" is the kiosk Pi (`sunsetdisplay`) driving the two portrait panels.
+It runs two Chromium windows pointed at `www.sunrisesunset.studio/kiosk/sunrise`
+and `/kiosk/sunset` — the production site, i.e. whatever is merged to `main`.
+
+Nothing on the Pi updates itself except **settings**. This page is the whole
+procedure; you should not need to re-derive any of it.
+
+## What kind of change did you make?
+
+| You changed | How it reaches the Pi | What you do |
+|---|---|---|
+| A dial in `/studio` | Hold **Deploy**. That copies the `studio` settings row to `live`; the kiosk polls `/api/kiosk/state` once a minute and picks it up. | Wait up to 60 s. Nothing else. |
+| Code (a merged PR) | Vercel builds `main` (~2 min). The Pi's Chromium tabs keep running the JavaScript they loaded at boot **until they reload**. | Wait for the build, then **reload the glass** (below). |
+| `scripts/pi/*.sh` | The Pi holds *copies* of these, not a checkout. They drift silently. | Reload with `--sync` (below). |
+
+"IN SYNC WITH GLASS" in `/studio` only means *studio row equals live row*. It
+says nothing about which build the Pi is running. If the studio preview and the
+panels disagree after a Deploy, the Pi is running an older build: reload it.
+
+## Reloading the glass
+
+From the repo root, on `main` (the scripts live in `scripts/pi/`):
+
+```bash
+bash scripts/pi/kiosk-doctor.sh --sync --reload
+```
+
+It checks, in order, and stops at the first failure:
+
+1. This Mac is on the tailnet.
+2. The Pi answers SSH.
+3. What the Pi is doing: X up, monitors awake, two Chromium windows, which URLs.
+4. `--sync`: copies `scripts/pi/*.sh` to the Pi.
+5. `--reload`: screenshots, sends Ctrl+R to each window through XTEST, screenshots again.
+
+Read the last block. "byte-identical across the reload" is a hard failure:
+nothing reloaded. "screen changed" is **not** proof on its own, because the
+mosaic drifts continuously; confirm by looking for something only the new
+build draws.
+
+Without the doctor script (older checkout, or in a hurry):
+
+```bash
+ssh pi@sunsetdisplay 'bash ~/reload-kiosk.sh'
+```
+
+It prints `Sent Ctrl+R to N of M`, and exits non-zero if N < M. "Sent", not
+"reloaded" — xdotool confirms delivery, not effect. Why that wording matters:
+`docs/solutions/integration-issues/chromium-ignores-xdotool-keystrokes-without-focus.md`.
+
+### Off the tailnet, on the same wifi as the Pi
+
+The Pi is on the GL-X3000 travel-router network. From a Mac on that wifi you
+can skip Tailscale by naming the host explicitly, which also skips the doctor's
+tailnet check:
+
+```bash
+KIOSK_HOST=sunsetdisplay.lan bash scripts/pi/kiosk-doctor.sh --sync --reload
+```
+
+(`192.168.8.223` is the Pi's wifi address if the router's DNS is not
+resolving.) Same key requirement as the tailnet route.
+
+## Confirming the build landed first
+
+Reloading before Vercel finishes just reloads the old build. Check:
+
+```bash
+vercel ls --prod
+```
+
+The top row should be `● Ready` and younger than your merge. Builds take about
+two minutes. Or watch the PR's checks on GitHub.
+
+## Order of operations for a new dial
+
+1. Merge the code. 2. Wait for the build. 3. Reload the glass. 4. **Then** set
+the dial in `/studio` and Deploy.
+
+Backwards, the settings API discards the unknown key and the studio status
+strip shows `⚠ not stored: <key> (unknown)`. Deploy will keep reporting in
+sync while the panels show nothing new.
+
+## When it does not work
+
+| Symptom | Meaning | Do |
+|---|---|---|
+| Doctor step 1 fails, `Tailscale status` says stopped | Tailscale is off on this Mac | `/Applications/Tailscale.app/Contents/MacOS/Tailscale up`, or the menu-bar toggle |
+| Step 1 fails and `systemextensionsctl list` shows the extension "activated waiting to upgrade" | The network extension is wedged | Reboot the Mac. Restarting the app does not clear it. |
+| Step 2 fails while step 1 passed | Pi is off, or the travel router is not where the Pi is | Check last-seen at login.tailscale.com/admin/machines, then power-cycle in person |
+| `Permission denied (publickey)` | The Pi is up but refused this Mac's `~/.ssh/id_ed25519`. On 2026-09-04 it refused on both routes for about 15 minutes and then accepted the same key with no change on either end; the doctor prints the ssh error so this is not mistaken for a dead Pi. | Retry after a few minutes first. If it persists, get on the Pi (keyboard, or another authorized machine) and add the Mac's `~/.ssh/id_ed25519.pub` to `/home/pi/.ssh/authorized_keys`; check `~/.ssh` is mode 700 and the file 600. |
+| Doctor says monitors asleep (DPMS Off) | Pi is fine, screens are blanked | `ssh pi@sunsetdisplay 'DISPLAY=:0 xset dpms force on'` |
+| "No visible Chromium kiosk windows" | `kiosk-launch.sh` did not run | `ssh pi@sunsetdisplay sudo reboot`; a cold boot brings both windows up with no interaction |
+| Reload reported success but the panels still look old | Build not finished, or you are looking at a settings problem | `vercel ls --prod`; then check `/studio` for `not stored` warnings |
+
+Full Pi access notes (addresses, wifi profile, autostart quirks):
+`docs/superpowers/specs/2026-04-13-gallery-display-pi-setup-design.md` and
+the `sunsetdisplay-kiosk-access` memory.
+
+## What is still manual, and the fix for it
+
+The Pi never notices a new build. Every merged change to the kiosk needs a
+human to run the reload. The cheap end of this loop is for `/api/kiosk/state`
+to return the build's commit SHA and for the kiosk page to `location.reload()`
+when the SHA it booted with changes, ideally only outside the quiet window so a
+deploy never flashes the panels mid-show. Until that ships, this page is the
+procedure.

--- a/docs/solutions/integration-issues/chromium-ignores-xdotool-keystrokes-without-focus.md
+++ b/docs/solutions/integration-issues/chromium-ignores-xdotool-keystrokes-without-focus.md
@@ -1,0 +1,255 @@
+---
+title: Kiosk reload script reports success but never reloads — Chromium ignores xdotool's synthetic keystrokes
+date: 2026-09-02
+category: docs/solutions/integration-issues
+module: kiosk-display
+problem_type: integration_issue
+component: tooling
+symptoms:
+  - "`reload-kiosk.sh` prints \"Reloaded all kiosk windows\" while the glass sits unchanged for days"
+  - "Two screenshots 25 seconds apart have identical md5sums — the wall is frozen, not drifting slowly"
+  - "Webcam frames on the display are stamped two days stale"
+  - "Merged, deployed code never appears on the kiosk even though prod is confirmed serving it"
+  - "`xdotool search --class chromium key ctrl+r` exits 0 and produces no observable effect"
+root_cause: wrong_api
+resolution_type: code_fix
+severity: high
+related_components: [development_workflow, documentation]
+tags: [xdotool, chromium, kiosk, raspberry-pi, x11, silent-failure, shell-script, verification]
+---
+
+# Kiosk reload script reports success but never reloads — Chromium ignores xdotool's synthetic keystrokes
+
+## Problem
+
+The kiosk reload script on the display Pi printed a success message on every run
+but never actually reloaded Chromium, so the wall silently served a page loaded
+days earlier while reporting that it had refreshed.
+
+## Symptoms
+
+- `ssh pi@sunsetdisplay 'bash ~/reload-kiosk.sh'` printed `Reloaded all kiosk
+  windows` and exited 0, on every invocation, regardless of outcome.
+- The mosaic did not change after merges that had already shipped to production.
+- Webcam frames on the glass were stamped `31-08-2026` while the current date
+  was `2026-09-02` — the page was two days stale.
+- Two `scrot` screenshots taken 25 seconds apart were byte-identical, so the
+  page was not merely animating slowly, it was frozen.
+- The Pi's `uptime` showed three days, matching how long the page had gone
+  without a real reload.
+
+## What Didn't Work
+
+None of these were wasted effort. Each was a plausible link in the chain between
+"code merged" and "pixels on the glass," and each had a direct observable check,
+which is the only reason they were cheap to eliminate. The lesson is not "we
+guessed wrong three times" — it is that a pipeline with an observable at every
+boundary can be bisected in minutes.
+
+**Hypothesis: production had not finished deploying the merge.** The merge
+landed at 18:48:51 and the reload was attempted minutes later, so a race against
+the Vercel build was credible. Ruled out by `vercel ls --prod`, which showed two
+production deployments in `Ready` state, both roughly 8 minutes old with
+2-minute build durations.
+
+**Hypothesis: production deployed, but the bundle did not contain the new
+code.** This repo has a documented history of `outputFileTracingIncludes` and
+`.vercelignore` shipping incomplete bundles, so "deployed but missing" was worth
+checking. Ruled out by extracting the chunk URLs from the served page and
+grepping each one for a dial name introduced by the new work:
+
+```bash
+curl -sS https://www.sunrisesunset.studio/kiosk/sunset -o kiosk.html
+grep -oE '/_next/static/chunks/[A-Za-z0-9._/-]+\.js' kiosk.html | sort -u > chunks.txt
+while read -r p; do
+  # motionMode is a placeholder: substitute any symbol only the new code contains.
+  curl -sS "https://www.sunrisesunset.studio$p" | grep -q "motionMode" && echo "FOUND in $p"
+done < chunks.txt
+```
+
+`motionMode` was present in the live bundle. Production was serving the new code.
+
+**Hypothesis: the kiosk was rendering the wrong mosaic version.** All of the new
+work lived in `app/components/mosaic/v2/`, and the registry pins
+`DEFAULT_MOSAIC_VERSION = 'v1'`. The kiosk URL carries no `?v=` parameter, so a
+v1 fallback would have hidden every line of the change. Ruled out by reading the
+resolution order in `app/kiosk/sunset/page.tsx` — the parameter falls back to
+the live `shared.activeVersion` setting, not to the registry default — and then
+querying that live setting, which returned `"activeVersion": "v2"`.
+
+Only after the deploy, the bundle, and the version selection were all confirmed
+healthy did suspicion move to the one component that had never been checked: the
+reload mechanism itself, which had been trusted because it said so.
+
+## Solution
+
+Focus each window before sending the keystroke, and report the count actually
+delivered instead of a fixed success line.
+
+**Before:**
+
+```bash
+DISPLAY=:0 xdotool search --class chromium key --clearmodifiers ctrl+r
+echo "Reloaded all kiosk windows"
+```
+
+**After** (`scripts/pi/reload-kiosk.sh`):
+
+```bash
+export DISPLAY=:0
+
+windows=$(xdotool search --onlyvisible --class chromium)
+
+if [ -z "$windows" ]; then
+  echo "No visible Chromium kiosk windows found — is the kiosk running?" >&2
+  exit 1
+fi
+
+total=0
+sent=0
+for w in $windows; do
+  total=$((total + 1))
+  if xdotool windowactivate --sync "$w" && xdotool key --clearmodifiers ctrl+r; then
+    sent=$((sent + 1))
+  else
+    echo "Failed to reload window $w" >&2
+  fi
+done
+
+echo "Sent Ctrl+R to $sent of $total focused kiosk window(s)"
+[ "$sent" -eq "$total" ] || exit 1
+```
+
+Three details in that script are load-bearing and easy to delete by mistake:
+
+- `--onlyvisible` filters out unmapped helper windows, which `windowactivate`
+  cannot focus. Without it a healthy kiosk prints failures on every run, which
+  trains the reader to ignore the one channel that reports real breakage.
+- `--sync` blocks until activation completes, so a keystroke cannot land on the
+  window that was focused a moment earlier. A hang here means the window
+  manager, not the network.
+- xdotool's stderr is deliberately not silenced. `Can't open display :0` is the
+  difference between an X problem and a Chromium problem, and swallowing it
+  sends the reader to the wrong component.
+
+The comparison is `-eq "$total"`, not `-gt 0`, because on a two-screen kiosk
+"1 of 2 reloaded" is an outage. Exiting 0 on a partial reload would be the same
+class of lie the fix exists to remove.
+
+The repo copy and the Pi copy must both be updated. The Pi runs
+`~/reload-kiosk.sh`, which is a copy, not a checkout:
+
+```bash
+scp scripts/pi/reload-kiosk.sh pi@sunsetdisplay:/home/pi/reload-kiosk.sh
+ssh pi@sunsetdisplay 'bash ~/reload-kiosk.sh'
+```
+
+**Verified.** The old form produced byte-identical screenshots before, during,
+and after a reload. The new form changed the screen within one second and kept
+changing three seconds later, and the page came back rendering a visibly
+different composition — tile rating overlays that the stale page did not have.
+That qualitative difference, not the hash change alone, is what confirmed the
+reload; see the caveat under Prevention.
+
+## Why This Works
+
+There were two independent defects on that one line, and `man xdotool` on the Pi
+documents both.
+
+**The keystroke went through the wrong API.** From the `SENDEVENT NOTES`
+section, quoted verbatim:
+
+> If you specify `xdotool type --window 12345 hello` xdotool will generate key
+> events and send them directly to window 12345. However, X11 servers will set a
+> special flag on all events generated in this way (see `XEvent.xany.send_event`
+> in X11's manual). Many programs observe this flag and reject these events.
+>
+> It is important to note that for key and mouse events, we only use XSendEvent
+> when a specific window is targeted. Otherwise, we use XTEST.
+
+`search` populates the window stack. The `key` documentation states that with a
+non-empty stack the window argument defaults to `%1`, and that only an empty
+stack causes the current window to be typed at using XTEST. So chaining `search`
+into `key` silently opts into XSendEvent, and Chromium is one of the many
+programs that reject flagged events. Removing the chain and focusing the window
+first leaves the stack empty at the moment `key` runs, which routes through
+XTEST — indistinguishable from real hardware input, and accepted.
+
+**The command targeted one window, not all of them.** The `COMMAND CHAINING`
+section notes that an omitted window argument defaults to `%1`, the first
+window, where `%@` is the notation for all windows. So even on an application
+that honored XSendEvent, the original line would have reloaded a single window
+while the comment above it promised "all Chromium windows." The loop makes the
+fan-out explicit and countable, which is why the fix reports `2` rather than
+asserting "all."
+
+**The success line was unconditional.** `echo` ran on the next line regardless of
+what `xdotool` did, and `xdotool` exits 0 after successfully *sending* an event
+that the receiver discards. The script had no way to be wrong out loud.
+
+## Prevention
+
+- **A remote-control script must report what it verified, not what it
+  attempted.** An unconditional success echo is a lie generator: it converts
+  silence into false confidence and costs days before anyone doubts it. Count
+  the operations that actually succeeded and print the count; exit non-zero when
+  the count is zero. This is the same failure class as letting an ML fallback
+  path masquerade as real model output — the fix there is persisting
+  `pathTaken` and surfacing a fallbacks counter, and it is the same fix here,
+  which is to make the observable distinguish the real path from the no-op path.
+
+- **When a process "runs but does nothing," verify it executes before theorizing
+  about the components downstream of it.** The three ruled-out hypotheses were
+  all downstream of a step that was never instrumented. Checking the silent
+  component first would have found this in one probe instead of four. The
+  `__main__`-entrypoint bug on camera-2 was the same shape: an ordering theory
+  for what turned out to be code that never ran.
+
+- **Use screenshot hashing as the ground-truth probe for "did the glass actually
+  change?"** It requires nothing installed in the browser and cannot be fooled
+  by a script's own reporting:
+
+  ```bash
+  ssh pi@sunsetdisplay 'export DISPLAY=:0; scrot -o /tmp/a.png; \
+    bash ~/reload-kiosk.sh; sleep 2; scrot -o /tmp/b.png; md5sum /tmp/a.png /tmp/b.png'
+  ```
+
+  Identical hashes across a reload mean the reload did not happen. This
+  generalizes to any headless display: capture, act, capture, compare.
+
+  **The probe is one-directional, and became more so on the day it was
+  written.** The mosaic now defaults to continuous slow drift with fading
+  frames, so consecutive screenshots differ whether or not anything reloaded.
+  Identical hashes still prove no reload; differing hashes prove nothing on
+  their own. To confirm a reload actually landed, look for content only the new
+  build produces rather than for movement.
+
+- **Prefer exit codes to echoes for anything invoked over SSH.** The caller sees
+  the remote exit status, so a non-zero exit is checkable by a wrapper, a cron
+  job, or a health check; a success string is only checkable by a human who
+  happens to be reading.
+
+- **Treat every fire-and-forget remote command as suspect.** `xdotool`,
+  `wmctrl`, `xset`, `DISPLAY=:0` one-liners, and systemd `--no-block` calls all
+  exit 0 on delivery, not on effect. Where the effect matters, add a read-back
+  that observes the effect rather than the attempt.
+
+- **Distrust "How it works" comments that describe intent.** The original
+  comment claimed the script sends Ctrl+R "to each" window. Both halves of that
+  sentence were false, and the comment made the line look reviewed. The
+  replacement comment states the mechanism and names the failure it avoids.
+
+## Related Issues
+
+- `docs/solutions/best-practices/dangerous-failures-here-are-silent.md` — the
+  house rule this is a concrete instance of. That doc catalogues failures where
+  behaviour is *absent* with no error; this one is the same silence produced by
+  a tool boundary that accepts a command and discards it.
+- `docs/solutions/2026-06-06-fallbacks-must-not-impersonate-real-signal.md` —
+  the sibling failure mode, a fallback writing a plausible fake value into the
+  real column. The unconditional success echo is that pattern in a shell script.
+- `docs/superpowers/plans/2026-04-13-gallery-kiosk-routes.md` and
+  `docs/superpowers/specs/2026-04-13-gallery-display-pi-setup-design.md` are
+  where the broken `xdotool search --class chromium key` form was first written
+  down as a copy-paste recipe. Both were marked superseded on 2026-09-02 and now
+  point at `scripts/pi/reload-kiosk.sh` instead.

--- a/docs/superpowers/plans/2026-04-13-gallery-kiosk-routes.md
+++ b/docs/superpowers/plans/2026-04-13-gallery-kiosk-routes.md
@@ -458,12 +458,13 @@ Create `scripts/pi/reload-kiosk.sh`:
 # Prerequisites on Pi:
 #   sudo apt install -y xdotool   (done during Pi setup)
 #
-# How it works:
-#   xdotool finds all Chromium windows by class name and sends Ctrl+R to each.
-#   This triggers a standard browser reload — fast, minimal flash (~1 sec).
-
-DISPLAY=:0 xdotool search --class chromium key --clearmodifiers ctrl+r
-echo "Reloaded all kiosk windows"
+# SUPERSEDED 2026-09-02 — do not copy the command this plan originally showed.
+#   `xdotool search --class chromium key ...` delivers the keystroke via
+#   XSendEvent, which Chromium ignores, and it targets only the first window.
+#   The script reported success for months while the glass never reloaded.
+#   Canonical version: scripts/pi/reload-kiosk.sh
+#   Why: docs/solutions/integration-issues/
+#        chromium-ignores-xdotool-keystrokes-without-focus.md
 ```
 
 - [ ] **Step 2: Make it executable and syntax-check it**

--- a/docs/superpowers/plans/2026-09-03-opening-night-runbook.md
+++ b/docs/superpowers/plans/2026-09-03-opening-night-runbook.md
@@ -54,7 +54,7 @@ Pacific first, UTC beside it. The show runs in the freshest hours of the UTC day
 - Rings, tick cadence, and flag state stay as they are from here. Live images
   keep flowing; the freeze is on configuration, not on content.
 - Decide from five preview days whether the ring stays on.
-- Merge or park `fix/kiosk-reload-verification`. It has never run against the Pi.
+- Merge the kiosk runbook PR (it carries `fix/kiosk-reload-verification`, which ran end to end on the Pi 2026-09-04). Procedure: `docs/ops/pushing-an-update-to-the-glass.md`.
 
 ### Thu Sep 11 — rehearsal
 - Run the kiosk exactly as it will run. Run `scripts/pi/kiosk-doctor.sh` on the Pi.
@@ -90,7 +90,7 @@ Pacific first, UTC beside it. The show runs in the freshest hours of the UTC day
 - [x] Gate check rebuilt into `scripts/windy-gate-check.mjs` after the scratchpad copy was lost
 
 ### Open risks on the glass — confirm
-- [ ] `fix/kiosk-reload-verification`: pushed, unmerged, never run on the Pi; also edits `CLAUDE.md`
+- [x] `fix/kiosk-reload-verification`: ran on the Pi 2026-09-04 (`--sync --reload`, 2 of 2 windows); lands with the kiosk runbook PR
 - [ ] Mosaic v3 on the actual panels: #120 and #122 merged; confirm the band scale on the glass, not the studio
 - [ ] Kiosk Pi reachable and rendering `main` (Deploy copies settings rows only; the Pi renders `main`)
 - [ ] Two known limits of retention (final review 2026-09-03): the hold is

--- a/docs/superpowers/specs/2026-04-13-gallery-display-pi-setup-design.md
+++ b/docs/superpowers/specs/2026-04-13-gallery-display-pi-setup-design.md
@@ -178,13 +178,12 @@ nano ~/reload-kiosk.sh
 
 Paste:
 
-```bash
-#!/bin/bash
-# Reload all Chromium kiosk windows by sending Ctrl+R via xdotool
-# Requires: sudo apt install -y xdotool (done in Step 2)
-DISPLAY=:0 xdotool search --class chromium key --clearmodifiers ctrl+r
-echo "Reloaded all kiosk windows"
-```
+> **SUPERSEDED 2026-09-02.** The one-liner this spec originally told you to
+> paste never worked: `xdotool search --class chromium key ...` delivers the
+> keystroke via XSendEvent, which Chromium ignores, and it targets only the
+> first window. The script printed success for months while the glass never
+> reloaded. Copy `scripts/pi/reload-kiosk.sh` from the repo instead. Background:
+> `docs/solutions/integration-issues/chromium-ignores-xdotool-keystrokes-without-focus.md`
 
 ```bash
 chmod +x ~/reload-kiosk.sh

--- a/scripts/pi/kiosk-doctor.sh
+++ b/scripts/pi/kiosk-doctor.sh
@@ -1,0 +1,152 @@
+#!/bin/bash
+# kiosk-doctor.sh — answer "what is the wall actually doing right now?" in one command.
+#
+# Usage (from your Mac):
+#   bash scripts/pi/kiosk-doctor.sh              # diagnose only
+#   bash scripts/pi/kiosk-doctor.sh --sync       # also copy scripts/pi/*.sh to the Pi
+#   bash scripts/pi/kiosk-doctor.sh --reload     # also reload, and prove it reloaded
+#   bash scripts/pi/kiosk-doctor.sh --sync --reload
+#
+# Env: KIOSK_HOST overrides the default host.
+#
+# Why this exists:
+#   "The kiosk looks wrong" has three completely different causes that all
+#   present identically as silence — this Mac is off the tailnet, the Pi is
+#   powered off, or the Pi is fine and only the monitors are off. Guessing
+#   between them wastes the most time, so this checks them in that order and
+#   refuses to move on until each one is settled.
+#
+#   Every check reports what it observed. Nothing here prints success it did
+#   not verify — see
+#   docs/solutions/integration-issues/chromium-ignores-xdotool-keystrokes-without-focus.md
+#   for the bug that motivated that rule.
+
+set -u
+
+HOST="${KIOSK_HOST:-sunsetdisplay}"
+DO_SYNC=0
+DO_RELOAD=0
+for arg in "$@"; do
+  case "$arg" in
+    --sync) DO_SYNC=1 ;;
+    --reload) DO_RELOAD=1 ;;
+    -h|--help) sed -n '2,20p' "$0"; exit 0 ;;
+    *) echo "Unknown option: $arg" >&2; exit 2 ;;
+  esac
+done
+
+say() { printf '\n\033[1m%s\033[0m\n' "$1"; }
+ok()   { printf '  ok    %s\n' "$1"; }
+bad()  { printf '  FAIL  %s\n' "$1"; }
+info() { printf '        %s\n' "$1"; }
+
+# ---------------------------------------------------------------- step 1: Mac
+# Checked first and fatally, because every downstream symptom is identical to
+# "the Pi is dead" when this Mac is simply not on the tailnet.
+say "1. This Mac's tailnet"
+if ifconfig 2>/dev/null | grep -q 'inet 100\.'; then
+  ok "on the tailnet"
+else
+  bad "this Mac has no 100.x tailnet address — the Pi's state is UNKNOWN from here"
+  info "Common cause: the Tailscale system extension is stuck mid-upgrade."
+  info "Check with:  systemextensionsctl list | grep -i tailscale"
+  info "A line reading 'activated waiting to upgrade' needs a Mac reboot."
+  info ""
+  info "To learn whether the Pi is up without fixing this Mac, open"
+  info "login.tailscale.com/admin/machines and read sunsetdisplay's last-seen."
+  exit 1
+fi
+
+# ---------------------------------------------------------------- step 2: Pi
+say "2. Reaching $HOST"
+if ssh -o ConnectTimeout=8 -o BatchMode=yes "pi@$HOST" true 2>/dev/null; then
+  ok "ssh succeeded — the Pi is powered and networked"
+else
+  bad "cannot ssh to $HOST"
+  info "This Mac IS on the tailnet, so this is the Pi's end: powered off, or"
+  info "off the network. Note the Pi rides the GL-X3000 travel router — if the"
+  info "router left the Pi's location, the Pi has no internet regardless of power."
+  info "Confirm which at login.tailscale.com/admin/machines, then power-cycle in person."
+  exit 1
+fi
+
+# ------------------------------------------------------- step 3: what it's doing
+# One SSH round trip; parsed on the Mac so the remote side stays quotable.
+say "3. Kiosk state"
+STATE=$(ssh -o ConnectTimeout=10 "pi@$HOST" '
+  export DISPLAY=:0
+  echo "UPTIME=$(uptime -p 2>/dev/null)"
+  if xset q >/dev/null 2>&1; then
+    echo "X=up"
+    echo "DPMS=$(xset q | awk "/Monitor is/ {print \$3}")"
+    echo "OUTPUTS=$(xrandr 2>/dev/null | grep -c " connected")"
+  else
+    echo "X=down"
+  fi
+  echo "WINDOWS=$(xdotool search --onlyvisible --class chromium 2>/dev/null | wc -l | tr -d " ")"
+  pgrep -a chromium 2>/dev/null | grep -o "https://[^ ]*" | sort -u | sed "s/^/URL=/"
+' 2>/dev/null)
+
+get() { printf '%s\n' "$STATE" | grep "^$1=" | head -1 | cut -d= -f2-; }
+
+info "$(get UPTIME)"
+
+if [ "$(get X)" = "up" ]; then
+  ok "X server is up"
+  DPMS=$(get DPMS)
+  OUTPUTS=$(get OUTPUTS)
+  info "monitors connected: ${OUTPUTS:-unknown}"
+  case "$DPMS" in
+    On)  ok "monitors are awake (DPMS On)" ;;
+    "")  info "DPMS state not reported" ;;
+    *)   bad "monitors are asleep or blanked (DPMS $DPMS)"
+         info "The Pi is fine; only the screens are dark. Wake them with:"
+         info "  ssh pi@$HOST 'DISPLAY=:0 xset dpms force on'" ;;
+  esac
+else
+  bad "no X server on :0 — the desktop session did not start"
+  info "Check the autostart profile is rpd-x, not LXDE-pi."
+fi
+
+WINDOWS=$(get WINDOWS)
+if [ "${WINDOWS:-0}" -ge 2 ]; then
+  ok "$WINDOWS visible Chromium kiosk windows"
+elif [ "${WINDOWS:-0}" -ge 1 ]; then
+  bad "only $WINDOWS visible Chromium window — expected 2"
+else
+  bad "no visible Chromium kiosk windows — kiosk-launch.sh did not run"
+fi
+
+printf '%s\n' "$STATE" | grep '^URL=' | sed 's/^URL=/        serving /'
+
+# ---------------------------------------------------------------- step 4: sync
+if [ "$DO_SYNC" = "1" ]; then
+  say "4. Syncing scripts/pi/*.sh"
+  # The Pi's copies are copies, not a checkout, so they drift silently.
+  if scp -q scripts/pi/*.sh "pi@$HOST:/home/pi/"; then
+    ok "copied $(ls -1 scripts/pi/*.sh | wc -l | tr -d ' ') script(s)"
+  else
+    bad "scp failed — the Pi is running whatever it had before"
+    exit 1
+  fi
+fi
+
+# -------------------------------------------------------------- step 5: reload
+if [ "$DO_RELOAD" = "1" ]; then
+  say "5. Reloading, and proving it"
+  BEFORE=$(ssh "pi@$HOST" 'export DISPLAY=:0; scrot -o /tmp/kd-a.png && md5 -q /tmp/kd-a.png 2>/dev/null || md5sum /tmp/kd-a.png | cut -d" " -f1' 2>/dev/null)
+  ssh "pi@$HOST" 'bash ~/reload-kiosk.sh' || bad "reload-kiosk.sh reported failure (see its stderr above)"
+  AFTER=$(ssh "pi@$HOST" 'export DISPLAY=:0; sleep 3; scrot -o /tmp/kd-b.png && md5 -q /tmp/kd-b.png 2>/dev/null || md5sum /tmp/kd-b.png | cut -d" " -f1' 2>/dev/null)
+
+  if [ -n "$BEFORE" ] && [ "$BEFORE" = "$AFTER" ]; then
+    bad "screen is byte-identical across the reload — nothing reloaded"
+    info "That is conclusive. Investigate the reload path, not the app."
+  else
+    info "screen changed across the reload"
+    info "NOT conclusive on its own: the mosaic drifts continuously, so pixels"
+    info "change with or without a reload. To confirm the new build is live,"
+    info "look for content only it produces."
+  fi
+fi
+
+say "Done"

--- a/scripts/pi/kiosk-doctor.sh
+++ b/scripts/pi/kiosk-doctor.sh
@@ -44,7 +44,11 @@ info() { printf '        %s\n' "$1"; }
 # Checked first and fatally, because every downstream symptom is identical to
 # "the Pi is dead" when this Mac is simply not on the tailnet.
 say "1. This Mac's tailnet"
-if ifconfig 2>/dev/null | grep -q 'inet 100\.'; then
+if [ -n "${KIOSK_HOST:-}" ]; then
+  # An explicit host is the LAN route (sunsetdisplay.lan / 192.168.8.x on the
+  # GL-X3000 wifi). The tailnet is irrelevant to it, so don't fail on it.
+  info "KIOSK_HOST=$HOST — skipping the tailnet check (LAN route)"
+elif ifconfig 2>/dev/null | grep -q 'inet 100\.'; then
   ok "on the tailnet"
 else
   bad "this Mac has no 100.x tailnet address — the Pi's state is UNKNOWN from here"
@@ -63,10 +67,29 @@ if ssh -o ConnectTimeout=8 -o BatchMode=yes "pi@$HOST" true 2>/dev/null; then
   ok "ssh succeeded — the Pi is powered and networked"
 else
   bad "cannot ssh to $HOST"
-  info "This Mac IS on the tailnet, so this is the Pi's end: powered off, or"
-  info "off the network. Note the Pi rides the GL-X3000 travel router — if the"
-  info "router left the Pi's location, the Pi has no internet regardless of power."
-  info "Confirm which at login.tailscale.com/admin/machines, then power-cycle in person."
+  # Re-run once, unsilenced, so the reason is on screen: a timeout means the
+  # Pi is unreachable; "Permission denied (publickey)" means it is up and
+  # refusing this Mac's key, which no amount of power-cycling will fix.
+  ERR=$(ssh -o ConnectTimeout=8 -o BatchMode=yes "pi@$HOST" true 2>&1)
+  info "ssh: $ERR"
+  case "$ERR" in
+    *"Permission denied"*)
+      info "The Pi is UP and refusing this Mac's key. Power-cycling will not help."
+      info "Add ~/.ssh/id_ed25519.pub to /home/pi/.ssh/authorized_keys on the Pi"
+      info "(dir mode 700, file mode 600), from its keyboard or another authorized machine." ;;
+    *"Host key verification"*)
+      info "No known_hosts entry for this name. Use the address instead, e.g."
+      info "  KIOSK_HOST=192.168.8.223 bash $0" ;;
+    *)
+      if [ -n "${KIOSK_HOST:-}" ]; then
+        info "Is this Mac on the Pi's wifi (the GL-X3000 network)? The LAN route needs it."
+      else
+        info "This Mac IS on the tailnet, so this is the Pi's end: powered off, or"
+        info "off the network. Note the Pi rides the GL-X3000 travel router — if the"
+        info "router left the Pi's location, the Pi has no internet regardless of power."
+        info "Confirm which at login.tailscale.com/admin/machines, then power-cycle in person."
+      fi ;;
+  esac
   exit 1
 fi
 

--- a/scripts/pi/reload-kiosk.sh
+++ b/scripts/pi/reload-kiosk.sh
@@ -8,8 +8,43 @@
 #   sudo apt install -y xdotool   (done during Pi setup)
 #
 # How it works:
-#   xdotool finds all Chromium windows by class name and sends Ctrl+R to each.
-#   This triggers a standard browser reload — fast, minimal flash (~1 sec).
+#   Chromium ignores synthetic key events delivered by XSendEvent, which is
+#   what `xdotool search --class chromium key ...` does to a window it has not
+#   focused. That form printed success while the page sat untouched for days.
+#   So: focus each window first, then send Ctrl+R through XTEST, which
+#   Chromium does accept — and report the count we actually delivered rather
+#   than a fixed success line.
+#
+#   `--sync` is load-bearing: it blocks until activation completes, so a
+#   keystroke cannot land on the window we were focused on a moment ago.
+#   Do not drop it. If this ever hangs, suspect the window manager, not SSH.
+#
+#   No `set -e`: `xdotool search` exits 1 when it matches nothing, and we want
+#   the friendly message below rather than a bare abort. xdotool's own stderr
+#   is deliberately not silenced — "Can't open display :0" is the difference
+#   between an X problem and a Chromium problem.
 
-DISPLAY=:0 xdotool search --class chromium key --clearmodifiers ctrl+r
-echo "Reloaded all kiosk windows"
+export DISPLAY=:0
+
+windows=$(xdotool search --onlyvisible --class chromium)
+
+if [ -z "$windows" ]; then
+  echo "No visible Chromium kiosk windows found — is the kiosk running?" >&2
+  exit 1
+fi
+
+total=0
+sent=0
+for w in $windows; do
+  total=$((total + 1))
+  if xdotool windowactivate --sync "$w" && xdotool key --clearmodifiers ctrl+r; then
+    sent=$((sent + 1))
+  else
+    echo "Failed to reload window $w" >&2
+  fi
+done
+
+# "Sent", not "Reloaded": xdotool exits 0 on delivery, not on effect. Claiming
+# the effect is the exact overreach that hid this bug for months.
+echo "Sent Ctrl+R to $sent of $total focused kiosk window(s)"
+[ "$sent" -eq "$total" ] || exit 1


### PR DESCRIPTION
## What

- **New runbook** `docs/ops/pushing-an-update-to-the-glass.md`: which changes reach the kiosk Pi on their own (settings, via the 60s poll) and which do not (code, until the Chromium tabs reload; `scripts/pi` copies), the one command to run, how to confirm the build landed first, the correct order for a new dial, and a symptom table.
- **CLAUDE.md** gets a short "kiosk Pi" section pointing at it.
- **Merges `fix/kiosk-reload-verification`** (the honest `reload-kiosk.sh` + `kiosk-doctor.sh`, the xdotool learning, `CONCEPTS.md`) so the runbook references scripts on main, not a parked branch. Merged clean against current main.
- **`kiosk-doctor.sh`**: `KIOSK_HOST=...` now means the LAN route and skips the tailnet check; step 2 prints the real ssh error and branches on it, because a Pi that is up but refusing the key looked identical to a dead Pi.
- Opening-night runbook: the reload-fix risk row is ticked.

## Verified

- `bash scripts/pi/kiosk-doctor.sh --sync --reload` against the Pi, 2026-09-04: X up, 2 windows, 2 scripts copied, `Sent Ctrl+R to 2 of 2`. md5 of the Pi's copies matches the repo.
- Both failure branches exercised for real earlier in the session: `Permission denied (publickey)` over the tailnet (the Pi refused the key for ~15 min, then accepted it unchanged) and `Host key verification failed` over `KIOSK_HOST=sunsetdisplay.lan`.
- `bash -n` clean. shellcheck is not installed on this Mac.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C6RWHGTND22jTcWW6PUtCP