### PR TITLE
feat(solo): /studio/solo, the bins transparency surface (phase 3)

### DIFF
--- a/app/api/kiosk/solo/advance/route.test.ts
+++ b/app/api/kiosk/solo/advance/route.test.ts
@@ -7,6 +7,9 @@ const commitAdvance = vi.fn();
 const countAdmittedSince = vi.fn();
 const getLiveSettingsCached = vi.fn();
 vi.mock('server-only', () => ({}));
+// sweepGeometry's module pulls in the Neon client; the route only uses its pure half.
+vi.mock('@/app/lib/db', () => ({ sql: vi.fn() }));
+vi.mock('@/app/lib/runtimeFlags', () => ({ isFlagEnabled: async () => false, SWEEP_FORCE_DAY_RING: 'x' }));
 vi.mock('@/app/lib/solo/store', () => ({
   listActiveEntries: (...a: unknown[]) => listActiveEntries(...a),
   getScreenState: (...a: unknown[]) => getScreenState(...a),

--- a/app/api/kiosk/solo/advance/route.ts
+++ b/app/api/kiosk/solo/advance/route.ts
@@ -5,7 +5,10 @@ import { afterShowing, next } from '@/app/lib/solo/engine';
 import { slotFor } from '@/app/lib/solo/schedule';
 import { SOLO_NAMESPACE, SOLO_SETTINGS_SCHEMA, dialsFrom } from '@/app/lib/solo/settingsSchema';
 import { commitAdvance, countAdmittedSince, getScreenState, listActiveEntries } from '@/app/lib/solo/store';
-import { buildStateView, parseFeed } from '../view';
+import { isFlagEnabled, SWEEP_FORCE_DAY_RING } from '@/app/lib/runtimeFlags';
+import { sweepGeometry } from '@/app/api/cron/update-cameras/lib/sweepGeometry';
+import { TERMINATOR_DAY_SIDE_OFFSETS_DEG } from '@/app/lib/masterConfig';
+import { buildStateView, parseFeed, toViewEntry } from '../view';
 
 export const dynamic = 'force-dynamic';
 export const runtime = 'nodejs';
@@ -61,9 +64,14 @@ export async function POST(request: Request) {
       }
     }
   }
-  const admitted = await countAdmittedSince(feed, nowMs - LAST_PULL_WINDOW_MS);
+  const [admitted, forcedDayRing] = await Promise.all([
+    countAdmittedSince(feed, nowMs - LAST_PULL_WINDOW_MS),
+    isFlagEnabled(SWEEP_FORCE_DAY_RING),
+  ]);
+  const geometry = sweepGeometry(forcedDayRing ? TERMINATOR_DAY_SIDE_OFFSETS_DEG : []);
+  const zone = { minDeg: geometry.coverageMinDeg, maxDeg: geometry.coverageMaxDeg };
   return NextResponse.json({
     advanced,
-    ...buildStateView({ feed, dials, entries, screen, nowMs, admitted }),
+    ...buildStateView({ feed, dials, entries: entries.map(toViewEntry), screen, nowMs, admitted, zone }),
   });
 }

--- a/app/api/kiosk/solo/state/route.test.ts
+++ b/app/api/kiosk/solo/state/route.test.ts
@@ -9,6 +9,9 @@ const countAdmittedSince = vi.fn();
 const getLiveSettingsCached = vi.fn();
 const getProfileSettings = vi.fn();
 vi.mock('server-only', () => ({}));
+// sweepGeometry's module pulls in the Neon client; the route only uses its pure half.
+vi.mock('@/app/lib/db', () => ({ sql: vi.fn() }));
+vi.mock('@/app/lib/runtimeFlags', () => ({ isFlagEnabled: async () => false, SWEEP_FORCE_DAY_RING: 'x' }));
 vi.mock('@/app/lib/owner', () => ({ requireOwner: () => requireOwner() }));
 vi.mock('@/app/lib/solo/store', () => ({
   listActiveEntries: (...a: unknown[]) => listActiveEntries(...a),
@@ -40,7 +43,9 @@ describe('GET /api/kiosk/solo/state', () => {
   it('live profile by default, no owner check', async () => {
     const res = await get('?feed=sunset');
     expect(res.status).toBe(200);
-    expect((await res.json()).dials.dwellS).toBe(30);
+    const body = await res.json();
+    expect(body.dials.dwellS).toBe(30);
+    expect(body.zone).toEqual({ minDeg: -24, maxDeg: -2 });
     expect(requireOwner).not.toHaveBeenCalled();
   });
   it('studio profile is owner-gated and projects with studio dials', async () => {

--- a/app/api/kiosk/solo/state/route.ts
+++ b/app/api/kiosk/solo/state/route.ts
@@ -5,7 +5,10 @@ import { getProfileSettings } from '@/app/lib/settings/store';
 import { mergeSettings } from '@/app/lib/settings/schema';
 import { SOLO_NAMESPACE, SOLO_SETTINGS_SCHEMA, dialsFrom } from '@/app/lib/solo/settingsSchema';
 import { countAdmittedSince, getScreenState, listActiveEntries } from '@/app/lib/solo/store';
-import { buildStateView, parseFeed } from '../view';
+import { isFlagEnabled, SWEEP_FORCE_DAY_RING } from '@/app/lib/runtimeFlags';
+import { sweepGeometry } from '@/app/api/cron/update-cameras/lib/sweepGeometry';
+import { TERMINATOR_DAY_SIDE_OFFSETS_DEG } from '@/app/lib/masterConfig';
+import { buildStateView, parseFeed, toViewEntry } from '../view';
 
 export const dynamic = 'force-dynamic';
 export const runtime = 'nodejs';
@@ -31,10 +34,16 @@ export async function GET(request: NextRequest) {
   const dials = dialsFrom(mergeSettings(SOLO_SETTINGS_SCHEMA, profile?.namespaces[SOLO_NAMESPACE]));
 
   const nowMs = Date.now();
-  const [entries, screen, admitted] = await Promise.all([
+  const [entries, screen, admitted, forcedDayRing] = await Promise.all([
     listActiveEntries(feed),
     getScreenState(feed),
     countAdmittedSince(feed, nowMs - LAST_PULL_WINDOW_MS),
+    isFlagEnabled(SWEEP_FORCE_DAY_RING),
   ]);
-  return NextResponse.json(buildStateView({ feed, dials, entries, screen, nowMs, admitted }));
+  // The same zone the cron ages entries against (binAdmission.maintainBins).
+  const geometry = sweepGeometry(forcedDayRing ? TERMINATOR_DAY_SIDE_OFFSETS_DEG : []);
+  const zone = { minDeg: geometry.coverageMinDeg, maxDeg: geometry.coverageMaxDeg };
+  return NextResponse.json(buildStateView({
+    feed, dials, entries: entries.map(toViewEntry), screen, nowMs, admitted, zone,
+  }));
 }

--- a/app/api/kiosk/solo/view.test.ts
+++ b/app/api/kiosk/solo/view.test.ts
@@ -1,15 +1,15 @@
 import { describe, it, expect } from 'vitest';
-import { buildStateView, parseFeed } from './view';
-import type { StoredEntry } from '@/app/lib/solo/store';
+import { buildStateView, parseFeed, toViewEntry, type ViewEntry } from './view';
 import { dialsFrom, SOLO_SETTINGS_SCHEMA } from '@/app/lib/solo/settingsSchema';
 import { schemaDefaults } from '@/app/lib/settings/schema';
 
 const D = dialsFrom(schemaDefaults(SOLO_SETTINGS_SCHEMA));
-const stored = (id: number, bin: 'sunset' | 'non_sunset', score: number, tally = 0): StoredEntry => ({
-  feed: 'sunset', snapshotId: id, webcamId: 100 + id, bin,
+const ZONE = { minDeg: -24, maxDeg: -2 };
+const stored = (id: number, bin: 'sunset' | 'non_sunset', score: number, tally = 0): ViewEntry => ({
+  snapshotId: id, webcamId: 100 + id, bin,
   quality: bin === 'sunset' ? score : null, detection: bin === 'sunset' ? 0.9 : score,
-  isNew: false, tally, enteredAt: id, firstShownAt: null, lastShownAt: null,
-  imageUrl: `u${id}`, title: `t${id}`, city: '', region: '', country: '', lat: 0, lng: 0,
+  isNew: false, tally, enteredAt: id,
+  imageUrl: `u${id}`, title: `t${id}`, city: '', region: '', country: '',
 });
 
 describe('parseFeed', () => {
@@ -21,10 +21,21 @@ describe('parseFeed', () => {
   });
 });
 
+describe('toViewEntry', () => {
+  it('drops coordinates and feed, keeps identity, scores, and place', () => {
+    const v = toViewEntry({
+      ...stored(1, 'sunset', 0.9), feed: 'sunset', lat: 1, lng: 2, firstShownAt: null, lastShownAt: null,
+    });
+    expect(v).not.toHaveProperty('lat');
+    expect(v).not.toHaveProperty('feed');
+    expect(v).toMatchObject({ snapshotId: 1, quality: 0.9, title: 't1' });
+  });
+});
+
 describe('buildStateView', () => {
   it('queued frames are absent from the bins; bins keep the remainder ranked by score', () => {
     const entries = [stored(1, 'sunset', 0.9), stored(2, 'sunset', 0.8), stored(3, 'non_sunset', 0.5), stored(4, 'sunset', 0.1)];
-    const v = buildStateView({ feed: 'sunset', dials: D, entries, screen: null, nowMs: 0, admitted: { sunset: 0, nonSunset: 0 } });
+    const v = buildStateView({ feed: 'sunset', dials: D, entries, screen: null, nowMs: 0, admitted: { sunset: 0, nonSunset: 0 }, zone: ZONE });
     expect(v.current).toBeNull();
     // Three eligible frames project eight draws: the cycle repeats, which is
     // exactly what the glass will do, so the queue shows it.
@@ -36,7 +47,7 @@ describe('buildStateView', () => {
     const entries = [stored(1, 'sunset', 0.9, 1), stored(2, 'sunset', 0.8)];
     const v = buildStateView({ feed: 'sunset', dials: D, entries,
       screen: { feed: 'sunset', currentSnapshotId: 1, shownSince: 5, slot: 3, sunsetStreak: 1 },
-      nowMs: 70_000, admitted: { sunset: 2, nonSunset: 0 } });
+      nowMs: 70_000, admitted: { sunset: 2, nonSunset: 0 }, zone: ZONE });
     expect(v.current?.entry.snapshotId).toBe(1);
     expect(v.current?.slot).toBe(3);
     expect(v.next[0].snapshotId).toBe(2);
@@ -45,9 +56,16 @@ describe('buildStateView', () => {
   });
   it('rank is the position within the bin by score, ignoring queue membership', () => {
     const entries = [stored(1, 'sunset', 0.7), stored(2, 'sunset', 0.9)];
-    const v = buildStateView({ feed: 'sunset', dials: D, entries, screen: null, nowMs: 0, admitted: { sunset: 0, nonSunset: 0 } });
+    const v = buildStateView({ feed: 'sunset', dials: D, entries, screen: null, nowMs: 0, admitted: { sunset: 0, nonSunset: 0 }, zone: ZONE });
     const byId = new Map(v.next.map((e) => [e.snapshotId, e.rank]));
     expect(byId.get(2)).toBe(1);
     expect(byId.get(1)).toBe(2);
+  });
+  it('echoes the raw entries and the zone so a client can re-project', () => {
+    const entries = [stored(1, 'sunset', 0.9)];
+    const v = buildStateView({ feed: 'sunset', dials: D, entries, screen: null, nowMs: 0,
+      admitted: { sunset: 0, nonSunset: 0 }, zone: { minDeg: -24, maxDeg: 14 } });
+    expect(v.entries).toHaveLength(1);
+    expect(v.zone).toEqual({ minDeg: -24, maxDeg: 14 });
   });
 });

--- a/app/api/kiosk/solo/view.ts
+++ b/app/api/kiosk/solo/view.ts
@@ -2,8 +2,13 @@ import { isEligible, project } from '@/app/lib/solo/engine';
 import { nextBoundaryMs, slotFor } from '@/app/lib/solo/schedule';
 import type { ScreenRow, StoredEntry } from '@/app/lib/solo/store';
 import type { BinEntry, Feed, SoloDials } from '@/app/lib/solo/types';
+import type { Zone } from '@/app/lib/solo/zone';
 
-/** The response shape both solo endpoints return. Pure: no I/O here. */
+/**
+ * The response shape both solo endpoints return. Pure: no I/O here, and no
+ * server-only import, so the studio can re-run it in the browser with its
+ * own dials.
+ */
 
 export const NEXT_COUNT = 8;
 
@@ -14,20 +19,24 @@ export function parseFeed(raw: string | null): Feed | null {
   return raw && (FEEDS as string[]).includes(raw) ? (raw as Feed) : null;
 }
 
-export interface EntryView {
-  snapshotId: number;
-  webcamId: number;
-  bin: BinEntry['bin'];
-  quality: number | null;
-  detection: number;
-  isNew: boolean;
-  tally: number;
-  enteredAt: number;
+/** What the client needs per frame. No coordinates, no feed: those stay server-side. */
+export interface ViewEntry extends BinEntry {
   imageUrl: string;
   title: string;
   city: string;
   region: string;
   country: string;
+}
+
+export function toViewEntry(e: StoredEntry): ViewEntry {
+  return {
+    snapshotId: e.snapshotId, webcamId: e.webcamId, bin: e.bin, quality: e.quality,
+    detection: e.detection, isNew: e.isNew, tally: e.tally, enteredAt: e.enteredAt,
+    imageUrl: e.imageUrl, title: e.title, city: e.city, region: e.region, country: e.country,
+  };
+}
+
+export interface EntryView extends ViewEntry {
   eligible: boolean;
   /** 1-based position within its bin by score, queue membership ignored. */
   rank: number;
@@ -41,12 +50,15 @@ export interface StateView {
   bins: { sunset: EntryView[]; nonSunset: EntryView[] };
   schedule: { slot: number; nextBoundaryMs: number };
   lastPull: { admitted: { sunset: number; nonSunset: number } };
+  /** Every active entry, raw, so a client can re-project with other dials. */
+  entries: ViewEntry[];
+  zone: Zone;
 }
 
-const scoreOf = (e: StoredEntry) => (e.bin === 'sunset' ? e.quality ?? -1 : e.detection);
-const byScore = (a: StoredEntry, b: StoredEntry) => scoreOf(b) - scoreOf(a) || a.enteredAt - b.enteredAt;
+const scoreOf = (e: ViewEntry) => (e.bin === 'sunset' ? e.quality ?? -1 : e.detection);
+const byScore = (a: ViewEntry, b: ViewEntry) => scoreOf(b) - scoreOf(a) || a.enteredAt - b.enteredAt;
 
-function rankMap(entries: StoredEntry[]): Map<number, number> {
+function rankMap(entries: ViewEntry[]): Map<number, number> {
   const out = new Map<number, number>();
   for (const bin of ['sunset', 'non_sunset'] as const) {
     entries
@@ -60,19 +72,19 @@ function rankMap(entries: StoredEntry[]): Map<number, number> {
 export function buildStateView(input: {
   feed: Feed;
   dials: SoloDials;
-  entries: StoredEntry[];
+  entries: ViewEntry[];
   screen: ScreenRow | null;
   nowMs: number;
   admitted: { sunset: number; nonSunset: number };
+  zone: Zone;
 }): StateView {
   const { feed, dials, entries, screen, nowMs } = input;
   const ranks = rankMap(entries);
   const byId = new Map(entries.map((e) => [e.snapshotId, e]));
-  const view = (e: StoredEntry): EntryView => ({
-    snapshotId: e.snapshotId, webcamId: e.webcamId, bin: e.bin, quality: e.quality,
-    detection: e.detection, isNew: e.isNew, tally: e.tally, enteredAt: e.enteredAt,
-    imageUrl: e.imageUrl, title: e.title, city: e.city, region: e.region, country: e.country,
-    eligible: isEligible(e, dials), rank: ranks.get(e.snapshotId) ?? 0,
+  const view = (e: ViewEntry): EntryView => ({
+    ...e,
+    eligible: isEligible(e, dials),
+    rank: ranks.get(e.snapshotId) ?? 0,
   });
 
   const currentEntry = screen?.currentSnapshotId != null ? byId.get(screen.currentSnapshotId) ?? null : null;
@@ -100,5 +112,7 @@ export function buildStateView(input: {
       nextBoundaryMs: nextBoundaryMs(nowMs, feed, dials.dwellS, dials.offsetS),
     },
     lastPull: { admitted: input.admitted },
+    entries,
+    zone: input.zone,
   };
 }

--- a/app/studio/StudioClient.tsx
+++ b/app/studio/StudioClient.tsx
@@ -178,6 +178,13 @@ export function StudioClient() {
             userSelect: resizing ? 'none' : undefined,
           }}
         >
+          <a
+            href="/studio/solo"
+            title="The solo kiosk's studio: bins, queue, and its own dials"
+            style={{ display: 'block', fontSize: 11, color: '#8b95a7', marginBottom: 6 }}
+          >
+            solo studio →
+          </a>
           <StudioRail
             api={settingsApi}
             onCollapse={() => setRailCollapsed(true)}

--- a/app/studio/solo/EntryRow.test.tsx
+++ b/app/studio/solo/EntryRow.test.tsx
@@ -1,0 +1,33 @@
+import { it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { EntryRow } from './EntryRow';
+
+const e = {
+  snapshotId: 7, webcamId: 3, bin: 'sunset' as const, quality: 0.91, detection: 0.88, isNew: true,
+  tally: 2, enteredAt: 0, imageUrl: 'u', title: 'Pier', city: 'Lisbon', region: '', country: 'Portugal',
+  eligible: true, rank: 1,
+};
+
+it('shows tally first, scores, place, and the tags', () => {
+  render(<EntryRow entry={e} feed="sunset" place="sunset" onClick={vi.fn()} />);
+  expect(screen.getByText('shown ×2')).toHaveStyle({ fontWeight: 800 });
+  expect(screen.getByText(/q 0\.91/)).toBeInTheDocument();
+  expect(screen.getByText(/d 0\.88/)).toBeInTheDocument();
+  expect(screen.getByText('NEW')).toBeInTheDocument();
+  expect(screen.getByText(/Lisbon, Portugal/)).toBeInTheDocument();
+});
+
+it('marks ineligible frames FLOOR and repeats as repeat', () => {
+  render(<EntryRow entry={{ ...e, eligible: false, isNew: false }} feed="sunset" place="sunset" onClick={vi.fn()} />);
+  expect(screen.getByText('FLOOR')).toBeInTheDocument();
+  render(<EntryRow entry={e} feed="sunset" place="queue" repeat onClick={vi.fn()} />);
+  expect(screen.getByText(/repeat/)).toBeInTheDocument();
+});
+
+it('non-sunset rows show only detection, and a click reports the entry', () => {
+  const onClick = vi.fn();
+  render(<EntryRow entry={{ ...e, bin: 'non_sunset', quality: null }} feed="sunset" place="non_sunset" onClick={onClick} />);
+  expect(screen.queryByText(/q /)).toBeNull();
+  fireEvent.click(screen.getByRole('button'));
+  expect(onClick).toHaveBeenCalledWith(expect.objectContaining({ snapshotId: 7 }));
+});

--- a/app/studio/solo/EntryRow.tsx
+++ b/app/studio/solo/EntryRow.tsx
@@ -1,0 +1,68 @@
+'use client';
+
+import type { EntryView } from '@/app/api/kiosk/solo/view';
+import type { Feed } from '@/app/lib/solo/types';
+
+const COLOR = { sunset: '#7ee2ac', non_sunset: '#c3cad6' } as const;
+const mono = 'ui-monospace, SFMono-Regular, Menlo, monospace';
+
+function Tag({ children, bg, fg, title }: { children: string; bg: string; fg: string; title: string }) {
+  return (
+    <span title={title} style={{
+      display: 'inline-block', fontSize: 8.5, fontWeight: 700, padding: '1px 4px', borderRadius: 3,
+      marginRight: 3, background: bg, color: fg, cursor: 'help',
+    }}>{children}</span>
+  );
+}
+
+/**
+ * One frame, wherever it sits: a bin or the queue. The outline is always the
+ * colour of the bin the frame belongs to, so the queue reads at a glance.
+ */
+export function EntryRow({ entry: e, feed, place, onGlass = false, repeat = false, cameraIndex, onClick }: {
+  entry: EntryView;
+  feed: Feed;
+  place: 'sunset' | 'non_sunset' | 'queue';
+  onGlass?: boolean;
+  repeat?: boolean;
+  cameraIndex?: { n: number; m: number };
+  onClick: (entry: EntryView) => void;
+}) {
+  const scores = e.bin === 'sunset'
+    ? `q ${(e.quality ?? 0).toFixed(2)} d ${e.detection.toFixed(2)}`
+    : `d ${e.detection.toFixed(2)}`;
+  const placeText = [e.city, e.country].filter(Boolean).join(', ');
+  const title =
+    `${e.title} · ${placeText}. Frame ${e.snapshotId}, ${feed} feed` +
+    (place === 'queue' ? ', in the queue. ' : '. ') +
+    (e.bin === 'sunset' ? 'Sunset bin, ordered by quality. ' : 'Non-sunset bin, ordered by detection. ') +
+    (!e.eligible ? 'Below the floor dial; not eligible. ' : '') +
+    (repeat ? 'Already appears earlier in the queue; this is a repeat showing. ' : '') +
+    `Shown ${e.tally} time${e.tally === 1 ? '' : 's'} today.`;
+  return (
+    <button type="button" onClick={() => onClick(e)} title={title} style={{
+      display: 'grid', gridTemplateColumns: '46px 1fr', gap: 5, alignItems: 'center', width: '100%',
+      textAlign: 'left', border: `1.5px solid ${COLOR[e.bin]}`, borderRadius: 5, padding: 3, marginBottom: 4,
+      background: '#0e1119', fontFamily: mono, fontSize: 9.5, color: '#9aa3b2', cursor: 'pointer',
+      opacity: !e.eligible || repeat ? 0.45 : 1, boxShadow: onGlass ? '0 0 0 2px #f5a344' : undefined,
+    }}>
+      {/* eslint-disable-next-line @next/next/no-img-element */}
+      <img src={e.imageUrl} alt="" style={{ width: 46, aspectRatio: '16/9', objectFit: 'cover', borderRadius: 3, display: 'block' }} />
+      <div style={{ minWidth: 0 }}>
+        <span style={{ fontWeight: e.tally > 0 ? 800 : 500, color: e.tally > 0 ? '#e5e7eb' : '#6b7280' }}>
+          shown ×{e.tally}
+        </span>
+        {' · '}{scores}{repeat ? ' · repeat' : ''}
+        <div style={{ marginTop: 2 }}>
+          {e.isNew && <Tag bg="#f5a344" fg="#1a1000" title="Newer frame from a camera already in the bin">NEW</Tag>}
+          {!e.eligible && <Tag bg="#3a4356" fg="#e5e7eb" title="Below the floor dial">FLOOR</Tag>}
+          {cameraIndex && (
+            <Tag bg="#7ea6e2" fg="#061224" title="Same camera as another queue entry">{`CAM ${cameraIndex.n}/${cameraIndex.m}`}</Tag>
+          )}
+        </div>
+        <div style={{ color: '#c3cad6', whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>{e.title}</div>
+        <div style={{ color: '#6b7280', whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>{placeText}</div>
+      </div>
+    </button>
+  );
+}

--- a/app/studio/solo/FeedColumn.test.tsx
+++ b/app/studio/solo/FeedColumn.test.tsx
@@ -1,0 +1,49 @@
+import { it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { FeedColumn } from './FeedColumn';
+import { dialsFrom, SOLO_SETTINGS_SCHEMA } from '@/app/lib/solo/settingsSchema';
+import { schemaDefaults } from '@/app/lib/settings/schema';
+import { buildStateView, type ViewEntry } from '@/app/api/kiosk/solo/view';
+
+const D = dialsFrom(schemaDefaults(SOLO_SETTINGS_SCHEMA));
+const entry = (id: number, bin: 'sunset' | 'non_sunset', score: number, webcamId = 100 + id): ViewEntry => ({
+  snapshotId: id, webcamId, bin, quality: bin === 'sunset' ? score : null, detection: bin === 'sunset' ? 0.9 : score,
+  isNew: false, tally: 0, enteredAt: id, imageUrl: `u${id}`, title: `cam${id}`, city: '', region: '', country: '',
+});
+const view = (dials = D) => buildStateView({
+  feed: 'sunset', dials,
+  entries: [entry(1, 'sunset', 0.9), entry(2, 'sunset', 0.8, 101), entry(3, 'non_sunset', 0.5), entry(4, 'sunset', 0.1)],
+  screen: { feed: 'sunset', currentSnapshotId: 1, shownSince: 0, slot: 0, sunsetStreak: 1 },
+  nowMs: 0, admitted: { sunset: 1, nonSunset: 0 }, zone: { minDeg: -24, maxDeg: -2 },
+});
+
+it('draws the on-glass frame at the top of the queue and keeps queued frames out of the bins', () => {
+  const v = view();
+  render(<FeedColumn feed="sunset" server={v} projected={v} liveDials={D} studioDials={D} nowMs={5_000} onSelect={vi.fn()} />);
+  // Sunset boundaries sit at 10 s, 30 s, … (offset 10): at 5 s the next is 5 s away.
+  expect(screen.getByText(/next frame in/).textContent).toContain('5 s');
+  expect(screen.getByText(/Sunset bin · 1 waiting/)).toBeInTheDocument(); // frame 4 (below floor) waits
+  expect(screen.getAllByText('cam1').length).toBeGreaterThan(0);
+  expect(screen.getAllByText(/CAM 1\/2/).length).toBeGreaterThan(0); // frames 1 and 2 share webcam 101
+});
+
+it('says so when the studio dials would draw a different next frame than the glass', () => {
+  const server = view();
+  const projected = view({ ...D, qualityFloor: 0.05, repeatAllowance: 0, sunsetFloor: 0 });
+  // With frame 4 admitted and shown frames sinking, the projection's first draw
+  // differs from the server's only if the two first entries disagree; assert on
+  // the message when they do, and on its absence when they do not, so the test
+  // documents the rule rather than a coincidence.
+  const expectMessage = server.next[0].snapshotId !== projected.next[0].snapshotId;
+  render(<FeedColumn feed="sunset" server={server} projected={projected} liveDials={D} studioDials={D} nowMs={0} onSelect={vi.fn()} />);
+  if (expectMessage) expect(screen.getByText(/projected with studio dials/)).toBeInTheDocument();
+  else expect(screen.queryByText(/projected with studio dials/)).toBeNull();
+});
+
+it('with nothing on glass the panel says so and the queue starts at the projection', () => {
+  const v = buildStateView({ feed: 'sunrise', dials: D, entries: [entry(9, 'sunset', 0.9)], screen: null, nowMs: 0,
+    admitted: { sunset: 0, nonSunset: 0 }, zone: { minDeg: -24, maxDeg: -2 } });
+  render(<FeedColumn feed="sunrise" server={v} projected={v} liveDials={D} studioDials={D} nowMs={0} onSelect={vi.fn()} />);
+  expect(screen.getByText('nothing on glass yet')).toBeInTheDocument();
+  expect(screen.getAllByText('cam9').length).toBeGreaterThan(0);
+});

--- a/app/studio/solo/FeedColumn.tsx
+++ b/app/studio/solo/FeedColumn.tsx
@@ -1,0 +1,141 @@
+'use client';
+
+import type { ReactNode } from 'react';
+import type { EntryView, StateView } from '@/app/api/kiosk/solo/view';
+import { nextBoundaryMs } from '@/app/lib/solo/schedule';
+import type { Feed, SoloDials } from '@/app/lib/solo/types';
+import { EntryRow } from './EntryRow';
+
+const mono = 'ui-monospace, SFMono-Regular, Menlo, monospace';
+const LABEL: Record<Feed, string> = { sunrise: 'Sunrise · left screen', sunset: 'Sunset · right screen' };
+
+function Bin({ color, title, hint, children }: { color: string; title: string; hint: string; children: ReactNode }) {
+  return (
+    <div style={{ border: `2px solid ${color}`, borderRadius: 8, background: '#0b0e14', padding: 5, minWidth: 0 }}>
+      <h5 title={hint} style={{
+        margin: '0 0 6px', fontSize: 10, textTransform: 'uppercase', letterSpacing: '.04em', color, cursor: 'help',
+      }}>{title}</h5>
+      {children}
+    </div>
+  );
+}
+
+/**
+ * One feed: the panel as the glass draws it (live dials), then the two bins
+ * and the queue as the STUDIO dials would order them. Every frame appears in
+ * exactly one of the three columns; the on-glass frame heads the queue.
+ */
+export function FeedColumn({ feed, server, projected, liveDials, nowMs, onSelect }: {
+  feed: Feed;
+  server: StateView;
+  projected: StateView;
+  liveDials: SoloDials;
+  studioDials: SoloDials;
+  nowMs: number;
+  onSelect: (entry: EntryView, feed: Feed) => void;
+}) {
+  const boundary = nextBoundaryMs(nowMs, feed, liveDials.dwellS, liveDials.offsetS);
+  const leftS = Math.max(0, Math.ceil((boundary - nowMs) / 1000));
+  const current = server.current;
+  const queue: EntryView[] = [...(current ? [current.entry] : []), ...projected.next];
+  const seen = new Set<number>();
+  const camCount = new Map<number, number>();
+  for (const e of queue) camCount.set(e.webcamId, (camCount.get(e.webcamId) ?? 0) + 1);
+  const camSeen = new Map<number, number>();
+  const differs =
+    !!server.next[0] && !!projected.next[0] && server.next[0].snapshotId !== projected.next[0].snapshotId;
+  const qSun = queue.filter((e) => e.bin === 'sunset').length;
+  const qNon = queue.length - qSun;
+
+  const caption = current && (
+    <>
+      {liveDials.showPlace && (
+        <div style={{ position: 'absolute', left: 12, bottom: 10, color: '#fff', textShadow: '0 1px 3px #000', fontSize: 14 }}>
+          {current.entry.title}
+          <small style={{ display: 'block', fontSize: 11, opacity: 0.8 }}>
+            {[current.entry.region, current.entry.country].filter(Boolean).join(', ')}
+          </small>
+        </div>
+      )}
+      <div style={{
+        position: 'absolute', right: 12, bottom: 10, color: '#fff', textShadow: '0 1px 3px #000',
+        fontFamily: mono, fontSize: 12, textAlign: 'right',
+      }}>
+        {liveDials.showTally && <div>shown <b style={{ color: '#f5a344' }}>×{current.entry.tally}</b></div>}
+        {liveDials.showRank && <div>{current.entry.bin === 'sunset' ? 'sunset' : 'non-sunset'} bin #{current.entry.rank}</div>}
+        {liveDials.showScores && (
+          <div>
+            {current.entry.bin === 'sunset' ? `q ${(current.entry.quality ?? 0).toFixed(2)} · ` : ''}
+            d {current.entry.detection.toFixed(2)}
+          </div>
+        )}
+      </div>
+      <div style={{
+        position: 'absolute', left: 0, bottom: 0, height: 3, background: '#f5a344',
+        width: `${(leftS / liveDials.dwellS) * 100}%`,
+      }} />
+    </>
+  );
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 8, minWidth: 0 }}>
+      <h3 style={{ margin: 0, fontSize: 13, color: '#9aa3b2', display: 'flex', justifyContent: 'space-between' }}>
+        <span>{LABEL[feed]}</span>
+        <span title="Time until this screen changes, on the live dials' clock">
+          next frame in <b style={{ color: '#f5a344', fontFamily: mono }}>{leftS} s</b>
+        </span>
+      </h3>
+      <div
+        title={current
+          ? 'What this screen is drawing right now, with the on-glass overlays as deployed'
+          : 'Nothing on glass yet: the solo renderer is not live, or no frame is eligible'}
+        onClick={() => current && onSelect(current.entry, feed)}
+        style={{
+          position: 'relative', aspectRatio: '16 / 9', background: '#000', border: '1px solid #2a3242',
+          borderRadius: 6, overflow: 'hidden', cursor: current ? 'pointer' : 'default',
+        }}
+      >
+        {current ? (
+          // eslint-disable-next-line @next/next/no-img-element
+          <img src={current.entry.imageUrl} alt="" style={{ width: '100%', height: '100%', objectFit: 'cover', display: 'block' }} />
+        ) : (
+          <div style={{ color: '#4b5568', fontFamily: mono, fontSize: 12, padding: 12 }}>nothing on glass yet</div>
+        )}
+        {caption}
+      </div>
+      <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr 1.15fr', gap: 6 }}>
+        <Bin color="#7ee2ac" title={`Sunset bin · ${projected.bins.sunset.length} waiting · ${qSun} queued`}
+          hint="Frames the detection head calls a sunset, ordered by quality. Shown frames sink below unshown ones. Dimmed rows are below the quality floor.">
+          {projected.bins.sunset.map((e) => (
+            <EntryRow key={e.snapshotId} entry={e} feed={feed} place="sunset" onClick={(x) => onSelect(x, feed)} />
+          ))}
+        </Bin>
+        <Bin color="#c3cad6" title={`Non-sunset bin · ${projected.bins.nonSunset.length} waiting · ${qNon} queued`}
+          hint="Frames the detection head does not call a sunset, ordered by detection probability so 'almost a sunset' is on top. Dimmed rows are below the detection floor.">
+          {projected.bins.nonSunset.map((e) => (
+            <EntryRow key={e.snapshotId} entry={e} feed={feed} place="non_sunset" onClick={(x) => onSelect(x, feed)} />
+          ))}
+        </Bin>
+        <Bin color="#4b5568" title="On glass + next up"
+          hint="The play order for this screen, computed from both bins by the five rules with the STUDIO dials. Top row is on glass. Row outline = which bin it came from. A queued frame is no longer in its bin.">
+          {differs && (
+            <div style={{ fontSize: 10, color: '#f5a344', marginBottom: 4 }}>
+              projected with studio dials; glass will draw {server.next[0].title}
+            </div>
+          )}
+          {queue.map((e, i) => {
+            const repeat = seen.has(e.snapshotId);
+            seen.add(e.snapshotId);
+            const m = camCount.get(e.webcamId) ?? 1;
+            const n = (camSeen.get(e.webcamId) ?? 0) + 1;
+            camSeen.set(e.webcamId, n);
+            return (
+              <EntryRow key={`${e.snapshotId}-${i}`} entry={e} feed={feed} place="queue" onGlass={i === 0 && !!current}
+                repeat={repeat} cameraIndex={m > 1 ? { n, m } : undefined} onClick={(x) => onSelect(x, feed)} />
+            );
+          })}
+        </Bin>
+      </div>
+    </div>
+  );
+}

--- a/app/studio/solo/RulesBox.test.tsx
+++ b/app/studio/solo/RulesBox.test.tsx
@@ -1,0 +1,15 @@
+import { it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { RulesBox } from './RulesBox';
+import { dialsFrom, SOLO_SETTINGS_SCHEMA } from '@/app/lib/solo/settingsSchema';
+import { schemaDefaults } from '@/app/lib/settings/schema';
+
+it('states the five rules with the dial values in force', () => {
+  const d = dialsFrom(schemaDefaults(SOLO_SETTINGS_SCHEMA));
+  render(<RulesBox dials={{ ...d, repeatAllowance: 2, sunsetFloor: 4, mix: 3 }} />);
+  expect(screen.getByText(/minus/).textContent).toContain('2');
+  expect(screen.getByText(/sunsets only/).textContent).toContain('4');
+  expect(screen.getByText(/per non-sunset/).textContent).toContain('3');
+  expect(screen.getByText(/Never the same frame twice/)).toBeInTheDocument();
+  expect(screen.getByText(/Floors/).textContent).toContain('0.55');
+});

--- a/app/studio/solo/RulesBox.tsx
+++ b/app/studio/solo/RulesBox.tsx
@@ -1,0 +1,23 @@
+'use client';
+
+import type { ReactNode } from 'react';
+import type { SoloDials } from '@/app/lib/solo/types';
+
+const box = {
+  fontSize: 11.5, color: '#9aa3b2', border: '1px dashed #2a3242', borderRadius: 6,
+  padding: '8px 10px', marginTop: 8, lineHeight: 1.5,
+} as const;
+const B = ({ children }: { children: ReactNode }) => <b style={{ color: '#4fd1c5' }}>{children}</b>;
+
+/** Spec §4, restated with the dial values currently in force. */
+export function RulesBox({ dials: d }: { dials: SoloDials }) {
+  return (
+    <div style={box} title="The ordering rules, in the order they apply, with the current dial values substituted.">
+      <div><B>1.</B> Lowest tier first across both bins; tier = shown tally, minus <B>{d.repeatAllowance}</B> for sunsets.</div>
+      <div><B>2.</B> In a tier: <B>{d.sunsetFloor}</B>+ sunsets → sunsets only, else <B>{d.mix}</B> sunsets per non-sunset.</div>
+      <div><B>3.</B> In a bin: best score first{d.promoteNew ? ', new frames +0.10' : ''}.</div>
+      <div><B>4.</B> Never the same frame twice in a row.</div>
+      <div><B>5.</B> Floors: sunsets q ≥ <B>{d.qualityFloor.toFixed(2)}</B>, non-sunsets d ≥ <B>{d.detectionFloor.toFixed(2)}</B>.</div>
+    </div>
+  );
+}

--- a/app/studio/solo/SoloRail.test.tsx
+++ b/app/studio/solo/SoloRail.test.tsx
@@ -1,0 +1,41 @@
+import { it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { SoloRail } from './SoloRail';
+import { SOLO_SETTINGS_SCHEMA } from '@/app/lib/solo/settingsSchema';
+import { mergeSettings } from '@/app/lib/settings/schema';
+import type { StudioSettingsApi } from '../useStudioSettings';
+
+function api(over: Partial<StudioSettingsApi> = {}): StudioSettingsApi {
+  return {
+    loading: false, studio: undefined, live: undefined, lastPollAt: null, liveRevision: 3,
+    effective: (ns) => (ns === 'solo' ? mergeSettings(SOLO_SETTINGS_SCHEMA, {}) : { activeVersion: 'v1', panelPreset: 'dell' }),
+    setKnob: vi.fn(), resetSection: vi.fn(), applyNamespace: () => [],
+    diffByNamespace: { solo: ['mix'] }, diffCount: 1,
+    deploy: async () => {}, revert: async () => {}, deployedAtMs: null, droppedKeys: [],
+    ...over,
+  };
+}
+
+it('renders every solo knob under its group and marks the differing one', () => {
+  render(<SoloRail api={api()} deploySlot={<span>DEPLOY</span>} />);
+  expect(screen.getByText('DEPLOY')).toBeInTheDocument();
+  for (const k of SOLO_SETTINGS_SCHEMA) expect(screen.getByLabelText(k.label)).toBeInTheDocument();
+  expect(screen.getByText('mix (sunsets per non-sunset)')).toHaveStyle({ fontWeight: 700 });
+  expect(screen.getByText('dwell (s)')).toHaveStyle({ fontWeight: 400 });
+});
+
+it('a range change calls setKnob with a number; a checkbox with a boolean', () => {
+  const a = api();
+  render(<SoloRail api={a} deploySlot={null} />);
+  fireEvent.change(screen.getByLabelText('dwell (s)'), { target: { value: '30' } });
+  expect(a.setKnob).toHaveBeenCalledWith('solo', 'dwellS', 30);
+  fireEvent.click(screen.getByLabelText('scores'));
+  expect(a.setKnob).toHaveBeenCalledWith('solo', 'showScores', true);
+});
+
+it('reset buttons clear one section each', () => {
+  const a = api();
+  render(<SoloRail api={a} deploySlot={null} />);
+  fireEvent.click(screen.getByText('reset glass'));
+  expect(a.resetSection).toHaveBeenCalledWith('solo', 'glass');
+});

--- a/app/studio/solo/SoloRail.tsx
+++ b/app/studio/solo/SoloRail.tsx
@@ -1,0 +1,87 @@
+'use client';
+
+import type { ReactNode } from 'react';
+import { SOLO_NAMESPACE, SOLO_SETTINGS_SCHEMA, dialsFrom } from '@/app/lib/solo/settingsSchema';
+import { SHARED_NAMESPACE } from '@/app/lib/settings/sharedSchema';
+import type { KnobDescriptor } from '@/app/lib/settings/schema';
+import type { StudioSettingsApi } from '../useStudioSettings';
+import { RulesBox } from './RulesBox';
+
+const GROUPS = [
+  { section: 'glass', title: 'Glass · what the screen draws', color: '#f5a344',
+    hint: 'These change what the screens draw. They never change which frame comes next.' },
+  { section: 'bins', title: 'Bins · the ordering algorithm', color: '#4fd1c5',
+    hint: 'These change which frame comes next. The queue re-runs the moment one moves.' },
+] as const;
+
+const mono = 'ui-monospace, SFMono-Regular, Menlo, monospace';
+
+function Control({ knob, value, differs, onChange }: {
+  knob: KnobDescriptor;
+  value: number | boolean | string;
+  differs: boolean;
+  onChange: (v: number | boolean) => void;
+}) {
+  const id = `solo-${knob.key}`;
+  const labelStyle = { color: '#c3cad6', fontSize: 12, fontWeight: differs ? 700 : 400, cursor: 'help' } as const;
+  if (knob.kind === 'boolean') {
+    return (
+      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', padding: '3px 4px' }}>
+        <label htmlFor={id} title={knob.description} style={labelStyle}>{knob.label}</label>
+        <input id={id} type="checkbox" checked={value as boolean} onChange={(e) => onChange(e.target.checked)} />
+      </div>
+    );
+  }
+  if (knob.kind === 'number') {
+    return (
+      <div style={{ display: 'grid', gridTemplateColumns: '1fr 48px', gap: 6, alignItems: 'center', padding: '3px 4px' }}>
+        <label htmlFor={id} title={knob.description} style={labelStyle}>{knob.label}</label>
+        <span style={{ fontFamily: mono, fontSize: 12, color: '#e5e7eb', textAlign: 'right' }}>{value}</span>
+        <input id={id} type="range" min={knob.min} max={knob.max} step={knob.step} value={value as number}
+          onChange={(e) => onChange(Number(e.target.value))} style={{ gridColumn: '1 / 2', width: '100%' }} />
+      </div>
+    );
+  }
+  return null; // no enum knobs in the solo schema
+}
+
+/**
+ * The solo studio's dial rail. Two colour-coded groups straight from the
+ * schema's sections, a bold label wherever the studio value differs from
+ * the glass, and the rules box stating §4 with the values in force.
+ */
+export function SoloRail({ api, deploySlot }: { api: StudioSettingsApi; deploySlot: ReactNode }) {
+  const values = api.effective(SOLO_NAMESPACE);
+  const shared = api.effective(SHARED_NAMESPACE);
+  const diff = new Set(api.diffByNamespace[SOLO_NAMESPACE] ?? []);
+  return (
+    <div style={{ fontSize: 12 }}>
+      {deploySlot}
+      <div style={{ fontFamily: mono, color: '#8b95a7', padding: '6px 4px' }}
+        title="Which version the glass runs and the panel geometry. Both are shared dials, set on /studio.">
+        glass {String(shared.activeVersion)} · panel {String(shared.panelPreset)}
+      </div>
+      {GROUPS.map((g) => (
+        <section key={g.section}>
+          <h4 title={g.hint} style={{
+            margin: '10px 0 6px', fontSize: 11, letterSpacing: '.06em', textTransform: 'uppercase',
+            padding: '4px 8px', borderRadius: 4, background: `${g.color}22`, color: g.color,
+            borderLeft: `3px solid ${g.color}`, display: 'flex', justifyContent: 'space-between', cursor: 'help',
+          }}>
+            <span>{g.title}</span>
+            <button type="button" onClick={() => api.resetSection(SOLO_NAMESPACE, g.section)}
+              title={`Put every ${g.section} dial back to its code default`}
+              style={{ background: 'transparent', border: 0, color: g.color, fontSize: 10, cursor: 'pointer' }}>
+              reset {g.section}
+            </button>
+          </h4>
+          {SOLO_SETTINGS_SCHEMA.filter((k) => k.section === g.section).map((k) => (
+            <Control key={k.key} knob={k} value={values[k.key]} differs={diff.has(k.key)}
+              onChange={(v) => api.setKnob(SOLO_NAMESPACE, k.key, v)} />
+          ))}
+        </section>
+      ))}
+      <RulesBox dials={dialsFrom(values)} />
+    </div>
+  );
+}

--- a/app/studio/solo/SoloStatusStrip.test.tsx
+++ b/app/studio/solo/SoloStatusStrip.test.tsx
@@ -1,0 +1,15 @@
+import { it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { SoloStatusStrip } from './SoloStatusStrip';
+import type { StateView } from '@/app/api/kiosk/solo/view';
+
+it('counts down to the next pull, reports the last pull per feed, the glass revision, and the zone', () => {
+  const lastPull = { admitted: { sunset: 3, nonSunset: 4 } };
+  const v = (feed: 'sunrise' | 'sunset') => ({ feed, lastPull } as unknown as StateView);
+  render(<SoloStatusStrip nowMs={60_000} sunrise={v('sunrise')} sunset={v('sunset')} liveRevision={41} diffCount={3} zone={{ minDeg: -24, maxDeg: 14 }} />);
+  expect(screen.getByText('9:00')).toBeInTheDocument();
+  expect(screen.getByText(/↑ 3 \+ 4 · ↓ 3 \+ 4/)).toBeInTheDocument();
+  expect(screen.getByText(/rev 41/)).toBeInTheDocument();
+  expect(screen.getByText(/3 differ/)).toBeInTheDocument();
+  expect(screen.getByText(/−24° … \+14°/)).toBeInTheDocument();
+});

--- a/app/studio/solo/SoloStatusStrip.tsx
+++ b/app/studio/solo/SoloStatusStrip.tsx
@@ -1,0 +1,40 @@
+'use client';
+
+import type { StateView } from '@/app/api/kiosk/solo/view';
+import type { Zone } from '@/app/lib/solo/zone';
+import { formatCountdown, nextCronMs } from './countdown';
+
+const mono = 'ui-monospace, SFMono-Regular, Menlo, monospace';
+const item = { marginRight: 18, cursor: 'help' } as const;
+const fmtDeg = (d: number) => `${d < 0 ? '−' : '+'}${Math.abs(d)}°`;
+
+/** The solo studio's telemetry line: the cron clock, what it last brought in, the glass revision, the zone. */
+export function SoloStatusStrip({ nowMs, sunrise, sunset, liveRevision, diffCount, zone }: {
+  nowMs: number;
+  sunrise?: StateView;
+  sunset?: StateView;
+  liveRevision: number;
+  diffCount: number;
+  zone?: Zone;
+}) {
+  const pull = (v?: StateView) => (v ? `${v.lastPull.admitted.sunset} + ${v.lastPull.admitted.nonSunset}` : '–');
+  return (
+    <div style={{ display: 'flex', alignItems: 'center', padding: '0 12px', fontFamily: mono, fontSize: 12, color: '#9aa3b2', height: '100%' }}>
+      <span style={item} title="The cron pulls every camera in the sweep from Windy on this clock. New frames enter the bins right after it runs.">
+        next pull in <b style={{ color: '#f5a344' }}>{formatCountdown(nextCronMs(nowMs) - nowMs)}</b>
+      </span>
+      <span style={item} title="Frames the last pull admitted, sunsets + non-sunsets, per feed (↑ sunrise, ↓ sunset).">
+        last pull: <b style={{ color: '#e5e7eb' }}>↑ {pull(sunrise)} · ↓ {pull(sunset)}</b>
+      </span>
+      <span style={item} title="The live settings revision the glass reads, and how many studio dials differ from it.">
+        glass <b style={{ color: '#e5e7eb' }}>rev {liveRevision}</b>
+        {diffCount > 0 ? ` · ${diffCount} differ` : ' · dials match glass'}
+      </span>
+      {zone && (
+        <span style={item} title="The sweep zone in solar altitude; cameras outside it leave the bins after the grace.">
+          zone <b style={{ color: '#e5e7eb' }}>{fmtDeg(zone.minDeg)} … {fmtDeg(zone.maxDeg)}</b>
+        </span>
+      )}
+    </div>
+  );
+}

--- a/app/studio/solo/SoloStudioClient.tsx
+++ b/app/studio/solo/SoloStudioClient.tsx
@@ -1,0 +1,88 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import Link from 'next/link';
+import { useStudioSettings } from '../useStudioSettings';
+import { DeployButton } from '../DeployButton';
+import { SoloRail } from './SoloRail';
+import { FeedColumn } from './FeedColumn';
+import { SoloStatusStrip } from './SoloStatusStrip';
+import { useSoloState } from './useSoloState';
+import { toWebcam } from './toWebcam';
+import { SOLO_NAMESPACE, SOLO_SETTINGS_SCHEMA, dialsFrom } from '@/app/lib/solo/settingsSchema';
+import { mergeSettings } from '@/app/lib/settings/schema';
+import type { EntryView } from '@/app/api/kiosk/solo/view';
+import type { Feed } from '@/app/lib/solo/types';
+import { FrameLabelCard } from '@/app/components/Webcam/FrameLabelCard';
+
+const bg = '#0b0e14';
+const railBg = '#10141d';
+const border = '#1d2432';
+const mono = 'ui-monospace, SFMono-Regular, Menlo, monospace';
+
+/**
+ * /studio/solo: the bins transparency surface (spec §6.4). Dials edit the
+ * studio profile through the same hook /studio uses; the queue columns
+ * re-project with those dials at once, while the panels and countdowns run
+ * on the live profile, because that is what the glass runs.
+ */
+export function SoloStudioClient() {
+  const api = useStudioSettings();
+  const studioDials = dialsFrom(api.effective(SOLO_NAMESPACE));
+  const liveDials = dialsFrom(mergeSettings(SOLO_SETTINGS_SCHEMA, api.live?.namespaces?.[SOLO_NAMESPACE]));
+  const sunrise = useSoloState('sunrise', studioDials);
+  const sunset = useSoloState('sunset', studioDials);
+  const [nowMs, setNowMs] = useState(() => Date.now());
+  const [selected, setSelected] = useState<{ entry: EntryView; feed: Feed } | null>(null);
+
+  useEffect(() => {
+    const t = setInterval(() => setNowMs(Date.now()), 1000);
+    return () => clearInterval(t);
+  }, []);
+
+  return (
+    <div style={{
+      display: 'grid', gridTemplateColumns: '250px 1fr', gridTemplateRows: '30px 1fr', height: '100vh',
+      background: bg, color: '#e5e7eb', overflow: 'hidden',
+    }}>
+      <div style={{ gridColumn: '1 / -1', background: '#0e1119', borderBottom: `1px solid ${border}`, display: 'flex', alignItems: 'center' }}>
+        <SoloStatusStrip nowMs={nowMs} sunrise={sunrise.server} sunset={sunset.server}
+          liveRevision={api.liveRevision} diffCount={api.diffCount} zone={sunset.server?.zone ?? sunrise.server?.zone} />
+        <Link href="/studio" style={{ marginLeft: 'auto', marginRight: 12, fontSize: 11, color: '#8b95a7' }} title="The mosaic studio">
+          ← mosaic studio
+        </Link>
+      </div>
+      <aside style={{ background: railBg, borderRight: `1px solid ${border}`, padding: 10, overflowY: 'auto' }}>
+        <SoloRail api={api} deploySlot={<DeployButton diffCount={api.diffCount} onDeploy={api.deploy} onRevert={api.revert} />} />
+      </aside>
+      <main style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 12, padding: 12, overflowY: 'auto', minWidth: 0 }}>
+        {(['sunrise', 'sunset'] as const).map((feed) => {
+          const s = feed === 'sunrise' ? sunrise : sunset;
+          return s.server && s.projected ? (
+            <FeedColumn key={feed} feed={feed} server={s.server} projected={s.projected} liveDials={liveDials}
+              studioDials={studioDials} nowMs={nowMs} onSelect={(entry, f) => setSelected({ entry, feed: f })} />
+          ) : (
+            <div key={feed} style={{ color: '#4b5568', fontFamily: mono, fontSize: 12 }}>{s.error ?? `loading ${feed}…`}</div>
+          );
+        })}
+      </main>
+      {selected && (
+        <div
+          onClick={(e) => { if (e.target === e.currentTarget) setSelected(null); }}
+          style={{ position: 'fixed', inset: 0, background: '#000a', zIndex: 50, display: 'flex', alignItems: 'center', justifyContent: 'center' }}
+        >
+          <div style={{ background: railBg, border: `1px solid ${border}`, borderRadius: 10, width: 'min(760px, 92vw)', padding: 14 }}>
+            <button type="button" onClick={() => setSelected(null)} style={{
+              float: 'right', background: 'transparent', color: '#8b95a7', border: `1px solid ${border}`,
+              borderRadius: 6, padding: '3px 8px', cursor: 'pointer',
+            }}>close</button>
+            <div style={{ fontFamily: mono, fontSize: 12, color: '#9aa3b2', marginBottom: 8 }}>
+              frame {selected.entry.snapshotId} · {selected.entry.bin === 'sunset' ? 'sunset' : 'non-sunset'} bin · shown ×{selected.entry.tally}
+            </div>
+            <FrameLabelCard webcam={toWebcam(selected.entry, selected.feed)} allowCapture={false} />
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/studio/solo/countdown.test.ts
+++ b/app/studio/solo/countdown.test.ts
@@ -1,0 +1,15 @@
+import { describe, it, expect } from 'vitest';
+import { nextCronMs, formatCountdown, CRON_PERIOD_MS } from './countdown';
+
+describe('countdown', () => {
+  it('nextCronMs is the next 10-minute mark', () => {
+    expect(nextCronMs(0)).toBe(CRON_PERIOD_MS);
+    expect(nextCronMs(CRON_PERIOD_MS - 1)).toBe(CRON_PERIOD_MS);
+    expect(nextCronMs(CRON_PERIOD_MS)).toBe(2 * CRON_PERIOD_MS);
+  });
+  it('formatCountdown renders m:ss and clamps at zero', () => {
+    expect(formatCountdown(605_000)).toBe('10:05');
+    expect(formatCountdown(59_000)).toBe('0:59');
+    expect(formatCountdown(-5)).toBe('0:00');
+  });
+});

--- a/app/studio/solo/countdown.ts
+++ b/app/studio/solo/countdown.ts
@@ -1,0 +1,12 @@
+export const CRON_PERIOD_MS = 10 * 60 * 1000;
+
+/** The next 10-minute mark on Unix time: when the cron pulls Windy next. */
+export function nextCronMs(nowMs: number): number {
+  return (Math.floor(nowMs / CRON_PERIOD_MS) + 1) * CRON_PERIOD_MS;
+}
+
+/** `m:ss`, clamped at zero. */
+export function formatCountdown(ms: number): string {
+  const s = Math.max(0, Math.ceil(ms / 1000));
+  return `${Math.floor(s / 60)}:${String(s % 60).padStart(2, '0')}`;
+}

--- a/app/studio/solo/page.tsx
+++ b/app/studio/solo/page.tsx
@@ -1,0 +1,15 @@
+'use client';
+
+import { Suspense } from 'react';
+import { OwnerGate } from '@/app/components/auth/OwnerGate';
+import { SoloStudioClient } from './SoloStudioClient';
+
+export default function SoloStudioPage() {
+  return (
+    <Suspense fallback={null}>
+      <OwnerGate label="Solo studio">
+        <SoloStudioClient />
+      </OwnerGate>
+    </Suspense>
+  );
+}

--- a/app/studio/solo/toWebcam.test.ts
+++ b/app/studio/solo/toWebcam.test.ts
@@ -1,0 +1,18 @@
+import { describe, it, expect } from 'vitest';
+import { toWebcam } from './toWebcam';
+
+describe('toWebcam', () => {
+  it('names the archived frame so the label card writes against it', () => {
+    const w = toWebcam({
+      snapshotId: 88213, webcamId: 42, bin: 'sunset', quality: 0.91, detection: 0.88, isNew: false,
+      tally: 1, enteredAt: 0, imageUrl: 'https://storage.googleapis.com/x.jpg', title: 'Pier',
+      city: 'Lisbon', region: 'Lisboa', country: 'Portugal', eligible: true, rank: 1,
+    }, 'sunset');
+    expect(w.frameId).toBe(88213);
+    expect(w.webcamId).toBe(42);
+    expect(w.phase).toBe('sunset');
+    expect(w.images?.current?.preview).toBe('https://storage.googleapis.com/x.jpg');
+    expect(w.location.city).toBe('Lisbon');
+    expect(w.aiRatingBinary).toBeCloseTo(1 + 0.88 * 4);
+  });
+});

--- a/app/studio/solo/toWebcam.ts
+++ b/app/studio/solo/toWebcam.ts
@@ -1,0 +1,25 @@
+import type { WindyWebcam } from '@/app/lib/types';
+import type { Feed } from '@/app/lib/solo/types';
+import type { EntryView } from '@/app/api/kiosk/solo/view';
+
+/**
+ * The label card speaks WindyWebcam. A bin entry IS an archived frame, so
+ * `frameId` is set and the card writes a gold label against that exact row
+ * without a capture step. Detection is carried in the 1–5 form the card's
+ * AI readout expects (1 + p × 4, the cron's own mapping).
+ */
+export function toWebcam(e: EntryView, feed: Feed): WindyWebcam {
+  return {
+    webcamId: e.webcamId,
+    title: e.title,
+    viewCount: 0,
+    status: 'active',
+    images: { current: { preview: e.imageUrl } },
+    location: { city: e.city, region: e.region, country: e.country, latitude: 0, longitude: 0 },
+    categories: [],
+    phase: feed,
+    frameId: e.snapshotId,
+    aiRatingRegression: e.quality == null ? undefined : 1 + e.quality * 4,
+    aiRatingBinary: 1 + e.detection * 4,
+  };
+}

--- a/app/studio/solo/useSoloState.test.tsx
+++ b/app/studio/solo/useSoloState.test.tsx
@@ -1,0 +1,37 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { useSoloState } from './useSoloState';
+import { dialsFrom, SOLO_SETTINGS_SCHEMA } from '@/app/lib/solo/settingsSchema';
+import { schemaDefaults } from '@/app/lib/settings/schema';
+
+const D = dialsFrom(schemaDefaults(SOLO_SETTINGS_SCHEMA));
+const entry = (id: number, q: number) => ({
+  snapshotId: id, webcamId: 100 + id, bin: 'sunset', quality: q, detection: 0.9, isNew: false,
+  tally: 0, enteredAt: id, imageUrl: `u${id}`, title: `t${id}`, city: '', region: '', country: '',
+});
+const serverView = {
+  feed: 'sunset', dials: D, current: null, next: [], bins: { sunset: [], nonSunset: [] },
+  schedule: { slot: 0, nextBoundaryMs: 0 }, lastPull: { admitted: { sunset: 0, nonSunset: 0 } },
+  entries: [entry(1, 0.9), entry(2, 0.5)], zone: { minDeg: -24, maxDeg: -2 },
+};
+
+beforeEach(() => {
+  vi.stubGlobal('fetch', vi.fn(async () => ({ ok: true, json: async () => serverView })));
+});
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('useSoloState', () => {
+  it('re-projects with the studio dials: a lower quality floor admits frame 2', async () => {
+    const dials = { ...D, qualityFloor: 0.4 };
+    const { result } = renderHook(() => useSoloState('sunset', dials));
+    await waitFor(() => expect(result.current.projected).toBeDefined());
+    expect(result.current.projected!.next.map((e) => e.snapshotId).slice(0, 2)).toEqual([1, 2]);
+  });
+  it('with the default floor frame 2 stays in the bin, ineligible', async () => {
+    const { result } = renderHook(() => useSoloState('sunset', D));
+    await waitFor(() => expect(result.current.projected).toBeDefined());
+    expect(result.current.projected!.bins.sunset[0]).toMatchObject({ snapshotId: 2, eligible: false });
+  });
+});

--- a/app/studio/solo/useSoloState.ts
+++ b/app/studio/solo/useSoloState.ts
@@ -1,0 +1,37 @@
+'use client';
+
+import { useMemo } from 'react';
+import useSWR from 'swr';
+import { buildStateView, type StateView } from '@/app/api/kiosk/solo/view';
+import type { Feed, SoloDials } from '@/app/lib/solo/types';
+
+const fetcher = (url: string) => fetch(url).then((r) => r.json());
+const POLL_MS = 5_000;
+
+/**
+ * One feed's bins as the server sees them, plus the same bins re-projected
+ * with the STUDIO dials so a dial move is visible before the PATCH lands and
+ * before Deploy. `server` is what the glass is doing; `projected` is what it
+ * would do with these dials.
+ *
+ * The response does not carry the screen's sunset streak, so the projection
+ * starts it at 0 and can differ from the server's own `next` by one draw.
+ * FeedColumn says so when the first entries disagree.
+ */
+export function useSoloState(feed: Feed, studioDials: SoloDials) {
+  const { data, error } = useSWR<StateView>(`/api/kiosk/solo/state?feed=${feed}`, fetcher, {
+    refreshInterval: POLL_MS,
+  });
+  const projected = useMemo(() => {
+    if (!data) return undefined;
+    const screen = data.current
+      ? { feed, currentSnapshotId: data.current.entry.snapshotId, shownSince: data.current.shownSince,
+          slot: data.current.slot, sunsetStreak: 0 }
+      : null;
+    return buildStateView({
+      feed, dials: studioDials, entries: data.entries, screen, nowMs: Date.now(),
+      admitted: data.lastPull.admitted, zone: data.zone,
+    });
+  }, [data, feed, studioDials]);
+  return { server: data, projected, error: error ? String(error) : undefined };
+}

--- a/docs/superpowers/plans/2026-09-04-solo-kiosk-phase2-glass.md
+++ b/docs/superpowers/plans/2026-09-04-solo-kiosk-phase2-glass.md
@@ -1,0 +1,531 @@
+# Solo Kiosk Phase 2 (Glass) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** The `solo` renderer: one archived frame filling each screen, advancing on the clock-derived schedule through `POST /api/kiosk/solo/advance`, with the next frame preloaded, an optional crossfade, and the on-glass overlays. Registered as a version so the existing active-version dial flips the glass to it and back.
+
+**Architecture:** `app/components/solo/` holds a `MosaicComponent` that ignores the `webcams` prop and drives itself from the phase 1 endpoints. A hook owns the loop: fetch state, sleep until the next boundary (live dials), advance with that slot, swap the frame, preload the next. Two stacked images give the crossfade. Two new landscape panel presets. `MosaicProps` gains two optional flags, `dozing` and `driveSchedule`, so the kiosk pages can stop the loop while dozing and `/studio`'s preview can follow the glass without advancing it.
+
+**Tech Stack:** React client component, Vitest + Testing Library with fake timers and a stubbed `fetch`.
+
+**Spec:** `docs/superpowers/specs/2026-09-04-solo-kiosk-design.md` §6.2, §6.3.
+
+## Global Constraints
+
+- Branch `feat/solo-glass` from `main` after PR #132 merges (needs `ViewEntry`/`entries` from phase 3's view change). Worktree via `scripts/wt.sh new feat/solo-glass`. Verify the branch in the same command as every commit; push with the gh credential helper.
+- No new dependencies.
+- The renderer never touches `webcams`, `peerWebcams`, or the terminator store.
+- Advancing happens only when `driveSchedule !== false` and `dozing !== true`. A preview follows; the glass drives.
+- Never advance twice for one slot: the hook remembers the last slot it posted.
+- A failed advance or fetch leaves the current frame up and retries at the next boundary. Never a black screen because a request failed.
+- Overlays draw only what the live dials say. `?debug=1` on the kiosk route (via `allowDebugOverlays`) adds a small monospace readout: slot, seconds to boundary, queue length, last error.
+
+---
+
+## File structure
+
+| path | responsibility |
+|---|---|
+| `app/kiosk/panelPreview.ts` (+ test) | `dell-l` 1920×1080, `ktc-l` 2560×1440 |
+| `app/components/mosaic/types.ts` | `dozing?: boolean`, `driveSchedule?: boolean` |
+| `app/kiosk/sunrise/page.tsx`, `app/kiosk/sunset/page.tsx` | pass `dozing` |
+| `app/studio/PreviewPane.tsx` | pass `driveSchedule={false}` |
+| `app/components/solo/schedule.ts` (+ test) | `msUntilBoundary` helper on top of `app/lib/solo/schedule.ts` |
+| `app/components/solo/useSoloGlass.ts` (+ test) | the loop: state, advance, preload |
+| `app/components/solo/SoloFrame.tsx` (+ test) | two-layer image with fade + overlays |
+| `app/components/solo/index.tsx` (+ test) | `SoloKiosk: MosaicComponent` |
+| `app/components/mosaic/registry.ts` (+ test) | `solo` in `MOSAIC_VERSIONS` |
+
+---
+
+### Task 1: Landscape presets and the two new props
+
+**Files:**
+- Modify: `app/kiosk/panelPreview.ts:22-27`, `app/kiosk/panelPreview.test.ts`
+- Modify: `app/components/mosaic/types.ts`
+- Modify: `app/kiosk/sunrise/page.tsx`, `app/kiosk/sunset/page.tsx`, `app/studio/PreviewPane.tsx`
+
+- [ ] **Step 1: Presets**
+
+```ts
+export const PANEL_PRESETS: Record<string, PanelSize> = {
+  dell: { width: 1080, height: 1920 },
+  ktc: { width: 1440, height: 2560 },
+  // The same two panels turned landscape, for the solo kiosk (spec §6.3).
+  'dell-l': { width: 1920, height: 1080 },
+  'ktc-l': { width: 2560, height: 1440 },
+};
+```
+
+Update the file's header comment ("portrait — the orientation they hang in") to say both orientations are listed. Add to `panelPreview.test.ts`:
+
+```ts
+it('offers each panel in both orientations', () => {
+  expect(parsePanelPreview(new URLSearchParams('panel=ktc-l'))).toEqual({ width: 2560, height: 1440 });
+  expect(PANEL_PRESETS['dell-l']).toEqual({ width: 1920, height: 1080 });
+});
+```
+
+- [ ] **Step 2: Props**
+
+In `MosaicProps`, after `allowDebugOverlays`:
+
+```ts
+  /**
+   * The kiosk is dozing (quiet hours, or the operator's doze switch). A
+   * version that advances state on a clock — the solo renderer's tally —
+   * must not do so while nobody can see the screen. Mosaic versions ignore it.
+   */
+  dozing?: boolean;
+  /**
+   * Whether this surface DRIVES the schedule (calls advance at boundaries) or
+   * only FOLLOWS what the glass is showing. Defaults to true; /studio's
+   * preview passes false. A preview that advanced the queue would count
+   * showings nobody saw on the wall.
+   */
+  driveSchedule?: boolean;
+```
+
+Both kiosk pages: `<Mosaic … dozing={dozing} />` (they already have `dozing` from `useKioskRuntime`). `PreviewPane.tsx`: add `driveSchedule={false}` where it renders the resolved `Mosaic`.
+
+- [ ] **Step 3: Run and commit**
+
+Run: `npx vitest run app/kiosk app/studio app/components/mosaic && npx eslint app/kiosk app/studio/PreviewPane.tsx app/components/mosaic/types.ts`
+
+```bash
+[ "$(git rev-parse --abbrev-ref HEAD)" = "feat/solo-glass" ] && git add app/kiosk/panelPreview.ts app/kiosk/panelPreview.test.ts app/components/mosaic/types.ts app/kiosk/sunrise/page.tsx app/kiosk/sunset/page.tsx app/studio/PreviewPane.tsx && git commit -m "feat(solo): landscape panel presets; dozing + driveSchedule props"
+```
+
+---
+
+### Task 2: `useSoloGlass`
+
+**Files:**
+- Create: `app/components/solo/schedule.ts` (+ test), `app/components/solo/useSoloGlass.ts` (+ test)
+
+**Interfaces:**
+- `msUntilBoundary(nowMs, feed, dwellS, offsetS): number` — strictly positive
+- `useSoloGlass({ feed, dials, drive, dozing }): { current: EntryView | null; next: EntryView | null; slot: number; boundaryMs: number; error: string | null; queueLength: number }`
+
+- [ ] **Step 1: Tests**
+
+```ts
+// schedule.test.ts
+import { it, expect } from 'vitest';
+import { msUntilBoundary } from './schedule';
+it('is the gap to the next boundary, never zero', () => {
+  expect(msUntilBoundary(0, 'sunrise', 20, 10)).toBe(20_000);
+  expect(msUntilBoundary(19_999, 'sunrise', 20, 10)).toBe(1);
+  expect(msUntilBoundary(20_000, 'sunrise', 20, 10)).toBe(20_000);
+  expect(msUntilBoundary(0, 'sunset', 20, 10)).toBe(10_000);
+});
+```
+
+```tsx
+// useSoloGlass.test.tsx
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { useSoloGlass } from './useSoloGlass';
+import { dialsFrom, SOLO_SETTINGS_SCHEMA } from '@/app/lib/solo/settingsSchema';
+import { schemaDefaults } from '@/app/lib/settings/schema';
+
+const D = dialsFrom(schemaDefaults(SOLO_SETTINGS_SCHEMA));
+const entry = (id: number) => ({ snapshotId: id, webcamId: 1, bin: 'sunset', quality: 0.9, detection: 0.9, isNew: false,
+  tally: 0, enteredAt: 0, imageUrl: `u${id}`, title: `t${id}`, city: '', region: '', country: '', eligible: true, rank: 1 });
+const state = (currentId: number | null, nextIds: number[]) => ({
+  feed: 'sunrise', dials: D, current: currentId ? { entry: entry(currentId), shownSince: 0, slot: 0 } : null,
+  next: nextIds.map(entry), bins: { sunset: [], nonSunset: [] }, schedule: { slot: 0, nextBoundaryMs: 0 },
+  lastPull: { admitted: { sunset: 0, nonSunset: 0 } }, entries: [], zone: { minDeg: -24, maxDeg: -2 },
+});
+
+let calls: { url: string; body?: unknown }[];
+beforeEach(() => {
+  calls = [];
+  vi.useFakeTimers();
+  vi.setSystemTime(new Date(1_000_000_000_000)); // sunrise boundary in exactly 0 ms → next at +20 s
+  vi.stubGlobal('Image', class { onload: null | (() => void) = null; set src(_v: string) { this.onload?.(); } decode() { return Promise.resolve(); } });
+  vi.stubGlobal('fetch', vi.fn(async (url: string, init?: RequestInit) => {
+    calls.push({ url, body: init?.body ? JSON.parse(String(init.body)) : undefined });
+    if (url.includes('/advance')) return { ok: true, json: async () => ({ advanced: true, ...state(2, [3]) }) };
+    return { ok: true, json: async () => state(1, [2]) };
+  }));
+});
+afterEach(() => { vi.useRealTimers(); vi.unstubAllGlobals(); });
+
+describe('useSoloGlass', () => {
+  it('shows the server current, preloads next, and advances at the boundary with the slot', async () => {
+    const { result } = renderHook(() => useSoloGlass({ feed: 'sunrise', dials: D, drive: true, dozing: false }));
+    await waitFor(() => expect(result.current.current?.snapshotId).toBe(1));
+    expect(result.current.next?.snapshotId).toBe(2);
+    await act(async () => { vi.advanceTimersByTime(20_000); });
+    await waitFor(() => expect(result.current.current?.snapshotId).toBe(2));
+    const adv = calls.find((c) => c.url.includes('/advance'));
+    expect(adv?.body).toEqual({ feed: 'sunrise', slot: 50_000_001 });
+  });
+  it('does not advance while dozing or when it only follows', async () => {
+    const { result, rerender } = renderHook((p: { drive: boolean; dozing: boolean }) =>
+      useSoloGlass({ feed: 'sunrise', dials: D, ...p }), { initialProps: { drive: false, dozing: false } });
+    await waitFor(() => expect(result.current.current?.snapshotId).toBe(1));
+    await act(async () => { vi.advanceTimersByTime(20_000); });
+    expect(calls.some((c) => c.url.includes('/advance'))).toBe(false);
+    rerender({ drive: true, dozing: true });
+    await act(async () => { vi.advanceTimersByTime(20_000); });
+    expect(calls.some((c) => c.url.includes('/advance'))).toBe(false);
+  });
+  it('keeps the frame up and records the error when advance fails', async () => {
+    (fetch as unknown as ReturnType<typeof vi.fn>).mockImplementation(async (url: string) =>
+      url.includes('/advance') ? { ok: false, status: 500, json: async () => ({}) } : { ok: true, json: async () => state(1, [2]) });
+    const { result } = renderHook(() => useSoloGlass({ feed: 'sunrise', dials: D, drive: true, dozing: false }));
+    await waitFor(() => expect(result.current.current?.snapshotId).toBe(1));
+    await act(async () => { vi.advanceTimersByTime(20_000); });
+    await waitFor(() => expect(result.current.error).toMatch(/500/));
+    expect(result.current.current?.snapshotId).toBe(1);
+  });
+});
+```
+
+- [ ] **Step 2: Implement `schedule.ts`**
+
+```ts
+import { nextBoundaryMs } from '@/app/lib/solo/schedule';
+import type { Feed } from '@/app/lib/solo/types';
+
+/** Milliseconds until this screen's next change. Always > 0. */
+export function msUntilBoundary(nowMs: number, feed: Feed, dwellS: number, offsetS: number): number {
+  return Math.max(1, nextBoundaryMs(nowMs, feed, dwellS, offsetS) - nowMs);
+}
+```
+
+- [ ] **Step 3: Implement `useSoloGlass.ts`**
+
+```ts
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+import type { EntryView, StateView } from '@/app/api/kiosk/solo/view';
+import { slotFor } from '@/app/lib/solo/schedule';
+import type { Feed, SoloDials } from '@/app/lib/solo/types';
+import { msUntilBoundary } from './schedule';
+
+const STATE_REFRESH_MS = 60_000;
+
+export interface SoloGlass {
+  current: EntryView | null;
+  next: EntryView | null;
+  slot: number;
+  boundaryMs: number;
+  error: string | null;
+  queueLength: number;
+}
+
+function preload(url: string): Promise<void> {
+  return new Promise((resolve) => {
+    const img = new Image();
+    img.onload = () => resolve();
+    img.onerror = () => resolve(); // a failed preload is not a reason to skip the frame
+    img.src = url;
+  });
+}
+
+/**
+ * The glass loop (spec §6.2): read the state, wait for the boundary the wall
+ * clock dictates, ask the server for the next frame with that slot, show it,
+ * preload the one after. Two tabs stay staggered because both read the same
+ * clock; a reload just waits for its next boundary.
+ */
+export function useSoloGlass({ feed, dials, drive, dozing }: {
+  feed: Feed; dials: SoloDials; drive: boolean; dozing: boolean;
+}): SoloGlass {
+  const [view, setView] = useState<StateView | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [tick, setTick] = useState(0);
+  const lastSlotPosted = useRef<number | null>(null);
+  const driveRef = useRef(drive);
+  const dozingRef = useRef(dozing);
+  driveRef.current = drive;
+  dozingRef.current = dozing;
+
+  // State refresh: on mount and every minute, so admissions from the cron
+  // reach the preload even when nothing advanced.
+  useEffect(() => {
+    let alive = true;
+    const load = async () => {
+      try {
+        const res = await fetch(`/api/kiosk/solo/state?feed=${feed}`);
+        if (!res.ok) throw new Error(`state ${res.status}`);
+        const v = (await res.json()) as StateView;
+        if (!alive) return;
+        setView(v);
+        if (v.next[0]) void preload(v.next[0].imageUrl);
+      } catch (e) {
+        if (alive) setError(String(e));
+      }
+    };
+    void load();
+    const t = setInterval(load, STATE_REFRESH_MS);
+    return () => { alive = false; clearInterval(t); };
+  }, [feed]);
+
+  // The boundary timer. Re-armed after every fire and whenever dials change.
+  useEffect(() => {
+    const nowMs = Date.now();
+    const wait = msUntilBoundary(nowMs, feed, dials.dwellS, dials.offsetS);
+    const t = setTimeout(async () => {
+      const fireMs = Date.now();
+      const slot = slotFor(fireMs, feed, dials.dwellS, dials.offsetS);
+      if (driveRef.current && !dozingRef.current && lastSlotPosted.current !== slot) {
+        lastSlotPosted.current = slot;
+        try {
+          const res = await fetch('/api/kiosk/solo/advance', {
+            method: 'POST', headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ feed, slot }),
+          });
+          if (!res.ok) throw new Error(`advance ${res.status}`);
+          const v = (await res.json()) as StateView & { advanced: boolean };
+          setView(v);
+          setError(null);
+          if (v.next[0]) void preload(v.next[0].imageUrl);
+        } catch (e) {
+          setError(String(e));
+        }
+      }
+      setTick((n) => n + 1); // re-arm
+    }, wait);
+    return () => clearTimeout(t);
+  }, [feed, dials.dwellS, dials.offsetS, tick]);
+
+  const nowMs = Date.now();
+  return {
+    current: view?.current?.entry ?? null,
+    next: view?.next[0] ?? null,
+    slot: slotFor(nowMs, feed, dials.dwellS, dials.offsetS),
+    boundaryMs: nowMs + msUntilBoundary(nowMs, feed, dials.dwellS, dials.offsetS),
+    error,
+    queueLength: view?.next.length ?? 0,
+  };
+}
+```
+
+A following surface (`drive` false) still refreshes state every minute, so `/studio`'s preview tracks the glass within a minute; it never posts.
+
+- [ ] **Step 4: Run tests, lint, commit**
+
+```bash
+[ "$(git rev-parse --abbrev-ref HEAD)" = "feat/solo-glass" ] && git add app/components/solo/schedule.ts app/components/solo/schedule.test.ts app/components/solo/useSoloGlass.ts app/components/solo/useSoloGlass.test.tsx && git commit -m "feat(solo): useSoloGlass — the clock-driven advance loop with preload"
+```
+
+---
+
+### Task 3: `SoloFrame` and the registered renderer
+
+**Files:**
+- Create: `app/components/solo/SoloFrame.tsx` (+ test), `app/components/solo/index.tsx` (+ test)
+- Modify: `app/components/mosaic/registry.ts`, `app/components/mosaic/registry.test.tsx`
+
+**Interfaces:**
+- `SoloFrame({ entry, previous, fadeS, dials, width, height })` renders `previous` under `entry`, the top layer fading in over `fadeS` seconds (0 = instant), `object-fit: cover`, overlays per `dials.showPlace/showScores/showRank/showTally`.
+- `SoloKiosk(props: MosaicProps)` — merges `props.settings` over `SOLO_SETTINGS_SCHEMA`, calls `useSoloGlass`, keeps the previous entry for the crossfade, renders `SoloFrame` and, when `allowDebugOverlays && search includes debug=1`, the debug readout.
+
+- [ ] **Step 1: Tests**
+
+```tsx
+// SoloFrame.test.tsx
+import { it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { SoloFrame } from './SoloFrame';
+import { dialsFrom, SOLO_SETTINGS_SCHEMA } from '@/app/lib/solo/settingsSchema';
+import { schemaDefaults } from '@/app/lib/settings/schema';
+
+const D = dialsFrom(schemaDefaults(SOLO_SETTINGS_SCHEMA));
+const e = { snapshotId: 1, webcamId: 1, bin: 'sunset' as const, quality: 0.91, detection: 0.88, isNew: false, tally: 2, enteredAt: 0,
+  imageUrl: 'u1', title: 'Pier', city: 'Lisbon', region: 'Lisboa', country: 'Portugal', eligible: true, rank: 3 };
+
+it('draws the place by default and nothing else', () => {
+  render(<SoloFrame entry={e} previous={null} fadeS={0} dials={D} width={1920} height={1080} />);
+  expect(screen.getByText('Pier')).toBeInTheDocument();
+  expect(screen.getByText(/Lisboa, Portugal/)).toBeInTheDocument();
+  expect(screen.queryByText(/shown/)).toBeNull();
+  expect(screen.queryByText(/q 0\.91/)).toBeNull();
+});
+
+it('draws scores, rank, and tally when dialled on; hides the place when dialled off', () => {
+  render(<SoloFrame entry={e} previous={null} fadeS={0} dials={{ ...D, showPlace: false, showScores: true, showRank: true, showTally: true }} width={1920} height={1080} />);
+  expect(screen.queryByText('Pier')).toBeNull();
+  expect(screen.getByText(/q 0\.91 · d 0\.88/)).toBeInTheDocument();
+  expect(screen.getByText(/sunset bin #3/)).toBeInTheDocument();
+  expect(screen.getByText(/×2/)).toBeInTheDocument();
+});
+
+it('keeps the previous frame underneath and sets the fade duration on the top layer', () => {
+  const prev = { ...e, snapshotId: 0, imageUrl: 'u0' };
+  render(<SoloFrame entry={e} previous={prev} fadeS={3} dials={D} width={1920} height={1080} />);
+  const imgs = screen.getAllByRole('presentation');
+  expect(imgs.map((i) => i.getAttribute('src'))).toEqual(['u0', 'u1']);
+  expect(imgs[1]).toHaveStyle({ transition: 'opacity 3s ease' });
+});
+```
+
+```tsx
+// index.test.tsx
+import { it, expect, vi } from 'vitest';
+import { render } from '@testing-library/react';
+import { SoloKiosk } from './index';
+
+vi.mock('./useSoloGlass', () => ({
+  useSoloGlass: vi.fn(() => ({ current: null, next: null, slot: 1, boundaryMs: 0, error: null, queueLength: 0 })),
+}));
+import { useSoloGlass } from './useSoloGlass';
+
+it('drives by default on the kiosk and follows in a preview; passes dozing through', () => {
+  render(<SoloKiosk webcams={[]} width={100} height={50} feed="sunset" />);
+  expect(useSoloGlass).toHaveBeenLastCalledWith(expect.objectContaining({ drive: true, dozing: false }));
+  render(<SoloKiosk webcams={[]} width={100} height={50} feed="sunset" driveSchedule={false} dozing />);
+  expect(useSoloGlass).toHaveBeenLastCalledWith(expect.objectContaining({ drive: false, dozing: true }));
+});
+```
+
+Add to `registry.test.tsx`:
+
+```ts
+it('registers the solo renderer as a version, so the active-version dial can select it', () => {
+  expect(MOSAIC_VERSIONS.solo).toBeDefined();
+  expect(MOSAIC_SETTINGS_SCHEMAS.solo).toBeDefined();
+  expect(DEFAULT_MOSAIC_VERSION).not.toBe('solo'); // the public site keeps the mosaic
+});
+```
+
+- [ ] **Step 2: Implement `SoloFrame.tsx`**
+
+```tsx
+'use client';
+
+import type { EntryView } from '@/app/api/kiosk/solo/view';
+import type { SoloDials } from '@/app/lib/solo/types';
+
+const mono = 'ui-monospace, SFMono-Regular, Menlo, monospace';
+
+/**
+ * One frame filling the panel. The previous frame sits underneath so a fade
+ * dial above zero crossfades instead of cutting; at zero the top layer is
+ * simply there. Overlays are what the live dials say and nothing else.
+ */
+export function SoloFrame({ entry, previous, fadeS, dials, width, height }: {
+  entry: EntryView; previous: EntryView | null; fadeS: number; dials: SoloDials; width: number; height: number;
+}) {
+  const layer = { position: 'absolute', inset: 0, width: '100%', height: '100%', objectFit: 'cover' } as const;
+  const scale = Math.max(1, Math.min(width, height) / 540); // overlay text scales with the panel
+  return (
+    <div style={{ position: 'relative', width, height, background: '#000', overflow: 'hidden' }}>
+      {previous && <img key={previous.snapshotId} src={previous.imageUrl} alt="" role="presentation" style={layer} />}
+      <img key={entry.snapshotId} src={entry.imageUrl} alt="" role="presentation"
+        style={{ ...layer, animation: fadeS > 0 ? `solo-fade-in ${fadeS}s ease` : undefined, transition: `opacity ${fadeS}s ease` }} />
+      <style>{`@keyframes solo-fade-in { from { opacity: 0 } to { opacity: 1 } }`}</style>
+      {dials.showPlace && (
+        <div style={{ position: 'absolute', left: 24 * scale, bottom: 20 * scale, color: '#fff', textShadow: '0 1px 4px #000', fontSize: 22 * scale, lineHeight: 1.2 }}>
+          {entry.title}
+          <div style={{ fontSize: 15 * scale, opacity: 0.85 }}>{[entry.region, entry.country].filter(Boolean).join(', ')}</div>
+        </div>
+      )}
+      {(dials.showScores || dials.showRank || dials.showTally) && (
+        <div style={{ position: 'absolute', right: 24 * scale, bottom: 20 * scale, color: '#fff', textShadow: '0 1px 4px #000', fontFamily: mono, fontSize: 16 * scale, textAlign: 'right', lineHeight: 1.4 }}>
+          {dials.showTally && <div>shown <b style={{ color: '#f5a344' }}>×{entry.tally}</b></div>}
+          {dials.showRank && <div>{entry.bin === 'sunset' ? 'sunset' : 'non-sunset'} bin #{entry.rank}</div>}
+          {dials.showScores && <div>{entry.bin === 'sunset' ? `q ${(entry.quality ?? 0).toFixed(2)} · ` : ''}d {entry.detection.toFixed(2)}</div>}
+        </div>
+      )}
+    </div>
+  );
+}
+```
+
+`role="presentation"` on an `<img alt="">` is what Testing Library queries; keep both. The `@next/next/no-img-element` rule needs the same eslint-disable comment the mosaic versions use on their `<img>` tags.
+
+- [ ] **Step 3: Implement `index.tsx`**
+
+```tsx
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+import type { MosaicProps } from '@/app/components/mosaic/types';
+import type { EntryView } from '@/app/api/kiosk/solo/view';
+import { mergeSettings } from '@/app/lib/settings/schema';
+import { SOLO_SETTINGS_SCHEMA, dialsFrom } from '@/app/lib/solo/settingsSchema';
+import { SoloFrame } from './SoloFrame';
+import { useSoloGlass } from './useSoloGlass';
+
+const mono = 'ui-monospace, SFMono-Regular, Menlo, monospace';
+
+/**
+ * The solo kiosk as a registered version (spec §6.3): one archived frame per
+ * screen, chosen by the server from the bins, advancing on the wall clock.
+ * Ignores the pool props entirely; everything it shows comes from
+ * /api/kiosk/solo.
+ */
+export function SoloKiosk(props: MosaicProps) {
+  const dials = dialsFrom(mergeSettings(SOLO_SETTINGS_SCHEMA, props.settings));
+  const glass = useSoloGlass({
+    feed: props.feed, dials, drive: props.driveSchedule !== false, dozing: props.dozing === true,
+  });
+  const [previous, setPrevious] = useState<EntryView | null>(null);
+  const lastRef = useRef<EntryView | null>(null);
+  useEffect(() => {
+    if (glass.current && lastRef.current && glass.current.snapshotId !== lastRef.current.snapshotId) {
+      setPrevious(lastRef.current);
+    }
+    lastRef.current = glass.current;
+  }, [glass.current]);
+
+  const debug = props.allowDebugOverlays !== false && (props.search ?? '').includes('debug=1');
+
+  return (
+    <div style={{ position: 'relative', width: props.width, height: props.height, background: '#000' }}>
+      {glass.current ? (
+        <SoloFrame entry={glass.current} previous={previous} fadeS={dials.fadeS} dials={dials} width={props.width} height={props.height} />
+      ) : null}
+      {debug && (
+        <div style={{ position: 'absolute', top: 8, left: 8, fontFamily: mono, fontSize: 12, color: '#7ee2ac', background: 'rgba(0,0,0,.7)', padding: '4px 8px', borderRadius: 4 }}>
+          slot {glass.slot} · next in {Math.max(0, Math.ceil((glass.boundaryMs - Date.now()) / 1000))} s · queue {glass.queueLength}
+          {glass.error ? ` · ${glass.error}` : ''}
+        </div>
+      )}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 4: Register**
+
+`registry.ts`: `import { SoloKiosk } from '@/app/components/solo';` and `solo: SoloKiosk,` in `MOSAIC_VERSIONS`. `DEFAULT_MOSAIC_VERSION` stays `v1`. `SHARED_SCHEMA.activeVersion` picks up `solo` automatically from the keys.
+
+- [ ] **Step 5: Run everything and commit**
+
+Run: `npx vitest run app/components/solo app/components/mosaic app/kiosk app/studio && npx eslint app/components/solo app/components/mosaic/registry.ts && npm run build`
+
+```bash
+[ "$(git rev-parse --abbrev-ref HEAD)" = "feat/solo-glass" ] && git add app/components/solo app/components/mosaic/registry.ts app/components/mosaic/registry.test.tsx && git commit -m "feat(solo): the solo renderer, registered as version 'solo'"
+```
+
+---
+
+### Task 4: On-desk check, then PR
+
+- [ ] **Step 1: Run the dev server in the worktree and open both routes with the version forced**
+
+```
+npm run dev
+```
+
+Then in a browser: `http://localhost:<port>/kiosk/sunset?v=solo&panel=ktc-l&debug=1` and the sunrise twin. Expect: a frame within a few seconds, the debug line counting down, a change at the boundary, the sunset tab changing 10 s after the sunrise tab. Open `/studio/solo` beside them: the panels there should show the same frames the tabs show, within 5 s.
+
+- [ ] **Step 2: PR**
+
+Title: `feat(solo): the glass renderer, registered as version 'solo' (phase 2)`. Body notes: no migration; `activeVersion` can now be set to `solo` but the default stays `v1`; the Pi shows nothing new until phase 4 flips the dial.
+
+---
+
+## Self-review against the spec
+
+- §6.2 clock-derived slots, idempotent advance, reload lands on rhythm: Task 2 (the hook re-derives the slot at fire time from `Date.now()`; a reload just arms the next boundary) ✔
+- §6.3 registered as `solo`, ignores `webcams`, reads state on mount and after advance, respects doze and `?panel=`, overlays as dials, landscape presets ✔ (Tasks 1, 3)
+- Fade dial via a CSS crossfade over the preloaded next image, 0 = cut ✔ (Task 3)
+- §9 "a reload lands on the next boundary" ✔ (Task 2 test 1 arms from the current clock)

--- a/docs/superpowers/plans/2026-09-04-solo-kiosk-phase3-studio.md
+++ b/docs/superpowers/plans/2026-09-04-solo-kiosk-phase3-studio.md
@@ -1,0 +1,1005 @@
+# Solo Kiosk Phase 3 (Studio) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** `/studio/solo`, the transparency surface: each feed's on-glass frame with overlays and a countdown, the queue as a column beside the two bins, a dial rail in two colour-coded groups with a live rules box, tooltips on everything, and click-to-rate through the shared `FrameLabelCard`.
+
+**Architecture:** One SWR poll per feed against `GET /api/kiosk/solo/state` (phase 1), refreshed every 5 s. The response now carries the raw `entries` list and the `zone`, so the client re-runs the pure `buildStateView` with the **studio** profile's dials the moment a dial moves, without waiting for the settings PATCH. Timing on the panel uses the **live** profile's dials, because that is what the glass runs. Dials, Deploy, and Revert reuse `useStudioSettings` and `DeployButton` unchanged; the `solo` namespace is already registered.
+
+**Tech Stack:** Next.js app router, SWR, React with inline styles (matches `/studio`), Vitest + Testing Library.
+
+**Spec:** `docs/superpowers/specs/2026-09-04-solo-kiosk-design.md` §6.4; mockup `.superpowers/brainstorm/83245-1788567565/content/studio-v3.html` in the main checkout.
+
+## Global Constraints
+
+- Branch `feat/solo-studio`, worktree `~/GitHub/the-sunset-webcam-map.worktrees/feat-solo-studio`. Verify the branch in the same command as every commit; stage explicit paths; push after each commit with the gh credential helper:
+  `GIT_TERMINAL_PROMPT=0 git -c credential.helper= -c credential.helper='!gh auth git-credential' push origin feat/solo-studio`
+- No new dependencies.
+- Colours, fixed: sunset bin `#7ee2ac`, non-sunset bin `#c3cad6`, queue outline `#4b5568`, on-glass ring `#f5a344`, glass dial group `#f5a344`, bins dial group `#4fd1c5`, NEW tag `#f5a344`, LEFT ZONE / FLOOR tags grey `#3a4356`. Backgrounds `#0b0e14` page, `#10141d` rail, `#0e1119` rows.
+- Tally text is `shown ×N`, always, bold when N > 0.
+- Every dial, bin header, tag, row, and status item has a `title` tooltip.
+- Detection is shown as a probability (0–1) with the label `d`; quality as `q`.
+- Rendering never blocks on the rating card: `FrameLabelCard` mounts only when a frame is selected.
+
+---
+
+## File structure
+
+| path | responsibility |
+|---|---|
+| `app/api/kiosk/solo/view.ts` (+ test) | `buildStateView` takes `ViewEntry[]` (client-safe) and returns `entries` + `zone` too |
+| `app/api/kiosk/solo/state/route.ts` (+ test) | maps `StoredEntry` → `ViewEntry`, computes `zone` from the day-ring flag |
+| `app/api/kiosk/solo/advance/route.ts` | same mapping (one helper) |
+| `app/studio/solo/page.tsx` | owner-gated route |
+| `app/studio/solo/SoloStudioClient.tsx` | layout: status strip, rail, two feed columns, detail modal |
+| `app/studio/solo/useSoloState.ts` (+ test) | SWR per feed + client re-projection with studio dials |
+| `app/studio/solo/countdown.ts` (+ test) | `nextCronMs`, `formatCountdown` |
+| `app/studio/solo/toWebcam.ts` (+ test) | `EntryView` → `WindyWebcam` for the label card |
+| `app/studio/solo/RulesBox.tsx` (+ test) | the five rules with live values |
+| `app/studio/solo/SoloRail.tsx` (+ test) | Deploy slot, two colour groups of dials from the schema, rules box |
+| `app/studio/solo/EntryRow.tsx` (+ test) | one frame row with thumbnail, tally, scores, tags, tooltip |
+| `app/studio/solo/FeedColumn.tsx` (+ test) | panel + countdown + three columns for one feed |
+| `app/studio/solo/SoloStatusStrip.tsx` (+ test) | cron countdown, last pull, glass revision, zone |
+| `app/studio/StudioClient.tsx` | one link pill to `/studio/solo` |
+
+---
+
+### Task 1: View carries raw entries and the zone
+
+**Files:**
+- Modify: `app/api/kiosk/solo/view.ts`, `app/api/kiosk/solo/view.test.ts`
+- Modify: `app/api/kiosk/solo/state/route.ts`, `app/api/kiosk/solo/state/route.test.ts`
+- Modify: `app/api/kiosk/solo/advance/route.ts`
+
+**Interfaces:**
+- Produces:
+  - `interface ViewEntry extends BinEntry { imageUrl; title; city; region; country }` (no lat/lng, no feed)
+  - `toViewEntry(e: StoredEntry): ViewEntry`
+  - `buildStateView(input: { feed; dials; entries: ViewEntry[]; screen; nowMs; admitted; zone: Zone }): StateView`
+  - `StateView` gains `entries: ViewEntry[]` and `zone: { minDeg: number; maxDeg: number }`
+
+- [ ] **Step 1: Update the view test**
+
+Replace the `stored()` fixture type with `ViewEntry` (drop `feed`, `lat`, `lng`, `firstShownAt`, `lastShownAt`) and pass `zone: { minDeg: -24, maxDeg: -2 }` in every `buildStateView` call. Add:
+
+```ts
+  it('echoes the raw entries and the zone so a client can re-project', () => {
+    const entries = [stored(1, 'sunset', 0.9)];
+    const v = buildStateView({ feed: 'sunset', dials: D, entries, screen: null, nowMs: 0,
+      admitted: { sunset: 0, nonSunset: 0 }, zone: { minDeg: -24, maxDeg: 14 } });
+    expect(v.entries).toHaveLength(1);
+    expect(v.zone).toEqual({ minDeg: -24, maxDeg: 14 });
+  });
+```
+
+- [ ] **Step 2: Run to see it fail**
+
+Run: `npx vitest run app/api/kiosk/solo/view.test.ts`
+Expected: FAIL on the new field and on the type of `entries`.
+
+- [ ] **Step 3: Update `view.ts`**
+
+```ts
+import type { StoredEntry, ScreenRow } from '@/app/lib/solo/store';
+import type { Zone } from '@/app/lib/solo/zone';
+
+/** What the client needs per frame. No coordinates, no feed: those stay server-side. */
+export interface ViewEntry extends BinEntry {
+  imageUrl: string;
+  title: string;
+  city: string;
+  region: string;
+  country: string;
+}
+
+export function toViewEntry(e: StoredEntry): ViewEntry {
+  return {
+    snapshotId: e.snapshotId, webcamId: e.webcamId, bin: e.bin, quality: e.quality,
+    detection: e.detection, isNew: e.isNew, tally: e.tally, enteredAt: e.enteredAt,
+    imageUrl: e.imageUrl, title: e.title, city: e.city, region: e.region, country: e.country,
+  };
+}
+```
+
+`EntryView` becomes `ViewEntry & { eligible: boolean; rank: number }`. `StateView` gains `entries: ViewEntry[]` and `zone: Zone`. `buildStateView` takes `entries: ViewEntry[]` and `zone: Zone`, and returns `entries` (the input, unchanged) and `zone`. Replace every `StoredEntry` in the file with `ViewEntry`; `scoreOf`, `rankMap`, `byScore` keep working since they read only `BinEntry` fields.
+
+- [ ] **Step 4: Update the routes**
+
+`state/route.ts`:
+
+```ts
+import { isFlagEnabled, SWEEP_FORCE_DAY_RING } from '@/app/lib/runtimeFlags';
+import { sweepGeometry } from '@/app/api/cron/update-cameras/lib/sweepGeometry';
+import { TERMINATOR_DAY_SIDE_OFFSETS_DEG } from '@/app/lib/masterConfig';
+import { buildStateView, parseFeed, toViewEntry } from '../view';
+// ...
+  const [entries, screen, admitted, forcedDayRing] = await Promise.all([
+    listActiveEntries(feed),
+    getScreenState(feed),
+    countAdmittedSince(feed, nowMs - LAST_PULL_WINDOW_MS),
+    isFlagEnabled(SWEEP_FORCE_DAY_RING),
+  ]);
+  const geometry = sweepGeometry(forcedDayRing ? TERMINATOR_DAY_SIDE_OFFSETS_DEG : []);
+  const zone = { minDeg: geometry.coverageMinDeg, maxDeg: geometry.coverageMaxDeg };
+  return NextResponse.json(buildStateView({
+    feed, dials, entries: entries.map(toViewEntry), screen, nowMs, admitted, zone,
+  }));
+```
+
+`advance/route.ts`: same flag read and geometry; pass `entries.map(toViewEntry)` and `zone` to `buildStateView`. The `stored.tally += 1` mutation stays on the `StoredEntry` list before mapping.
+
+`state/route.test.ts`: add mocks
+
+```ts
+vi.mock('@/app/lib/runtimeFlags', () => ({ isFlagEnabled: async () => false, SWEEP_FORCE_DAY_RING: 'x' }));
+```
+
+and assert `(await res.json()).zone` equals `{ minDeg: -24, maxDeg: -2 }` in the live-profile test. `advance/route.test.ts` gets the same `runtimeFlags` mock.
+
+- [ ] **Step 5: Run tests and lint**
+
+Run: `npx vitest run app/api/kiosk/solo && npx eslint app/api/kiosk/solo`
+Expected: PASS, clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+[ "$(git rev-parse --abbrev-ref HEAD)" = "feat/solo-studio" ] && git add app/api/kiosk/solo && git commit -m "feat(solo): state view carries raw entries and the zone for client re-projection"
+```
+
+---
+
+### Task 2: Pure helpers: countdown and toWebcam
+
+**Files:**
+- Create: `app/studio/solo/countdown.ts`, `app/studio/solo/countdown.test.ts`
+- Create: `app/studio/solo/toWebcam.ts`, `app/studio/solo/toWebcam.test.ts`
+
+**Interfaces:**
+- `CRON_PERIOD_MS = 10 * 60 * 1000`
+- `nextCronMs(nowMs: number): number` — next multiple of the cron period on Unix time
+- `formatCountdown(ms: number): string` — `m:ss`, never negative
+- `toWebcam(entry: EntryView, feed: Feed): WindyWebcam` — `frameId = snapshotId`, `phase = feed`, images.current.preview = imageUrl, location from city/region/country, ai fields filled
+
+- [ ] **Step 1: Tests**
+
+```ts
+// countdown.test.ts
+import { describe, it, expect } from 'vitest';
+import { nextCronMs, formatCountdown, CRON_PERIOD_MS } from './countdown';
+
+describe('countdown', () => {
+  it('nextCronMs is the next 10-minute mark', () => {
+    expect(nextCronMs(0)).toBe(CRON_PERIOD_MS);
+    expect(nextCronMs(CRON_PERIOD_MS - 1)).toBe(CRON_PERIOD_MS);
+    expect(nextCronMs(CRON_PERIOD_MS)).toBe(2 * CRON_PERIOD_MS);
+  });
+  it('formatCountdown renders m:ss and clamps at zero', () => {
+    expect(formatCountdown(605_000)).toBe('10:05');
+    expect(formatCountdown(59_000)).toBe('0:59');
+    expect(formatCountdown(-5)).toBe('0:00');
+  });
+});
+```
+
+```ts
+// toWebcam.test.ts
+import { describe, it, expect } from 'vitest';
+import { toWebcam } from './toWebcam';
+
+describe('toWebcam', () => {
+  it('names the archived frame so the label card writes against it', () => {
+    const w = toWebcam({
+      snapshotId: 88213, webcamId: 42, bin: 'sunset', quality: 0.91, detection: 0.88, isNew: false,
+      tally: 1, enteredAt: 0, imageUrl: 'https://storage.googleapis.com/x.jpg', title: 'Pier',
+      city: 'Lisbon', region: 'Lisboa', country: 'Portugal', eligible: true, rank: 1,
+    }, 'sunset');
+    expect(w.frameId).toBe(88213);
+    expect(w.webcamId).toBe(42);
+    expect(w.phase).toBe('sunset');
+    expect(w.images?.current?.preview).toBe('https://storage.googleapis.com/x.jpg');
+    expect(w.location.city).toBe('Lisbon');
+    expect(w.aiRatingBinary).toBeCloseTo(1 + 0.88 * 4);
+  });
+});
+```
+
+- [ ] **Step 2: Run to see them fail**, then implement:
+
+```ts
+// countdown.ts
+export const CRON_PERIOD_MS = 10 * 60 * 1000;
+
+export function nextCronMs(nowMs: number): number {
+  return (Math.floor(nowMs / CRON_PERIOD_MS) + 1) * CRON_PERIOD_MS;
+}
+
+export function formatCountdown(ms: number): string {
+  const s = Math.max(0, Math.ceil(ms / 1000));
+  return `${Math.floor(s / 60)}:${String(s % 60).padStart(2, '0')}`;
+}
+```
+
+```ts
+// toWebcam.ts
+import type { WindyWebcam } from '@/app/lib/types';
+import type { Feed } from '@/app/lib/solo/types';
+import type { EntryView } from '@/app/api/kiosk/solo/view';
+
+/**
+ * The label card speaks WindyWebcam. A bin entry IS an archived frame, so
+ * `frameId` is set and the card writes a gold label against that exact row
+ * without a capture step. Detection is carried in the 1–5 form the card's
+ * AI readout expects (1 + p × 4, the cron's own mapping).
+ */
+export function toWebcam(e: EntryView, feed: Feed): WindyWebcam {
+  return {
+    webcamId: e.webcamId,
+    title: e.title,
+    viewCount: 0,
+    status: 'active',
+    images: { current: { preview: e.imageUrl } },
+    location: { city: e.city, region: e.region, country: e.country, latitude: 0, longitude: 0 },
+    categories: [],
+    phase: feed,
+    frameId: e.snapshotId,
+    aiRatingRegression: e.quality == null ? undefined : 1 + e.quality * 4,
+    aiRatingBinary: 1 + e.detection * 4,
+  };
+}
+```
+
+If `WindyWebcam.images.current` requires more than `preview`, fill the other fields with `imageUrl` too.
+
+- [ ] **Step 3: Run tests, commit**
+
+```bash
+[ "$(git rev-parse --abbrev-ref HEAD)" = "feat/solo-studio" ] && git add app/studio/solo/countdown.ts app/studio/solo/countdown.test.ts app/studio/solo/toWebcam.ts app/studio/solo/toWebcam.test.ts && git commit -m "feat(solo-studio): countdown + toWebcam helpers"
+```
+
+---
+
+### Task 3: `useSoloState`
+
+**Files:**
+- Create: `app/studio/solo/useSoloState.ts`, `app/studio/solo/useSoloState.test.tsx`
+
+**Interfaces:**
+- `useSoloState(feed: Feed, studioDials: SoloDials): { server: StateView | undefined; projected: StateView | undefined; error?: string }`
+  - `server` = what the endpoint returned (live dials)
+  - `projected` = `buildStateView` re-run client-side over `server.entries` with `studioDials`, `server.current`'s screen row reconstructed, `Date.now()`
+
+- [ ] **Step 1: Test**
+
+```tsx
+// useSoloState.test.tsx
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { useSoloState } from './useSoloState';
+import { dialsFrom, SOLO_SETTINGS_SCHEMA } from '@/app/lib/solo/settingsSchema';
+import { schemaDefaults } from '@/app/lib/settings/schema';
+
+const D = dialsFrom(schemaDefaults(SOLO_SETTINGS_SCHEMA));
+const entry = (id: number, q: number) => ({
+  snapshotId: id, webcamId: 100 + id, bin: 'sunset', quality: q, detection: 0.9, isNew: false,
+  tally: 0, enteredAt: id, imageUrl: `u${id}`, title: `t${id}`, city: '', region: '', country: '',
+});
+const serverView = {
+  feed: 'sunset', dials: D, current: null, next: [], bins: { sunset: [], nonSunset: [] },
+  schedule: { slot: 0, nextBoundaryMs: 0 }, lastPull: { admitted: { sunset: 0, nonSunset: 0 } },
+  entries: [entry(1, 0.9), entry(2, 0.5)], zone: { minDeg: -24, maxDeg: -2 },
+};
+
+beforeEach(() => {
+  vi.stubGlobal('fetch', vi.fn(async () => ({ ok: true, json: async () => serverView })));
+});
+
+describe('useSoloState', () => {
+  it('re-projects with the studio dials: a lower quality floor admits frame 2', async () => {
+    const { result } = renderHook(() => useSoloState('sunset', { ...D, qualityFloor: 0.4 }));
+    await waitFor(() => expect(result.current.projected).toBeDefined());
+    expect(result.current.projected!.next.map((e) => e.snapshotId).slice(0, 2)).toEqual([1, 2]);
+  });
+  it('with the default floor frame 2 stays in the bin, ineligible', async () => {
+    const { result } = renderHook(() => useSoloState('sunset', D));
+    await waitFor(() => expect(result.current.projected).toBeDefined());
+    expect(result.current.projected!.bins.sunset[0]).toMatchObject({ snapshotId: 2, eligible: false });
+  });
+});
+```
+
+- [ ] **Step 2: Implement**
+
+```ts
+'use client';
+
+import { useMemo } from 'react';
+import useSWR from 'swr';
+import { buildStateView, type StateView } from '@/app/api/kiosk/solo/view';
+import type { Feed, SoloDials } from '@/app/lib/solo/types';
+
+const fetcher = (url: string) => fetch(url).then((r) => r.json());
+const POLL_MS = 5_000;
+
+/**
+ * One feed's bins as the server sees them, plus the same bins re-projected
+ * with the STUDIO dials so a dial move is visible before the PATCH lands and
+ * before Deploy. `server` is what the glass is doing; `projected` is what it
+ * would do with these dials.
+ */
+export function useSoloState(feed: Feed, studioDials: SoloDials) {
+  const { data, error } = useSWR<StateView>(`/api/kiosk/solo/state?feed=${feed}`, fetcher, {
+    refreshInterval: POLL_MS,
+  });
+  const projected = useMemo(() => {
+    if (!data) return undefined;
+    const screen = data.current
+      ? { feed, currentSnapshotId: data.current.entry.snapshotId, shownSince: data.current.shownSince,
+          slot: data.current.slot, sunsetStreak: 0 }
+      : null;
+    return buildStateView({
+      feed, dials: studioDials, entries: data.entries, screen, nowMs: Date.now(),
+      admitted: data.lastPull.admitted, zone: data.zone,
+    });
+  }, [data, feed, studioDials]);
+  return { server: data, projected, error: error ? String(error) : undefined };
+}
+```
+
+`sunsetStreak` is not in the response; the projection starts the streak at 0, which can differ from the server by at most one draw. Note this in a comment; the server's own `next` is the authority and both are shown when they differ (Task 6).
+
+- [ ] **Step 3: Run tests, lint, commit**
+
+```bash
+[ "$(git rev-parse --abbrev-ref HEAD)" = "feat/solo-studio" ] && git add app/studio/solo/useSoloState.ts app/studio/solo/useSoloState.test.tsx && git commit -m "feat(solo-studio): useSoloState polls and re-projects with studio dials"
+```
+
+---
+
+### Task 4: `RulesBox` and `SoloRail`
+
+**Files:**
+- Create: `app/studio/solo/RulesBox.tsx` (+ test), `app/studio/solo/SoloRail.tsx` (+ test)
+
+**Interfaces:**
+- `RulesBox({ dials }: { dials: SoloDials })` renders five lines, each rule with the current numbers in `<b>`.
+- `SoloRail({ api, deploySlot }: { api: StudioSettingsApi; deploySlot: ReactNode })` renders: deploySlot; a line with the glass version and panel; group headers "Glass · what the screen draws" (amber) and "Bins · the ordering algorithm" (teal); one control per knob in `SOLO_SETTINGS_SCHEMA` for that section (range input with a value readout for numbers, checkbox for booleans), label bold when the key is in `api.diffByNamespace.solo`; a "reset" button per group calling `api.resetSection('solo', section)`; `RulesBox` at the bottom.
+
+- [ ] **Step 1: Tests**
+
+```tsx
+// RulesBox.test.tsx
+import { render, screen } from '@testing-library/react';
+import { RulesBox } from './RulesBox';
+import { dialsFrom, SOLO_SETTINGS_SCHEMA } from '@/app/lib/solo/settingsSchema';
+import { schemaDefaults } from '@/app/lib/settings/schema';
+
+it('states the five rules with the dial values in force', () => {
+  const d = dialsFrom(schemaDefaults(SOLO_SETTINGS_SCHEMA));
+  render(<RulesBox dials={{ ...d, repeatAllowance: 2, sunsetFloor: 4, mix: 3 }} />);
+  expect(screen.getByText(/minus/).textContent).toContain('2');
+  expect(screen.getByText(/sunsets only/).textContent).toContain('4');
+  expect(screen.getByText(/per non-sunset/).textContent).toContain('3');
+  expect(screen.getByText(/Never the same frame twice/)).toBeInTheDocument();
+  expect(screen.getByText(/Floors/).textContent).toContain('0.55');
+});
+```
+
+```tsx
+// SoloRail.test.tsx
+import { render, screen, fireEvent } from '@testing-library/react';
+import { SoloRail } from './SoloRail';
+import { SOLO_SETTINGS_SCHEMA } from '@/app/lib/solo/settingsSchema';
+import { schemaDefaults, mergeSettings } from '@/app/lib/settings/schema';
+import type { StudioSettingsApi } from '../useStudioSettings';
+
+function api(over: Partial<StudioSettingsApi> = {}): StudioSettingsApi {
+  return {
+    loading: false, studio: undefined, live: undefined, lastPollAt: null, liveRevision: 3,
+    effective: (ns) => (ns === 'solo' ? mergeSettings(SOLO_SETTINGS_SCHEMA, {}) : { activeVersion: 'v1', panelPreset: 'dell' }),
+    setKnob: vi.fn(), resetSection: vi.fn(), applyNamespace: () => [],
+    diffByNamespace: { solo: ['mix'] }, diffCount: 1,
+    deploy: async () => {}, revert: async () => {}, deployedAtMs: null, droppedKeys: [],
+    ...over,
+  };
+}
+
+it('renders every solo knob under its group and marks the differing one', () => {
+  render(<SoloRail api={api()} deploySlot={<span>DEPLOY</span>} />);
+  expect(screen.getByText('DEPLOY')).toBeInTheDocument();
+  for (const k of SOLO_SETTINGS_SCHEMA) expect(screen.getByLabelText(k.label)).toBeInTheDocument();
+  expect(screen.getByText('mix (sunsets per non-sunset)').closest('label')).toHaveStyle({ fontWeight: 700 });
+});
+
+it('a range change calls setKnob with a number; a checkbox with a boolean', () => {
+  const a = api();
+  render(<SoloRail api={a} deploySlot={null} />);
+  fireEvent.change(screen.getByLabelText('dwell (s)'), { target: { value: '30' } });
+  expect(a.setKnob).toHaveBeenCalledWith('solo', 'dwellS', 30);
+  fireEvent.click(screen.getByLabelText('scores'));
+  expect(a.setKnob).toHaveBeenCalledWith('solo', 'showScores', true);
+});
+
+it('reset buttons clear one section each', () => {
+  const a = api();
+  render(<SoloRail api={a} deploySlot={null} />);
+  fireEvent.click(screen.getByText('reset glass'));
+  expect(a.resetSection).toHaveBeenCalledWith('solo', 'glass');
+});
+```
+
+Use `vi` from vitest in the imports.
+
+- [ ] **Step 2: Implement `RulesBox.tsx`**
+
+```tsx
+'use client';
+
+import type { SoloDials } from '@/app/lib/solo/types';
+
+const box = { fontSize: 11.5, color: '#9aa3b2', border: '1px dashed #2a3242', borderRadius: 6, padding: '8px 10px', marginTop: 8, lineHeight: 1.5 } as const;
+const B = ({ children }: { children: React.ReactNode }) => <b style={{ color: '#4fd1c5' }}>{children}</b>;
+
+/** Spec §4, restated with the dial values currently in force. */
+export function RulesBox({ dials: d }: { dials: SoloDials }) {
+  return (
+    <div style={box} title="The ordering rules, in the order they apply, with the current dial values substituted.">
+      <div><B>1.</B> Lowest tier first across both bins; tier = shown tally, minus <B>{d.repeatAllowance}</B> for sunsets.</div>
+      <div><B>2.</B> In a tier: <B>{d.sunsetFloor}</B>+ sunsets → sunsets only, else <B>{d.mix}</B> sunsets per non-sunset.</div>
+      <div><B>3.</B> In a bin: best score first{d.promoteNew ? ', new frames +0.10' : ''}.</div>
+      <div><B>4.</B> Never the same frame twice in a row.</div>
+      <div><B>5.</B> Floors: sunsets q ≥ <B>{d.qualityFloor.toFixed(2)}</B>, non-sunsets d ≥ <B>{d.detectionFloor.toFixed(2)}</B>.</div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 3: Implement `SoloRail.tsx`**
+
+```tsx
+'use client';
+
+import type { ReactNode } from 'react';
+import { SOLO_NAMESPACE, SOLO_SETTINGS_SCHEMA, dialsFrom } from '@/app/lib/solo/settingsSchema';
+import { SHARED_NAMESPACE } from '@/app/lib/settings/sharedSchema';
+import type { KnobDescriptor } from '@/app/lib/settings/schema';
+import type { StudioSettingsApi } from '../useStudioSettings';
+import { RulesBox } from './RulesBox';
+
+const GROUPS = [
+  { section: 'glass', title: 'Glass · what the screen draws', color: '#f5a344',
+    hint: 'These change what the screens draw. They never change which frame comes next.' },
+  { section: 'bins', title: 'Bins · the ordering algorithm', color: '#4fd1c5',
+    hint: 'These change which frame comes next. The queue re-runs the moment one moves.' },
+] as const;
+
+const mono = 'ui-monospace, SFMono-Regular, Menlo, monospace';
+
+function Control({ knob, value, differs, onChange }: {
+  knob: KnobDescriptor; value: number | boolean | string; differs: boolean;
+  onChange: (v: number | boolean) => void;
+}) {
+  const id = `solo-${knob.key}`;
+  const labelStyle = { color: '#c3cad6', fontSize: 12, fontWeight: differs ? 700 : 400, cursor: 'help' } as const;
+  if (knob.kind === 'boolean') {
+    return (
+      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', padding: '3px 4px' }}>
+        <label htmlFor={id} title={knob.description} style={labelStyle}>{knob.label}</label>
+        <input id={id} type="checkbox" checked={value as boolean} onChange={(e) => onChange(e.target.checked)} />
+      </div>
+    );
+  }
+  if (knob.kind === 'number') {
+    return (
+      <div style={{ display: 'grid', gridTemplateColumns: '1fr 48px', gap: 6, alignItems: 'center', padding: '3px 4px' }}>
+        <label htmlFor={id} title={knob.description} style={labelStyle}>{knob.label}</label>
+        <span style={{ fontFamily: mono, fontSize: 12, color: '#e5e7eb', textAlign: 'right' }}>{value}</span>
+        <input id={id} type="range" min={knob.min} max={knob.max} step={knob.step} value={value as number}
+          onChange={(e) => onChange(Number(e.target.value))} style={{ gridColumn: '1 / 2', width: '100%' }} />
+      </div>
+    );
+  }
+  return null; // no enum knobs in the solo schema
+}
+
+export function SoloRail({ api, deploySlot }: { api: StudioSettingsApi; deploySlot: ReactNode }) {
+  const values = api.effective(SOLO_NAMESPACE);
+  const shared = api.effective(SHARED_NAMESPACE);
+  const diff = new Set(api.diffByNamespace[SOLO_NAMESPACE] ?? []);
+  return (
+    <div style={{ fontSize: 12 }}>
+      {deploySlot}
+      <div style={{ fontFamily: mono, color: '#8b95a7', padding: '6px 4px' }}
+        title="Which version the glass runs and the panel geometry. Both are shared dials, set on /studio.">
+        glass {String(shared.activeVersion)} · panel {String(shared.panelPreset)}
+      </div>
+      {GROUPS.map((g) => (
+        <section key={g.section}>
+          <h4 title={g.hint} style={{ margin: '10px 0 6px', fontSize: 11, letterSpacing: '.06em', textTransform: 'uppercase',
+            padding: '4px 8px', borderRadius: 4, background: `${g.color}22`, color: g.color, borderLeft: `3px solid ${g.color}`,
+            display: 'flex', justifyContent: 'space-between' }}>
+            <span>{g.title}</span>
+            <button type="button" onClick={() => api.resetSection(SOLO_NAMESPACE, g.section)}
+              style={{ background: 'transparent', border: 0, color: g.color, fontSize: 10, cursor: 'pointer' }}>
+              reset {g.section}
+            </button>
+          </h4>
+          {SOLO_SETTINGS_SCHEMA.filter((k) => k.section === g.section).map((k) => (
+            <Control key={k.key} knob={k} value={values[k.key]} differs={diff.has(k.key)}
+              onChange={(v) => api.setKnob(SOLO_NAMESPACE, k.key, v)} />
+          ))}
+        </section>
+      ))}
+      <RulesBox dials={dialsFrom(values)} />
+    </div>
+  );
+}
+```
+
+- [ ] **Step 4: Run tests, lint, commit**
+
+```bash
+[ "$(git rev-parse --abbrev-ref HEAD)" = "feat/solo-studio" ] && git add app/studio/solo/RulesBox.tsx app/studio/solo/RulesBox.test.tsx app/studio/solo/SoloRail.tsx app/studio/solo/SoloRail.test.tsx && git commit -m "feat(solo-studio): dial rail in two colour groups with a live rules box"
+```
+
+---
+
+### Task 5: `EntryRow`
+
+**Files:**
+- Create: `app/studio/solo/EntryRow.tsx`, `app/studio/solo/EntryRow.test.tsx`
+
+**Interfaces:**
+- `EntryRow({ entry, feed, place, onGlass, repeat, onClick })` where `place: 'sunset' | 'non_sunset' | 'queue'`, `onGlass` draws the amber ring, `repeat` dims and prefixes "repeat", tags rendered: NEW (`isNew`), FLOOR (`!eligible`), `CAM n/m` via optional `cameraIndex?: { n: number; m: number }`.
+
+- [ ] **Step 1: Test**
+
+```tsx
+import { render, screen, fireEvent } from '@testing-library/react';
+import { vi } from 'vitest';
+import { EntryRow } from './EntryRow';
+
+const e = { snapshotId: 7, webcamId: 3, bin: 'sunset' as const, quality: 0.91, detection: 0.88, isNew: true,
+  tally: 2, enteredAt: 0, imageUrl: 'u', title: 'Pier', city: 'Lisbon', region: '', country: 'Portugal', eligible: true, rank: 1 };
+
+it('shows tally first, scores, place, and the tags', () => {
+  render(<EntryRow entry={e} feed="sunset" place="sunset" onClick={vi.fn()} />);
+  expect(screen.getByText('shown ×2')).toHaveStyle({ fontWeight: 800 });
+  expect(screen.getByText(/q 0\.91/)).toBeInTheDocument();
+  expect(screen.getByText(/d 0\.88/)).toBeInTheDocument();
+  expect(screen.getByText('NEW')).toBeInTheDocument();
+  expect(screen.getByText(/Lisbon, Portugal/)).toBeInTheDocument();
+});
+
+it('marks ineligible frames FLOOR and repeats as repeat', () => {
+  render(<EntryRow entry={{ ...e, eligible: false, isNew: false }} feed="sunset" place="sunset" onClick={vi.fn()} />);
+  expect(screen.getByText('FLOOR')).toBeInTheDocument();
+  render(<EntryRow entry={e} feed="sunset" place="queue" repeat onClick={vi.fn()} />);
+  expect(screen.getByText(/repeat/)).toBeInTheDocument();
+});
+
+it('non-sunset rows show only detection, and a click reports the entry', () => {
+  const onClick = vi.fn();
+  render(<EntryRow entry={{ ...e, bin: 'non_sunset', quality: null }} feed="sunset" place="non_sunset" onClick={onClick} />);
+  expect(screen.queryByText(/q /)).toBeNull();
+  fireEvent.click(screen.getByRole('button'));
+  expect(onClick).toHaveBeenCalledWith(expect.objectContaining({ snapshotId: 7 }));
+});
+```
+
+- [ ] **Step 2: Implement**
+
+```tsx
+'use client';
+
+import type { EntryView } from '@/app/api/kiosk/solo/view';
+import type { Feed } from '@/app/lib/solo/types';
+
+const COLOR = { sunset: '#7ee2ac', non_sunset: '#c3cad6' } as const;
+const mono = 'ui-monospace, SFMono-Regular, Menlo, monospace';
+
+function Tag({ children, bg, fg, title }: { children: string; bg: string; fg: string; title: string }) {
+  return <span title={title} style={{ display: 'inline-block', fontSize: 8.5, fontWeight: 700, padding: '1px 4px', borderRadius: 3, marginRight: 3, background: bg, color: fg, cursor: 'help' }}>{children}</span>;
+}
+
+export function EntryRow({ entry: e, feed, place, onGlass = false, repeat = false, cameraIndex, onClick }: {
+  entry: EntryView;
+  feed: Feed;
+  place: 'sunset' | 'non_sunset' | 'queue';
+  onGlass?: boolean;
+  repeat?: boolean;
+  cameraIndex?: { n: number; m: number };
+  onClick: (entry: EntryView) => void;
+}) {
+  const scores = e.bin === 'sunset' ? `q ${(e.quality ?? 0).toFixed(2)} d ${e.detection.toFixed(2)}` : `d ${e.detection.toFixed(2)}`;
+  const placeText = [e.city, e.country].filter(Boolean).join(', ');
+  const title = `${e.title} · ${placeText}. Frame ${e.snapshotId}, ${feed} feed. ` +
+    (e.bin === 'sunset' ? 'Sunset bin, ordered by quality. ' : 'Non-sunset bin, ordered by detection. ') +
+    (!e.eligible ? 'Below the floor dial; not eligible. ' : '') +
+    (repeat ? 'Already appears earlier in the queue; this is a repeat showing. ' : '') +
+    `Shown ${e.tally} time${e.tally === 1 ? '' : 's'} today.`;
+  return (
+    <button type="button" onClick={() => onClick(e)} title={title}
+      style={{ display: 'grid', gridTemplateColumns: '46px 1fr', gap: 5, alignItems: 'center', width: '100%', textAlign: 'left',
+        border: `1.5px solid ${COLOR[e.bin]}`, borderRadius: 5, padding: 3, marginBottom: 4, background: '#0e1119',
+        fontFamily: mono, fontSize: 9.5, color: '#9aa3b2', cursor: 'pointer',
+        opacity: !e.eligible || repeat ? 0.45 : 1, boxShadow: onGlass ? '0 0 0 2px #f5a344' : undefined }}>
+      <img src={e.imageUrl} alt="" style={{ width: 46, aspectRatio: '16/9', objectFit: 'cover', borderRadius: 3, display: 'block' }} />
+      <div style={{ minWidth: 0 }}>
+        <span style={{ fontWeight: e.tally > 0 ? 800 : 500, color: e.tally > 0 ? '#e5e7eb' : '#6b7280' }}>shown ×{e.tally}</span>
+        {' · '}{scores}{repeat ? ' · repeat' : ''}
+        <div style={{ marginTop: 2 }}>
+          {e.isNew && <Tag bg="#f5a344" fg="#1a1000" title="Newer frame from a camera already in the bin">NEW</Tag>}
+          {!e.eligible && <Tag bg="#3a4356" fg="#e5e7eb" title="Below the floor dial">FLOOR</Tag>}
+          {cameraIndex && <Tag bg="#7ea6e2" fg="#061224" title="Same camera as another queue entry">{`CAM ${cameraIndex.n}/${cameraIndex.m}`}</Tag>}
+        </div>
+        <div style={{ color: '#c3cad6', whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>{e.title}</div>
+        <div style={{ color: '#6b7280', whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>{placeText}</div>
+      </div>
+    </button>
+  );
+}
+```
+
+`place` is accepted for the queue's bin-coloured outline logic (the outline follows `e.bin` in every place, which is the spec), so it is only used in the tooltip.
+
+- [ ] **Step 3: Run tests, lint, commit**
+
+```bash
+[ "$(git rev-parse --abbrev-ref HEAD)" = "feat/solo-studio" ] && git add app/studio/solo/EntryRow.tsx app/studio/solo/EntryRow.test.tsx && git commit -m "feat(solo-studio): EntryRow"
+```
+
+---
+
+### Task 6: `FeedColumn`
+
+**Files:**
+- Create: `app/studio/solo/FeedColumn.tsx`, `app/studio/solo/FeedColumn.test.tsx`
+
+**Interfaces:**
+- `FeedColumn({ feed, server, projected, liveDials, studioDials, nowMs, onSelect })`
+  - Header: feed label, `next frame in N s` from `nextBoundaryMs(nowMs, feed, liveDials.dwellS, liveDials.offsetS)`.
+  - Panel: `server.current.entry.imageUrl` (or a dark placeholder "nothing on glass yet: phase 2 renderer not live") with overlays per `liveDials.show*`, a draining bar.
+  - Three columns from `projected`: sunset bin, non-sunset bin, queue (current first with the ring, then `next`). Queue rows get `repeat` when the snapshotId appeared earlier in the queue, and `cameraIndex` when the same webcamId appears more than once.
+  - Bin headers: `Sunset bin · N waiting · M queued`.
+  - When `projected.next` differs from `server.next` in its first entry, a small amber line under the queue header: "projected with studio dials; glass will draw {server.next[0].title}".
+
+- [ ] **Step 1: Test**
+
+```tsx
+import { render, screen } from '@testing-library/react';
+import { vi } from 'vitest';
+import { FeedColumn } from './FeedColumn';
+import { dialsFrom, SOLO_SETTINGS_SCHEMA } from '@/app/lib/solo/settingsSchema';
+import { schemaDefaults } from '@/app/lib/settings/schema';
+import { buildStateView } from '@/app/api/kiosk/solo/view';
+
+const D = dialsFrom(schemaDefaults(SOLO_SETTINGS_SCHEMA));
+const entry = (id: number, bin: 'sunset' | 'non_sunset', score: number, webcamId = 100 + id) => ({
+  snapshotId: id, webcamId, bin, quality: bin === 'sunset' ? score : null, detection: bin === 'sunset' ? 0.9 : score,
+  isNew: false, tally: 0, enteredAt: id, imageUrl: `u${id}`, title: `cam${id}`, city: '', region: '', country: '',
+});
+const view = (dials = D) => buildStateView({
+  feed: 'sunset', dials, entries: [entry(1, 'sunset', 0.9), entry(2, 'sunset', 0.8, 101), entry(3, 'non_sunset', 0.5), entry(4, 'sunset', 0.1)],
+  screen: { feed: 'sunset', currentSnapshotId: 1, shownSince: 0, slot: 0, sunsetStreak: 1 },
+  nowMs: 0, admitted: { sunset: 1, nonSunset: 0 }, zone: { minDeg: -24, maxDeg: -2 },
+});
+
+it('draws the on-glass frame at the top of the queue and keeps queued frames out of the bins', () => {
+  const v = view();
+  render(<FeedColumn feed="sunset" server={v} projected={v} liveDials={D} studioDials={D} nowMs={5_000} onSelect={vi.fn()} />);
+  expect(screen.getByText(/next frame in 15 s/)).toBeInTheDocument();
+  expect(screen.getByText(/Sunset bin · 1 waiting/)).toBeInTheDocument(); // frame 4 (below floor) waits
+  expect(screen.getAllByText('cam1').length).toBeGreaterThan(0);
+  expect(screen.getByText(/CAM 1\/2/)).toBeInTheDocument(); // frames 1 and 2 share webcam 101
+});
+
+it('says so when the studio dials would draw a different next frame than the glass', () => {
+  const server = view();
+  const projected = view({ ...D, promoteNew: true, qualityFloor: 0.05 });
+  render(<FeedColumn feed="sunset" server={server} projected={projected} liveDials={D} studioDials={D} nowMs={0} onSelect={vi.fn()} />);
+  expect(screen.getByText(/projected with studio dials/)).toBeInTheDocument();
+});
+```
+
+If the second test's projection happens to match, change the projected dials to `{ ...D, repeatAllowance: 0 }` and a fixture where that changes the first draw.
+
+- [ ] **Step 2: Implement**
+
+```tsx
+'use client';
+
+import type { EntryView, StateView } from '@/app/api/kiosk/solo/view';
+import { nextBoundaryMs } from '@/app/lib/solo/schedule';
+import type { Feed, SoloDials } from '@/app/lib/solo/types';
+import { EntryRow } from './EntryRow';
+
+const mono = 'ui-monospace, SFMono-Regular, Menlo, monospace';
+const LABEL: Record<Feed, string> = { sunrise: 'Sunrise · left screen', sunset: 'Sunset · right screen' };
+
+function Bin({ color, title, hint, children }: { color: string; title: string; hint: string; children: React.ReactNode }) {
+  return (
+    <div style={{ border: `2px solid ${color}`, borderRadius: 8, background: '#0b0e14', padding: 5, minWidth: 0 }}>
+      <h5 title={hint} style={{ margin: '0 0 6px', fontSize: 10, textTransform: 'uppercase', letterSpacing: '.04em', color, cursor: 'help' }}>{title}</h5>
+      {children}
+    </div>
+  );
+}
+
+export function FeedColumn({ feed, server, projected, liveDials, studioDials, nowMs, onSelect }: {
+  feed: Feed; server: StateView; projected: StateView; liveDials: SoloDials; studioDials: SoloDials;
+  nowMs: number; onSelect: (entry: EntryView, feed: Feed) => void;
+}) {
+  const boundary = nextBoundaryMs(nowMs, feed, liveDials.dwellS, liveDials.offsetS);
+  const leftS = Math.max(0, Math.ceil((boundary - nowMs) / 1000));
+  const current = server.current;
+  const queue: EntryView[] = [...(current ? [current.entry] : []), ...projected.next];
+  const seen = new Set<number>();
+  const camCount = new Map<number, number>();
+  for (const e of queue) camCount.set(e.webcamId, (camCount.get(e.webcamId) ?? 0) + 1);
+  const camSeen = new Map<number, number>();
+  const differs = server.next[0] && projected.next[0] && server.next[0].snapshotId !== projected.next[0].snapshotId;
+  const qSun = queue.filter((e) => e.bin === 'sunset').length;
+  const qNon = queue.length - qSun;
+
+  const caption = current && (
+    <>
+      {liveDials.showPlace && (
+        <div style={{ position: 'absolute', left: 12, bottom: 10, color: '#fff', textShadow: '0 1px 3px #000', fontSize: 14 }}>
+          {current.entry.title}
+          <small style={{ display: 'block', fontSize: 11, opacity: 0.8 }}>{[current.entry.region, current.entry.country].filter(Boolean).join(', ')}</small>
+        </div>
+      )}
+      <div style={{ position: 'absolute', right: 12, bottom: 10, color: '#fff', textShadow: '0 1px 3px #000', fontFamily: mono, fontSize: 12, textAlign: 'right' }}>
+        {liveDials.showTally && <div>shown <b style={{ color: '#f5a344' }}>×{current.entry.tally}</b></div>}
+        {liveDials.showRank && <div>{current.entry.bin === 'sunset' ? 'sunset' : 'non-sunset'} bin #{current.entry.rank}</div>}
+        {liveDials.showScores && <div>{current.entry.bin === 'sunset' ? `q ${(current.entry.quality ?? 0).toFixed(2)} · ` : ''}d {current.entry.detection.toFixed(2)}</div>}
+      </div>
+      <div style={{ position: 'absolute', left: 0, bottom: 0, height: 3, background: '#f5a344', width: `${(leftS / liveDials.dwellS) * 100}%` }} />
+    </>
+  );
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 8, minWidth: 0 }}>
+      <h3 style={{ margin: 0, fontSize: 13, color: '#9aa3b2', display: 'flex', justifyContent: 'space-between' }}>
+        <span>{LABEL[feed]}</span>
+        <span title="Time until this screen changes, on the live dials' clock">next frame in <b style={{ color: '#f5a344', fontFamily: mono }}>{leftS} s</b></span>
+      </h3>
+      <div title={current ? 'What this screen is drawing right now, with the on-glass overlays as deployed' : 'Nothing on glass yet: the solo renderer is not live, or no frame is eligible'}
+        onClick={() => current && onSelect(current.entry, feed)}
+        style={{ position: 'relative', aspectRatio: '16 / 9', background: '#000', border: '1px solid #2a3242', borderRadius: 6, overflow: 'hidden', cursor: current ? 'pointer' : 'default' }}>
+        {current ? <img src={current.entry.imageUrl} alt="" style={{ width: '100%', height: '100%', objectFit: 'cover', display: 'block' }} />
+          : <div style={{ color: '#4b5568', fontFamily: mono, fontSize: 12, padding: 12 }}>nothing on glass yet</div>}
+        {caption}
+      </div>
+      <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr 1.15fr', gap: 6 }}>
+        <Bin color="#7ee2ac" title={`Sunset bin · ${projected.bins.sunset.length} waiting · ${qSun} queued`}
+          hint="Frames the detection head calls a sunset, ordered by quality. Shown frames sink below unshown ones. Dimmed rows are below the quality floor.">
+          {projected.bins.sunset.map((e) => <EntryRow key={e.snapshotId} entry={e} feed={feed} place="sunset" onClick={(x) => onSelect(x, feed)} />)}
+        </Bin>
+        <Bin color="#c3cad6" title={`Non-sunset bin · ${projected.bins.nonSunset.length} waiting · ${qNon} queued`}
+          hint="Frames the detection head does not call a sunset, ordered by detection probability so 'almost a sunset' is on top. Dimmed rows are below the detection floor.">
+          {projected.bins.nonSunset.map((e) => <EntryRow key={e.snapshotId} entry={e} feed={feed} place="non_sunset" onClick={(x) => onSelect(x, feed)} />)}
+        </Bin>
+        <Bin color="#4b5568" title="On glass + next up"
+          hint="The play order for this screen, computed from both bins by the five rules with the STUDIO dials. Top row is on glass. Row outline = which bin it came from. A queued frame is no longer in its bin.">
+          {differs && <div style={{ fontSize: 10, color: '#f5a344', marginBottom: 4 }}>projected with studio dials; glass will draw {server.next[0].title}</div>}
+          {queue.map((e, i) => {
+            const repeat = seen.has(e.snapshotId); seen.add(e.snapshotId);
+            const m = camCount.get(e.webcamId) ?? 1;
+            const n = (camSeen.get(e.webcamId) ?? 0) + 1; camSeen.set(e.webcamId, n);
+            return <EntryRow key={`${e.snapshotId}-${i}`} entry={e} feed={feed} place="queue" onGlass={i === 0 && !!current}
+              repeat={repeat} cameraIndex={m > 1 ? { n, m } : undefined} onClick={(x) => onSelect(x, feed)} />;
+          })}
+        </Bin>
+      </div>
+    </div>
+  );
+}
+```
+
+`studioDials` is accepted so the header can later say which dials the projection used; it is unused in this task beyond the prop, and that is fine.
+
+- [ ] **Step 3: Run tests, lint, commit**
+
+```bash
+[ "$(git rev-parse --abbrev-ref HEAD)" = "feat/solo-studio" ] && git add app/studio/solo/FeedColumn.tsx app/studio/solo/FeedColumn.test.tsx && git commit -m "feat(solo-studio): FeedColumn with panel, countdown, bins, and queue"
+```
+
+---
+
+### Task 7: `SoloStatusStrip`, `SoloStudioClient`, the page, and the link
+
+**Files:**
+- Create: `app/studio/solo/SoloStatusStrip.tsx` (+ test), `app/studio/solo/SoloStudioClient.tsx`, `app/studio/solo/page.tsx`
+- Modify: `app/studio/StudioClient.tsx` (a link pill next to the collapse pill area; see below)
+
+**Interfaces:**
+- `SoloStatusStrip({ nowMs, sunrise, sunset, liveRevision, diffCount, zone })` where `sunrise`/`sunset` are `StateView | undefined`.
+
+- [ ] **Step 1: Strip test**
+
+```tsx
+import { render, screen } from '@testing-library/react';
+import { SoloStatusStrip } from './SoloStatusStrip';
+
+it('counts down to the next pull, reports the last pull per feed, the glass revision, and the zone', () => {
+  const lastPull = { admitted: { sunset: 3, nonSunset: 4 } };
+  const v = (feed: 'sunrise' | 'sunset') => ({ feed, lastPull } as never);
+  render(<SoloStatusStrip nowMs={60_000} sunrise={v('sunrise')} sunset={v('sunset')} liveRevision={41} diffCount={3} zone={{ minDeg: -24, maxDeg: 14 }} />);
+  expect(screen.getByText('9:00')).toBeInTheDocument();
+  expect(screen.getByText(/↑ 3 \+ 4 · ↓ 3 \+ 4/)).toBeInTheDocument();
+  expect(screen.getByText(/rev 41/)).toBeInTheDocument();
+  expect(screen.getByText(/3 differ/)).toBeInTheDocument();
+  expect(screen.getByText(/−24° … \+14°/)).toBeInTheDocument();
+});
+```
+
+- [ ] **Step 2: Implement the strip**
+
+```tsx
+'use client';
+
+import type { StateView } from '@/app/api/kiosk/solo/view';
+import type { Zone } from '@/app/lib/solo/zone';
+import { formatCountdown, nextCronMs } from './countdown';
+
+const mono = 'ui-monospace, SFMono-Regular, Menlo, monospace';
+const item = { marginRight: 18, cursor: 'help' } as const;
+const fmtDeg = (d: number) => `${d < 0 ? '−' : '+'}${Math.abs(d)}°`;
+
+export function SoloStatusStrip({ nowMs, sunrise, sunset, liveRevision, diffCount, zone }: {
+  nowMs: number; sunrise?: StateView; sunset?: StateView; liveRevision: number; diffCount: number; zone?: Zone;
+}) {
+  const pull = (v?: StateView) => (v ? `${v.lastPull.admitted.sunset} + ${v.lastPull.admitted.nonSunset}` : '–');
+  return (
+    <div style={{ display: 'flex', alignItems: 'center', padding: '0 12px', fontFamily: mono, fontSize: 12, color: '#9aa3b2', height: '100%' }}>
+      <span style={item} title="The cron pulls every camera in the sweep from Windy on this clock. New frames enter the bins right after it runs.">
+        next pull in <b style={{ color: '#f5a344' }}>{formatCountdown(nextCronMs(nowMs) - nowMs)}</b>
+      </span>
+      <span style={item} title="Frames the last pull admitted, sunsets + non-sunsets, per feed (↑ sunrise, ↓ sunset).">
+        last pull: <b style={{ color: '#e5e7eb' }}>↑ {pull(sunrise)} · ↓ {pull(sunset)}</b>
+      </span>
+      <span style={item} title="The live settings revision the glass reads, and how many studio dials differ from it.">
+        glass <b style={{ color: '#e5e7eb' }}>rev {liveRevision}</b>{diffCount > 0 ? ` · ${diffCount} differ` : ' · dials match glass'}
+      </span>
+      {zone && (
+        <span style={item} title="The sweep zone in solar altitude; cameras outside it leave the bins after the grace.">
+          zone <b style={{ color: '#e5e7eb' }}>{fmtDeg(zone.minDeg)} … {fmtDeg(zone.maxDeg)}</b>
+        </span>
+      )}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 3: `SoloStudioClient.tsx`**
+
+```tsx
+'use client';
+
+import { useEffect, useState } from 'react';
+import Link from 'next/link';
+import { useStudioSettings } from '../useStudioSettings';
+import { DeployButton } from '../DeployButton';
+import { SoloRail } from './SoloRail';
+import { FeedColumn } from './FeedColumn';
+import { SoloStatusStrip } from './SoloStatusStrip';
+import { useSoloState } from './useSoloState';
+import { toWebcam } from './toWebcam';
+import { SOLO_NAMESPACE, SOLO_SETTINGS_SCHEMA, dialsFrom } from '@/app/lib/solo/settingsSchema';
+import { mergeSettings } from '@/app/lib/settings/schema';
+import type { EntryView } from '@/app/api/kiosk/solo/view';
+import type { Feed } from '@/app/lib/solo/types';
+import { FrameLabelCard } from '@/app/components/Webcam/FrameLabelCard';
+
+const bg = '#0b0e14';
+const railBg = '#10141d';
+const border = '#1d2432';
+
+export function SoloStudioClient() {
+  const api = useStudioSettings();
+  const studioDials = dialsFrom(api.effective(SOLO_NAMESPACE));
+  const liveDials = dialsFrom(mergeSettings(SOLO_SETTINGS_SCHEMA, api.live?.namespaces?.[SOLO_NAMESPACE]));
+  const sunrise = useSoloState('sunrise', studioDials);
+  const sunset = useSoloState('sunset', studioDials);
+  const [nowMs, setNowMs] = useState(() => Date.now());
+  const [selected, setSelected] = useState<{ entry: EntryView; feed: Feed } | null>(null);
+
+  useEffect(() => {
+    const t = setInterval(() => setNowMs(Date.now()), 1000);
+    return () => clearInterval(t);
+  }, []);
+
+  return (
+    <div style={{ display: 'grid', gridTemplateColumns: '250px 1fr', gridTemplateRows: '30px 1fr', height: '100vh', background: bg, color: '#e5e7eb', overflow: 'hidden' }}>
+      <div style={{ gridColumn: '1 / -1', background: '#0e1119', borderBottom: `1px solid ${border}`, display: 'flex', alignItems: 'center' }}>
+        <SoloStatusStrip nowMs={nowMs} sunrise={sunrise.server} sunset={sunset.server}
+          liveRevision={api.liveRevision} diffCount={api.diffCount} zone={sunset.server?.zone ?? sunrise.server?.zone} />
+        <Link href="/studio" style={{ marginLeft: 'auto', marginRight: 12, fontSize: 11, color: '#8b95a7' }} title="The mosaic studio">← mosaic studio</Link>
+      </div>
+      <aside style={{ background: railBg, borderRight: `1px solid ${border}`, padding: 10, overflowY: 'auto' }}>
+        <SoloRail api={api} deploySlot={<DeployButton diffCount={api.diffCount} onDeploy={api.deploy} onRevert={api.revert} />} />
+      </aside>
+      <main style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 12, padding: 12, overflowY: 'auto', minWidth: 0 }}>
+        {(['sunrise', 'sunset'] as const).map((feed) => {
+          const s = feed === 'sunrise' ? sunrise : sunset;
+          return s.server && s.projected ? (
+            <FeedColumn key={feed} feed={feed} server={s.server} projected={s.projected} liveDials={liveDials}
+              studioDials={studioDials} nowMs={nowMs} onSelect={(entry, f) => setSelected({ entry, feed: f })} />
+          ) : (
+            <div key={feed} style={{ color: '#4b5568', fontFamily: 'monospace', fontSize: 12 }}>{s.error ?? `loading ${feed}…`}</div>
+          );
+        })}
+      </main>
+      {selected && (
+        <div onClick={(e) => { if (e.target === e.currentTarget) setSelected(null); }}
+          style={{ position: 'fixed', inset: 0, background: '#000a', zIndex: 50, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+          <div style={{ background: railBg, border: `1px solid ${border}`, borderRadius: 10, width: 'min(760px, 92vw)', padding: 14 }}>
+            <button type="button" onClick={() => setSelected(null)} style={{ float: 'right', background: 'transparent', color: '#8b95a7', border: `1px solid ${border}`, borderRadius: 6, padding: '3px 8px', cursor: 'pointer' }}>close</button>
+            <div style={{ fontFamily: 'monospace', fontSize: 12, color: '#9aa3b2', marginBottom: 8 }}>
+              frame {selected.entry.snapshotId} · {selected.entry.bin === 'sunset' ? 'sunset' : 'non-sunset'} bin · shown ×{selected.entry.tally}
+            </div>
+            <FrameLabelCard webcam={toWebcam(selected.entry, selected.feed)} allowCapture={false} />
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 4: `page.tsx`**
+
+```tsx
+'use client';
+
+import { Suspense } from 'react';
+import { OwnerGate } from '@/app/components/auth/OwnerGate';
+import { SoloStudioClient } from './SoloStudioClient';
+
+export default function SoloStudioPage() {
+  return (
+    <Suspense fallback={null}>
+      <OwnerGate label="Solo studio">
+        <SoloStudioClient />
+      </OwnerGate>
+    </Suspense>
+  );
+}
+```
+
+- [ ] **Step 5: Link from the mosaic studio**
+
+In `app/studio/StudioClient.tsx`, inside the `<aside>` before `<StudioRail`, add:
+
+```tsx
+          <a href="/studio/solo" title="The solo kiosk's studio: bins, queue, and its own dials"
+            style={{ display: 'block', fontSize: 11, color: '#8b95a7', marginBottom: 6 }}>solo studio →</a>
+```
+
+- [ ] **Step 6: Run everything**
+
+Run: `npx vitest run app/studio app/api/kiosk/solo && npx eslint app/studio/solo app/studio/StudioClient.tsx && npm run build`
+Expected: PASS, clean, build succeeds and lists `/studio/solo`.
+
+- [ ] **Step 7: Commit, push, PR**
+
+```bash
+[ "$(git rev-parse --abbrev-ref HEAD)" = "feat/solo-studio" ] && git add app/studio/solo app/studio/StudioClient.tsx && git commit -m "feat(solo-studio): /studio/solo — bins, queue, dials, rules, countdowns, click-to-rate"
+GIT_TERMINAL_PROMPT=0 git -c credential.helper= -c credential.helper='!gh auth git-credential' push -u origin feat/solo-studio
+```
+
+PR title: `feat(solo): /studio/solo, the bins transparency surface (phase 3)`.
+
+---
+
+## Self-review against the spec §6.4
+
+- Status strip: cron countdown, last pull per bin, glass revision + diff, zone ✔ (Task 7)
+- Rail in two colour groups, rules box with live values, tooltips ✔ (Task 4)
+- Two feed columns, panel with overlays and draining bar, three bins with the queue in the bin's colour, amber ring on glass, `N waiting · M queued` ✔ (Task 6)
+- Rows: thumbnail, `shown ×N` first, scores, camera, place, tags NEW / FLOOR / LEFT ZONE / CAM n/m ✔ (Task 5; LEFT ZONE rows are not returned by the active-entries query, so that tag waits for the removed-rows listing in phase 5)
+- Click → `FrameLabelCard` against the archive row ✔ (Task 7)
+- Projection with studio dials, glass on live dials ✔ (Tasks 3, 6)
+- Repeats drawn visibly (the phase 1 note) ✔ (Task 5, 6)

--- a/docs/superpowers/plans/2026-09-04-solo-kiosk-phase4-pi.md
+++ b/docs/superpowers/plans/2026-09-04-solo-kiosk-phase4-pi.md
@@ -1,0 +1,229 @@
+# Solo Kiosk Phase 4 (Pi) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Put the solo kiosk on the glass, reversibly: the two panels turned landscape by a one-line setting on the Pi, the panel preset and active version flipped from `/studio`, verified on the screens with the doctor script and the solo studio, and the whole procedure written into the runbook with its rollback.
+
+**Architecture:** The Pi's `~/kiosk-launch.sh` is today the only copy of the rotation logic and lives outside the repo. This phase brings it into `scripts/pi/` as the canonical copy, makes orientation a value in `/home/pi/kiosk.env` (default `portrait`, so nothing changes until someone edits it), and teaches the doctor to report each output's rotation. Switching modes is then: edit one line on the Pi, reboot, flip two dials, Deploy.
+
+**Tech Stack:** bash, xrandr, ssh, the existing `kiosk-doctor.sh --sync --reload` flow.
+
+**Spec:** `docs/superpowers/specs/2026-09-04-solo-kiosk-design.md` §8 phase 4; `docs/ops/pushing-an-update-to-the-glass.md`.
+
+## Global Constraints
+
+- Branch `docs/solo-pi-rotation` from `main` after phase 2 merges. The scripts and doc changes are a PR; the Pi steps are run by hand and their outputs pasted into the PR.
+- Nothing here changes Pi behaviour until `ORIENTATION=landscape` is written on the Pi. Default is `portrait`, today's behaviour, byte for byte in the xrandr calls.
+- Every Pi command is one line, paste-safe. Heredocs only where marked, with `EOF` flush-left.
+- The physical turn of the monitors on their stands is a human step and is listed as one.
+- Verification is on the glass, never inferred: screenshots through the doctor, and the frame on the panel matching `/studio/solo`'s "on glass" row.
+
+---
+
+## File structure
+
+| path | responsibility |
+|---|---|
+| `scripts/pi/kiosk-launch.sh` | canonical launch script, orientation from `kiosk.env` |
+| `scripts/pi/kiosk.env.example` | the one setting, documented |
+| `scripts/pi/kiosk-doctor.sh` | report rotation + mode per output |
+| `docs/ops/pushing-an-update-to-the-glass.md` | "Switching the glass between mosaic and solo" section |
+
+---
+
+### Task 1: Bring the launch script into the repo
+
+- [ ] **Step 1: Copy the Pi's script into the worktree, unchanged**
+
+```bash
+scp pi@sunsetdisplay:/home/pi/kiosk-launch.sh scripts/pi/kiosk-launch.sh
+```
+
+If the tailnet is down, `scp pi@192.168.8.223:/home/pi/kiosk-launch.sh scripts/pi/kiosk-launch.sh` from the GL-X3000 wifi.
+
+- [ ] **Step 2: Read it and record what it does**
+
+Open the file. Note the exact xrandr invocation (output names, `--rotate right`, the `--pos 0x0` / `--pos 1080x0` tiling) and the two chromium lines. These are the lines Task 2 parametrises; nothing else changes.
+
+- [ ] **Step 3: Commit the unchanged copy first**
+
+```bash
+[ "$(git rev-parse --abbrev-ref HEAD)" = "docs/solo-pi-rotation" ] && git add scripts/pi/kiosk-launch.sh && git commit -m "chore(pi): bring kiosk-launch.sh into the repo, unchanged from the Pi"
+```
+
+That commit is the rollback reference for everything after it.
+
+---
+
+### Task 2: Orientation as a setting
+
+**Files:**
+- Modify: `scripts/pi/kiosk-launch.sh`
+- Create: `scripts/pi/kiosk.env.example`
+
+- [ ] **Step 1: `kiosk.env.example`**
+
+```bash
+# /home/pi/kiosk.env — read by kiosk-launch.sh at boot. Copy this file there.
+#
+# ORIENTATION=portrait   both panels rotated right, tiled at x=0 and x=<short edge>  (mosaic)
+# ORIENTATION=landscape  both panels unrotated, tiled at x=0 and x=<long edge>       (solo)
+#
+# After changing it: sudo reboot, then in /studio set panel = dell/ktc (portrait)
+# or dell-l/ktc-l (landscape) and activeVersion = v1…v4 (portrait) or solo
+# (landscape), then Deploy.
+ORIENTATION=portrait
+```
+
+- [ ] **Step 2: Parametrise the launcher**
+
+Replace the fixed xrandr block with (keep the script's existing output-name discovery if it has one; otherwise this reads the two connected outputs in xrandr order):
+
+```bash
+ORIENTATION=portrait
+[ -f /home/pi/kiosk.env ] && . /home/pi/kiosk.env
+
+# The two connected outputs, in xrandr order. The first is the sunrise panel
+# (nearest the USB-C power port), the second the sunset panel.
+mapfile -t OUTPUTS < <(xrandr --query | awk '/ connected/ {print $1}')
+LEFT="${OUTPUTS[0]}"; RIGHT="${OUTPUTS[1]}"
+# Native mode of the first output, e.g. 2560x1440.
+MODE=$(xrandr --query | awk -v o="$LEFT" '$1==o {getline; print $1}')
+W=${MODE%x*}; H=${MODE#*x}
+
+case "$ORIENTATION" in
+  landscape)
+    xrandr --output "$LEFT"  --mode "$MODE" --rotate normal --pos 0x0 \
+           --output "$RIGHT" --mode "$MODE" --rotate normal --pos "${W}x0"
+    SECOND_X=$W ;;
+  *)
+    xrandr --output "$LEFT"  --mode "$MODE" --rotate right --pos 0x0 \
+           --output "$RIGHT" --mode "$MODE" --rotate right --pos "${H}x0"
+    SECOND_X=$H ;;
+esac
+echo "kiosk-launch: ORIENTATION=$ORIENTATION mode=$MODE second panel at x=$SECOND_X"
+```
+
+Then the two chromium lines use `--window-position=0,0` and `--window-position=${SECOND_X},0` (matching whatever flag the script uses today). If the current script hard-codes `1080`, that is the value `SECOND_X` replaces. If it uses `--rotate left`, keep `left` in the portrait branch: the direction is a property of how the panels are mounted, not of this plan.
+
+- [ ] **Step 3: Dry-run the rotation logic on the Pi without launching**
+
+```bash
+ssh pi@sunsetdisplay 'export DISPLAY=:0; xrandr --query | awk "/ connected/ {print \$1}"; xrandr --query | head -8'
+```
+
+Expected: two output names and their modes. Confirm `MODE` parsing gives the native landscape mode (`2560x1440` for KTC, `1920x1080` for Dell), not a rotated one.
+
+- [ ] **Step 4: Commit**
+
+```bash
+[ "$(git rev-parse --abbrev-ref HEAD)" = "docs/solo-pi-rotation" ] && git add scripts/pi/kiosk-launch.sh scripts/pi/kiosk.env.example && git commit -m "feat(pi): orientation from /home/pi/kiosk.env; portrait stays the default"
+```
+
+---
+
+### Task 3: Doctor reports rotation
+
+**Files:**
+- Modify: `scripts/pi/kiosk-doctor.sh:105` (the state probe) and the block that prints it
+
+- [ ] **Step 1: Probe**
+
+After the `OUTPUTS=` line inside the remote script:
+
+```bash
+  xrandr --query 2>/dev/null | awk "/ connected/ {print \"ROT=\" \$1 \" \" \$3 \" \" \$4 \" \" \$5}"
+  echo "ORIENTATION=$(grep -s '^ORIENTATION=' /home/pi/kiosk.env | cut -d= -f2)"
+```
+
+`$3 $4 $5` carry the geometry and the rotation word (`right`, `left`, or nothing for normal) as xrandr prints them.
+
+- [ ] **Step 2: Report**
+
+In the "X server is up" branch, after the monitor count:
+
+```bash
+  info "kiosk.env ORIENTATION=$(get ORIENTATION)"
+  printf '%s\n' "$STATE" | grep '^ROT=' | sed 's/^ROT=/        /' | while read -r line; do info "$line"; done
+```
+
+- [ ] **Step 3: Run the doctor against the Pi**
+
+```bash
+bash scripts/pi/kiosk-doctor.sh
+```
+
+Expected: the two ROT lines show the current geometry and `right` (or `left`), and ORIENTATION reads empty until the env file exists. Paste the block into the PR.
+
+- [ ] **Step 4: Commit**
+
+```bash
+[ "$(git rev-parse --abbrev-ref HEAD)" = "docs/solo-pi-rotation" ] && git add scripts/pi/kiosk-doctor.sh && git commit -m "feat(pi): doctor reports each output's rotation and the kiosk.env orientation"
+```
+
+---
+
+### Task 4: Runbook section
+
+**Files:**
+- Modify: `docs/ops/pushing-an-update-to-the-glass.md` (new section before "When it does not work")
+
+- [ ] **Step 1: Write it**
+
+```markdown
+## Switching the glass between mosaic and solo
+
+The solo kiosk (spec `docs/superpowers/specs/2026-09-04-solo-kiosk-design.md`)
+runs the panels **landscape**. Three things must agree: the Pi's rotation,
+the panel preset, and the active version. Change them in this order.
+
+### Mosaic → solo
+
+1. Merge and build phase 2 (`solo` in the version list). `vercel ls --prod`.
+2. Sync the scripts and reload: `bash scripts/pi/kiosk-doctor.sh --sync --reload`.
+3. On the Pi, set the orientation and reboot:
+   `ssh pi@sunsetdisplay 'printf "ORIENTATION=landscape\n" > /home/pi/kiosk.env && sudo reboot'`
+4. Turn the monitors on their stands. The doctor's ROT lines say which way
+   the Pi now draws; the picture on the panels says whether the stand agrees.
+5. In `/studio`: panel = `ktc-l` (or `dell-l`), active version = `solo`.
+   Hold Deploy. The tabs pick it up within a minute and start advancing.
+6. Verify on the glass: `bash scripts/pi/kiosk-doctor.sh --reload` twice, 30 s
+   apart; the two screenshots must differ AND the frame on each panel must be
+   the "on glass" row in `/studio/solo` for that feed.
+
+### Solo → mosaic (rollback)
+
+1. In `/studio`: active version = `v1` (or whichever was live), panel = `ktc`
+   (or `dell`). Hold Deploy.
+2. `ssh pi@sunsetdisplay 'printf "ORIENTATION=portrait\n" > /home/pi/kiosk.env && sudo reboot'`
+3. Turn the monitors back. Doctor to confirm.
+
+`ORIENTATION` unset or anything but `landscape` means portrait, so a lost env
+file falls back to the mosaic arrangement, never to a blank screen.
+```
+
+- [ ] **Step 2: Commit, push, PR**
+
+```bash
+[ "$(git rev-parse --abbrev-ref HEAD)" = "docs/solo-pi-rotation" ] && git add docs/ops/pushing-an-update-to-the-glass.md && git commit -m "docs(ops): switching the glass between mosaic and solo, with rollback"
+GIT_TERMINAL_PROMPT=0 git -c credential.helper= -c credential.helper='!gh auth git-credential' push -u origin docs/solo-pi-rotation
+```
+
+PR title: `feat(pi): landscape orientation as a setting; runbook for switching to the solo kiosk (phase 4)`.
+
+---
+
+### Task 5: The switch itself (run by hand, after the PR merges)
+
+- [ ] Follow "Mosaic → solo" in the runbook, step by step.
+- [ ] Paste the doctor output and the two screenshot hashes into the PR, or into the opening-night tracker.
+- [ ] Watch `/studio/solo` for ten minutes: the "on glass" row on each feed must change every 20 s, the two feeds 10 s apart, and the tally on a frame must rise after it shows.
+- [ ] Leave the dials at their defaults for the first night; tune the next day with the bins in view.
+
+---
+
+## Self-review against the spec
+
+- §8 phase 4: rotate both panels, runbook step, panel preset, flip `activeVersion`, verify with the doctor ✔ (Tasks 2–5)
+- Reversible by a switch, no code change to go back ✔ (Task 2 default + Task 4 rollback)
+- The Pi's launch script is no longer the only copy of the rotation logic ✔ (Task 1)


### PR DESCRIPTION
Phase 3 of `docs/superpowers/specs/2026-09-04-solo-kiosk-design.md` (§6.4). Plan: `docs/superpowers/plans/2026-09-04-solo-kiosk-phase3-studio.md`.

- `/studio/solo` (owner-gated): status strip (next Windy pull countdown, last pull per feed, glass revision + diff, zone), dial rail in two colour groups (amber = glass, teal = bins) with a rules box that restates the five rules with the values in force, and one column per feed: panel with on-glass overlays and a draining countdown, then sunset bin / non-sunset bin / queue. Every frame is in exactly one column; the on-glass frame heads the queue with an amber ring; repeats and same-camera entries are marked.
- The queue re-projects with the **studio** dials the moment a dial moves (no wait for the PATCH); panels and countdowns run on the **live** dials. When the two disagree on the next frame the queue says so.
- Click any frame → the shared `FrameLabelCard`, writing a gold label against that exact archive row.
- State endpoint now returns the raw `entries` and the `zone` so the client can re-project. No schema change.
- Link from `/studio` ("solo studio →") and back.

No migration. Verified: full suite 2,047 passing, `npm run build` passes and lists `/studio/solo`.

Note: until phase 2 registers the renderer nothing advances on the glass, so both panels read "nothing on glass yet" and the queue starts at the projection. The bins and their ordering are live now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0125sgxgU6Co8b9ZQqCTzSw2
