### PR TITLE
feat(solo): the glass renderer as version 'solo', plus Pi orientation as a setting (phases 2 + 4)

### DIFF
--- a/app/components/mosaic/registry.test.tsx
+++ b/app/components/mosaic/registry.test.tsx
@@ -10,8 +10,16 @@ import { MosaicV1 } from './v1';
 vi.mock('./v1', () => ({
   MosaicV1: () => null,
 }));
+vi.mock('@/app/components/solo', () => ({
+  SoloKiosk: () => null,
+}));
 
 describe('mosaic registry', () => {
+  it('registers the solo renderer as a version, so the active-version dial can select it', () => {
+    expect(MOSAIC_VERSIONS.solo).toBeDefined();
+    expect(DEFAULT_MOSAIC_VERSION).not.toBe('solo'); // the public site keeps the mosaic
+  });
+
   it('pins v1 as the default version', () => {
     expect(DEFAULT_MOSAIC_VERSION).toBe('v1');
     expect(MOSAIC_VERSIONS[DEFAULT_MOSAIC_VERSION]).toBeDefined();

--- a/app/components/mosaic/registry.ts
+++ b/app/components/mosaic/registry.ts
@@ -9,6 +9,7 @@ import { MosaicV4 } from './v4';
 import { V4_SETTINGS_SCHEMA } from './v4/settingsSchema';
 import type { SettingsSchema } from '@/app/lib/settings/schema';
 import { SOLO_SETTINGS_SCHEMA } from '@/app/lib/solo/settingsSchema';
+import { SoloKiosk } from '@/app/components/solo';
 
 /**
  * Every mosaic version deployed, side by side. All versions ship in one
@@ -22,6 +23,9 @@ export const MOSAIC_VERSIONS: Record<string, MosaicComponent> = {
   v2: MosaicV2,
   v3: MosaicV3,
   v4: MosaicV4,
+  // Not a mosaic: one archived frame per screen from the server-owned bins.
+  // Registered here so the active-version dial can put it on the glass.
+  solo: SoloKiosk,
 };
 
 export const DEFAULT_MOSAIC_VERSION = 'v1';
@@ -32,8 +36,6 @@ export const MOSAIC_SETTINGS_SCHEMAS: Record<string, SettingsSchema> = {
   v2: V2_SETTINGS_SCHEMA,
   v3: V3_SETTINGS_SCHEMA,
   v4: V4_SETTINGS_SCHEMA,
-  // Phase 1 of the solo kiosk registers the namespace so PATCH /api/kiosk/settings
-  // accepts its dials; the renderer joins MOSAIC_VERSIONS in phase 2.
   solo: SOLO_SETTINGS_SCHEMA,
 };
 

--- a/app/components/mosaic/types.ts
+++ b/app/components/mosaic/types.ts
@@ -31,6 +31,19 @@ export interface MosaicProps {
    * while keeping the overlay reachable by hand on the device.
    */
   allowDebugOverlays?: boolean;
+  /**
+   * The kiosk is dozing (quiet hours, or the operator's doze switch). A
+   * version that advances state on a clock — the solo renderer's tally —
+   * must not do so while nobody can see the screen. Mosaic versions ignore it.
+   */
+  dozing?: boolean;
+  /**
+   * Whether this surface DRIVES the schedule (calls advance at boundaries) or
+   * only FOLLOWS what the glass is showing. Defaults to true; /studio's
+   * preview passes false. A preview that advanced the queue would count
+   * showings nobody saw on the wall.
+   */
+  driveSchedule?: boolean;
   onSelect?: (webcam: WindyWebcam) => void;
   /** Raw query string of the hosting page, for version-specific params. */
   search?: string;

--- a/app/components/solo/SoloFrame.test.tsx
+++ b/app/components/solo/SoloFrame.test.tsx
@@ -1,0 +1,36 @@
+import { it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { SoloFrame } from './SoloFrame';
+import { dialsFrom, SOLO_SETTINGS_SCHEMA } from '@/app/lib/solo/settingsSchema';
+import { schemaDefaults } from '@/app/lib/settings/schema';
+
+const D = dialsFrom(schemaDefaults(SOLO_SETTINGS_SCHEMA));
+const e = {
+  snapshotId: 1, webcamId: 1, bin: 'sunset' as const, quality: 0.91, detection: 0.88, isNew: false, tally: 2, enteredAt: 0,
+  imageUrl: 'u1', title: 'Pier', city: 'Lisbon', region: 'Lisboa', country: 'Portugal', eligible: true, rank: 3,
+};
+
+it('draws the place by default and nothing else', () => {
+  render(<SoloFrame entry={e} previous={null} fadeS={0} dials={D} width={1920} height={1080} />);
+  expect(screen.getByText('Pier')).toBeInTheDocument();
+  expect(screen.getByText(/Lisboa, Portugal/)).toBeInTheDocument();
+  expect(screen.queryByText(/shown/)).toBeNull();
+  expect(screen.queryByText(/q 0\.91/)).toBeNull();
+});
+
+it('draws scores, rank, and tally when dialled on; hides the place when dialled off', () => {
+  render(<SoloFrame entry={e} previous={null} fadeS={0}
+    dials={{ ...D, showPlace: false, showScores: true, showRank: true, showTally: true }} width={1920} height={1080} />);
+  expect(screen.queryByText('Pier')).toBeNull();
+  expect(screen.getByText(/q 0\.91 · d 0\.88/)).toBeInTheDocument();
+  expect(screen.getByText(/sunset bin #3/)).toBeInTheDocument();
+  expect(screen.getByText(/×2/)).toBeInTheDocument();
+});
+
+it('keeps the previous frame underneath and sets the fade duration on the top layer', () => {
+  const prev = { ...e, snapshotId: 0, imageUrl: 'u0' };
+  render(<SoloFrame entry={e} previous={prev} fadeS={3} dials={D} width={1920} height={1080} />);
+  const imgs = screen.getAllByRole('presentation');
+  expect(imgs.map((i) => i.getAttribute('src'))).toEqual(['u0', 'u1']);
+  expect(imgs[1]).toHaveStyle({ transition: 'opacity 3s ease' });
+});

--- a/app/components/solo/SoloFrame.tsx
+++ b/app/components/solo/SoloFrame.tsx
@@ -1,0 +1,67 @@
+'use client';
+
+import type { EntryView } from '@/app/api/kiosk/solo/view';
+import type { SoloDials } from '@/app/lib/solo/types';
+
+const mono = 'ui-monospace, SFMono-Regular, Menlo, monospace';
+
+/**
+ * One frame filling the panel. The previous frame sits underneath so a fade
+ * dial above zero crossfades instead of cutting; at zero the top layer is
+ * simply there. Overlays are what the live dials say and nothing else.
+ */
+export function SoloFrame({ entry, previous, fadeS, dials, width, height }: {
+  entry: EntryView;
+  previous: EntryView | null;
+  fadeS: number;
+  dials: SoloDials;
+  width: number;
+  height: number;
+}) {
+  const layer = { position: 'absolute', inset: 0, width: '100%', height: '100%', objectFit: 'cover' } as const;
+  const scale = Math.max(1, Math.min(width, height) / 540); // overlay text scales with the panel
+  return (
+    <div style={{ position: 'relative', width, height, background: '#000', overflow: 'hidden' }}>
+      {previous && (
+        // eslint-disable-next-line @next/next/no-img-element
+        <img key={previous.snapshotId} src={previous.imageUrl} alt="" role="presentation" style={layer} />
+      )}
+      {/* eslint-disable-next-line @next/next/no-img-element */}
+      <img
+        key={entry.snapshotId}
+        src={entry.imageUrl}
+        alt=""
+        role="presentation"
+        style={{
+          ...layer,
+          animation: fadeS > 0 ? `solo-fade-in ${fadeS}s ease` : undefined,
+          transition: `opacity ${fadeS}s ease`,
+        }}
+      />
+      <style>{'@keyframes solo-fade-in { from { opacity: 0 } to { opacity: 1 } }'}</style>
+      {dials.showPlace && (
+        <div style={{
+          position: 'absolute', left: 24 * scale, bottom: 20 * scale, color: '#fff',
+          textShadow: '0 1px 4px #000', fontSize: 22 * scale, lineHeight: 1.2,
+        }}>
+          {entry.title}
+          <div style={{ fontSize: 15 * scale, opacity: 0.85 }}>
+            {[entry.region, entry.country].filter(Boolean).join(', ')}
+          </div>
+        </div>
+      )}
+      {(dials.showScores || dials.showRank || dials.showTally) && (
+        <div style={{
+          position: 'absolute', right: 24 * scale, bottom: 20 * scale, color: '#fff',
+          textShadow: '0 1px 4px #000', fontFamily: mono, fontSize: 16 * scale, textAlign: 'right', lineHeight: 1.4,
+        }}>
+          {dials.showTally && <div>shown <b style={{ color: '#f5a344' }}>×{entry.tally}</b></div>}
+          {dials.showRank && <div>{entry.bin === 'sunset' ? 'sunset' : 'non-sunset'} bin #{entry.rank}</div>}
+          {dials.showScores && (
+            <div>{entry.bin === 'sunset' ? `q ${(entry.quality ?? 0).toFixed(2)} · ` : ''}d {entry.detection.toFixed(2)}</div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/components/solo/index.test.tsx
+++ b/app/components/solo/index.test.tsx
@@ -1,0 +1,15 @@
+import { it, expect, vi } from 'vitest';
+import { render } from '@testing-library/react';
+import { SoloKiosk } from './index';
+
+vi.mock('./useSoloGlass', () => ({
+  useSoloGlass: vi.fn(() => ({ current: null, next: null, slot: 1, boundaryMs: 0, error: null, queueLength: 0 })),
+}));
+import { useSoloGlass } from './useSoloGlass';
+
+it('drives by default on the kiosk and follows in a preview; passes dozing through', () => {
+  render(<SoloKiosk webcams={[]} width={100} height={50} feed="sunset" />);
+  expect(useSoloGlass).toHaveBeenLastCalledWith(expect.objectContaining({ drive: true, dozing: false }));
+  render(<SoloKiosk webcams={[]} width={100} height={50} feed="sunset" driveSchedule={false} dozing />);
+  expect(useSoloGlass).toHaveBeenLastCalledWith(expect.objectContaining({ drive: false, dozing: true }));
+});

--- a/app/components/solo/index.tsx
+++ b/app/components/solo/index.tsx
@@ -1,0 +1,56 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+import type { MosaicProps } from '@/app/components/mosaic/types';
+import type { EntryView } from '@/app/api/kiosk/solo/view';
+import { mergeSettings } from '@/app/lib/settings/schema';
+import { SOLO_SETTINGS_SCHEMA, dialsFrom } from '@/app/lib/solo/settingsSchema';
+import { SoloFrame } from './SoloFrame';
+import { useSoloGlass } from './useSoloGlass';
+
+const mono = 'ui-monospace, SFMono-Regular, Menlo, monospace';
+
+/**
+ * The solo kiosk as a registered version (spec §6.3): one archived frame per
+ * screen, chosen by the server from the bins, advancing on the wall clock.
+ * Ignores the pool props entirely; everything it shows comes from
+ * /api/kiosk/solo.
+ */
+export function SoloKiosk(props: MosaicProps) {
+  const dials = dialsFrom(mergeSettings(SOLO_SETTINGS_SCHEMA, props.settings));
+  const glass = useSoloGlass({
+    feed: props.feed,
+    dials,
+    drive: props.driveSchedule !== false,
+    dozing: props.dozing === true,
+  });
+  const current = glass.current;
+  const [previous, setPrevious] = useState<EntryView | null>(null);
+  const lastRef = useRef<EntryView | null>(null);
+  useEffect(() => {
+    if (current && lastRef.current && current.snapshotId !== lastRef.current.snapshotId) {
+      setPrevious(lastRef.current);
+    }
+    lastRef.current = current;
+  }, [current]);
+
+  const debug = props.allowDebugOverlays !== false && (props.search ?? '').includes('debug=1');
+
+  return (
+    <div style={{ position: 'relative', width: props.width, height: props.height, background: '#000' }}>
+      {current ? (
+        <SoloFrame entry={current} previous={previous} fadeS={dials.fadeS} dials={dials}
+          width={props.width} height={props.height} />
+      ) : null}
+      {debug && (
+        <div style={{
+          position: 'absolute', top: 8, left: 8, fontFamily: mono, fontSize: 12, color: '#7ee2ac',
+          background: 'rgba(0,0,0,.7)', padding: '4px 8px', borderRadius: 4,
+        }}>
+          slot {glass.slot} · next in {Math.max(0, Math.ceil((glass.boundaryMs - Date.now()) / 1000))} s
+          · queue {glass.queueLength}{glass.error ? ` · ${glass.error}` : ''}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/components/solo/schedule.test.ts
+++ b/app/components/solo/schedule.test.ts
@@ -1,0 +1,9 @@
+import { it, expect } from 'vitest';
+import { msUntilBoundary } from './schedule';
+
+it('is the gap to the next boundary, never zero', () => {
+  expect(msUntilBoundary(0, 'sunrise', 20, 10)).toBe(20_000);
+  expect(msUntilBoundary(19_999, 'sunrise', 20, 10)).toBe(1);
+  expect(msUntilBoundary(20_000, 'sunrise', 20, 10)).toBe(20_000);
+  expect(msUntilBoundary(0, 'sunset', 20, 10)).toBe(10_000);
+});

--- a/app/components/solo/schedule.ts
+++ b/app/components/solo/schedule.ts
@@ -1,0 +1,7 @@
+import { nextBoundaryMs } from '@/app/lib/solo/schedule';
+import type { Feed } from '@/app/lib/solo/types';
+
+/** Milliseconds until this screen's next change. Always > 0. */
+export function msUntilBoundary(nowMs: number, feed: Feed, dwellS: number, offsetS: number): number {
+  return Math.max(1, nextBoundaryMs(nowMs, feed, dwellS, offsetS) - nowMs);
+}

--- a/app/components/solo/useSoloGlass.test.tsx
+++ b/app/components/solo/useSoloGlass.test.tsx
@@ -1,0 +1,82 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useSoloGlass } from './useSoloGlass';
+import { dialsFrom, SOLO_SETTINGS_SCHEMA } from '@/app/lib/solo/settingsSchema';
+import { schemaDefaults } from '@/app/lib/settings/schema';
+
+const D = dialsFrom(schemaDefaults(SOLO_SETTINGS_SCHEMA));
+const entry = (id: number) => ({
+  snapshotId: id, webcamId: 1, bin: 'sunset', quality: 0.9, detection: 0.9, isNew: false,
+  tally: 0, enteredAt: 0, imageUrl: `u${id}`, title: `t${id}`, city: '', region: '', country: '', eligible: true, rank: 1,
+});
+const state = (currentId: number | null, nextIds: number[]) => ({
+  feed: 'sunrise', dials: D, current: currentId ? { entry: entry(currentId), shownSince: 0, slot: 0 } : null,
+  next: nextIds.map(entry), bins: { sunset: [], nonSunset: [] }, schedule: { slot: 0, nextBoundaryMs: 0 },
+  lastPull: { admitted: { sunset: 0, nonSunset: 0 } }, entries: [], zone: { minDeg: -24, maxDeg: -2 },
+});
+
+let calls: { url: string; body?: unknown }[];
+const fetchMock = vi.fn();
+// Testing Library's waitFor polls with setTimeout, which the fake clock
+// freezes; flushing the fake clock by a few ms settles the fetch chain instead.
+const flush = () => act(async () => { await vi.advanceTimersByTimeAsync(5); });
+const advance = (ms: number) => act(async () => { await vi.advanceTimersByTimeAsync(ms); });
+
+beforeEach(() => {
+  calls = [];
+  vi.useFakeTimers();
+  vi.setSystemTime(new Date(1_000_000_000_000)); // on a sunrise boundary; next at +20 s
+  vi.stubGlobal('Image', class {
+    onload: null | (() => void) = null;
+    onerror: null | (() => void) = null;
+    set src(_v: string) { this.onload?.(); }
+  });
+  fetchMock.mockImplementation(async (url: string, init?: RequestInit) => {
+    calls.push({ url, body: init?.body ? JSON.parse(String(init.body)) : undefined });
+    if (url.includes('/advance')) return { ok: true, json: async () => ({ advanced: true, ...state(2, [3]) }) };
+    return { ok: true, json: async () => state(1, [2]) };
+  });
+  vi.stubGlobal('fetch', fetchMock);
+});
+afterEach(() => {
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+});
+
+describe('useSoloGlass', () => {
+  it('shows the server current, preloads next, and advances at the boundary with the slot', async () => {
+    const { result } = renderHook(() => useSoloGlass({ feed: 'sunrise', dials: D, drive: true, dozing: false }));
+    await flush();
+    expect(result.current.current?.snapshotId).toBe(1);
+    expect(result.current.next?.snapshotId).toBe(2);
+    await advance(20_000);
+    expect(result.current.current?.snapshotId).toBe(2);
+    const adv = calls.find((c) => c.url.includes('/advance'));
+    expect(adv?.body).toEqual({ feed: 'sunrise', slot: 50_000_001 });
+  });
+  it('does not advance while dozing or when it only follows', async () => {
+    const { result, rerender } = renderHook(
+      (p: { drive: boolean; dozing: boolean }) => useSoloGlass({ feed: 'sunrise', dials: D, ...p }),
+      { initialProps: { drive: false, dozing: false } },
+    );
+    await flush();
+    expect(result.current.current?.snapshotId).toBe(1);
+    await advance(20_000);
+    expect(calls.some((c) => c.url.includes('/advance'))).toBe(false);
+    rerender({ drive: true, dozing: true });
+    await advance(20_000);
+    expect(calls.some((c) => c.url.includes('/advance'))).toBe(false);
+  });
+  it('keeps the frame up and records the error when advance fails', async () => {
+    fetchMock.mockImplementation(async (url: string) =>
+      url.includes('/advance')
+        ? { ok: false, status: 500, json: async () => ({}) }
+        : { ok: true, json: async () => state(1, [2]) });
+    const { result } = renderHook(() => useSoloGlass({ feed: 'sunrise', dials: D, drive: true, dozing: false }));
+    await flush();
+    expect(result.current.current?.snapshotId).toBe(1);
+    await advance(20_000);
+    expect(result.current.error).toMatch(/500/);
+    expect(result.current.current?.snapshotId).toBe(1);
+  });
+});

--- a/app/components/solo/useSoloGlass.ts
+++ b/app/components/solo/useSoloGlass.ts
@@ -1,0 +1,111 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+import type { EntryView, StateView } from '@/app/api/kiosk/solo/view';
+import { slotFor } from '@/app/lib/solo/schedule';
+import type { Feed, SoloDials } from '@/app/lib/solo/types';
+import { msUntilBoundary } from './schedule';
+
+const STATE_REFRESH_MS = 60_000;
+
+export interface SoloGlass {
+  current: EntryView | null;
+  next: EntryView | null;
+  slot: number;
+  boundaryMs: number;
+  error: string | null;
+  queueLength: number;
+}
+
+function preload(url: string): Promise<void> {
+  return new Promise((resolve) => {
+    const img = new Image();
+    img.onload = () => resolve();
+    img.onerror = () => resolve(); // a failed preload is not a reason to skip the frame
+    img.src = url;
+  });
+}
+
+/**
+ * The glass loop (spec §6.2): read the state, wait for the boundary the wall
+ * clock dictates, ask the server for the next frame with that slot, show it,
+ * preload the one after. Two tabs stay staggered because both read the same
+ * clock; a reload just waits for its next boundary.
+ */
+export function useSoloGlass({ feed, dials, drive, dozing }: {
+  feed: Feed;
+  dials: SoloDials;
+  drive: boolean;
+  dozing: boolean;
+}): SoloGlass {
+  const [view, setView] = useState<StateView | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [tick, setTick] = useState(0);
+  const lastSlotPosted = useRef<number | null>(null);
+  const driveRef = useRef(drive);
+  const dozingRef = useRef(dozing);
+  driveRef.current = drive;
+  dozingRef.current = dozing;
+
+  // State refresh: on mount and every minute, so admissions from the cron
+  // reach the preload even when nothing advanced, and a following surface
+  // tracks the glass within a minute.
+  useEffect(() => {
+    let alive = true;
+    const load = async () => {
+      try {
+        const res = await fetch(`/api/kiosk/solo/state?feed=${feed}`);
+        if (!res.ok) throw new Error(`state ${res.status}`);
+        const v = (await res.json()) as StateView;
+        if (!alive) return;
+        setView(v);
+        if (v.next[0]) void preload(v.next[0].imageUrl);
+      } catch (e) {
+        if (alive) setError(String(e));
+      }
+    };
+    void load();
+    const t = setInterval(load, STATE_REFRESH_MS);
+    return () => {
+      alive = false;
+      clearInterval(t);
+    };
+  }, [feed]);
+
+  // The boundary timer. Re-armed after every fire and whenever dials change.
+  useEffect(() => {
+    const wait = msUntilBoundary(Date.now(), feed, dials.dwellS, dials.offsetS);
+    const t = setTimeout(async () => {
+      const slot = slotFor(Date.now(), feed, dials.dwellS, dials.offsetS);
+      if (driveRef.current && !dozingRef.current && lastSlotPosted.current !== slot) {
+        lastSlotPosted.current = slot;
+        try {
+          const res = await fetch('/api/kiosk/solo/advance', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ feed, slot }),
+          });
+          if (!res.ok) throw new Error(`advance ${res.status}`);
+          const v = (await res.json()) as StateView & { advanced: boolean };
+          setView(v);
+          setError(null);
+          if (v.next[0]) void preload(v.next[0].imageUrl);
+        } catch (e) {
+          setError(String(e));
+        }
+      }
+      setTick((n) => n + 1); // re-arm
+    }, wait);
+    return () => clearTimeout(t);
+  }, [feed, dials.dwellS, dials.offsetS, tick]);
+
+  const nowMs = Date.now();
+  return {
+    current: view?.current?.entry ?? null,
+    next: view?.next[0] ?? null,
+    slot: slotFor(nowMs, feed, dials.dwellS, dials.offsetS),
+    boundaryMs: nowMs + msUntilBoundary(nowMs, feed, dials.dwellS, dials.offsetS),
+    error,
+    queueLength: view?.next.length ?? 0,
+  };
+}

--- a/app/kiosk/panelPreview.test.ts
+++ b/app/kiosk/panelPreview.test.ts
@@ -1,9 +1,13 @@
 import { describe, it, expect } from 'vitest';
-import { parsePanelPreview, fitScale } from './panelPreview';
+import { parsePanelPreview, fitScale, PANEL_PRESETS } from './panelPreview';
 
 const parse = (qs: string) => parsePanelPreview(new URLSearchParams(qs));
 
 describe('parsePanelPreview', () => {
+  it('offers each panel in both orientations', () => {
+    expect(parsePanelPreview(new URLSearchParams('panel=ktc-l'))).toEqual({ width: 2560, height: 1440 });
+    expect(PANEL_PRESETS['dell-l']).toEqual({ width: 1920, height: 1080 });
+  });
   it('returns null when no panel is requested, so the kiosk fills the window', () => {
     expect(parse('')).toBeNull();
     expect(parse('setup=1&floor=120')).toBeNull();

--- a/app/kiosk/panelPreview.ts
+++ b/app/kiosk/panelPreview.ts
@@ -14,7 +14,8 @@ export interface PanelSize {
 }
 
 /**
- * The panels actually in play, portrait — the orientation they hang in.
+ * The panels actually in play, in both orientations: portrait for the mosaic
+ * versions, landscape (`-l`) for the solo kiosk.
  *
  * The single definition. `?panel=` parses against it, the shared settings
  * schema builds its enum and its help text from it, and /studio sizes the
@@ -23,6 +24,11 @@ export interface PanelSize {
 export const PANEL_PRESETS: Record<string, PanelSize> = {
   dell: { width: 1080, height: 1920 },
   ktc: { width: 1440, height: 2560 },
+  // The same two panels turned landscape, for the solo kiosk (spec
+  // 2026-09-04-solo-kiosk-design §6.3). Which orientation the Pi draws is a
+  // setting on the Pi; this preset must agree with it.
+  'dell-l': { width: 1920, height: 1080 },
+  'ktc-l': { width: 2560, height: 1440 },
 };
 
 export const DEFAULT_PANEL_PRESET = 'dell';

--- a/app/kiosk/sunrise/page.tsx
+++ b/app/kiosk/sunrise/page.tsx
@@ -57,6 +57,7 @@ function SunriseKioskContent() {
         peerWebcams={peerWebcams}
         setupMode={searchParams.get('setup') === '1'}
         allowDebugOverlays={searchParams.get('debug') === '1'}
+        dozing={dozing}
         search={queryString}
         settings={liveSettings?.namespaces[versionName]}
       />

--- a/app/kiosk/sunset/page.tsx
+++ b/app/kiosk/sunset/page.tsx
@@ -57,6 +57,7 @@ function SunsetKioskContent() {
         peerWebcams={peerWebcams}
         setupMode={searchParams.get('setup') === '1'}
         allowDebugOverlays={searchParams.get('debug') === '1'}
+        dozing={dozing}
         search={queryString}
         settings={liveSettings?.namespaces[versionName]}
       />

--- a/app/lib/settings/sharedSchema.test.ts
+++ b/app/lib/settings/sharedSchema.test.ts
@@ -7,10 +7,10 @@ describe('SHARED_SCHEMA', () => {
   it('activeVersion defaults to the registry pin so an empty DB changes nothing', () => {
     expect(schemaDefaults(SHARED_SCHEMA).activeVersion).toBe(DEFAULT_MOSAIC_VERSION);
   });
-  it('panelPreset options are the named panelPreview presets', () => {
+  it('panelPreset options are the named panelPreview presets, both orientations', () => {
     const knob = SHARED_SCHEMA.find((k) => k.key === 'panelPreset');
     expect(knob?.kind).toBe('enum');
-    expect(knob && 'options' in knob ? [...knob.options] : []).toEqual(['dell', 'ktc']);
+    expect(knob && 'options' in knob ? [...knob.options] : []).toEqual(['dell', 'ktc', 'dell-l', 'ktc-l']);
   });
   it('exports the namespace constant used by storage rows', () => {
     expect(SHARED_NAMESPACE).toBe('shared');

--- a/app/studio/PreviewPane.tsx
+++ b/app/studio/PreviewPane.tsx
@@ -347,6 +347,7 @@ export function PreviewPane({
                   peerWebcams={peerOf(feed)}
                   search=""
                   settings={settings}
+                  driveSchedule={false}
                   at={at}
                   onSelect={setSelected}
                 />

--- a/docs/ops/pushing-an-update-to-the-glass.md
+++ b/docs/ops/pushing-an-update-to-the-glass.md
@@ -83,6 +83,41 @@ Backwards, the settings API discards the unknown key and the studio status
 strip shows `⚠ not stored: <key> (unknown)`. Deploy will keep reporting in
 sync while the panels show nothing new.
 
+## Switching the glass between mosaic and solo
+
+The solo kiosk (spec `docs/superpowers/specs/2026-09-04-solo-kiosk-design.md`)
+runs the panels **landscape**. Three things must agree: the Pi's rotation
+(`/home/pi/kiosk.env`), the panel preset (`dell` vs `dell-l`), and the active
+version (`v1`..`v4` vs `solo`). Change them in this order.
+
+`kiosk-launch.sh` is now in the repo (`scripts/pi/`) and reaches the Pi with
+`--sync`; the Pi reads `ORIENTATION` from `/home/pi/kiosk.env` at boot.
+Missing file means portrait, so a lost file falls back to the mosaic
+arrangement, never to a blank glass. The doctor prints both the setting and
+what xrandr is actually doing.
+
+### Mosaic → solo
+
+1. Merge and build the code that carries `solo` in the version list.
+   `vercel ls --prod`.
+2. Sync the scripts and reload: `bash scripts/pi/kiosk-doctor.sh --sync --reload`.
+3. Set the orientation and reboot the Pi:
+   `ssh pi@sunsetdisplay 'printf "ORIENTATION=landscape\n" > /home/pi/kiosk.env && sudo reboot'`
+4. Turn the monitors on their stands. The doctor's `xrandr` lines say which
+   way the Pi draws; the picture on the panels says whether the stand agrees.
+5. In `/studio`: panel = `dell-l`, active version = `solo`. Hold Deploy. The
+   tabs pick it up within a minute and start advancing.
+6. Verify on the glass: `bash scripts/pi/kiosk-doctor.sh --reload` twice,
+   30 s apart; the two screenshots must differ AND the frame on each panel
+   must be the "on glass" row in `/studio/solo` for that feed.
+
+### Solo → mosaic (rollback)
+
+1. In `/studio`: active version = `v1` (or whichever was live), panel =
+   `dell`. Hold Deploy.
+2. `ssh pi@sunsetdisplay 'printf "ORIENTATION=portrait\n" > /home/pi/kiosk.env && sudo reboot'`
+3. Turn the monitors back. Doctor to confirm.
+
 ## When it does not work
 
 | Symptom | Meaning | Do |

--- a/docs/superpowers/plans/2026-09-04-solo-kiosk-phase4-pi.md
+++ b/docs/superpowers/plans/2026-09-04-solo-kiosk-phase4-pi.md
@@ -4,7 +4,7 @@
 
 **Goal:** Put the solo kiosk on the glass, reversibly: the two panels turned landscape by a one-line setting on the Pi, the panel preset and active version flipped from `/studio`, verified on the screens with the doctor script and the solo studio, and the whole procedure written into the runbook with its rollback.
 
-**Architecture:** The Pi's `~/kiosk-launch.sh` is today the only copy of the rotation logic and lives outside the repo. This phase brings it into `scripts/pi/` as the canonical copy, makes orientation a value in `/home/pi/kiosk.env` (default `portrait`, so nothing changes until someone edits it), and teaches the doctor to report each output's rotation. Switching modes is then: edit one line on the Pi, reboot, flip two dials, Deploy.
+**Architecture:** (Corrected 2026-09-04 after reading the Pi's script: the panels are Dell 1920×1080 mounted "open book", each output rotated the opposite way, `right` and `left`, tiled at x=0 and x=1080. Landscape is both outputs `normal` at x=0 and x=1920, windows 1920×1080, preset `dell-l`. The plan's Task 2 code below was written before that and is superseded by the committed `scripts/pi/kiosk-launch.sh`.) The Pi's `~/kiosk-launch.sh` is today the only copy of the rotation logic and lives outside the repo. This phase brings it into `scripts/pi/` as the canonical copy, makes orientation a value in `/home/pi/kiosk.env` (default `portrait`, so nothing changes until someone edits it), and teaches the doctor to report each output's rotation. Switching modes is then: edit one line on the Pi, reboot, flip two dials, Deploy.
 
 **Tech Stack:** bash, xrandr, ssh, the existing `kiosk-doctor.sh --sync --reload` flow.
 

--- a/scripts/pi/kiosk-doctor.sh
+++ b/scripts/pi/kiosk-doctor.sh
@@ -103,6 +103,8 @@ STATE=$(ssh -o ConnectTimeout=10 "pi@$HOST" '
     echo "X=up"
     echo "DPMS=$(xset q | awk "/Monitor is/ {print \$3}")"
     echo "OUTPUTS=$(xrandr 2>/dev/null | grep -c " connected")"
+    xrandr --query 2>/dev/null | awk "/connected/ {print \"ROT=\" \$1 \" \" \$2 \" \" \$3 \" \" \$4 \" \" \$5}"
+    echo "ORIENTATION=$(grep -s "^ORIENTATION=" /home/pi/kiosk.env | cut -d= -f2)"
   else
     echo "X=down"
   fi
@@ -119,6 +121,11 @@ if [ "$(get X)" = "up" ]; then
   DPMS=$(get DPMS)
   OUTPUTS=$(get OUTPUTS)
   info "monitors connected: ${OUTPUTS:-unknown}"
+  # Orientation is a setting on the Pi (kiosk.env) and a fact in X (xrandr).
+  # Both are printed so a mismatch between them, or with the /studio panel
+  # preset, is visible here rather than only on the glass.
+  info "kiosk.env ORIENTATION=$(get ORIENTATION) (empty = portrait default)"
+  printf '%s\n' "$STATE" | grep '^ROT=' | sed 's/^ROT=/xrandr /' | while read -r line; do info "$line"; done
   case "$DPMS" in
     On)  ok "monitors are awake (DPMS On)" ;;
     "")  info "DPMS state not reported" ;;

--- a/scripts/pi/kiosk-launch.sh
+++ b/scripts/pi/kiosk-launch.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+# Dual-monitor sunrise/sunset kiosk launcher for sunsetdisplay.
+# Called from the desktop session autostart. Assumes X11 session.
+#
+# Monitors are mounted "open book" style: both portrait, with the panels'
+# native bottom bezels (Dell logos) facing the CENTER seam. That means the
+# two panels are physically rotated opposite directions, so each output
+# gets its own rotation below.
+
+LABEL_MODE=0   # 1 = show local SUNRISE/SUNSET identification pages, 0 = production mosaics
+
+ROT_LEFT_SCREEN="right"   # rotation for output tiled at x=0 (left half of book)
+ROT_RIGHT_SCREEN="left"   # rotation for output tiled at x=1080 (right half)
+
+sleep 6  # let X and displays settle after login
+
+xset s off
+xset -dpms
+xset s noblank
+pkill -f xscreensaver 2>/dev/null
+
+OUTS=($(xrandr | awk '/ connected/{print $1}'))
+[ -n "${OUTS[0]}" ] && xrandr --output "${OUTS[0]}" --mode 1920x1080 --rotate "$ROT_LEFT_SCREEN" --pos 0x0
+[ -n "${OUTS[1]}" ] && xrandr --output "${OUTS[1]}" --mode 1920x1080 --rotate "$ROT_RIGHT_SCREEN" --pos 1080x0
+
+if [ "$LABEL_MODE" = "1" ]; then
+  URL_A="file:///home/pi/labels/sunrise.html"
+  URL_B="file:///home/pi/labels/sunset.html"
+else
+  URL_A="https://www.sunrisesunset.studio/kiosk/sunrise"
+  URL_B="https://www.sunrisesunset.studio/kiosk/sunset"
+fi
+
+launch() {
+  chromium --kiosk --noerrdialogs --disable-infobars --incognito \
+    --password-store=basic --no-first-run \
+    --user-data-dir="$2" \
+    --window-position=$3,0 --window-size=1080,1920 \
+    "$1" &
+}
+
+launch "$URL_A" /home/pi/.kiosk-sunrise 0
+launch "$URL_B" /home/pi/.kiosk-sunset  1080

--- a/scripts/pi/kiosk-launch.sh
+++ b/scripts/pi/kiosk-launch.sh
@@ -2,15 +2,44 @@
 # Dual-monitor sunrise/sunset kiosk launcher for sunsetdisplay.
 # Called from the desktop session autostart. Assumes X11 session.
 #
-# Monitors are mounted "open book" style: both portrait, with the panels'
-# native bottom bezels (Dell logos) facing the CENTER seam. That means the
-# two panels are physically rotated opposite directions, so each output
-# gets its own rotation below.
+# The canonical copy lives in the repo at scripts/pi/kiosk-launch.sh and is
+# pushed to the Pi by `kiosk-doctor.sh --sync`. Edit it there, not on the Pi.
+#
+# Orientation is a SETTING, read from /home/pi/kiosk.env (see
+# scripts/pi/kiosk.env.example). Anything but ORIENTATION=landscape means
+# portrait, which is exactly what this script did before the setting existed,
+# so a missing or garbled file falls back to the mosaic arrangement rather
+# than to a blank or mis-tiled glass.
+#
+# portrait  — the "open book": both panels portrait with their native bottom
+#             bezels (Dell logos) facing the CENTER seam, so the two outputs
+#             are rotated opposite ways. Tiled at x=0 and x=1080; each window
+#             1080x1920. The mosaic versions.
+# landscape — both panels unrotated, tiled at x=0 and x=1920; each window
+#             1920x1080. The solo kiosk (one frame per screen).
 
-LABEL_MODE=0   # 1 = show local SUNRISE/SUNSET identification pages, 0 = production mosaics
+LABEL_MODE=0   # 1 = show local SUNRISE/SUNSET identification pages, 0 = production
 
-ROT_LEFT_SCREEN="right"   # rotation for output tiled at x=0 (left half of book)
-ROT_RIGHT_SCREEN="left"   # rotation for output tiled at x=1080 (right half)
+ORIENTATION=portrait
+[ -f /home/pi/kiosk.env ] && . /home/pi/kiosk.env
+
+MODE=1920x1080   # the panels' native mode (Dell 27", landscape)
+
+case "$ORIENTATION" in
+  landscape)
+    ROT_LEFT_SCREEN="normal"
+    ROT_RIGHT_SCREEN="normal"
+    SECOND_X=1920
+    WIN_W=1920; WIN_H=1080
+    ;;
+  *)
+    ORIENTATION=portrait
+    ROT_LEFT_SCREEN="right"   # output tiled at x=0 (left half of the book)
+    ROT_RIGHT_SCREEN="left"   # output tiled at x=1080 (right half)
+    SECOND_X=1080
+    WIN_W=1080; WIN_H=1920
+    ;;
+esac
 
 sleep 6  # let X and displays settle after login
 
@@ -20,8 +49,9 @@ xset s noblank
 pkill -f xscreensaver 2>/dev/null
 
 OUTS=($(xrandr | awk '/ connected/{print $1}'))
-[ -n "${OUTS[0]}" ] && xrandr --output "${OUTS[0]}" --mode 1920x1080 --rotate "$ROT_LEFT_SCREEN" --pos 0x0
-[ -n "${OUTS[1]}" ] && xrandr --output "${OUTS[1]}" --mode 1920x1080 --rotate "$ROT_RIGHT_SCREEN" --pos 1080x0
+[ -n "${OUTS[0]}" ] && xrandr --output "${OUTS[0]}" --mode "$MODE" --rotate "$ROT_LEFT_SCREEN" --pos 0x0
+[ -n "${OUTS[1]}" ] && xrandr --output "${OUTS[1]}" --mode "$MODE" --rotate "$ROT_RIGHT_SCREEN" --pos "${SECOND_X}x0"
+echo "kiosk-launch: ORIENTATION=$ORIENTATION outputs=${OUTS[0]:-none},${OUTS[1]:-none} second panel at x=$SECOND_X window ${WIN_W}x${WIN_H}"
 
 if [ "$LABEL_MODE" = "1" ]; then
   URL_A="file:///home/pi/labels/sunrise.html"
@@ -35,9 +65,9 @@ launch() {
   chromium --kiosk --noerrdialogs --disable-infobars --incognito \
     --password-store=basic --no-first-run \
     --user-data-dir="$2" \
-    --window-position=$3,0 --window-size=1080,1920 \
+    --window-position=$3,0 --window-size=${WIN_W},${WIN_H} \
     "$1" &
 }
 
 launch "$URL_A" /home/pi/.kiosk-sunrise 0
-launch "$URL_B" /home/pi/.kiosk-sunset  1080
+launch "$URL_B" /home/pi/.kiosk-sunset  "$SECOND_X"

--- a/scripts/pi/kiosk.env.example
+++ b/scripts/pi/kiosk.env.example
@@ -1,0 +1,15 @@
+# /home/pi/kiosk.env — read by kiosk-launch.sh at boot. Copy this file there:
+#   scp scripts/pi/kiosk.env.example pi@sunsetdisplay:/home/pi/kiosk.env
+#
+# ORIENTATION=portrait   the "open book": each panel rotated toward the centre
+#                        seam, tiled at x=0 and x=1080, windows 1080x1920.
+#                        The mosaic versions (v1..v4). Default when the file is
+#                        missing, so a lost file never blanks the glass.
+# ORIENTATION=landscape  both panels unrotated, tiled at x=0 and x=1920,
+#                        windows 1920x1080. The solo kiosk.
+#
+# After changing it: sudo reboot. Then in /studio set panel = dell (portrait)
+# or dell-l (landscape) and active version = v1..v4 (portrait) or solo
+# (landscape), and hold Deploy. Full procedure and rollback:
+#   docs/ops/pushing-an-update-to-the-glass.md, "Switching the glass".
+ORIENTATION=portrait


### PR DESCRIPTION
Phases 2 and 4 of `docs/superpowers/specs/2026-09-04-solo-kiosk-design.md`. Plans: `…plans/2026-09-04-solo-kiosk-phase2-glass.md`, `…phase4-pi.md`.

**Phase 2, the renderer**
- `app/components/solo/`: one archived frame per screen, driven by the wall clock (spec §6.2). At each boundary the tab posts its slot to `/api/kiosk/solo/advance`, swaps the frame, and preloads the next. The two tabs stay 10 s apart without talking to each other; a reload waits for its next boundary.
- Registered as version **`solo`** in `MOSAIC_VERSIONS`, so `activeVersion` on `/studio` flips the glass to it and back. `DEFAULT_MOSAIC_VERSION` stays `v1`.
- Fade dial = CSS crossfade over the preloaded image; 0 is a cut. On-glass overlays as dialled: place, scores, bin rank, shown tally. `?debug=1` adds a slot/countdown/queue readout.
- Two optional `MosaicProps`: `dozing` (kiosk pages pass it; the loop never advances while dozing, so tallies only count showings someone could see) and `driveSchedule` (`/studio`'s preview passes `false`: it follows the glass, never advances it).
- Landscape presets `dell-l` 1920×1080 and `ktc-l` 2560×1440.

**Phase 4, the Pi**
- `scripts/pi/kiosk-launch.sh` is now in the repo (first commit is the byte-for-byte copy from the Pi, md5 matched). It reads `ORIENTATION` from `/home/pi/kiosk.env`; anything but `landscape` is today's open-book portrait exactly, so a missing file never blanks the glass. `scripts/pi/kiosk.env.example` documents the one setting.
- `kiosk-doctor.sh` now prints the env setting and each output's xrandr rotation.
- Runbook: "Switching the glass between mosaic and solo", with rollback.

**Not done in this PR, by design:** nothing on the Pi has been changed. The switch itself (write `kiosk.env`, reboot, turn the monitors, set `dell-l` + `solo`, Deploy) is the runbook's step list and waits for a human at the glass. Note the doctor currently reports both HDMI outputs *disconnected*, so the panels are not plugged into the Pi right now.

Verified: full suite green, `npm run build` passes, launcher logic exercised for `landscape`, `portrait`, a bogus value, and a missing file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0125sgxgU6Co8b9ZQqCTzSw2
