### PR TITLE
fix(mosaic/v4): label every overlay number; strip says dials match, not picture

### DIFF
--- a/app/components/mosaic/v4/index.tsx
+++ b/app/components/mosaic/v4/index.tsx
@@ -114,8 +114,8 @@ export function MosaicV4({
         <TileRatings
           layout={layout}
           byId={byId}
-          qualitySource={cfg.qualitySource}
-          gateThreshold={cfg.gateThreshold}
+          cfg={cfg}
+          feed={feed}
           scale={cfg.overlayScale}
         />
       )}

--- a/app/components/mosaic/v4/overlays/ModelReadout.tsx
+++ b/app/components/mosaic/v4/overlays/ModelReadout.tsx
@@ -47,12 +47,15 @@ export function ModelReadout({
               <div>not scored</div>
             ) : (
               <>
+                {/* Named heads: detection is a probability, quality a 1-5
+                    rating. Two bare numbers on different scales read as one
+                    score, which is how a 1.9 got compared against a 0.75. */}
                 <div>
                   {detection
-                    ? `${detection.verdict} ${detection.probability.toFixed(2)}`
-                    : '—'}
+                    ? `detect ${detection.probability.toFixed(2)} · ${detection.verdict}`
+                    : 'detect —'}
                 </div>
-                <div>{quality === null ? '—' : quality.toFixed(1)}</div>
+                <div>{quality === null ? 'quality —' : `quality ${quality.toFixed(1)} / 5`}</div>
               </>
             )}
             {tile.pinnedToFloor && <div>floored</div>}

--- a/app/components/mosaic/v4/overlays/TileRatings.tsx
+++ b/app/components/mosaic/v4/overlays/TileRatings.tsx
@@ -1,13 +1,45 @@
 import type { WindyWebcam } from '@/app/lib/types';
-import { explainSignal, type QualitySource } from '../qualitySignal';
-import type { Layout } from '../engine/types';
+import { explainSignal } from '../qualitySignal';
+import { exitEdgeDeg } from '../engine/axis';
+import { exitTaper, normalizeScore } from '../engine/sizing';
+import type { Layout, PlacedTile, V4Config } from '../engine/types';
 
 /**
- * Per-tile troubleshooting readout: what the tile scored, whether it passed
- * the gate, and which judge decided. The judge matters more than it looks —
- * the gate threshold acts on model-scored frames only, so a feed running on
- * Claude's verdict will not react to the dial at all, and this is where that
- * shows up instead of looking like a composition bug.
+ * Why a tile is not at the height its quality alone would give it. Null when
+ * it is, which is the common case and needs no line. The rules mirror
+ * `sizeTiles` exactly; a reason here that the engine does not apply is a bug.
+ */
+export function sizeReason(
+  tile: Pick<PlacedTile, 'passes' | 'score' | 'sunAltitudeDeg'>,
+  cfg: V4Config,
+  feed: 'sunrise' | 'sunset'
+): string | null {
+  if (tile.score === null) return null; // "unscored" is already the whole story
+  if (!tile.passes) return 'floor · failed gate';
+  if (cfg.curve === 'percentileAmongPassers') return null; // ranked, not absolute
+  if (normalizeScore(tile.score, cfg) <= 0) {
+    return `floor · quality ≤ ${cfg.scoreFloor.toFixed(2)}`;
+  }
+  const taper = exitTaper(tile.sunAltitudeDeg, cfg, feed);
+  if (taper <= 0) {
+    return `floor · past ${feed === 'sunset' ? 'night' : 'day'} edge (${exitEdgeDeg(cfg, feed)}°)`;
+  }
+  if (taper < 1) return `exit taper ×${taper.toFixed(2)}`;
+  return null;
+}
+
+/**
+ * Per-tile troubleshooting readout. Every number is named, because the two
+ * heads are on different scales and the one that sizes the tile is not the
+ * one that looks like a score: quality is [0,1] and drives height, detection
+ * is printed on the 1-5 rating scale against the gate and only decides
+ * pass/fail. Unlabelled, the detection figure got read as "the score", and a
+ * quality-0.52 tile beside a quality-0.04 one read as a sizing bug.
+ *
+ * The judge matters more than it looks — the gate threshold acts on
+ * model-scored frames only, so a feed running on Claude's verdict will not
+ * react to the dial at all, and this is where that shows up instead of
+ * looking like a composition bug.
  *
  * Sized by `scale` rather than a fixed 10px, because the panels are read at
  * arm's length on 1440x2560 glass, not in a browser tab.
@@ -15,14 +47,14 @@ import type { Layout } from '../engine/types';
 export function TileRatings({
   layout,
   byId,
-  qualitySource,
-  gateThreshold,
+  cfg,
+  feed,
   scale = 1,
 }: {
   layout: Layout;
   byId: Map<number, { img: HTMLImageElement; webcam: WindyWebcam }>;
-  qualitySource: QualitySource;
-  gateThreshold: number;
+  cfg: V4Config;
+  feed: 'sunrise' | 'sunset';
   scale?: number;
 }) {
   const font = 10 * scale;
@@ -33,16 +65,30 @@ export function TileRatings({
       {layout.tiles.map((tile) => {
         const entry = byId.get(tile.id);
         if (!entry) return null;
-        const s = explainSignal(entry.webcam, qualitySource, gateThreshold);
-        // The gate margin is only meaningful when the gate had something to
-        // compare. For llm and unscored frames the dial is inert, and saying
+        const s = explainSignal(entry.webcam, cfg.qualitySource, cfg.gateThreshold);
+
+        // Line 1: the number the engine sizes with, named for its judge.
+        const scoreName = s.judge === 'llm' ? 'claude' : 'quality';
+        const scoreLine =
+          tile.score === null
+            ? 'unscored'
+            : `${scoreName} ${tile.score.toFixed(2)} ${tile.passes ? '✓' : '✗'} · ${Math.round(tile.height)}px`;
+
+        // Line 2: what the gate compared. Only meaningful when it had
+        // something to compare; for llm frames the dial is inert, and saying
         // so beats printing a number that never moves.
-        const gateLine =
-          s.gateInput !== null && s.gateValue !== null
-            ? `${s.gateInput.toFixed(2)} / ${s.gateValue.toFixed(2)}`
-            : s.judge === 'llm'
-              ? 'gate n/a'
-              : 'unscored';
+        let gateLine: string;
+        if (s.gateInput !== null && s.gateValue !== null) {
+          const op = s.gateInput >= s.gateValue ? '≥' : '<';
+          gateLine = `detect ${s.gateInput.toFixed(2)} ${op} gate ${s.gateValue.toFixed(2)}`;
+        } else if (s.judge === 'llm') {
+          gateLine = `claude says ${s.passes ? 'sunset' : 'not sunset'} · gate n/a`;
+        } else {
+          gateLine = 'no judge';
+        }
+
+        // Line 3: only when the height is not the quality's own.
+        const reason = sizeReason(tile, cfg, feed);
 
         return (
           <div
@@ -71,13 +117,13 @@ export function TileRatings({
               whiteSpace: 'nowrap',
             }}
           >
-            <div>
-              {tile.score === null ? '—' : tile.score.toFixed(2)}
-              {tile.passes ? ' ✓' : ' ✗'}
-            </div>
-            <div style={{ opacity: 0.75, fontWeight: 400 }}>
-              {s.judge} {gateLine}
-            </div>
+            <div>{scoreLine}</div>
+            {tile.score !== null && (
+              <div style={{ opacity: 0.75, fontWeight: 400 }}>{gateLine}</div>
+            )}
+            {reason && (
+              <div style={{ opacity: 0.75, fontWeight: 400, color: '#f5a344' }}>{reason}</div>
+            )}
           </div>
         );
       })}

--- a/app/components/mosaic/v4/overlays/overlays.test.tsx
+++ b/app/components/mosaic/v4/overlays/overlays.test.tsx
@@ -6,6 +6,7 @@ import { SetupOverlay } from './SetupOverlay';
 import { ModelReadout } from './ModelReadout';
 import { CentreLine } from './CentreLine';
 import type { Layout } from '../engine/types';
+import { v4Config } from '../engine/testConfig';
 import type { WindyWebcam } from '@/app/lib/types';
 
 const webcam = {
@@ -37,10 +38,22 @@ describe('FeedLabel', () => {
   });
 });
 
-const ratingProps = { qualitySource: 'auto' as const, gateThreshold: 0.55 };
+const ratingCfg = v4Config({
+  qualitySource: 'auto', gateThreshold: 0.55, scoreFloor: 0, scoreCeiling: 1,
+  exitTaperDeg: 6, axisNightEdgeDeg: -24, axisDayEdgeDeg: -2, curve: 'linear',
+});
+const ratingProps = { cfg: ratingCfg, feed: 'sunset' as const };
+
+const withTile = (over: Partial<Layout['tiles'][number]>): Layout => {
+  const base = layout();
+  return { ...base, tiles: [{ ...base.tiles[0], ...over }] };
+};
+
+const idFor = (cam: WindyWebcam) =>
+  new Map([[1, { img: {} as HTMLImageElement, webcam: cam }]]);
 
 describe('TileRatings', () => {
-  it('renders a chip per tile showing the score', () => {
+  it('renders a chip per tile', () => {
     render(<TileRatings layout={layout()} byId={byId()} {...ratingProps} />);
     expect(screen.getAllByTestId('v4-rating-chip')).toHaveLength(1);
   });
@@ -55,24 +68,89 @@ describe('TileRatings', () => {
     expect(screen.getByTestId('v4-rating-chip')).toHaveAttribute('data-judge', 'model');
   });
 
-  it('shows the two numbers the gate compared, on the rating scale', () => {
+  // The number that sizes the tile is the quality head, and it is the ONE
+  // number an operator needs to read against the tile's size. Unlabelled, the
+  // 1-5 detection figure on the next line got read as "the score" and a
+  // quality-0.52 tile beside a quality-0.04 one looked like a sizing bug.
+  it('labels the sizing score as quality and shows the height it produced', () => {
     render(<TileRatings layout={layout()} byId={byId()} {...ratingProps} />);
-    // aiRatingBinary 4 against a 0.55 threshold, which is 3.20 as a rating.
-    expect(screen.getByTestId('v4-rating-chip')).toHaveTextContent('4.00 / 3.20');
+    const chip = screen.getByTestId('v4-rating-chip');
+    expect(chip).toHaveTextContent('quality 0.80 ✓');
+    expect(chip).toHaveTextContent('75px');
   });
 
-  it('says the gate is inert rather than printing a dead number for llm frames', () => {
-    const llmCam = { webcamId: 1, title: 'cam', llmIsSunset: true, llmQuality: 0.8 } as WindyWebcam;
+  it('labels the two numbers the gate compared, on the rating scale', () => {
+    render(<TileRatings layout={layout()} byId={byId()} {...ratingProps} />);
+    // aiRatingBinary 4 against a 0.55 threshold, which is 3.20 as a rating.
+    expect(screen.getByTestId('v4-rating-chip')).toHaveTextContent('detect 4.00 ≥ gate 3.20');
+  });
+
+  it('says a gate-failer is at the floor because of the gate, not its quality', () => {
+    const failer = { webcamId: 1, title: 'cam', aiRatingBinary: 2, aiRatingRegression: 4.2 } as WindyWebcam;
     render(
       <TileRatings
-        layout={layout()}
-        byId={new Map([[1, { img: {} as HTMLImageElement, webcam: llmCam }]])}
+        layout={withTile({ passes: false, pinnedToFloor: true, height: 40 })}
+        byId={idFor(failer)}
         {...ratingProps}
       />
     );
     const chip = screen.getByTestId('v4-rating-chip');
+    expect(chip).toHaveTextContent('quality 0.80 ✗');
+    expect(chip).toHaveTextContent('detect 2.00 < gate 3.20');
+    expect(chip).toHaveTextContent('floor · failed gate');
+  });
+
+  it('explains a passer sitting at the floor because its quality is under the score floor', () => {
+    render(
+      <TileRatings
+        layout={layout()}
+        byId={byId()}
+        cfg={v4Config({ ...ratingCfg, scoreFloor: 0.9 })}
+        feed="sunset"
+      />
+    );
+    expect(screen.getByTestId('v4-rating-chip')).toHaveTextContent('floor · quality ≤ 0.90');
+  });
+
+  it('explains the exit taper when the camera is leaving the window', () => {
+    // 3° inside a 6° taper on the -24 night edge: smoothstep(0.5) = 0.50.
+    render(
+      <TileRatings layout={withTile({ sunAltitudeDeg: -21 })} byId={byId()} {...ratingProps} />
+    );
+    expect(screen.getByTestId('v4-rating-chip')).toHaveTextContent('exit taper ×0.50');
+  });
+
+  it('explains a passer past the exit edge, which the taper pins to the floor', () => {
+    render(
+      <TileRatings layout={withTile({ sunAltitudeDeg: -26 })} byId={byId()} {...ratingProps} />
+    );
+    expect(screen.getByTestId('v4-rating-chip')).toHaveTextContent('floor · past night edge');
+  });
+
+  it('adds no explanation when the tile is simply at its quality height', () => {
+    render(<TileRatings layout={layout()} byId={byId()} {...ratingProps} />);
+    const text = screen.getByTestId('v4-rating-chip').textContent ?? '';
+    expect(text).not.toMatch(/floor|taper/);
+  });
+
+  it('names Claude as the judge and says the gate is inert for llm frames', () => {
+    const llmCam = { webcamId: 1, title: 'cam', llmIsSunset: true, llmQuality: 0.8 } as WindyWebcam;
+    render(<TileRatings layout={layout()} byId={idFor(llmCam)} {...ratingProps} />);
+    const chip = screen.getByTestId('v4-rating-chip');
     expect(chip).toHaveAttribute('data-judge', 'llm');
-    expect(chip).toHaveTextContent('gate n/a');
+    expect(chip).toHaveTextContent('claude 0.80 ✓');
+    expect(chip).toHaveTextContent('claude says sunset · gate n/a');
+  });
+
+  it('says unscored rather than printing dashes for a frame no judge saw', () => {
+    render(
+      <TileRatings
+        layout={withTile({ passes: false, score: null, pinnedToFloor: true })}
+        byId={idFor(unscoredWebcam)}
+        {...ratingProps}
+      />
+    );
+    expect(screen.getByTestId('v4-rating-chip')).toHaveTextContent('unscored');
   });
 
   it('scales the text so it is readable across a room', () => {
@@ -113,8 +191,9 @@ describe('ModelReadout', () => {
   it('renders a chip containing both readouts', () => {
     render(<ModelReadout layout={layout()} byId={byId()} />);
     const chip = screen.getByTestId('v4-model-chip');
-    expect(chip).toHaveTextContent('sunset 0.75');
-    expect(chip).toHaveTextContent('4.2');
+    // Both heads named, so the two numbers cannot be read as one score.
+    expect(chip).toHaveTextContent('detect 0.75 · sunset');
+    expect(chip).toHaveTextContent('quality 4.2 / 5');
   });
 
   it('renders exactly one "not scored" line and nothing bogus when neither readout is present', () => {

--- a/app/studio/StatusStrip.test.tsx
+++ b/app/studio/StatusStrip.test.tsx
@@ -32,7 +32,7 @@ describe('StatusStrip', () => {
     expect(screen.getByText('rev 14')).toBeInTheDocument();
     expect(screen.getByText('polled 32s ago')).toBeInTheDocument();
     expect(screen.getByText('↑1/39 ↓3/42 pass')).toBeInTheDocument();
-    expect(screen.getByText('in sync')).toBeInTheDocument();
+    expect(screen.getByText('dials match glass')).toBeInTheDocument();
   });
 
   it('shows the deploying state with a countdown to the next poll', () => {
@@ -73,7 +73,31 @@ describe('StatusStrip', () => {
       />
     );
 
-    expect(screen.getByText('7 differ')).toBeInTheDocument();
+    expect(screen.getByText('7 dials differ')).toBeInTheDocument();
+  });
+
+  // "in sync" used to be the whole state word, and it was read as "the glass
+  // shows this picture". It never meant that: the strip compares settings
+  // rows, and a scene preview is a different pool at a different moment.
+  it('says the preview is a scene when one is selected, so matching dials is not read as a matching picture', () => {
+    const now = new Date('2026-08-30T12:00:00Z');
+    vi.setSystemTime(now);
+
+    render(
+      <StatusStrip
+        glassVersion="v4"
+        liveRevision={14}
+        lastPollAt={new Date(now.getTime() - 5_000).toISOString()}
+        deployedAtMs={null}
+        diffCount={0}
+        sunrisePass={{ pass: 1, total: 39 }}
+        sunsetPass={{ pass: 3, total: 42 }}
+        previewing="scene"
+      />
+    );
+
+    expect(screen.getByText(/dials match glass/)).toBeInTheDocument();
+    expect(screen.getByText(/previewing a scene · glass is live/)).toBeInTheDocument();
   });
 
   it('shows the stale state with a red kiosk-unreachable poll label when there has been no poll', () => {

--- a/app/studio/StatusStrip.tsx
+++ b/app/studio/StatusStrip.tsx
@@ -39,6 +39,7 @@ export function StatusStrip({
   sunrisePass,
   sunsetPass,
   droppedKeys = [],
+  previewing = 'live',
 }: {
   glassVersion: string;
   liveRevision: number;
@@ -48,6 +49,13 @@ export function StatusStrip({
   sunrisePass: GatePassCount;
   sunsetPass: GatePassCount;
   droppedKeys?: DroppedKey[];
+  /**
+   * What the pane beside this strip is composing. The state word compares
+   * settings rows, nothing else; "in sync" got read as "the glass shows this
+   * picture", which a scene preview never is. Naming the source keeps a
+   * matching dial set from being mistaken for a matching picture.
+   */
+  previewing?: 'live' | 'scene';
 }) {
   const [nowMs, setNowMs] = useState(() => Date.now());
 
@@ -72,7 +80,7 @@ export function StatusStrip({
   let stateWord: React.ReactNode;
   switch (state.kind) {
     case 'insync':
-      stateWord = <span style={{ color: dim }}>in sync</span>;
+      stateWord = <span style={{ color: dim }}>dials match glass</span>;
       break;
     case 'deploying':
       stateWord = (
@@ -82,7 +90,7 @@ export function StatusStrip({
       );
       break;
     case 'drift':
-      stateWord = <span style={{ color: amber }}>{diffCount} differ</span>;
+      stateWord = <span style={{ color: amber }}>{diffCount} dials differ</span>;
       break;
     case 'stale':
       stateWord = <span style={{ color: red }}>stale</span>;
@@ -132,7 +140,20 @@ export function StatusStrip({
           {droppedKeys.map((d) => `${d.key} (${d.reason})`).join(', ')}
         </span>
       )}
-      <span style={{ marginLeft: 'auto' }}>{stateWord}</span>
+      {previewing === 'scene' && (
+        <span
+          data-testid="status-strip-previewing"
+          style={{ marginLeft: 'auto', color: amber }}
+          title={
+            'The pane is composing a saved scene: a pool from another moment. ' +
+            'The glass is composing the live pool. Matching dials do not make ' +
+            'these the same picture.'
+          }
+        >
+          previewing a scene · glass is live
+        </span>
+      )}
+      <span style={{ marginLeft: previewing === 'scene' ? 0 : 'auto' }}>{stateWord}</span>
     </div>
   );
 }

--- a/app/studio/StudioClient.tsx
+++ b/app/studio/StudioClient.tsx
@@ -306,6 +306,7 @@ export function StudioClient() {
           sunrisePass={sunrisePass}
           sunsetPass={sunsetPass}
           droppedKeys={settingsApi.droppedKeys}
+          previewing={sceneSource.kind}
         />
       </div>
     </div>


### PR DESCRIPTION
## Why

Jesse saved scenes 6 and 7 on 2026-09-04 reporting a 1.93-scored tile drawn larger than a 1.72-scored one, and that the studio strip said the glass was "in sync" when the picture plainly differed.

Both were legibility bugs, not composition bugs:

- The v4 tile-ratings chip printed three bare numbers on two scales: the [0,1] **quality** score that sizes the tile, then the 1-5 **detection** rating against the 1-5 **gate**. With `gateThreshold` 0.18 the gate prints as 1.72 on every chip, and the 1.9x figures were detection ratings. Size follows quality (Danderyd 0.52 → 446px vs Hessi Jerbi 0.04 → floor), after `scoreFloor` 0.42 and the exit taper, neither of which the chip mentioned.
- "in sync" compares settings rows and poll freshness, nothing else. Jesse was previewing a saved scene, so the picture could never match the glass. (The Pi tabs were checked: plain `/kiosk/sunrise` and `/kiosk/sunset` at 1080x1920, no `?v=`, matching the public live route.)

## What

- `TileRatings` now reads `quality 0.52 ✓ · 446px` / `detect 1.91 ≥ gate 1.72`, plus an amber third line **only** when the height is not the quality's own: `floor · failed gate`, `floor · quality ≤ 0.42`, `exit taper ×0.10`, `floor · past night edge (-24°)`. `sizeReason` mirrors `sizeTiles` rule for rule. Claude-judged frames read `claude 0.80 ✓` / `claude says sunset · gate n/a`.
- `ModelReadout` names its heads: `detect 0.75 · sunset` / `quality 4.2 / 5`.
- `StatusStrip`: "in sync" → "dials match glass", "7 differ" → "7 dials differ", and a `previewing` prop adds "previewing a scene · glass is live" while a scene is selected.

## Verified

- `vitest run app/components/mosaic/v4 app/studio`: 372 passed. New tests cover each third-line reason, the llm wording, and the scene-preview strip.
- Rendered locally against the live dials (`/kiosk/sunset?panel=1080x1920&showTileRatings=1`): chips read as above; a tile at the night edge shows the taper line.

## Known limits (unchanged behavior, now more visible)

- On floor-size tiles the chip clips at tile width, so the trailing `px` figure can be cut.
- With both overlays on at once, the two chips overlap on floor tiles.
- Not in this PR: v4's `qualitySignal` ignores the per-camera `calibrationMultiplier` that v1 applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GNE1nn2WRZTUL47ieefShX
