### PR TITLE
fix(nav): site nav gets its own band instead of floating over the view

### DIFF
--- a/app/HomeClient.tsx
+++ b/app/HomeClient.tsx
@@ -27,6 +27,9 @@ import { HardExamplesQueue } from './components/HardExamples/HardExamplesQueue';
 import { OpsTab } from './components/Ops/OpsTab';
 import { KioskTab } from './components/Kiosk/KioskTab';
 
+/** Height of the navigation band above the view, in px. */
+const NAV_BAND_HEIGHT = 44;
+
 interface Props {
   manifestRuns: ManifestEntry[];
 }
@@ -91,13 +94,39 @@ export function HomeClient({ manifestRuns }: Props) {
   const allWebcams = useAllWebcamsStore((t) => t.allWebcams);
 
   return (
-    <main className="relative w-full">
-      <div>
+    <main
+      className="relative w-full"
+      style={{
+        height: '100vh',
+        display: 'flex',
+        flexDirection: 'column',
+        overflow: 'hidden',
+      }}
+    >
+      {/*
+        Navigation gets its own band above the view rather than floating over
+        it. A floating control in the top-right corner sat on top of anything
+        the view drew there, and a map popup could never rise above it because
+        the popup lives inside the map's stacking context. The band costs
+        NAV_BAND_HEIGHT of globe and buys a corner nothing else can claim.
+      */}
+      <header
+        style={{
+          height: NAV_BAND_HEIGHT,
+          flex: 'none',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'flex-end',
+          padding: '0 16px',
+          background: '#000',
+        }}
+      >
+        <MapMosaicModeToggle mode={mode} onModeChange={setMode} />
+      </header>
+
+      <div style={{ position: 'relative', flex: 1, minHeight: 0 }}>
         {/* Main View Container - handles map, globe, and mosaic modes */}
         <MainViewContainer userLocation={userLocation} mode={mode} />
-
-        {/* Mode Toggle */}
-        <MapMosaicModeToggle mode={mode} onModeChange={setMode} />
 
         {/* Drawer Toggle Button - positioned over the map */}
         <IconButton

--- a/app/components/MainViewContainer.tsx
+++ b/app/components/MainViewContainer.tsx
@@ -47,7 +47,7 @@ export default function MainViewContainer({
 
     case 'rating':
       return (
-        <section className="map-container w-full h-screen">
+        <section className="map-container w-full h-full">
           <div className="flex flex-col h-full">
             <div className="flex-1" style={{ position: 'relative' }}>
               <RatingPanel variant="fullscreen" />
@@ -62,14 +62,14 @@ export default function MainViewContainer({
     case 'gallery':
       // TODO: Implement SnapshotGallery component
       return (
-        <div className="w-full h-screen flex items-center justify-center bg-black">
+        <div className="w-full h-full flex items-center justify-center bg-black">
           <p className="text-white">Gallery view coming soon...</p>
         </div>
       );
 
     default:
       return (
-        <div className="w-full h-screen flex items-center justify-center">
+        <div className="w-full h-full flex items-center justify-center">
           <p>Unknown view mode: {mode}</p>
         </div>
       );

--- a/app/components/Map/SimpleMap.tsx
+++ b/app/components/Map/SimpleMap.tsx
@@ -120,9 +120,9 @@ export default function SimpleMap({
   });
 
   return (
-    <div>
-      {/* First Section - Full Screen Map */}
-      <section className="map-container w-full h-screen">
+    <div className="h-full">
+      {/* Fills whatever the page gives it (the homepage view area below the nav band) */}
+      <section className="map-container w-full h-full">
         <div ref={interactionContainerRef} className="w-full h-full">
           <div
             ref={mapContainer}

--- a/app/components/MapMosaicModeToggle.tsx
+++ b/app/components/MapMosaicModeToggle.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Box, ToggleButton, ToggleButtonGroup } from '@mui/material';
+import { ToggleButton, ToggleButtonGroup } from '@mui/material';
 import { useRouter } from 'next/navigation';
 import type { ViewMode } from './MainViewContainer';
 import { homeHrefFor } from './viewModeParam';
@@ -29,6 +29,12 @@ interface MapMosaicModeToggleProps {
  * Studio and My Cameras are both shown to everyone. Each gates itself on
  * arrival (OwnerGate), which puts the sign-in prompt where someone actually
  * asked for the thing rather than hiding the door.
+ *
+ * Renders inline: the caller decides where it lives in the page chrome. It
+ * used to float absolutely in the top-right corner, which put it over
+ * whatever the page drew there — the studio's tile-detail card opened under
+ * it, and a map popup near the top edge could never rise above it because
+ * the popup lives inside the map's own stacking context.
  */
 export function MapMosaicModeToggle({
   mode,
@@ -36,58 +42,49 @@ export function MapMosaicModeToggle({
 }: MapMosaicModeToggleProps) {
   const router = useRouter();
   return (
-    <Box
-      sx={{
-        position: 'absolute',
-        top: 16,
-        right: 16,
-        zIndex: 3,
+    <ToggleButtonGroup
+      value={mode}
+      exclusive
+      onChange={(_, newTarget: ToggleTarget | null) => {
+        if (newTarget === null || newTarget === mode) return;
+        if (newTarget === 'studio') {
+          router.push('/studio');
+          return;
+        }
+        // On the homepage this is a state flip; from /studio there is no
+        // state to flip, so the view rides along in the URL instead.
+        if (onModeChange) onModeChange(newTarget);
+        else router.push(homeHrefFor(newTarget));
       }}
-    >
-      <ToggleButtonGroup
-        value={mode}
-        exclusive
-        onChange={(_, newTarget: ToggleTarget | null) => {
-          if (newTarget === null || newTarget === mode) return;
-          if (newTarget === 'studio') {
-            router.push('/studio');
-            return;
-          }
-          // On the homepage this is a state flip; from /studio there is no
-          // state to flip, so the view rides along in the URL instead.
-          if (onModeChange) onModeChange(newTarget);
-          else router.push(homeHrefFor(newTarget));
-        }}
-        size="small"
-        sx={{
-          backgroundColor: 'rgba(0, 0, 0, 0.7)',
-          '& .MuiToggleButton-root': {
+      size="small"
+      sx={{
+        backgroundColor: 'rgba(0, 0, 0, 0.7)',
+        '& .MuiToggleButton-root': {
+          color: 'white',
+          borderColor: 'rgba(255, 255, 255, 0.3)',
+          padding: '4px 8px', // Add this to make buttons smaller
+          fontSize: '8px', // Add this to make text smaller
+          minWidth: 'auto', // Add this to remove minimum width
+          fontFamily: 'Roboto, Arial, sans-serif', // Explicitly set Roboto font
+          '&.Mui-selected': {
+            backgroundColor: 'rgba(255, 255, 255, 0.2)',
             color: 'white',
-            borderColor: 'rgba(255, 255, 255, 0.3)',
-            padding: '4px 8px', // Add this to make buttons smaller
-            fontSize: '8px', // Add this to make text smaller
-            minWidth: 'auto', // Add this to remove minimum width
-            fontFamily: 'Roboto, Arial, sans-serif', // Explicitly set Roboto font
-            '&.Mui-selected': {
-              backgroundColor: 'rgba(255, 255, 255, 0.2)',
-              color: 'white',
-              '&:hover': {
-                backgroundColor: 'rgba(255, 255, 255, 0.3)',
-              },
-            },
             '&:hover': {
-              backgroundColor: 'rgba(255, 255, 255, 0.1)',
+              backgroundColor: 'rgba(255, 255, 255, 0.3)',
             },
           },
-        }}
-      >
-        <ToggleButton value="globe">Globe</ToggleButton>
-        <ToggleButton value="studio">Studio</ToggleButton>
-        <ToggleButton value="my-cameras">My Cameras</ToggleButton>
-        {/*<ToggleButton value="rating">Rating</ToggleButton>
-        <ToggleButton value="swipe">Swipe</ToggleButton>
-        <ToggleButton value="gallery">Gallery</ToggleButton> */}
-      </ToggleButtonGroup>
-    </Box>
+          '&:hover': {
+            backgroundColor: 'rgba(255, 255, 255, 0.1)',
+          },
+        },
+      }}
+    >
+      <ToggleButton value="globe">Globe</ToggleButton>
+      <ToggleButton value="studio">Studio</ToggleButton>
+      <ToggleButton value="my-cameras">My Cameras</ToggleButton>
+      {/*<ToggleButton value="rating">Rating</ToggleButton>
+      <ToggleButton value="swipe">Swipe</ToggleButton>
+      <ToggleButton value="gallery">Gallery</ToggleButton> */}
+    </ToggleButtonGroup>
   );
 }

--- a/app/components/MyCameras/MyCamerasView.tsx
+++ b/app/components/MyCameras/MyCamerasView.tsx
@@ -33,7 +33,7 @@ export function MyCamerasView({ userLocation }: { userLocation: Location }) {
   const markerWebcams = useMemo(() => visible.map(myCameraToWindyWebcam), [visible]);
 
   return (
-    <section className="map-container w-full h-screen" style={{ position: 'relative' }}>
+    <section className="map-container w-full h-full" style={{ position: 'relative' }}>
       <SimpleMap
         userLocation={userLocation}
         mode="my-cameras"

--- a/app/studio/PreviewPane.test.tsx
+++ b/app/studio/PreviewPane.test.tsx
@@ -82,6 +82,21 @@ describe('PreviewPane', () => {
     });
   });
 
+  it('renders the nav slot in its top row, so navigation shares the chrome instead of floating over it', () => {
+    render(
+      <PreviewPane
+        view="both"
+        onViewChange={() => {}}
+        panel={PANEL}
+        panelPresetLabel="ktc · 1440×2560"
+        versionName="v1"
+        nav={<button type="button">nav-probe</button>}
+      />
+    );
+
+    expect(screen.getByRole('button', { name: 'nav-probe' })).toBeInTheDocument();
+  });
+
   it("renders both stages for view='both'", () => {
     render(
       <PreviewPane

--- a/app/studio/PreviewPane.tsx
+++ b/app/studio/PreviewPane.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useEffect, useState, type ReactNode } from 'react';
 import { useTerminatorStore } from '@/app/store/useTerminatorStore';
 import { resolveMosaic } from '@/app/components/mosaic/registry';
 import type { PanelSize } from '@/app/kiosk/panelPreview';
@@ -56,6 +56,7 @@ export function PreviewPane({
   error = null,
   at,
   onSceneSaved,
+  nav,
 }: {
   view: FeedView;
   onViewChange: (v: FeedView) => void;
@@ -79,6 +80,12 @@ export function PreviewPane({
   error?: string | null;
   at?: string;
   onSceneSaved?: (id: number) => void;
+  /**
+   * Site navigation, rendered at the right end of the top row. It shares the
+   * row with the view controls instead of floating over the pane, so nothing
+   * the pane draws (the tile-detail card in particular) can end up under it.
+   */
+  nav?: ReactNode;
 }) {
   const liveSunrise = useTerminatorStore((t) => t.sunrise);
   const liveSunset = useTerminatorStore((t) => t.sunset);
@@ -132,94 +139,119 @@ export function PreviewPane({
         position: 'relative',
       }}
     >
-      <div style={{ display: 'flex', alignItems: 'center', gap: 12 }}>
+      {/*
+        1fr | controls | 1fr keeps the controls centered while the nav sits
+        at the right edge. When the pane is too narrow for both, the grid
+        columns give way rather than letting the two paint over each other.
+      */}
+      <div
+        style={{
+          width: '100%',
+          display: 'grid',
+          gridTemplateColumns: '1fr auto 1fr',
+          alignItems: 'center',
+          gap: 12,
+        }}
+      >
+        <div />
         <div
-          role="group"
-          aria-label="feed view"
           style={{
             display: 'flex',
-            border: `1px solid ${hairline}`,
-            borderRadius: 6,
-            overflow: 'hidden',
+            alignItems: 'center',
+            justifyContent: 'center',
+            flexWrap: 'wrap',
+            gap: 12,
           }}
         >
-          {SEGMENTS.map((seg) => (
-            <button
-              key={seg}
-              type="button"
-              aria-pressed={view === seg}
-              onClick={() => onViewChange(seg)}
-              style={{
-                padding: '4px 14px',
-                fontSize: 12,
-                textTransform: 'capitalize',
-                cursor: 'pointer',
-                border: 'none',
-                background: view === seg ? '#1d2432' : 'transparent',
-                color: view === seg ? '#e5e7eb' : dim,
-              }}
-            >
-              {seg}
-            </button>
-          ))}
-        </div>
+          <div
+            role="group"
+            aria-label="feed view"
+            style={{
+              display: 'flex',
+              border: `1px solid ${hairline}`,
+              borderRadius: 6,
+              overflow: 'hidden',
+            }}
+          >
+            {SEGMENTS.map((seg) => (
+              <button
+                key={seg}
+                type="button"
+                aria-pressed={view === seg}
+                onClick={() => onViewChange(seg)}
+                style={{
+                  padding: '4px 14px',
+                  fontSize: 12,
+                  textTransform: 'capitalize',
+                  cursor: 'pointer',
+                  border: 'none',
+                  background: view === seg ? '#1d2432' : 'transparent',
+                  color: view === seg ? '#e5e7eb' : dim,
+                }}
+              >
+                {seg}
+              </button>
+            ))}
+          </div>
 
-        <span
-          data-testid="studio-geometry-chip"
-          style={{
-            fontFamily: mono,
-            fontSize: 11,
-            letterSpacing: '0.05em',
-            color: dim,
-            border: `1px solid ${hairline}`,
-            borderRadius: 999,
-            padding: '3px 12px',
-          }}
-        >
-          {panelPresetLabel}
-        </span>
-
-        <select
-          aria-label="data source"
-          data-testid="studio-scene-select"
-          value={sceneSource.kind === 'live' ? 'live' : String(sceneSource.id)}
-          onChange={(e) => {
-            const raw = e.target.value;
-            onSceneSourceChange?.(
-              raw === 'live' ? { kind: 'live' } : { kind: 'scene', id: Number(raw) }
-            );
-          }}
-          style={{
-            fontSize: 12,
-            background: '#0e1119',
-            color: '#e5e7eb',
-            border: `1px solid ${hairline}`,
-            borderRadius: 6,
-            padding: '4px 8px',
-          }}
-        >
-          <option value="live">live</option>
-          {scenes.map((scene) => (
-            <option key={scene.id} value={scene.id}>
-              {sceneOptionLabel(scene)}
-            </option>
-          ))}
-        </select>
-
-        <SaveSceneButton onSaved={onSceneSaved} />
-
-        {sceneUnresolved && (
           <span
-            data-testid="studio-scene-status"
+            data-testid="studio-geometry-chip"
             style={{
               fontFamily: mono,
               fontSize: 11,
-              color: error ? '#f0a04b' : dim,
+              letterSpacing: '0.05em',
+              color: dim,
+              border: `1px solid ${hairline}`,
+              borderRadius: 999,
+              padding: '3px 12px',
             }}
           >
-            {error ?? 'loading scene…'}
+            {panelPresetLabel}
           </span>
-        )}
+
+          <select
+            aria-label="data source"
+            data-testid="studio-scene-select"
+            value={sceneSource.kind === 'live' ? 'live' : String(sceneSource.id)}
+            onChange={(e) => {
+              const raw = e.target.value;
+              onSceneSourceChange?.(
+                raw === 'live' ? { kind: 'live' } : { kind: 'scene', id: Number(raw) }
+              );
+            }}
+            style={{
+              fontSize: 12,
+              background: '#0e1119',
+              color: '#e5e7eb',
+              border: `1px solid ${hairline}`,
+              borderRadius: 6,
+              padding: '4px 8px',
+            }}
+          >
+            <option value="live">live</option>
+            {scenes.map((scene) => (
+              <option key={scene.id} value={scene.id}>
+                {sceneOptionLabel(scene)}
+              </option>
+            ))}
+          </select>
+
+          <SaveSceneButton onSaved={onSceneSaved} />
+
+          {sceneUnresolved && (
+            <span
+              data-testid="studio-scene-status"
+              style={{
+                fontFamily: mono,
+                fontSize: 11,
+                color: error ? '#f0a04b' : dim,
+              }}
+            >
+              {error ?? 'loading scene…'}
+            </span>
+          )}
+        </div>
+        <div style={{ justifySelf: 'end' }}>{nav}</div>
       </div>
 
       {showSceneRow && (
@@ -329,7 +361,9 @@ export function PreviewPane({
           data-testid="studio-tile-detail"
           style={{
             position: 'absolute',
-            top: 16,
+            // Below the top row (16 padding + ~28 row + 16 gap), not over it:
+            // the nav lives at the row's right end and must stay clickable.
+            top: 60,
             right: 16,
             zIndex: 5,
             display: 'flex',

--- a/app/studio/StudioClient.tsx
+++ b/app/studio/StudioClient.tsx
@@ -238,12 +238,12 @@ export function StudioClient() {
           error={sceneError}
           at={sceneRepresentsAt ?? undefined}
           onSceneSaved={refreshScenes}
+          /* Same control as the homepage, so the two surfaces are reachable
+             from each other. No onModeChange: there is no homepage view state
+             here, so picking one navigates. Rendered in the pane's top row,
+             not floated over it, so the tile-detail card cannot open under it. */
+          nav={<MapMosaicModeToggle mode="studio" />}
         />
-
-        {/* Same control as the homepage, so the two surfaces are reachable
-            from each other. No onModeChange: there is no homepage view state
-            here, so picking one navigates. */}
-        <MapMosaicModeToggle mode="studio" />
 
         {railCollapsed && (
           <div


### PR DESCRIPTION
## Problem

The Globe / Studio / My Cameras toggle floated in the top-right corner over whatever the page drew there.

- In /studio, clicking a tile to rate a camera opened the detail card in that same corner, with its **close** button under the nav.
- On the homepage, a map popup near the top edge sat under the nav and could never rise above it: the popup lives inside the map's stacking context, so no z-index on it can beat a sibling of the map.

## Fix

`MapMosaicModeToggle` now renders inline; each page gives it real chrome.

- **Homepage:** a 44px header band above the view. The view fills the remainder (`h-screen` → `h-full` down the tree; `main` is 100vh and does not scroll). A popup cannot overlap the nav because the map starts below it.
- **Studio:** the toggle is passed to `PreviewPane` as a `nav` slot and sits at the right end of the existing top row, in a `1fr | controls | 1fr` grid that keeps the controls centered and gives way on narrow panes instead of overlapping. The tile-detail card opens below that row (`top: 60`).

## Verified

- Local dev, 1440×900 and 390×844: header occupies y 0–44, map y 44–bottom, popup opens fully below the band, no page scroll, no horizontal overflow.
- `vitest` on studio / Map / MyCameras / toggle suites: 172 passed, including a new PreviewPane test for the nav slot.
- `next lint`: no errors. `tsc`: only pre-existing errors in files this PR does not touch.
- **Not verified visually:** /studio itself (owner sign-in). Please give the top row and the tile-detail card a look with the rail open and closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C6RWHGTND22jTcWW6PUtCP