### PR TITLE
feat: solo2 — rhythm, anticipation, prelude, transitions, local time (a version beside solo)

### DIFF
--- a/app/api/kiosk/solo/advance/route.test.ts
+++ b/app/api/kiosk/solo/advance/route.test.ts
@@ -24,6 +24,7 @@ const entry = (id: number, q: number, tally = 0) => ({
   feed: 'sunset', snapshotId: id, webcamId: 100 + id, bin: 'sunset', quality: q, detection: 0.9,
   isNew: false, tally, enteredAt: id, firstShownAt: null, lastShownAt: null,
   imageUrl: `u${id}`, title: '', city: '', region: '', country: '', lat: 0, lng: 0,
+  capturedAt: 0, timezone: null, sunAltitudeDeg: null,
 });
 const post = (body: unknown) =>
   POST(new Request('http://t/api/kiosk/solo/advance', { method: 'POST', body: JSON.stringify(body) }));
@@ -58,6 +59,17 @@ describe('POST /api/kiosk/solo/advance', () => {
     expect(body.current.entry.snapshotId).toBe(1);
     expect(body.current.entry.tally).toBe(1);
     expect(commitAdvance).toHaveBeenCalledWith('sunrise', 50_000_000, expect.objectContaining({ snapshotId: 1 }), 1);
+  });
+  it('version=solo2 with valleys 1 draws the valley on an odd slot', async () => {
+    getLiveSettingsCached.mockResolvedValue({ namespaces: { solo2: { valleys: 1 } }, revision: 1 });
+    listActiveEntries.mockResolvedValue([entry(1, 0.9), entry(2, 0.8), entry(3, 0.7)]);
+    vi.setSystemTime(new Date(1_000_000_020_000)); // slot 50_000_001: beat 1 = valley
+    const res = await post({ feed: 'sunrise', slot: 50_000_001, version: 'solo2' });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.current.entry.snapshotId).toBe(3);
+    expect(body.nextRoles[0]).toBe('peak');
+    expect((await post({ feed: 'sunrise', slot: 50_000_001, version: 'nope' })).status).toBe(400);
   });
   it('is a no-op for a slot already committed', async () => {
     getScreenState.mockResolvedValue({ feed: 'sunrise', currentSnapshotId: 1, shownSince: 1, slot: 50_000_000, sunsetStreak: 1 });

--- a/app/api/kiosk/solo/advance/route.ts
+++ b/app/api/kiosk/solo/advance/route.ts
@@ -1,9 +1,9 @@
 import { NextResponse } from 'next/server';
 import { getLiveSettingsCached } from '@/app/lib/settings/liveSettings';
 import { mergeSettings } from '@/app/lib/settings/schema';
-import { afterShowing, next } from '@/app/lib/solo/engine';
+import { afterShowing } from '@/app/lib/solo/engine';
 import { slotFor } from '@/app/lib/solo/schedule';
-import { SOLO_NAMESPACE, SOLO_SETTINGS_SCHEMA, dialsFrom } from '@/app/lib/solo/settingsSchema';
+import { resolveSoloVersion } from '@/app/lib/solo/versions';
 import { commitAdvance, countAdmittedSince, getScreenState, listActiveEntries } from '@/app/lib/solo/store';
 import { isFlagEnabled, SWEEP_FORCE_DAY_RING } from '@/app/lib/runtimeFlags';
 import { sweepGeometry } from '@/app/api/cron/update-cameras/lib/sweepGeometry';
@@ -24,7 +24,7 @@ const SLOT_TOLERANCE = 1;
  * lands on the same frame.
  */
 export async function POST(request: Request) {
-  let body: { feed?: unknown; slot?: unknown };
+  let body: { feed?: unknown; slot?: unknown; version?: unknown };
   try {
     body = await request.json();
   } catch {
@@ -35,9 +35,11 @@ export async function POST(request: Request) {
   if (!feed || slot === null) {
     return NextResponse.json({ error: 'feed and integer slot required' }, { status: 400 });
   }
+  const version = resolveSoloVersion(typeof body.version === 'string' ? body.version : null);
+  if (!version) return NextResponse.json({ error: 'version must be solo or solo2' }, { status: 400 });
 
   const live = await getLiveSettingsCached();
-  const dials = dialsFrom(mergeSettings(SOLO_SETTINGS_SCHEMA, live?.namespaces[SOLO_NAMESPACE]));
+  const dials = version.dialsFrom(mergeSettings(version.schema, live?.namespaces[version.namespace]));
   const nowMs = Date.now();
   const serverSlot = slotFor(nowMs, feed, dials.dwellS, dials.offsetS);
   if (Math.abs(slot - serverSlot) > SLOT_TOLERANCE) {
@@ -52,7 +54,7 @@ export async function POST(request: Request) {
       lastSnapshotId: screenBefore?.currentSnapshotId ?? null,
       sunsetStreak: screenBefore?.sunsetStreak ?? 0,
     };
-    const pick = next(entries, dials, state);
+    const pick = version.next(entries, dials, state, slot, feed);
     if (pick) {
       const after = afterShowing(pick, state);
       advanced = await commitAdvance(feed, slot, pick, after.sunsetStreak);
@@ -72,6 +74,6 @@ export async function POST(request: Request) {
   const zone = { minDeg: geometry.coverageMinDeg, maxDeg: geometry.coverageMaxDeg };
   return NextResponse.json({
     advanced,
-    ...buildStateView({ feed, dials, entries: entries.map(toViewEntry), screen, nowMs, admitted, zone }),
+    ...buildStateView({ feed, dials, entries: entries.map(toViewEntry), screen, nowMs, admitted, zone, version }),
   });
 }

--- a/app/api/kiosk/solo/state/route.test.ts
+++ b/app/api/kiosk/solo/state/route.test.ts
@@ -31,7 +31,7 @@ beforeEach(() => {
   listActiveEntries.mockResolvedValue([]);
   getScreenState.mockResolvedValue(null);
   countAdmittedSince.mockResolvedValue({ sunset: 0, nonSunset: 0 });
-  getLiveSettingsCached.mockResolvedValue({ namespaces: { solo: { dwellS: 30 } }, revision: 1 });
+  getLiveSettingsCached.mockResolvedValue({ namespaces: { solo: { dwellS: 30 }, solo2: { dwellS: 9, valleys: 1 } }, revision: 1 });
   getProfileSettings.mockResolvedValue({ namespaces: { solo: { dwellS: 7 } }, revision: 1 });
 });
 
@@ -39,6 +39,15 @@ describe('GET /api/kiosk/solo/state', () => {
   it('rejects a missing or unknown feed', async () => {
     expect((await get('')).status).toBe(400);
     expect((await get('?feed=noon')).status).toBe(400);
+  });
+  it('version=solo2 reads the solo2 namespace and reports roles; unknown versions are refused', async () => {
+    expect((await get('?feed=sunset&version=v4')).status).toBe(400);
+    const res = await get('?feed=sunset&version=solo2');
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.dials.dwellS).toBe(9);
+    expect(body.dials.valleys).toBe(1);
+    expect(body.nextRoles).toEqual([]);
   });
   it('live profile by default, no owner check', async () => {
     const res = await get('?feed=sunset');

--- a/app/api/kiosk/solo/state/route.ts
+++ b/app/api/kiosk/solo/state/route.ts
@@ -3,7 +3,7 @@ import { requireOwner } from '@/app/lib/owner';
 import { getLiveSettingsCached } from '@/app/lib/settings/liveSettings';
 import { getProfileSettings } from '@/app/lib/settings/store';
 import { mergeSettings } from '@/app/lib/settings/schema';
-import { SOLO_NAMESPACE, SOLO_SETTINGS_SCHEMA, dialsFrom } from '@/app/lib/solo/settingsSchema';
+import { resolveSoloVersion } from '@/app/lib/solo/versions';
 import { countAdmittedSince, getScreenState, listActiveEntries } from '@/app/lib/solo/store';
 import { isFlagEnabled, SWEEP_FORCE_DAY_RING } from '@/app/lib/runtimeFlags';
 import { sweepGeometry } from '@/app/api/cron/update-cameras/lib/sweepGeometry';
@@ -24,6 +24,9 @@ const LAST_PULL_WINDOW_MS = 10 * 60 * 1000;
 export async function GET(request: NextRequest) {
   const feed = parseFeed(request.nextUrl.searchParams.get('feed'));
   if (!feed) return NextResponse.json({ error: 'feed must be sunrise or sunset' }, { status: 400 });
+  // Which version's dials and engine: solo unless told otherwise (solo2 spec §5.2).
+  const version = resolveSoloVersion(request.nextUrl.searchParams.get('version'));
+  if (!version) return NextResponse.json({ error: 'version must be solo or solo2' }, { status: 400 });
 
   const studio = request.nextUrl.searchParams.get('profile') === 'studio';
   if (studio) {
@@ -31,7 +34,7 @@ export async function GET(request: NextRequest) {
     if (denied) return denied;
   }
   const profile = studio ? await getProfileSettings('studio') : await getLiveSettingsCached();
-  const dials = dialsFrom(mergeSettings(SOLO_SETTINGS_SCHEMA, profile?.namespaces[SOLO_NAMESPACE]));
+  const dials = version.dialsFrom(mergeSettings(version.schema, profile?.namespaces[version.namespace]));
 
   const nowMs = Date.now();
   const [entries, screen, admitted, forcedDayRing] = await Promise.all([
@@ -44,6 +47,6 @@ export async function GET(request: NextRequest) {
   const geometry = sweepGeometry(forcedDayRing ? TERMINATOR_DAY_SIDE_OFFSETS_DEG : []);
   const zone = { minDeg: geometry.coverageMinDeg, maxDeg: geometry.coverageMaxDeg };
   return NextResponse.json(buildStateView({
-    feed, dials, entries: entries.map(toViewEntry), screen, nowMs, admitted, zone,
+    feed, dials, entries: entries.map(toViewEntry), screen, nowMs, admitted, zone, version,
   }));
 }

--- a/app/api/kiosk/solo/view.test.ts
+++ b/app/api/kiosk/solo/view.test.ts
@@ -10,6 +10,7 @@ const stored = (id: number, bin: 'sunset' | 'non_sunset', score: number, tally =
   quality: bin === 'sunset' ? score : null, detection: bin === 'sunset' ? 0.9 : score,
   isNew: false, tally, enteredAt: id,
   imageUrl: `u${id}`, title: `t${id}`, city: '', region: '', country: '',
+  capturedAt: 0, timezone: null, sunAltitudeDeg: null,
 });
 
 describe('parseFeed', () => {
@@ -25,6 +26,7 @@ describe('toViewEntry', () => {
   it('drops coordinates and feed, keeps identity, scores, and place', () => {
     const v = toViewEntry({
       ...stored(1, 'sunset', 0.9), feed: 'sunset', lat: 1, lng: 2, firstShownAt: null, lastShownAt: null,
+      capturedAt: 5, timezone: 'Europe/Lisbon', sunAltitudeDeg: -1.5,
     });
     expect(v).not.toHaveProperty('lat');
     expect(v).not.toHaveProperty('feed');
@@ -67,5 +69,24 @@ describe('buildStateView', () => {
       admitted: { sunset: 0, nonSunset: 0 }, zone: { minDeg: -24, maxDeg: 14 } });
     expect(v.entries).toHaveLength(1);
     expect(v.zone).toEqual({ minDeg: -24, maxDeg: 14 });
+  });
+});
+
+describe('buildStateView with a version', () => {
+  it('solo2 with valleys 1 alternates roles and draws peaks best-first, valleys worst-first', async () => {
+    const { SOLO_VERSIONS } = await import('@/app/lib/solo/versions');
+    const v2 = SOLO_VERSIONS.solo2;
+    const dials = { ...v2.dialsFrom(schemaDefaults(v2.schema)), valleys: 1 };
+    const entries = [stored(1, 'sunset', 0.9), stored(2, 'sunset', 0.8), stored(3, 'sunset', 0.7)];
+    // nowMs 0 on sunrise → slot 0 now, first draw at slot 1 (a valley).
+    const v = buildStateView({ feed: 'sunrise', dials, entries, screen: null, nowMs: 0,
+      admitted: { sunset: 0, nonSunset: 0 }, zone: ZONE, version: v2 });
+    expect(v.nextRoles.slice(0, 4)).toEqual(['valley', 'peak', 'valley', 'peak']);
+    expect(v.next.slice(0, 4).map((e) => e.snapshotId)).toEqual([3, 1, 2, 1]);
+  });
+  it('solo reports every draw as a peak', () => {
+    const v = buildStateView({ feed: 'sunset', dials: D, entries: [stored(1, 'sunset', 0.9)], screen: null, nowMs: 0,
+      admitted: { sunset: 0, nonSunset: 0 }, zone: ZONE });
+    expect(v.nextRoles).toEqual(v.next.map(() => 'peak'));
   });
 });

--- a/app/api/kiosk/solo/view.ts
+++ b/app/api/kiosk/solo/view.ts
@@ -1,4 +1,6 @@
-import { isEligible, project } from '@/app/lib/solo/engine';
+import { isEligible } from '@/app/lib/solo/engine';
+import { SOLO_VERSIONS, type SoloVersionSpec } from '@/app/lib/solo/versions';
+import type { Role } from '@/app/lib/solo2/types';
 import { nextBoundaryMs, slotFor } from '@/app/lib/solo/schedule';
 import type { ScreenRow, StoredEntry } from '@/app/lib/solo/store';
 import type { BinEntry, Feed, SoloDials } from '@/app/lib/solo/types';
@@ -26,6 +28,12 @@ export interface ViewEntry extends BinEntry {
   city: string;
   region: string;
   country: string;
+  /** When the picture was taken, ms since epoch. */
+  capturedAt: number;
+  /** IANA zone at the camera, for the local-time caption; null when unknown. */
+  timezone: string | null;
+  /** Solar altitude at the camera when the picture was taken, degrees; null when unknown. */
+  sunAltitudeDeg: number | null;
 }
 
 export function toViewEntry(e: StoredEntry): ViewEntry {
@@ -33,6 +41,7 @@ export function toViewEntry(e: StoredEntry): ViewEntry {
     snapshotId: e.snapshotId, webcamId: e.webcamId, bin: e.bin, quality: e.quality,
     detection: e.detection, isNew: e.isNew, tally: e.tally, enteredAt: e.enteredAt,
     imageUrl: e.imageUrl, title: e.title, city: e.city, region: e.region, country: e.country,
+    capturedAt: e.capturedAt, timezone: e.timezone, sunAltitudeDeg: e.sunAltitudeDeg,
   };
 }
 
@@ -47,6 +56,8 @@ export interface StateView {
   dials: SoloDials;
   current: { entry: EntryView; shownSince: number | null; slot: number | null } | null;
   next: EntryView[];
+  /** Parallel to `next`: what each draw is inside its bar. All peaks for solo. */
+  nextRoles: Role[];
   bins: { sunset: EntryView[]; nonSunset: EntryView[] };
   schedule: { slot: number; nextBoundaryMs: number };
   lastPull: { admitted: { sunset: number; nonSunset: number } };
@@ -77,8 +88,11 @@ export function buildStateView(input: {
   nowMs: number;
   admitted: { sunset: number; nonSunset: number };
   zone: Zone;
+  /** Which engine projects the queue. Defaults to solo, so older callers are unchanged. */
+  version?: SoloVersionSpec;
 }): StateView {
   const { feed, dials, entries, screen, nowMs } = input;
+  const version = input.version ?? (SOLO_VERSIONS.solo as SoloVersionSpec);
   const ranks = rankMap(entries);
   const byId = new Map(entries.map((e) => [e.snapshotId, e]));
   const view = (e: ViewEntry): EntryView => ({
@@ -92,7 +106,9 @@ export function buildStateView(input: {
     lastSnapshotId: currentEntry?.snapshotId ?? null,
     sunsetStreak: screen?.sunsetStreak ?? 0,
   };
-  const next = project(entries, dials, state, NEXT_COUNT);
+  // The next draw happens at the next boundary, whose slot is one past now's.
+  const firstSlot = slotFor(nowMs, feed, dials.dwellS, dials.offsetS) + 1;
+  const next = version.project(entries, dials, state, NEXT_COUNT, firstSlot, feed);
   const queued = new Set([currentEntry?.snapshotId, ...next.map((e) => e.snapshotId)]);
   const remaining = entries.filter((e) => !queued.has(e.snapshotId));
 
@@ -103,6 +119,7 @@ export function buildStateView(input: {
       ? { entry: view(currentEntry), shownSince: screen?.shownSince ?? null, slot: screen?.slot ?? null }
       : null,
     next: next.map((e) => view(byId.get(e.snapshotId)!)),
+    nextRoles: next.map((_, i) => version.roleAt(firstSlot + i, feed, dials)),
     bins: {
       sunset: remaining.filter((e) => e.bin === 'sunset').sort(byScore).map(view),
       nonSunset: remaining.filter((e) => e.bin === 'non_sunset').sort(byScore).map(view),

--- a/app/components/mosaic/registry.test.tsx
+++ b/app/components/mosaic/registry.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi } from 'vitest';
 import {
   MOSAIC_VERSIONS,
+  MOSAIC_SETTINGS_SCHEMAS,
   DEFAULT_MOSAIC_VERSION,
   resolveMosaic,
   resolveMosaicName,
@@ -13,11 +14,20 @@ vi.mock('./v1', () => ({
 vi.mock('@/app/components/solo', () => ({
   SoloKiosk: () => null,
 }));
+vi.mock('@/app/components/solo2', () => ({
+  Solo2Kiosk: () => null,
+}));
 
 describe('mosaic registry', () => {
   it('registers the solo renderer as a version, so the active-version dial can select it', () => {
     expect(MOSAIC_VERSIONS.solo).toBeDefined();
     expect(DEFAULT_MOSAIC_VERSION).not.toBe('solo'); // the public site keeps the mosaic
+  });
+
+  it('registers solo2 beside solo with its own schema, so the dial can switch between them', () => {
+    expect(MOSAIC_VERSIONS.solo2).toBeDefined();
+    expect(MOSAIC_SETTINGS_SCHEMAS.solo2).not.toBe(MOSAIC_SETTINGS_SCHEMAS.solo);
+    expect(MOSAIC_SETTINGS_SCHEMAS.solo2.some((k) => k.key === 'valleys')).toBe(true);
   });
 
   it('pins v1 as the default version', () => {

--- a/app/components/mosaic/registry.ts
+++ b/app/components/mosaic/registry.ts
@@ -10,6 +10,8 @@ import { V4_SETTINGS_SCHEMA } from './v4/settingsSchema';
 import type { SettingsSchema } from '@/app/lib/settings/schema';
 import { SOLO_SETTINGS_SCHEMA } from '@/app/lib/solo/settingsSchema';
 import { SoloKiosk } from '@/app/components/solo';
+import { SOLO2_SETTINGS_SCHEMA } from '@/app/lib/solo2/settingsSchema';
+import { Solo2Kiosk } from '@/app/components/solo2';
 
 /**
  * Every mosaic version deployed, side by side. All versions ship in one
@@ -26,6 +28,8 @@ export const MOSAIC_VERSIONS: Record<string, MosaicComponent> = {
   // Not a mosaic: one archived frame per screen from the server-owned bins.
   // Registered here so the active-version dial can put it on the glass.
   solo: SoloKiosk,
+  // solo with rhythm, lead, prelude, transitions and local time (solo2 spec).
+  solo2: Solo2Kiosk,
 };
 
 export const DEFAULT_MOSAIC_VERSION = 'v1';
@@ -37,6 +41,7 @@ export const MOSAIC_SETTINGS_SCHEMAS: Record<string, SettingsSchema> = {
   v3: V3_SETTINGS_SCHEMA,
   v4: V4_SETTINGS_SCHEMA,
   solo: SOLO_SETTINGS_SCHEMA,
+  solo2: SOLO2_SETTINGS_SCHEMA,
 };
 
 /** Unknown or missing names fall back to the pinned default. */

--- a/app/components/solo/SoloFrame.test.tsx
+++ b/app/components/solo/SoloFrame.test.tsx
@@ -8,6 +8,7 @@ const D = dialsFrom(schemaDefaults(SOLO_SETTINGS_SCHEMA));
 const e = {
   snapshotId: 1, webcamId: 1, bin: 'sunset' as const, quality: 0.91, detection: 0.88, isNew: false, tally: 2, enteredAt: 0,
   imageUrl: 'u1', title: 'Pier', city: 'Lisbon', region: 'Lisboa', country: 'Portugal', eligible: true, rank: 3,
+  capturedAt: 0, timezone: null, sunAltitudeDeg: null,
 };
 
 it('draws the place by default and nothing else', () => {

--- a/app/components/solo/useSoloGlass.test.tsx
+++ b/app/components/solo/useSoloGlass.test.tsx
@@ -52,7 +52,17 @@ describe('useSoloGlass', () => {
     await advance(20_000);
     expect(result.current.current?.snapshotId).toBe(2);
     const adv = calls.find((c) => c.url.includes('/advance'));
-    expect(adv?.body).toEqual({ feed: 'sunrise', slot: 50_000_001 });
+    expect(adv?.body).toEqual({ feed: 'sunrise', slot: 50_000_001, version: 'solo' });
+    expect(calls[0].url).toContain('version=solo');
+  });
+  it('names its version in the state URL and the advance body, and surfaces the entries', async () => {
+    const { result } = renderHook(() => useSoloGlass({ feed: 'sunrise', dials: D, drive: true, dozing: false, version: 'solo2' }));
+    await flush();
+    expect(calls[0].url).toContain('version=solo2');
+    expect(result.current.entries).toEqual([]);
+    expect(result.current.nextEntries.map((e) => e.snapshotId)).toEqual([2]);
+    await advance(20_000);
+    expect(calls.find((c) => c.url.includes('/advance'))?.body).toMatchObject({ version: 'solo2' });
   });
   it('does not advance while dozing or when it only follows', async () => {
     const { result, rerender } = renderHook(

--- a/app/components/solo/useSoloGlass.ts
+++ b/app/components/solo/useSoloGlass.ts
@@ -1,9 +1,10 @@
 'use client';
 
 import { useEffect, useRef, useState } from 'react';
-import type { EntryView, StateView } from '@/app/api/kiosk/solo/view';
+import type { EntryView, StateView, ViewEntry } from '@/app/api/kiosk/solo/view';
 import { slotFor } from '@/app/lib/solo/schedule';
 import type { Feed, SoloDials } from '@/app/lib/solo/types';
+import type { SoloVersionName } from '@/app/lib/solo/versions';
 import { msUntilBoundary } from './schedule';
 
 const STATE_REFRESH_MS = 60_000;
@@ -15,6 +16,10 @@ export interface SoloGlass {
   boundaryMs: number;
   error: string | null;
   queueLength: number;
+  /** The whole projected queue, for preloading beyond the first. */
+  nextEntries: EntryView[];
+  /** Every active entry, so a renderer can derive a prelude (solo2). */
+  entries: ViewEntry[];
 }
 
 function preload(url: string): Promise<void> {
@@ -32,11 +37,13 @@ function preload(url: string): Promise<void> {
  * preload the one after. Two tabs stay staggered because both read the same
  * clock; a reload just waits for its next boundary.
  */
-export function useSoloGlass({ feed, dials, drive, dozing }: {
+export function useSoloGlass({ feed, dials, drive, dozing, version = 'solo' }: {
   feed: Feed;
   dials: SoloDials;
   drive: boolean;
   dozing: boolean;
+  /** Which version's dials and engine the server should use. */
+  version?: SoloVersionName;
 }): SoloGlass {
   const [view, setView] = useState<StateView | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -54,7 +61,7 @@ export function useSoloGlass({ feed, dials, drive, dozing }: {
     let alive = true;
     const load = async () => {
       try {
-        const res = await fetch(`/api/kiosk/solo/state?feed=${feed}`);
+        const res = await fetch(`/api/kiosk/solo/state?feed=${feed}&version=${version}`);
         if (!res.ok) throw new Error(`state ${res.status}`);
         const v = (await res.json()) as StateView;
         if (!alive) return;
@@ -70,7 +77,7 @@ export function useSoloGlass({ feed, dials, drive, dozing }: {
       alive = false;
       clearInterval(t);
     };
-  }, [feed]);
+  }, [feed, version]);
 
   // The boundary timer. Re-armed after every fire and whenever dials change.
   useEffect(() => {
@@ -83,7 +90,7 @@ export function useSoloGlass({ feed, dials, drive, dozing }: {
           const res = await fetch('/api/kiosk/solo/advance', {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ feed, slot }),
+            body: JSON.stringify({ feed, slot, version }),
           });
           if (!res.ok) throw new Error(`advance ${res.status}`);
           const v = (await res.json()) as StateView & { advanced: boolean };
@@ -97,7 +104,7 @@ export function useSoloGlass({ feed, dials, drive, dozing }: {
       setTick((n) => n + 1); // re-arm
     }, wait);
     return () => clearTimeout(t);
-  }, [feed, dials.dwellS, dials.offsetS, tick]);
+  }, [feed, version, dials.dwellS, dials.offsetS, tick]);
 
   const nowMs = Date.now();
   return {
@@ -107,5 +114,7 @@ export function useSoloGlass({ feed, dials, drive, dozing }: {
     boundaryMs: nowMs + msUntilBoundary(nowMs, feed, dials.dwellS, dials.offsetS),
     error,
     queueLength: view?.next.length ?? 0,
+    nextEntries: view?.next ?? [],
+    entries: view?.entries ?? [],
   };
 }

--- a/app/components/solo2/Solo2Frame.test.tsx
+++ b/app/components/solo2/Solo2Frame.test.tsx
@@ -1,0 +1,61 @@
+import { it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { Solo2Frame } from './Solo2Frame';
+import { dialsFrom2, SOLO2_SETTINGS_SCHEMA } from '@/app/lib/solo2/settingsSchema';
+import { schemaDefaults } from '@/app/lib/settings/schema';
+import { fitPlan } from '@/app/lib/solo2/plan';
+
+const D = dialsFrom2(schemaDefaults(SOLO2_SETTINGS_SCHEMA));
+const AT = Date.UTC(2026, 8, 5, 2, 42); // 7:42 pm in Mazatlán
+const e = {
+  snapshotId: 3, webcamId: 1, bin: 'sunset' as const, quality: 0.91, detection: 0.88, isNew: false, tally: 2, enteredAt: 0,
+  imageUrl: 'u3', title: 'Pier', city: 'Cabo', region: 'Baja California Sur', country: 'Mexico', eligible: true, rank: 3,
+  capturedAt: AT, timezone: 'America/Mazatlan', sunAltitudeDeg: 1.2,
+};
+const prelude = [{ snapshotId: 1, imageUrl: 'u1' }, { snapshotId: 2, imageUrl: 'u2' }];
+const plan = fitPlan({ ...D, prelude: true, leadS: 4 }, 2);
+const main = { layer: 'main' as const, leadProgress: 0 };
+
+it('main stage: the chosen frame with place and local time, no scores by default', () => {
+  render(<Solo2Frame entry={e} prelude={prelude} previous={null} stage={main} plan={plan} dials={D} width={1920} height={1080} />);
+  expect(screen.getByTestId('top')).toHaveAttribute('src', 'u3');
+  expect(screen.getByText('Pier')).toBeInTheDocument();
+  expect(screen.getByText('Baja California Sur, Mexico · 7:42 pm')).toBeInTheDocument();
+  expect(screen.queryByText(/q 0\.91/)).toBeNull();
+});
+
+it('prelude stage: an earlier frame with no caption and no scores', () => {
+  render(<Solo2Frame entry={e} prelude={prelude} previous={null} stage={{ layer: 'prelude', index: 1 }} plan={plan}
+    dials={{ ...D, showScores: true, showTally: true }} width={1920} height={1080} />);
+  expect(screen.getByTestId('top')).toHaveAttribute('src', 'u2');
+  expect(screen.queryByText('Pier')).toBeNull();
+  expect(screen.queryByText(/shown/)).toBeNull();
+});
+
+it('time style off leaves just the place; 24h reads 19:42', () => {
+  const { rerender } = render(<Solo2Frame entry={e} prelude={[]} previous={null} stage={main} plan={plan} dials={{ ...D, timeStyle: 'off' }} width={1920} height={1080} />);
+  expect(screen.getByText('Baja California Sur, Mexico')).toBeInTheDocument();
+  rerender(<Solo2Frame entry={e} prelude={[]} previous={null} stage={main} plan={plan} dials={{ ...D, timeStyle: '24h' }} width={1920} height={1080} />);
+  expect(screen.getByText('Baja California Sur, Mexico · 19:42')).toBeInTheDocument();
+});
+
+it('cut shows no previous layer; crossfade keeps it and animates the top; dip adds the black veil', () => {
+  const prev = { ...e, snapshotId: 0, imageUrl: 'u0' };
+  const { rerender } = render(<Solo2Frame entry={e} prelude={[]} previous={prev} stage={main} plan={plan} dials={D} width={100} height={50} />);
+  expect(screen.getAllByRole('presentation').map((i) => i.getAttribute('src'))).toEqual(['u3']);
+  rerender(<Solo2Frame entry={e} prelude={[]} previous={prev} stage={main} plan={plan} dials={{ ...D, transition: 'crossfade', fadeS: 2 }} width={100} height={50} />);
+  expect(screen.getAllByRole('presentation').map((i) => i.getAttribute('src'))).toEqual(['u0', 'u3']);
+  expect(screen.getByTestId('top').parentElement!.parentElement).toHaveStyle({ animation: 'solo2-fade-in 2s ease both' });
+  expect(screen.queryByTestId('dip')).toBeNull();
+  rerender(<Solo2Frame entry={e} prelude={[]} previous={prev} stage={main} plan={plan} dials={{ ...D, transition: 'dip', fadeS: 2 }} width={100} height={50} />);
+  expect(screen.getByTestId('dip')).toHaveStyle({ animation: 'solo2-dip 1s linear both' });
+});
+
+it('the lead pushes the frame in by progress and lands the next frame still', () => {
+  const { rerender } = render(<Solo2Frame entry={e} prelude={[]} previous={null} stage={{ layer: 'main', leadProgress: 0.5 }} plan={plan}
+    dials={{ ...D, leadS: 4, leadScale: 1.04 }} width={100} height={50} />);
+  expect(screen.getByTestId('push')).toHaveStyle({ transform: 'scale(1.0200)', transition: 'transform 260ms linear' });
+  rerender(<Solo2Frame entry={{ ...e, snapshotId: 4 }} prelude={[]} previous={e} stage={main} plan={plan}
+    dials={{ ...D, leadS: 4, leadScale: 1.04 }} width={100} height={50} />);
+  expect(screen.getByTestId('push')).toHaveStyle({ transform: 'scale(1.0000)', transition: 'none' });
+});

--- a/app/components/solo2/Solo2Frame.test.tsx
+++ b/app/components/solo2/Solo2Frame.test.tsx
@@ -32,6 +32,28 @@ it('prelude stage: an earlier frame with no caption and no scores', () => {
   expect(screen.queryByText(/shown/)).toBeNull();
 });
 
+it('the sequence is stacked: frames up to the stage are opaque, later ones transparent, each dissolving over the same-camera fade capped at the step', () => {
+  const { rerender } = render(<Solo2Frame entry={e} prelude={prelude} previous={null} stage={{ layer: 'prelude', index: 1 }} plan={plan}
+    dials={{ ...D, sameCameraFadeS: 1 }} width={1920} height={1080} />);
+  const layers = () => screen.getAllByTestId(/^seq-/).map((l) => [l.getAttribute('data-testid'), l.style.opacity, l.style.transition]);
+  expect(layers()).toEqual([
+    ['seq-0', '1', 'none'],
+    ['seq-1', '1', 'opacity 1s linear'],
+    ['seq-2', '0', 'opacity 1s linear'],
+  ]);
+  rerender(<Solo2Frame entry={e} prelude={prelude} previous={null} stage={main} plan={plan}
+    dials={{ ...D, sameCameraFadeS: 5 }} width={1920} height={1080} />);
+  expect(layers()).toEqual([
+    ['seq-0', '1', 'none'],
+    ['seq-1', '1', 'opacity 1.5s linear'], // capped at the 1.5 s step
+    ['seq-2', '1', 'opacity 1.5s linear'],
+  ]);
+  expect(screen.getByTestId('top')).toHaveAttribute('src', 'u3');
+  rerender(<Solo2Frame entry={e} prelude={prelude} previous={null} stage={main} plan={plan}
+    dials={{ ...D, sameCameraFadeS: 0 }} width={1920} height={1080} />);
+  expect(layers().map((l) => l[2])).toEqual(['none', 'none', 'none']); // 0 is a cut
+});
+
 it('time style off leaves just the place; 24h reads 19:42', () => {
   const { rerender } = render(<Solo2Frame entry={e} prelude={[]} previous={null} stage={main} plan={plan} dials={{ ...D, timeStyle: 'off' }} width={1920} height={1080} />);
   expect(screen.getByText('Baja California Sur, Mexico')).toBeInTheDocument();
@@ -40,15 +62,30 @@ it('time style off leaves just the place; 24h reads 19:42', () => {
 });
 
 it('cut shows no previous layer; crossfade keeps it and animates the top; dip adds the black veil', () => {
-  const prev = { ...e, snapshotId: 0, imageUrl: 'u0' };
-  const { rerender } = render(<Solo2Frame entry={e} prelude={[]} previous={prev} stage={main} plan={plan} dials={D} width={100} height={50} />);
+  const prev = { ...e, snapshotId: 0, webcamId: 99, imageUrl: 'u0' };
+  const { rerender } = render(<Solo2Frame entry={e} prelude={[]} previous={prev} stage={main} plan={plan} dials={{ ...D, transition: 'cut' }} width={100} height={50} />);
   expect(screen.getAllByRole('presentation').map((i) => i.getAttribute('src'))).toEqual(['u3']);
   rerender(<Solo2Frame entry={e} prelude={[]} previous={prev} stage={main} plan={plan} dials={{ ...D, transition: 'crossfade', fadeS: 2 }} width={100} height={50} />);
   expect(screen.getAllByRole('presentation').map((i) => i.getAttribute('src'))).toEqual(['u0', 'u3']);
-  expect(screen.getByTestId('top').parentElement!.parentElement).toHaveStyle({ animation: 'solo2-fade-in 2s ease both' });
+  expect(screen.getByTestId('stack')).toHaveStyle({ animation: 'solo2-fade-in 2s ease both' });
   expect(screen.queryByTestId('dip')).toBeNull();
   rerender(<Solo2Frame entry={e} prelude={[]} previous={prev} stage={main} plan={plan} dials={{ ...D, transition: 'dip', fadeS: 2 }} width={100} height={50} />);
   expect(screen.getByTestId('dip')).toHaveStyle({ animation: 'solo2-dip 1s linear both' });
+});
+
+it('a change to the same camera dissolves over the same-camera fade, never through black', () => {
+  const prev = { ...e, snapshotId: 0, imageUrl: 'u0' }; // same webcamId as e
+  render(<Solo2Frame entry={e} prelude={[]} previous={prev} stage={main} plan={plan}
+    dials={{ ...D, transition: 'dip', fadeS: 4, sameCameraFadeS: 1 }} width={100} height={50} />);
+  expect(screen.getAllByRole('presentation').map((i) => i.getAttribute('src'))).toEqual(['u0', 'u3']);
+  expect(screen.queryByTestId('dip')).toBeNull();
+  expect(screen.getByTestId('stack')).toHaveStyle({ animation: 'solo2-fade-in 1s ease both' });
+});
+
+it('the defaults dip through black between cameras', () => {
+  const prev = { ...e, snapshotId: 0, webcamId: 99, imageUrl: 'u0' };
+  render(<Solo2Frame entry={e} prelude={[]} previous={prev} stage={main} plan={plan} dials={D} width={100} height={50} />);
+  expect(screen.getByTestId('dip')).toHaveStyle({ animation: 'solo2-dip 0.75s linear both' });
 });
 
 it('the lead pushes the frame in by progress and lands the next frame still', () => {

--- a/app/components/solo2/Solo2Frame.tsx
+++ b/app/components/solo2/Solo2Frame.tsx
@@ -1,0 +1,105 @@
+'use client';
+
+import type { EntryView } from '@/app/api/kiosk/solo/view';
+import { captionLines } from '@/app/lib/solo2/caption';
+import type { DwellPlan, Stage } from '@/app/lib/solo2/plan';
+import type { Solo2Dials } from '@/app/lib/solo2/types';
+
+const mono = 'ui-monospace, SFMono-Regular, Menlo, monospace';
+
+export interface PreludeFrame {
+  snapshotId: number;
+  imageUrl: string;
+}
+
+const KEYFRAMES = `
+@keyframes solo2-fade-in { from { opacity: 0 } to { opacity: 1 } }
+@keyframes solo2-dip { from { opacity: 0 } to { opacity: 1 } }
+`;
+
+/**
+ * One dwell on one panel (spec §4). Layers, bottom to top: the previous
+ * frame (unless the transition is a cut), the dip's black veil, and the top
+ * image, which is a prelude frame or the chosen frame depending on the
+ * stage. The chosen frame's overlays mount only when it is on; prelude
+ * frames carry nothing, so the score on glass is always the score of the
+ * picture on glass.
+ */
+export function Solo2Frame({ entry, prelude, previous, stage, plan, dials, width, height }: {
+  entry: EntryView;
+  prelude: PreludeFrame[];
+  previous: EntryView | null;
+  stage: Stage;
+  plan: DwellPlan;
+  dials: Solo2Dials;
+  width: number;
+  height: number;
+}) {
+  const layer = { position: 'absolute', inset: 0, width: '100%', height: '100%', objectFit: 'cover' } as const;
+  const scale = Math.max(1, Math.min(width, height) / 540); // overlay text scales with the panel
+  const onMain = stage.layer === 'main';
+  const top = onMain ? entry : prelude[Math.min(stage.index, prelude.length - 1)] ?? entry;
+  const fade = dials.transition === 'cut' ? 0 : dials.fadeS;
+  const showPrevious = fade > 0 && !!previous;
+
+  const inAnimation =
+    dials.transition === 'crossfade' && fade > 0 ? `solo2-fade-in ${fade}s ease both`
+    : dials.transition === 'dip' && fade > 0 ? `solo2-fade-in ${fade / 2}s ease ${fade / 2}s both`
+    : undefined;
+
+  // The lead: a slow push over the last seconds, driven by the clock stage
+  // so a late tab is in sync. No transition when the progress is 0, so a
+  // new frame lands at scale 1 without shrinking into place.
+  const leadProgress = onMain ? stage.leadProgress : 0;
+  const push = 1 + (dials.leadScale - 1) * leadProgress;
+  const pushStyle = {
+    position: 'absolute', inset: 0,
+    transform: `scale(${push.toFixed(4)})`,
+    transition: leadProgress > 0 && plan.leadS > 0 ? 'transform 260ms linear' : 'none',
+  } as const;
+
+  const caption = onMain ? captionLines(entry, dials) : null;
+
+  return (
+    <div style={{ position: 'relative', width, height, background: '#000', overflow: 'hidden' }}>
+      <style>{KEYFRAMES}</style>
+      {showPrevious && (
+        // eslint-disable-next-line @next/next/no-img-element
+        <img key={`prev-${previous.snapshotId}`} src={previous.imageUrl} alt="" role="presentation" style={layer} />
+      )}
+      {dials.transition === 'dip' && showPrevious && (
+        <div key={`dip-${entry.snapshotId}`} data-testid="dip" style={{
+          ...layer, background: '#000', animation: `solo2-dip ${fade / 2}s linear both`,
+        }} />
+      )}
+      {/* keyed by the chosen frame so the entry animation runs once per dwell; prelude steps only swap the src */}
+      <div key={`top-${entry.snapshotId}`} style={{ ...layer, animation: inAnimation }}>
+        <div style={pushStyle} data-testid="push">
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img src={top.imageUrl} alt="" role="presentation" data-testid="top" style={layer} />
+        </div>
+      </div>
+      {caption && (
+        <div style={{
+          position: 'absolute', left: 24 * scale, bottom: 20 * scale, color: '#fff',
+          textShadow: '0 1px 4px #000', fontSize: 22 * scale, lineHeight: 1.2,
+        }}>
+          {caption.title}
+          <div style={{ fontSize: 15 * scale, opacity: 0.85 }}>{caption.sub}</div>
+        </div>
+      )}
+      {onMain && (dials.showScores || dials.showRank || dials.showTally) && (
+        <div style={{
+          position: 'absolute', right: 24 * scale, bottom: 20 * scale, color: '#fff',
+          textShadow: '0 1px 4px #000', fontFamily: mono, fontSize: 16 * scale, textAlign: 'right', lineHeight: 1.4,
+        }}>
+          {dials.showTally && <div>shown <b style={{ color: '#f5a344' }}>×{entry.tally}</b></div>}
+          {dials.showRank && <div>{entry.bin === 'sunset' ? 'sunset' : 'non-sunset'} bin #{entry.rank}</div>}
+          {dials.showScores && (
+            <div>{entry.bin === 'sunset' ? `q ${(entry.quality ?? 0).toFixed(2)} · ` : ''}d {entry.detection.toFixed(2)}</div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/components/solo2/Solo2Frame.tsx
+++ b/app/components/solo2/Solo2Frame.tsx
@@ -18,15 +18,31 @@ const KEYFRAMES = `
 `;
 
 /**
+ * How this dwell arrives (spec §4.2). The same camera always dissolves, over
+ * the same-camera fade; a camera change uses the transition dial and its
+ * fade. Exported so the studio can say the same thing about a queued row.
+ */
+export function arrival(
+  entry: { webcamId: number }, previous: { webcamId: number } | null, d: Pick<Solo2Dials, 'transition' | 'fadeS' | 'sameCameraFadeS'>,
+): { kind: Solo2Dials['transition']; fadeS: number } {
+  if (previous && previous.webcamId === entry.webcamId) {
+    return d.sameCameraFadeS > 0 ? { kind: 'crossfade', fadeS: d.sameCameraFadeS } : { kind: 'cut', fadeS: 0 };
+  }
+  return d.transition === 'cut' || d.fadeS <= 0 ? { kind: 'cut', fadeS: 0 } : { kind: d.transition, fadeS: d.fadeS };
+}
+
+/**
  * One dwell on one panel (spec §4). Layers, bottom to top: the previous
- * frame (unless the transition is a cut), the dip's black veil, and the top
- * image, which is a prelude frame or the chosen frame depending on the
- * stage. The chosen frame's overlays mount only when it is on; prelude
- * frames carry nothing, so the score on glass is always the score of the
- * picture on glass.
+ * frame (unless the arrival is a cut), the dip's black veil, then the
+ * sequence: every prelude frame and the chosen frame stacked in capture
+ * order, each opaque once the clock-driven stage has reached it and
+ * dissolving in over the same-camera fade. The chosen frame's overlays mount
+ * only when it is on; prelude frames carry nothing, so the score on glass is
+ * always the score of the picture on glass.
  */
 export function Solo2Frame({ entry, prelude, previous, stage, plan, dials, width, height }: {
   entry: EntryView;
+  /** Already cut to what the plan shows (preludePlan), oldest first. */
   prelude: PreludeFrame[];
   previous: EntryView | null;
   stage: Stage;
@@ -38,13 +54,15 @@ export function Solo2Frame({ entry, prelude, previous, stage, plan, dials, width
   const layer = { position: 'absolute', inset: 0, width: '100%', height: '100%', objectFit: 'cover' } as const;
   const scale = Math.max(1, Math.min(width, height) / 540); // overlay text scales with the panel
   const onMain = stage.layer === 'main';
-  const top = onMain ? entry : prelude[Math.min(stage.index, prelude.length - 1)] ?? entry;
-  const fade = dials.transition === 'cut' ? 0 : dials.fadeS;
-  const showPrevious = fade > 0 && !!previous;
+  const sequence: PreludeFrame[] = [...prelude, entry];
+  const shown = onMain ? sequence.length - 1 : Math.min(stage.index, prelude.length - 1);
+  const stepFade = Math.min(Math.max(0, dials.sameCameraFadeS), plan.preludeStepS);
 
+  const arrive = arrival(entry, previous, dials);
+  const showPrevious = arrive.kind !== 'cut' && !!previous;
   const inAnimation =
-    dials.transition === 'crossfade' && fade > 0 ? `solo2-fade-in ${fade}s ease both`
-    : dials.transition === 'dip' && fade > 0 ? `solo2-fade-in ${fade / 2}s ease ${fade / 2}s both`
+    arrive.kind === 'crossfade' ? `solo2-fade-in ${arrive.fadeS}s ease both`
+    : arrive.kind === 'dip' ? `solo2-fade-in ${arrive.fadeS / 2}s ease ${arrive.fadeS / 2}s both`
     : undefined;
 
   // The lead: a slow push over the last seconds, driven by the clock stage
@@ -67,16 +85,23 @@ export function Solo2Frame({ entry, prelude, previous, stage, plan, dials, width
         // eslint-disable-next-line @next/next/no-img-element
         <img key={`prev-${previous.snapshotId}`} src={previous.imageUrl} alt="" role="presentation" style={layer} />
       )}
-      {dials.transition === 'dip' && showPrevious && (
+      {arrive.kind === 'dip' && showPrevious && (
         <div key={`dip-${entry.snapshotId}`} data-testid="dip" style={{
-          ...layer, background: '#000', animation: `solo2-dip ${fade / 2}s linear both`,
+          ...layer, background: '#000', animation: `solo2-dip ${arrive.fadeS / 2}s linear both`,
         }} />
       )}
-      {/* keyed by the chosen frame so the entry animation runs once per dwell; prelude steps only swap the src */}
-      <div key={`top-${entry.snapshotId}`} style={{ ...layer, animation: inAnimation }}>
+      {/* keyed by the chosen frame so the arrival runs once per dwell; the stage only changes opacities inside */}
+      <div key={`stack-${entry.snapshotId}`} data-testid="stack" style={{ ...layer, animation: inAnimation }}>
         <div style={pushStyle} data-testid="push">
-          {/* eslint-disable-next-line @next/next/no-img-element */}
-          <img src={top.imageUrl} alt="" role="presentation" data-testid="top" style={layer} />
+          {sequence.map((f, i) => (
+            <div key={f.snapshotId} data-testid={`seq-${i}`} style={{
+              ...layer, opacity: i <= shown ? 1 : 0,
+              transition: i > 0 && stepFade > 0 ? `opacity ${stepFade}s linear` : 'none',
+            }}>
+              {/* eslint-disable-next-line @next/next/no-img-element */}
+              <img src={f.imageUrl} alt="" role="presentation" data-testid={i === shown ? 'top' : undefined} style={layer} />
+            </div>
+          ))}
         </div>
       </div>
       {caption && (

--- a/app/components/solo2/index.test.tsx
+++ b/app/components/solo2/index.test.tsx
@@ -1,0 +1,39 @@
+import { it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { Solo2Kiosk } from './index';
+
+const entry = (id: number, capturedAt: number) => ({
+  snapshotId: id, webcamId: 7, bin: 'sunset' as const, quality: 0.9, detection: 0.9, isNew: false, tally: 0, enteredAt: id,
+  imageUrl: `u${id}`, title: `t${id}`, city: '', region: 'R', country: 'C', eligible: true, rank: 1,
+  capturedAt, timezone: null, sunAltitudeDeg: null,
+});
+const glass = { current: entry(3, 300), next: null, slot: 1, boundaryMs: 0, error: null, queueLength: 1,
+  nextEntries: [], entries: [entry(1, 100), entry(2, 200), entry(3, 300)] };
+vi.mock('@/app/components/solo/useSoloGlass', () => ({ useSoloGlass: vi.fn(() => glass) }));
+import { useSoloGlass } from '@/app/components/solo/useSoloGlass';
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.setSystemTime(new Date(20_000)); // boundaryMs 0 with dwell 20 s → the dwell began at −20 s: elapsed 40 s, main stage
+});
+afterEach(() => vi.useRealTimers());
+
+it('asks the glass hook for solo2, drives by default, follows in a preview', () => {
+  render(<Solo2Kiosk webcams={[]} width={100} height={50} feed="sunset" />);
+  expect(useSoloGlass).toHaveBeenLastCalledWith(expect.objectContaining({ version: 'solo2', drive: true, dozing: false }));
+  render(<Solo2Kiosk webcams={[]} width={100} height={50} feed="sunset" driveSchedule={false} dozing />);
+  expect(useSoloGlass).toHaveBeenLastCalledWith(expect.objectContaining({ drive: false, dozing: true }));
+});
+
+it('draws the current frame with the caption once the dwell is in its hold', () => {
+  render(<Solo2Kiosk webcams={[]} width={100} height={50} feed="sunset" />);
+  expect(screen.getByTestId('top')).toHaveAttribute('src', 'u3');
+  expect(screen.getByText('t3')).toBeInTheDocument();
+});
+
+it('with the prelude dial on and the dwell just begun, shows the earlier frame from the same camera', () => {
+  vi.setSystemTime(new Date(-19_500)); // 0.5 s into the dwell that began at −20 s
+  render(<Solo2Kiosk webcams={[]} width={100} height={50} feed="sunset" settings={{ prelude: true, preludeFrames: 2 }} />);
+  expect(screen.getByTestId('top')).toHaveAttribute('src', 'u1');
+  expect(screen.queryByText('t3')).toBeNull();
+});

--- a/app/components/solo2/index.tsx
+++ b/app/components/solo2/index.tsx
@@ -1,0 +1,82 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+import type { MosaicProps } from '@/app/components/mosaic/types';
+import type { EntryView } from '@/app/api/kiosk/solo/view';
+import { mergeSettings } from '@/app/lib/settings/schema';
+import { SOLO2_SETTINGS_SCHEMA, dialsFrom2 } from '@/app/lib/solo2/settingsSchema';
+import { fitPlan } from '@/app/lib/solo2/plan';
+import { preludeFor } from '@/app/lib/solo2/prelude';
+import { useSoloGlass } from '@/app/components/solo/useSoloGlass';
+import { Solo2Frame } from './Solo2Frame';
+import { useStage } from './useStage';
+
+const mono = 'ui-monospace, SFMono-Regular, Menlo, monospace';
+
+function preload(url: string) {
+  const img = new Image();
+  img.src = url;
+}
+
+/**
+ * solo2 as a registered version (spec §5.3): solo's bins and schedule, with
+ * rhythm decided on the server and the prelude, lead, transition and local
+ * time drawn here. Everything it shows comes from /api/kiosk/solo with
+ * `version=solo2`.
+ */
+export function Solo2Kiosk(props: MosaicProps) {
+  const dials = dialsFrom2(mergeSettings(SOLO2_SETTINGS_SCHEMA, props.settings));
+  const glass = useSoloGlass({
+    feed: props.feed,
+    dials,
+    drive: props.driveSchedule !== false,
+    dozing: props.dozing === true,
+    version: 'solo2',
+  });
+  const current = glass.current;
+  const [previous, setPrevious] = useState<EntryView | null>(null);
+  const lastRef = useRef<EntryView | null>(null);
+  useEffect(() => {
+    if (current && lastRef.current && current.snapshotId !== lastRef.current.snapshotId) {
+      setPrevious(lastRef.current);
+    }
+    lastRef.current = current;
+  }, [current]);
+
+  const prelude = current && dials.prelude ? preludeFor(current, glass.entries, dials.preludeFrames) : [];
+  const plan = fitPlan(dials, prelude.length);
+  // The dwell began one dwell before the next boundary; both are pure clock math.
+  const startMs = glass.boundaryMs - dials.dwellS * 1000;
+  const stage = useStage(plan, startMs);
+
+  // Preload the projected next frame and its prelude, so the cut is clean.
+  const nextEntry = glass.nextEntries[0] ?? null;
+  const nextId = nextEntry?.snapshotId ?? null;
+  useEffect(() => {
+    if (!nextEntry) return;
+    preload(nextEntry.imageUrl);
+    if (dials.prelude) for (const p of preludeFor(nextEntry, glass.entries, dials.preludeFrames)) preload(p.imageUrl);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [nextId, dials.prelude, dials.preludeFrames]);
+
+  const debug = props.allowDebugOverlays !== false && (props.search ?? '').includes('debug=1');
+
+  return (
+    <div style={{ position: 'relative', width: props.width, height: props.height, background: '#000' }}>
+      {current ? (
+        <Solo2Frame entry={current} prelude={prelude} previous={previous} stage={stage} plan={plan} dials={dials}
+          width={props.width} height={props.height} />
+      ) : null}
+      {debug && (
+        <div style={{
+          position: 'absolute', top: 8, left: 8, fontFamily: mono, fontSize: 12, color: '#7ee2ac',
+          background: 'rgba(0,0,0,.7)', padding: '4px 8px', borderRadius: 4,
+        }}>
+          slot {glass.slot} · next in {Math.max(0, Math.ceil((glass.boundaryMs - Date.now()) / 1000))} s
+          · queue {glass.queueLength} · {stage.layer === 'prelude' ? `prelude ${stage.index + 1}/${plan.preludeFrames}` : `hold, lead ${Math.round(stage.leadProgress * 100)}%`}
+          {plan.clamped ? ' · clamped' : ''}{glass.error ? ` · ${glass.error}` : ''}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/components/solo2/index.tsx
+++ b/app/components/solo2/index.tsx
@@ -6,7 +6,7 @@ import type { EntryView } from '@/app/api/kiosk/solo/view';
 import { mergeSettings } from '@/app/lib/settings/schema';
 import { SOLO2_SETTINGS_SCHEMA, dialsFrom2 } from '@/app/lib/solo2/settingsSchema';
 import { fitPlan } from '@/app/lib/solo2/plan';
-import { preludeFor } from '@/app/lib/solo2/prelude';
+import { preludePlan } from '@/app/lib/solo2/prelude';
 import { useSoloGlass } from '@/app/components/solo/useSoloGlass';
 import { Solo2Frame } from './Solo2Frame';
 import { useStage } from './useStage';
@@ -43,8 +43,10 @@ export function Solo2Kiosk(props: MosaicProps) {
     lastRef.current = current;
   }, [current]);
 
-  const prelude = current && dials.prelude ? preludeFor(current, glass.entries, dials.preludeFrames) : [];
-  const plan = fitPlan(dials, prelude.length);
+  // The prelude continues from the previous frame when it is the same camera (spec §4.4).
+  const { frames: prelude, plan } = current
+    ? preludePlan(current, glass.entries, dials, previous)
+    : { frames: [] as EntryView[], plan: fitPlan(dials, 0) };
   // The dwell began one dwell before the next boundary; both are pure clock math.
   const startMs = glass.boundaryMs - dials.dwellS * 1000;
   const stage = useStage(plan, startMs);
@@ -55,9 +57,9 @@ export function Solo2Kiosk(props: MosaicProps) {
   useEffect(() => {
     if (!nextEntry) return;
     preload(nextEntry.imageUrl);
-    if (dials.prelude) for (const p of preludeFor(nextEntry, glass.entries, dials.preludeFrames)) preload(p.imageUrl);
+    for (const p of preludePlan(nextEntry, glass.entries, dials, current).frames) preload(p.imageUrl);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [nextId, dials.prelude, dials.preludeFrames]);
+  }, [nextId, dials.prelude, dials.preludeFrames, dials.preludeStepS, dials.dwellS, dials.leadS]);
 
   const debug = props.allowDebugOverlays !== false && (props.search ?? '').includes('debug=1');
 

--- a/app/components/solo2/useStage.test.ts
+++ b/app/components/solo2/useStage.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useStage } from './useStage';
+import type { DwellPlan } from '@/app/lib/solo2/plan';
+
+const plan: DwellPlan = { dwellS: 6, preludeFrames: 2, preludeStepS: 1, leadS: 2, holdS: 2, clamped: false };
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.setSystemTime(new Date(100_000));
+});
+afterEach(() => vi.useRealTimers());
+
+describe('useStage', () => {
+  it('walks prelude → main → lead on the wall clock', () => {
+    const { result } = renderHook(() => useStage(plan, 100_000));
+    expect(result.current).toEqual({ layer: 'prelude', index: 0 });
+    act(() => { vi.advanceTimersByTime(1_000); });
+    expect(result.current).toEqual({ layer: 'prelude', index: 1 });
+    act(() => { vi.advanceTimersByTime(1_000); });
+    expect(result.current).toEqual({ layer: 'main', leadProgress: 0 });
+    act(() => { vi.advanceTimersByTime(3_000); });
+    expect(result.current).toEqual({ layer: 'main', leadProgress: 0.5 });
+  });
+  it('joins a dwell that started earlier at the right step', () => {
+    const { result } = renderHook(() => useStage(plan, 100_000 - 1_500));
+    expect(result.current).toEqual({ layer: 'prelude', index: 1 });
+  });
+  it('a new start resets to the first stage', () => {
+    const { result, rerender } = renderHook((p: { start: number }) => useStage(plan, p.start), { initialProps: { start: 100_000 - 5_000 } });
+    expect(result.current).toEqual({ layer: 'main', leadProgress: 0.5 });
+    rerender({ start: 100_000 });
+    expect(result.current).toEqual({ layer: 'prelude', index: 0 });
+  });
+});

--- a/app/components/solo2/useStage.ts
+++ b/app/components/solo2/useStage.ts
@@ -1,0 +1,30 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { stageAt, type DwellPlan, type Stage } from '@/app/lib/solo2/plan';
+
+const same = (a: Stage, b: Stage) =>
+  a.layer === b.layer &&
+  (a.layer === 'prelude' ? a.index === (b as { index: number }).index
+    : a.leadProgress === (b as { leadProgress: number }).leadProgress);
+
+/**
+ * Where the current dwell is, re-read from the wall clock every `tickMs`
+ * (spec §4.1). `startMs` is the boundary the dwell began at; it changes once
+ * per dwell, so a tab that loads mid-dwell joins at the right step.
+ */
+export function useStage(plan: DwellPlan, startMs: number, tickMs = 250): Stage {
+  const [stage, setStage] = useState<Stage>(() => stageAt(Date.now() - startMs, plan));
+  const { dwellS, preludeFrames, preludeStepS, leadS, holdS, clamped } = plan;
+  useEffect(() => {
+    const p = { dwellS, preludeFrames, preludeStepS, leadS, holdS, clamped };
+    const read = () => setStage((prev) => {
+      const nextStage = stageAt(Date.now() - startMs, p);
+      return same(prev, nextStage) ? prev : nextStage;
+    });
+    read();
+    const t = setInterval(read, tickMs);
+    return () => clearInterval(t);
+  }, [startMs, tickMs, dwellS, preludeFrames, preludeStepS, leadS, holdS, clamped]);
+  return stage;
+}

--- a/app/lib/solo/store.test.ts
+++ b/app/lib/solo/store.test.ts
@@ -30,12 +30,17 @@ describe('listActiveEntries', () => {
       snapshot_id: '7', webcam_id: '3', bin: 'sunset', quality: '0.91', detection: '0.88',
       is_new: true, tally: '2', entered_at: '2026-09-04T01:00:00Z', first_shown_at: null, last_shown_at: null,
       firebase_url: 'https://storage.googleapis.com/x.jpg', title: 'Pier', city: 'Lisbon', region: 'Lisboa',
-      country: 'Portugal', lat: '38.700000', lng: '-9.400000',
+      country: 'Portugal', lat: '38.700000', lng: '-9.400000', captured_at: '2026-09-04 00:59:30.5',
     }]);
     const [e] = await listActiveEntries('sunset');
     expect(e).toMatchObject({ snapshotId: 7, webcamId: 3, bin: 'sunset', quality: 0.91, detection: 0.88,
       isNew: true, tally: 2, feed: 'sunset', lat: 38.7, lng: -9.4, imageUrl: 'https://storage.googleapis.com/x.jpg' });
     expect(e.enteredAt).toBe(Date.parse('2026-09-04T01:00:00Z'));
+    // captured_at is naive UTC text: parsed as UTC whatever the host's zone.
+    expect(e.capturedAt).toBe(Date.UTC(2026, 8, 4, 0, 59, 30, 500));
+    expect(e.timezone).toBe('Europe/Lisbon');
+    expect(e.sunAltitudeDeg).toBeLessThan(0); // 01:59 in Lisbon is night
+    expect(lastQuery()).toMatch(/captured_at::text/);
     expect(lastQuery()).toMatch(/removed_at is null/i);
   });
 });

--- a/app/lib/solo/store.ts
+++ b/app/lib/solo/store.ts
@@ -1,6 +1,8 @@
 import 'server-only';
+import tzLookup from 'tz-lookup';
 import { sql } from '@/app/lib/db';
 import type { BinEntry, BinKind, Feed } from './types';
+import { sunAltitudeDeg } from './zone';
 
 /**
  * Every SQL touch of kiosk_bin_entries and kiosk_screen_state (spec §5).
@@ -16,6 +18,12 @@ export interface StoredEntry extends BinEntry {
   country: string;
   lat: number;
   lng: number;
+  /** When the picture was taken, ms since epoch (UTC). */
+  capturedAt: number;
+  /** IANA zone at the camera, from its coordinates; null when unresolvable. */
+  timezone: string | null;
+  /** Solar altitude at the camera when the picture was taken, degrees. */
+  sunAltitudeDeg: number | null;
   firstShownAt: number | null;
   lastShownAt: number | null;
 }
@@ -29,6 +37,8 @@ interface EntryRow {
   is_new: boolean;
   tally: string | number;
   entered_at: string;
+  /** `captured_at::text`: a naive UTC timestamp, see parseUtcText. */
+  captured_at: string;
   first_shown_at: string | null;
   last_shown_at: string | null;
   firebase_url: string;
@@ -43,7 +53,29 @@ interface EntryRow {
 const num = (v: string | number) => Number(v);
 const ms = (v: string | null) => (v ? Date.parse(v) : null);
 
+/**
+ * `webcam_snapshots.captured_at` is `timestamp without time zone` holding
+ * UTC. The Neon driver parses a naive timestamp as CLIENT-local, which is
+ * right on Vercel (UTC) and seven hours off on a Mac, so the query selects
+ * `::text` and this parses it as UTC explicitly (solo2 spec §4.5).
+ */
+export function parseUtcText(text: string): number {
+  const t = text.trim().replace(' ', 'T');
+  return Date.parse(/(Z|[+-]\d\d(:?\d\d)?)$/.test(t) ? t : `${t}Z`);
+}
+
+function zoneOf(lat: number, lng: number): string | null {
+  try {
+    return Number.isFinite(lat) && Number.isFinite(lng) ? tzLookup(lat, lng) : null;
+  } catch {
+    return null;
+  }
+}
+
 function toEntry(feed: Feed, r: EntryRow): StoredEntry {
+  const lat = num(r.lat);
+  const lng = num(r.lng);
+  const capturedAt = parseUtcText(r.captured_at);
   return {
     feed,
     snapshotId: num(r.snapshot_id),
@@ -61,8 +93,12 @@ function toEntry(feed: Feed, r: EntryRow): StoredEntry {
     city: r.city ?? '',
     region: r.region ?? '',
     country: r.country ?? '',
-    lat: num(r.lat),
-    lng: num(r.lng),
+    lat,
+    lng,
+    capturedAt,
+    timezone: zoneOf(lat, lng),
+    sunAltitudeDeg: Number.isFinite(capturedAt) && Number.isFinite(lat) && Number.isFinite(lng)
+      ? sunAltitudeDeg(new Date(capturedAt), lat, lng) : null,
   };
 }
 
@@ -70,7 +106,7 @@ export async function listActiveEntries(feed: Feed): Promise<StoredEntry[]> {
   const rows = (await sql`
     select e.snapshot_id, e.webcam_id, e.bin, e.quality, e.detection, e.is_new, e.tally,
            e.entered_at, e.first_shown_at, e.last_shown_at,
-           s.firebase_url, w.title, w.city, w.region, w.country, w.lat, w.lng
+           s.firebase_url, s.captured_at::text as captured_at, w.title, w.city, w.region, w.country, w.lat, w.lng
     from kiosk_bin_entries e
     join webcam_snapshots s on s.id = e.snapshot_id
     join webcams w on w.id = e.webcam_id

--- a/app/lib/solo/versions.test.ts
+++ b/app/lib/solo/versions.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest';
+import { schemaDefaults } from '@/app/lib/settings/schema';
+import { project } from './engine';
+import { SOLO_VERSIONS, resolveSoloVersion } from './versions';
+import type { BinEntry } from './types';
+
+const sun = (id: number, q: number): BinEntry => ({
+  snapshotId: id, webcamId: 1000 + id, bin: 'sunset', quality: q, detection: 0.9, isNew: false, tally: 0, enteredAt: id,
+});
+const S0 = { lastSnapshotId: null, sunsetStreak: 0 };
+
+describe('resolveSoloVersion', () => {
+  it('nothing is solo, names resolve, anything else is null', () => {
+    expect(resolveSoloVersion(null)?.name).toBe('solo');
+    expect(resolveSoloVersion(undefined)?.name).toBe('solo');
+    expect(resolveSoloVersion('')?.name).toBe('solo');
+    expect(resolveSoloVersion('solo2')?.name).toBe('solo2');
+    expect(resolveSoloVersion('v4')).toBeNull();
+    expect(resolveSoloVersion('toString')).toBeNull();
+  });
+});
+
+describe('descriptors', () => {
+  const entries = [sun(1, 0.9), sun(2, 0.8), sun(3, 0.7)];
+  it('solo ignores the slot and matches its engine; every draw is a peak', () => {
+    const v = SOLO_VERSIONS.solo;
+    const d = v.dialsFrom(schemaDefaults(v.schema));
+    expect(v.project(entries, d, S0, 3, 17, 'sunset')).toEqual(project(entries, d, S0, 3));
+    expect(v.roleAt(1, 'sunset', d)).toBe('peak');
+    expect(v.namespace).toBe('solo');
+  });
+  it('solo2 reads its own namespace and follows the beat', () => {
+    const v = SOLO_VERSIONS.solo2;
+    const d = { ...v.dialsFrom(schemaDefaults(v.schema)), valleys: 1 };
+    expect(v.namespace).toBe('solo2');
+    expect(v.roleAt(1, 'sunrise', d)).toBe('valley');
+    expect(v.project(entries, d, S0, 3, 0, 'sunrise').map((e) => e.snapshotId)).toEqual([1, 3, 2]);
+  });
+});

--- a/app/lib/solo/versions.ts
+++ b/app/lib/solo/versions.ts
@@ -1,0 +1,59 @@
+import type { SettingsSchema, SettingsValues } from '@/app/lib/settings/schema';
+import { next, project } from './engine';
+import { SOLO_NAMESPACE, SOLO_SETTINGS_SCHEMA, dialsFrom } from './settingsSchema';
+import type { BinEntry, Feed, ScreenState, SoloDials } from './types';
+import { next2, project2, roleAt } from '@/app/lib/solo2/engine';
+import { SOLO2_NAMESPACE, SOLO2_SETTINGS_SCHEMA, dialsFrom2 } from '@/app/lib/solo2/settingsSchema';
+import type { Role, Solo2Dials } from '@/app/lib/solo2/types';
+
+/**
+ * The solo kiosk's versions, side by side (solo2 spec §5.1). Both read the
+ * same bins and screen state; a descriptor says which namespace's dials to
+ * read and which engine to run. Client-safe: no server-only imports, so the
+ * studio can re-project in the browser.
+ */
+export interface SoloVersionSpec<D extends SoloDials = SoloDials> {
+  name: SoloVersionName;
+  namespace: string;
+  schema: SettingsSchema;
+  dialsFrom(values: SettingsValues): D;
+  /** The next frame for a draw at `slot`; solo ignores the slot. */
+  next(entries: BinEntry[], d: D, state: ScreenState, slot: number, feed: Feed): BinEntry | null;
+  /** `n` draws forward, the first at `firstSlot`. */
+  project(entries: BinEntry[], d: D, state: ScreenState, n: number, firstSlot: number, feed: Feed): BinEntry[];
+  /** What a draw at `slot` is inside the bar; solo is all peaks. */
+  roleAt(slot: number, feed: Feed, d: D): Role;
+}
+
+export type SoloVersionName = 'solo' | 'solo2';
+
+const solo: SoloVersionSpec<SoloDials> = {
+  name: 'solo',
+  namespace: SOLO_NAMESPACE,
+  schema: SOLO_SETTINGS_SCHEMA,
+  dialsFrom,
+  next: (entries, d, state) => next(entries, d, state),
+  project: (entries, d, state, n) => project(entries, d, state, n),
+  roleAt: () => 'peak',
+};
+
+const solo2: SoloVersionSpec<Solo2Dials> = {
+  name: 'solo2',
+  namespace: SOLO2_NAMESPACE,
+  schema: SOLO2_SETTINGS_SCHEMA,
+  dialsFrom: dialsFrom2,
+  next: next2,
+  project: project2,
+  roleAt,
+};
+
+export const SOLO_VERSIONS = { solo, solo2 } as const;
+
+/**
+ * Nothing → solo, so every caller that predates solo2 keeps working; an
+ * unknown name → null, so an endpoint can answer 400 instead of guessing.
+ */
+export function resolveSoloVersion(raw: string | null | undefined): SoloVersionSpec | null {
+  if (raw == null || raw === '') return solo as SoloVersionSpec;
+  return raw in SOLO_VERSIONS ? (SOLO_VERSIONS[raw as SoloVersionName] as SoloVersionSpec) : null;
+}

--- a/app/lib/solo/versions.ts
+++ b/app/lib/solo/versions.ts
@@ -55,5 +55,5 @@ export const SOLO_VERSIONS = { solo, solo2 } as const;
  */
 export function resolveSoloVersion(raw: string | null | undefined): SoloVersionSpec | null {
   if (raw == null || raw === '') return solo as SoloVersionSpec;
-  return raw in SOLO_VERSIONS ? (SOLO_VERSIONS[raw as SoloVersionName] as SoloVersionSpec) : null;
+  return Object.hasOwn(SOLO_VERSIONS, raw) ? (SOLO_VERSIONS[raw as SoloVersionName] as SoloVersionSpec) : null;
 }

--- a/app/lib/solo2/caption.test.ts
+++ b/app/lib/solo2/caption.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest';
+import { captionLines, formatTime } from './caption';
+
+// 02:42 UTC on 2026-09-05 is 7:42 pm the evening before in Mazatlán (UTC−7).
+const AT = Date.UTC(2026, 8, 5, 2, 42);
+const TZ = 'America/Mazatlan';
+
+describe('formatTime', () => {
+  it('renders each style', () => {
+    expect(formatTime('off', AT, TZ, 1.23)).toBeNull();
+    expect(formatTime('12h', AT, TZ, 1.23)).toBe('7:42 pm');
+    expect(formatTime('12h-there', AT, TZ, 1.23)).toBe('7:42 pm there');
+    expect(formatTime('24h', AT, TZ, 1.23)).toBe('19:42');
+    expect(formatTime('sun', AT, TZ, 1.23)).toBe('sun 1.2° above the horizon');
+    expect(formatTime('12h-sun', AT, TZ, -2.15)).toBe('7:42 pm · sun 2.1° below the horizon');
+  });
+  it('a morning time reads am', () => {
+    expect(formatTime('12h', Date.UTC(2026, 8, 5, 13, 5), TZ, 0)).toBe('6:05 am');
+  });
+  it('without a timezone the clock styles say nothing and the sun still can', () => {
+    expect(formatTime('12h', AT, null, 1)).toBeNull();
+    expect(formatTime('24h', AT, null, 1)).toBeNull();
+    expect(formatTime('12h-sun', AT, null, 1)).toBe('sun 1.0° above the horizon');
+    expect(formatTime('sun', AT, TZ, null)).toBeNull();
+  });
+  it('an unknown zone name is treated as no zone', () => {
+    expect(formatTime('12h', AT, 'Mars/Olympus', 1)).toBeNull();
+  });
+});
+
+describe('captionLines', () => {
+  const e = { title: 'Pier', region: 'Baja California Sur', country: 'Mexico', capturedAt: AT, timezone: TZ, sunAltitudeDeg: 1.2 };
+  it('joins place and time with a middle dot', () => {
+    expect(captionLines(e, { showPlace: true, timeStyle: '12h' })).toEqual({ title: 'Pier', sub: 'Baja California Sur, Mexico · 7:42 pm' });
+  });
+  it('omits the dot when there is no time, and everything when the place is off', () => {
+    expect(captionLines(e, { showPlace: true, timeStyle: 'off' })!.sub).toBe('Baja California Sur, Mexico');
+    expect(captionLines({ ...e, region: '', country: '' }, { showPlace: true, timeStyle: '12h' })!.sub).toBe('7:42 pm');
+    expect(captionLines(e, { showPlace: false, timeStyle: '12h' })).toBeNull();
+  });
+});

--- a/app/lib/solo2/caption.ts
+++ b/app/lib/solo2/caption.ts
@@ -1,0 +1,60 @@
+import type { Solo2Dials, TimeStyle } from './types';
+
+/** The fields the caption needs; the glass and the studio both pass an EntryView. */
+export interface CaptionEntry {
+  title: string;
+  region: string;
+  country: string;
+  capturedAt: number;
+  timezone: string | null;
+  sunAltitudeDeg: number | null;
+}
+
+function clock(capturedAt: number, timezone: string, hour12: boolean): string | null {
+  try {
+    const s = new Intl.DateTimeFormat('en-US', { timeZone: timezone, hour: 'numeric', minute: '2-digit', hour12 })
+      .format(new Date(capturedAt));
+    // "7:42 PM" → "7:42 pm"; 24h comes back as "19:42".
+    return s.replace(/\s?(AM|PM)$/i, (m) => ` ${m.trim().toLowerCase()}`).replace(/^24:/, '00:');
+  } catch {
+    return null; // an IANA name Intl does not know
+  }
+}
+
+function sun(deg: number): string {
+  const abs = Math.abs(deg).toFixed(1);
+  return `sun ${abs}° ${deg >= 0 ? 'above' : 'below'} the horizon`;
+}
+
+/**
+ * The trailing item of the caption's second line for one time style (spec
+ * §4.5), or null when there is nothing to say (style off, or the data the
+ * style needs is missing).
+ */
+export function formatTime(
+  style: TimeStyle, capturedAt: number, timezone: string | null, sunAltitudeDeg: number | null,
+): string | null {
+  const twelve = timezone ? clock(capturedAt, timezone, true) : null;
+  const sunPart = sunAltitudeDeg == null || !Number.isFinite(sunAltitudeDeg) ? null : sun(sunAltitudeDeg);
+  switch (style) {
+    case 'off': return null;
+    case '12h': return twelve;
+    case '12h-there': return twelve ? `${twelve} there` : null;
+    case '24h': return timezone ? clock(capturedAt, timezone, false) : null;
+    case 'sun': return sunPart;
+    case '12h-sun': return [twelve, sunPart].filter(Boolean).join(' · ') || null;
+  }
+}
+
+/**
+ * What the glass writes under a frame: the camera's title, then region and
+ * country with the time after a middle dot. Null when the place dial is off.
+ */
+export function captionLines(
+  e: CaptionEntry, d: Pick<Solo2Dials, 'showPlace' | 'timeStyle'>,
+): { title: string; sub: string } | null {
+  if (!d.showPlace) return null;
+  const place = [e.region, e.country].filter(Boolean).join(', ');
+  const time = formatTime(d.timeStyle, e.capturedAt, e.timezone, e.sunAltitudeDeg);
+  return { title: e.title, sub: [place, time].filter(Boolean).join(' · ') };
+}

--- a/app/lib/solo2/engine.test.ts
+++ b/app/lib/solo2/engine.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect } from 'vitest';
+import { schemaDefaults } from '@/app/lib/settings/schema';
+import { project } from '@/app/lib/solo/engine';
+import type { BinEntry, ScreenState } from '@/app/lib/solo/types';
+import { beatOf, next2, project2, roleAt } from './engine';
+import { SOLO2_SETTINGS_SCHEMA, dialsFrom2 } from './settingsSchema';
+import type { Solo2Dials } from './types';
+
+const D: Solo2Dials = dialsFrom2(schemaDefaults(SOLO2_SETTINGS_SCHEMA));
+const S0: ScreenState = { lastSnapshotId: null, sunsetStreak: 0 };
+
+function sun(id: number, q: number, extra: Partial<BinEntry> = {}): BinEntry {
+  return { snapshotId: id, webcamId: 1000 + id, bin: 'sunset', quality: q, detection: 0.9,
+    isNew: false, tally: 0, enteredAt: id, ...extra };
+}
+function non(id: number, det: number, extra: Partial<BinEntry> = {}): BinEntry {
+  return { snapshotId: id, webcamId: 2000 + id, bin: 'non_sunset', quality: null, detection: det,
+    isNew: false, tally: 0, enteredAt: id, ...extra };
+}
+const eightNon = () => [1, 2, 3, 4, 5, 6, 7, 8].map((i) => non(100 + i, 0.6 - i * 0.02));
+/** S1..S21 by descending quality, all eligible. */
+const twentyOne = () => Array.from({ length: 21 }, (_, i) => sun(i + 1, 0.99 - i * 0.02));
+const labels = (out: BinEntry[]) => out.map((e) => (e.bin === 'sunset' ? `S${e.snapshotId}` : `N${e.snapshotId - 100}`));
+
+describe('beatOf / roleAt', () => {
+  it('valleys 0: every slot is a peak', () => {
+    for (const s of [-3, 0, 1, 2, 7]) expect(roleAt(s, 'sunrise', D)).toBe('peak');
+  });
+  it('valleys 1, together: even slots peak on both screens', () => {
+    const d = { ...D, valleys: 1 };
+    expect([0, 1, 2, 3].map((s) => roleAt(s, 'sunrise', d))).toEqual(['peak', 'valley', 'peak', 'valley']);
+    expect([0, 1, 2, 3].map((s) => roleAt(s, 'sunset', d))).toEqual(['peak', 'valley', 'peak', 'valley']);
+  });
+  it('valleys 1, alternate: the sunset screen peaks on the opposite beat', () => {
+    const d = { ...D, valleys: 1, screens: 'alternate' as const };
+    expect([0, 1, 2, 3].map((s) => roleAt(s, 'sunset', d))).toEqual(['valley', 'peak', 'valley', 'peak']);
+    expect([0, 1, 2, 3].map((s) => roleAt(s, 'sunrise', d))).toEqual(['peak', 'valley', 'peak', 'valley']);
+  });
+  it('negative slots wrap into the bar', () => {
+    const d = { ...D, valleys: 2 };
+    expect([-3, -2, -1, 0, 1, 2].map((s) => beatOf(s, 'sunrise', d))).toEqual([0, 1, 2, 0, 1, 2]);
+  });
+});
+
+describe('valleys 0 is solo', () => {
+  it('reproduces the thin-night fixtures for every allowance', () => {
+    for (const repeatAllowance of [0, 1, 2]) {
+      const d = { ...D, repeatAllowance };
+      const entries = [sun(1, 0.97), ...eightNon()];
+      expect(labels(project2(entries, d, S0, 12, 5, 'sunset'))).toEqual(labels(project(entries, d, S0, 12)));
+    }
+  });
+  it('reproduces solo on a full sunset bin', () => {
+    expect(labels(project2(twentyOne(), D, S0, 8, 0, 'sunrise'))).toEqual(labels(project(twentyOne(), D, S0, 8)));
+  });
+});
+
+describe('rhythm', () => {
+  it('valleys 1: peaks best-first, valleys worst-first, alternating', () => {
+    const d = { ...D, valleys: 1 };
+    expect(labels(project2(twentyOne(), d, S0, 6, 0, 'sunrise'))).toEqual(['S1', 'S21', 'S2', 'S20', 'S3', 'S19']);
+  });
+  it('valleys 2: one peak then two valleys', () => {
+    const d = { ...D, valleys: 2 };
+    expect(labels(project2(twentyOne(), d, S0, 6, 0, 'sunrise'))).toEqual(['S1', 'S21', 'S20', 'S2', 'S19', 'S18']);
+  });
+  it('starting mid-bar starts on that beat', () => {
+    const d = { ...D, valleys: 1 };
+    expect(labels(project2(twentyOne(), d, S0, 3, 1, 'sunrise'))).toEqual(['S21', 'S1', 'S20']);
+  });
+  it('alternate: at the same slot one screen peaks and the other dips', () => {
+    const d = { ...D, valleys: 1, screens: 'alternate' as const };
+    expect(labels(project2(twentyOne(), d, S0, 2, 0, 'sunrise'))).toEqual(['S1', 'S21']);
+    expect(labels(project2(twentyOne(), d, S0, 2, 0, 'sunset'))).toEqual(['S21', 'S1']);
+  });
+  it('a valley prefers an unshown frame over a lower-scored one already shown', () => {
+    const d = { ...D, valleys: 1, repeatAllowance: 1 };
+    // tally 1 with allowance 1 is still tier 0, so both compete in the pool.
+    const entries = [sun(1, 0.95), sun(2, 0.6), sun(3, 0.58, { tally: 1 })];
+    expect(next2(entries, d, S0, 1, 'sunrise')?.snapshotId).toBe(2);
+  });
+  it('rule 4 holds on a valley: never the frame on glass', () => {
+    const d = { ...D, valleys: 1 };
+    const entries = [sun(1, 0.95), sun(2, 0.6)];
+    expect(next2(entries, d, { lastSnapshotId: 2, sunsetStreak: 1 }, 1, 'sunrise')?.snapshotId).toBe(1);
+  });
+  it('non-sunsets still arrive through mix; they are the deepest valleys', () => {
+    const d = { ...D, valleys: 1 };
+    const entries = [sun(1, 0.9), sun(2, 0.8), sun(3, 0.7), ...eightNon()];
+    // rule 2: three sunsets < floor 6 → mix 2 → S S N …; the beat only orders within the pool.
+    expect(project2(entries, d, S0, 3, 0, 'sunset').map((e) => e.bin)).toEqual(['sunset', 'sunset', 'non_sunset']);
+    // slot 2 is a peak: the highest-detection non-sunset; slot 1 was a valley: the lowest eligible sunset.
+    expect(labels(project2(entries, d, S0, 3, 0, 'sunset'))).toEqual(['S1', 'S3', 'N1']);
+  });
+  it('the promote-new bonus counts against a valley too', () => {
+    const d = { ...D, valleys: 1 };
+    const entries = [sun(1, 0.95), sun(2, 0.6), sun(3, 0.55, { isNew: true })];
+    // 0.55 + 0.10 = 0.65 > 0.60, so frame 2 is now the lowest.
+    expect(next2(entries, d, S0, 1, 'sunrise')?.snapshotId).toBe(2);
+  });
+});

--- a/app/lib/solo2/engine.ts
+++ b/app/lib/solo2/engine.ts
@@ -1,0 +1,87 @@
+import { afterShowing, isEligible, rankScore, tierOf } from '@/app/lib/solo/engine';
+import type { BinEntry, Feed, ScreenState } from '@/app/lib/solo/types';
+import type { Role, Solo2Dials } from './types';
+
+/**
+ * solo's rules with rule 3 on a beat (spec §3). Pure: no clock, no I/O.
+ * Composes solo's helpers rather than copying them; solo's engine is not
+ * touched.
+ */
+
+/** period = valleys + 1; the sunset screen's phase is half a bar when the screens alternate. */
+export function beatOf(slot: number, feed: Feed, d: Pick<Solo2Dials, 'valleys' | 'screens'>): number {
+  const period = Math.max(1, Math.floor(d.valleys) + 1);
+  const phase = feed === 'sunset' && d.screens === 'alternate' ? Math.floor(period / 2) : 0;
+  return (((slot - phase) % period) + period) % period;
+}
+
+export function roleAt(slot: number, feed: Feed, d: Pick<Solo2Dials, 'valleys' | 'screens'>): Role {
+  return beatOf(slot, feed, d) === 0 ? 'peak' : 'valley';
+}
+
+/** solo's rule 3 order: tally, best score, earliest, id. */
+function comparePeak(d: Solo2Dials) {
+  return (a: BinEntry, b: BinEntry): number =>
+    a.tally - b.tally ||
+    rankScore(b, d) - rankScore(a, d) ||
+    a.enteredAt - b.enteredAt ||
+    a.snapshotId - b.snapshotId;
+}
+
+/** A valley: still unshown first, then the LOWEST score, earliest, id. */
+function compareValley(d: Solo2Dials) {
+  return (a: BinEntry, b: BinEntry): number =>
+    a.tally - b.tally ||
+    rankScore(a, d) - rankScore(b, d) ||
+    a.enteredAt - b.enteredAt ||
+    a.snapshotId - b.snapshotId;
+}
+
+/** The next frame for one screen drawing at `slot`, or null when nothing is eligible. */
+export function next2(
+  entries: BinEntry[], d: Solo2Dials, state: ScreenState, slot: number, feed: Feed,
+): BinEntry | null {
+  const eligible = entries.filter((e) => isEligible(e, d));
+  // Rule 4.
+  let candidates = eligible.filter((e) => e.snapshotId !== state.lastSnapshotId);
+  if (candidates.length === 0) candidates = eligible;
+  if (candidates.length === 0) return null;
+
+  // Rule 1.
+  const minTier = Math.min(...candidates.map((e) => tierOf(e, d)));
+  const tier = candidates.filter((e) => tierOf(e, d) === minTier);
+  const sunsets = tier.filter((e) => e.bin === 'sunset');
+  const nonSunsets = tier.filter((e) => e.bin === 'non_sunset');
+
+  // Rule 2.
+  let pool: BinEntry[];
+  if (nonSunsets.length === 0) pool = sunsets;
+  else if (sunsets.length === 0) pool = nonSunsets;
+  else if (sunsets.length >= d.sunsetFloor) pool = sunsets;
+  else pool = state.sunsetStreak >= d.mix ? nonSunsets : sunsets;
+
+  // Rule 3, on the beat.
+  const cmp = roleAt(slot, feed, d) === 'peak' ? comparePeak(d) : compareValley(d);
+  return [...pool].sort(cmp)[0];
+}
+
+/**
+ * `n` draws forward from `state`, the first at `firstSlot`, each applied to
+ * a private copy of the entries. Inputs are never mutated.
+ */
+export function project2(
+  entries: BinEntry[], d: Solo2Dials, state: ScreenState, n: number, firstSlot: number, feed: Feed,
+): BinEntry[] {
+  const working = entries.map((e) => ({ ...e }));
+  let s = state;
+  const out: BinEntry[] = [];
+  for (let i = 0; i < n; i++) {
+    const pick = next2(working, d, s, firstSlot + i, feed);
+    if (!pick) break;
+    out.push({ ...pick });
+    pick.tally += 1;
+    pick.isNew = false;
+    s = afterShowing(pick, s);
+  }
+  return out;
+}

--- a/app/lib/solo2/plan.test.ts
+++ b/app/lib/solo2/plan.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from 'vitest';
+import { MIN_HOLD_S, describePlan, fitPlan, stageAt, type DwellPlan } from './plan';
+
+const base = { dwellS: 20, prelude: true, preludeFrames: 3, preludeStepS: 1.5, leadS: 4 };
+
+describe('fitPlan', () => {
+  it('fits as-is when there is room', () => {
+    expect(fitPlan(base, 5)).toEqual({ dwellS: 20, preludeFrames: 3, preludeStepS: 1.5, leadS: 4, holdS: 11.5, clamped: false });
+  });
+  it('prelude off means no prelude frames, whatever is available', () => {
+    expect(fitPlan({ ...base, prelude: false }, 5).preludeFrames).toBe(0);
+  });
+  it('never asks for more frames than the camera has', () => {
+    expect(fitPlan(base, 1).preludeFrames).toBe(1);
+    expect(fitPlan(base, 0).preludeFrames).toBe(0);
+  });
+  it('drops prelude frames first until the hold is at least the floor', () => {
+    // 8 s dwell: 3×1.5 + 4 leaves −0.5 → 2 frames leaves 1 → 1 frame leaves 2.5 → 0 frames leaves 4 ≥ 3.
+    const p = fitPlan({ ...base, dwellS: 8 }, 5);
+    expect(p).toMatchObject({ preludeFrames: 0, leadS: 4, holdS: 4, clamped: true });
+  });
+  it('then shortens the lead', () => {
+    const p = fitPlan({ ...base, dwellS: 6, prelude: false }, 0);
+    expect(p).toMatchObject({ preludeFrames: 0, leadS: 3, holdS: MIN_HOLD_S, clamped: true });
+  });
+  it('a dwell shorter than the floor gives lead 0 and whatever hold remains', () => {
+    expect(fitPlan({ ...base, dwellS: 2, prelude: false }, 0)).toMatchObject({ leadS: 0, holdS: 2, clamped: true });
+  });
+});
+
+describe('stageAt', () => {
+  const p: DwellPlan = { dwellS: 20, preludeFrames: 3, preludeStepS: 1.5, leadS: 4, holdS: 11.5, clamped: false };
+  it('walks the prelude by elapsed time', () => {
+    expect(stageAt(0, p)).toEqual({ layer: 'prelude', index: 0 });
+    expect(stageAt(1_499, p)).toEqual({ layer: 'prelude', index: 0 });
+    expect(stageAt(1_500, p)).toEqual({ layer: 'prelude', index: 1 });
+    expect(stageAt(4_499, p)).toEqual({ layer: 'prelude', index: 2 });
+  });
+  it('then holds the main frame with no lead', () => {
+    expect(stageAt(4_500, p)).toEqual({ layer: 'main', leadProgress: 0 });
+    expect(stageAt(15_999, p)).toEqual({ layer: 'main', leadProgress: 0 });
+  });
+  it('leads linearly over the last seconds, clamped at 1', () => {
+    expect(stageAt(16_000, p)).toEqual({ layer: 'main', leadProgress: 0 });
+    expect(stageAt(18_000, p)).toEqual({ layer: 'main', leadProgress: 0.5 });
+    expect(stageAt(20_000, p)).toEqual({ layer: 'main', leadProgress: 1 });
+    expect(stageAt(25_000, p)).toEqual({ layer: 'main', leadProgress: 1 });
+  });
+  it('negative elapsed is the first stage; no prelude means main from the start', () => {
+    expect(stageAt(-500, p)).toEqual({ layer: 'prelude', index: 0 });
+    expect(stageAt(0, { ...p, preludeFrames: 0, holdS: 16 })).toEqual({ layer: 'main', leadProgress: 0 });
+  });
+  it('lead 0 never moves', () => {
+    expect(stageAt(19_999, { ...p, leadS: 0, holdS: 15.5 })).toEqual({ layer: 'main', leadProgress: 0 });
+  });
+});
+
+describe('describePlan', () => {
+  it('prints the budget and marks a clamp', () => {
+    expect(describePlan(fitPlan(base, 5))).toBe('prelude 4.5 s + lead 4 s + hold 11.5 s');
+    expect(describePlan(fitPlan({ ...base, dwellS: 8 }, 5))).toBe('prelude 0 s + lead 4 s + hold 4 s (clamped)');
+  });
+});

--- a/app/lib/solo2/plan.ts
+++ b/app/lib/solo2/plan.ts
@@ -1,0 +1,63 @@
+import type { Solo2Dials } from './types';
+
+/** The chosen frame sits still with its caption for at least this long (spec §4.1). */
+export const MIN_HOLD_S = 3;
+
+/** One dwell's timeline, in seconds, after the budget rule has been applied. */
+export interface DwellPlan {
+  dwellS: number;
+  /** Prelude frames actually shown. 0 when the dial is off or nothing fits. */
+  preludeFrames: number;
+  preludeStepS: number;
+  leadS: number;
+  holdS: number;
+  /** True when a prelude frame or some lead was dropped to keep the hold. */
+  clamped: boolean;
+}
+
+export type PlanDials = Pick<Solo2Dials, 'dwellS' | 'prelude' | 'preludeFrames' | 'preludeStepS' | 'leadS'>;
+
+/**
+ * Fit prelude and lead into the dwell. `available` is how many earlier frames
+ * this camera actually has. Prelude frames go first (oldest first, i.e. the
+ * count shrinks), then the lead, until `hold ≥ MIN_HOLD_S`.
+ */
+export function fitPlan(d: PlanDials, available: number): DwellPlan {
+  const step = d.preludeStepS;
+  let frames = d.prelude ? Math.max(0, Math.min(Math.floor(d.preludeFrames), Math.floor(available))) : 0;
+  let lead = Math.max(0, d.leadS);
+  let clamped = false;
+  const hold = () => d.dwellS - frames * step - lead;
+  while (frames > 0 && hold() < MIN_HOLD_S) { frames -= 1; clamped = true; }
+  if (hold() < MIN_HOLD_S && lead > 0) {
+    lead = Math.max(0, d.dwellS - frames * step - MIN_HOLD_S);
+    clamped = true;
+  }
+  return { dwellS: d.dwellS, preludeFrames: frames, preludeStepS: step, leadS: lead, holdS: hold(), clamped };
+}
+
+export type Stage =
+  | { layer: 'prelude'; index: number }
+  | { layer: 'main'; leadProgress: number };
+
+/**
+ * Where a dwell is at `elapsedMs` after its boundary. Pure, so a tab that
+ * loads mid-dwell joins at the right step and the studio can draw the same
+ * timeline.
+ */
+export function stageAt(elapsedMs: number, p: DwellPlan): Stage {
+  const t = Math.max(0, elapsedMs) / 1000;
+  const preludeEnd = p.preludeFrames * p.preludeStepS;
+  if (p.preludeFrames > 0 && t < preludeEnd) {
+    return { layer: 'prelude', index: Math.min(p.preludeFrames - 1, Math.floor(t / p.preludeStepS)) };
+  }
+  const leadStart = p.dwellS - p.leadS;
+  const leadProgress = p.leadS > 0 ? Math.min(1, Math.max(0, (t - leadStart) / p.leadS)) : 0;
+  return { layer: 'main', leadProgress };
+}
+
+/** The budget line the studio prints: `prelude 4.5 s + lead 4 s + hold 11.5 s`. */
+export function describePlan(p: DwellPlan): string {
+  const s = (n: number) => `${Number(n.toFixed(1))} s`;
+  return `prelude ${s(p.preludeFrames * p.preludeStepS)} + lead ${s(p.leadS)} + hold ${s(p.holdS)}${p.clamped ? ' (clamped)' : ''}`;
+}

--- a/app/lib/solo2/prelude.test.ts
+++ b/app/lib/solo2/prelude.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { preludeFor } from './prelude';
+import { preludeFor, preludePlan } from './prelude';
 
 const f = (snapshotId: number, webcamId: number, capturedAt: number) => ({ snapshotId, webcamId, capturedAt });
 
@@ -15,5 +15,36 @@ describe('preludeFor', () => {
   it('a camera alone has no prelude; max 0 asks for none', () => {
     expect(preludeFor(f(3, 9, 250), pool, 3)).toEqual([]);
     expect(preludeFor(f(6, 7, 500), pool, 0)).toEqual([]);
+  });
+});
+
+describe('preludeFor after a moment', () => {
+  const pool = [f(1, 7, 100), f(2, 7, 200), f(4, 7, 300), f(5, 7, 400)];
+  it('keeps only captures after `afterMs`, so a prelude continues from the frame on glass', () => {
+    expect(preludeFor(f(5, 7, 400), pool, 10, 200).map((e) => e.snapshotId)).toEqual([4]);
+    expect(preludeFor(f(5, 7, 400), pool, 10, 300)).toEqual([]);
+  });
+});
+
+describe('preludePlan', () => {
+  const dials = { dwellS: 20, prelude: true, preludeFrames: 3, preludeStepS: 1.5, leadS: 4 };
+  const pool = [f(1, 7, 100), f(2, 7, 200), f(3, 7, 300), f(4, 7, 400), f(5, 7, 500), f(9, 8, 450)];
+  it('returns the frames the plan actually shows, newest kept when the budget clamps', () => {
+    // 6 s dwell: 3×1.5 + 4 > 6 − 3 → frames drop oldest-first to 0, then the lead shortens.
+    const r = preludePlan(f(5, 7, 500), pool, { ...dials, dwellS: 8 });
+    expect(r.plan.preludeFrames).toBe(0);
+    expect(r.frames).toEqual([]);
+    const full = preludePlan(f(5, 7, 500), pool, dials);
+    expect(full.frames.map((e) => e.snapshotId)).toEqual([2, 3, 4]);
+    expect(full.plan).toMatchObject({ preludeFrames: 3, holdS: 11.5 });
+  });
+  it('with the dial off there is no prelude and the plan says so', () => {
+    const r = preludePlan(f(5, 7, 500), pool, { ...dials, prelude: false });
+    expect(r.frames).toEqual([]);
+    expect(r.plan.preludeFrames).toBe(0);
+  });
+  it('continues from a same-camera previous frame and ignores another camera\'s', () => {
+    expect(preludePlan(f(5, 7, 500), pool, dials, f(3, 7, 300)).frames.map((e) => e.snapshotId)).toEqual([4]);
+    expect(preludePlan(f(5, 7, 500), pool, dials, f(9, 8, 450)).frames.map((e) => e.snapshotId)).toEqual([2, 3, 4]);
   });
 });

--- a/app/lib/solo2/prelude.test.ts
+++ b/app/lib/solo2/prelude.test.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect } from 'vitest';
+import { preludeFor } from './prelude';
+
+const f = (snapshotId: number, webcamId: number, capturedAt: number) => ({ snapshotId, webcamId, capturedAt });
+
+describe('preludeFor', () => {
+  const pool = [f(1, 7, 100), f(2, 7, 200), f(3, 9, 250), f(4, 7, 300), f(5, 7, 400), f(6, 7, 500)];
+  it('same camera, earlier captures, in capture order, the last max', () => {
+    expect(preludeFor(f(5, 7, 400), pool, 2).map((e) => e.snapshotId)).toEqual([2, 4]);
+    expect(preludeFor(f(5, 7, 400), pool, 10).map((e) => e.snapshotId)).toEqual([1, 2, 4]);
+  });
+  it('never includes later frames, other cameras, or itself', () => {
+    expect(preludeFor(f(4, 7, 300), pool, 10).map((e) => e.snapshotId)).toEqual([1, 2]);
+  });
+  it('a camera alone has no prelude; max 0 asks for none', () => {
+    expect(preludeFor(f(3, 9, 250), pool, 3)).toEqual([]);
+    expect(preludeFor(f(6, 7, 500), pool, 0)).toEqual([]);
+  });
+});

--- a/app/lib/solo2/prelude.ts
+++ b/app/lib/solo2/prelude.ts
@@ -1,15 +1,36 @@
+import { fitPlan, type DwellPlan, type PlanDials } from './plan';
+
+export interface PreludeEntry { webcamId: number; snapshotId: number; capturedAt: number }
+
 /**
  * The prelude of a frame: the same camera's earlier captures, oldest first,
  * the last `max` of them (spec §4.4). Pure over whatever the state endpoint
  * already returned: no query. Frames below a floor are fine here; they are
- * earlier pictures of the same scene.
+ * earlier pictures of the same scene. `afterMs` keeps only captures after
+ * that moment, so a prelude can continue from the frame already on glass
+ * instead of rewinding past it.
  */
-export function preludeFor<T extends { webcamId: number; snapshotId: number; capturedAt: number }>(
-  entry: T, entries: T[], max: number,
-): T[] {
+export function preludeFor<T extends PreludeEntry>(entry: T, entries: T[], max: number, afterMs = -Infinity): T[] {
   if (max <= 0) return [];
   return entries
-    .filter((e) => e.webcamId === entry.webcamId && e.snapshotId !== entry.snapshotId && e.capturedAt < entry.capturedAt)
+    .filter((e) => e.webcamId === entry.webcamId && e.snapshotId !== entry.snapshotId
+      && e.capturedAt < entry.capturedAt && e.capturedAt > afterMs)
     .sort((a, b) => a.capturedAt - b.capturedAt || a.snapshotId - b.snapshotId)
     .slice(-Math.floor(max));
+}
+
+/**
+ * What one dwell of `entry` shows before the chosen frame, and its plan: the
+ * prelude the dials ask for, cut to what the budget keeps (newest kept, since
+ * fitPlan drops oldest-first). When `previous` is the same camera the prelude
+ * picks up after it. The glass and the studio call this with the same inputs
+ * so the studio's group is the glass's sequence.
+ */
+export function preludePlan<T extends PreludeEntry>(
+  entry: T, entries: T[], dials: PlanDials & { preludeFrames: number }, previous?: PreludeEntry | null,
+): { frames: T[]; plan: DwellPlan } {
+  const after = previous && previous.webcamId === entry.webcamId ? previous.capturedAt : -Infinity;
+  const wanted = dials.prelude ? preludeFor(entry, entries, dials.preludeFrames, after) : [];
+  const plan = fitPlan(dials, wanted.length);
+  return { frames: plan.preludeFrames > 0 ? wanted.slice(-plan.preludeFrames) : [], plan };
 }

--- a/app/lib/solo2/prelude.ts
+++ b/app/lib/solo2/prelude.ts
@@ -1,0 +1,15 @@
+/**
+ * The prelude of a frame: the same camera's earlier captures, oldest first,
+ * the last `max` of them (spec §4.4). Pure over whatever the state endpoint
+ * already returned: no query. Frames below a floor are fine here; they are
+ * earlier pictures of the same scene.
+ */
+export function preludeFor<T extends { webcamId: number; snapshotId: number; capturedAt: number }>(
+  entry: T, entries: T[], max: number,
+): T[] {
+  if (max <= 0) return [];
+  return entries
+    .filter((e) => e.webcamId === entry.webcamId && e.snapshotId !== entry.snapshotId && e.capturedAt < entry.capturedAt)
+    .sort((a, b) => a.capturedAt - b.capturedAt || a.snapshotId - b.snapshotId)
+    .slice(-Math.floor(max));
+}

--- a/app/lib/solo2/settingsSchema.test.ts
+++ b/app/lib/solo2/settingsSchema.test.ts
@@ -7,22 +7,24 @@ describe('solo2 settings schema', () => {
   it('is its own namespace', () => {
     expect(SOLO2_NAMESPACE).toBe('solo2');
   });
-  it('carries every solo dial with the same default and section', () => {
+  it('carries every solo dial with the same section, and the same default except the fade', () => {
     for (const k of SOLO_SETTINGS_SCHEMA) {
       const mine = SOLO2_SETTINGS_SCHEMA.find((x) => x.key === k.key);
       expect(mine, k.key).toBeDefined();
-      expect(mine!.default).toBe(k.default);
+      if (k.key !== 'fadeS') expect(mine!.default, k.key).toBe(k.default);
       expect(mine!.section).toBe(k.section);
     }
   });
-  it('the additions default to solo\'s behaviour, except the time caption', () => {
+  it('the additions default to solo\'s behaviour, except the time caption and the dissolves', () => {
     const d = dialsFrom2(schemaDefaults(SOLO2_SETTINGS_SCHEMA));
     expect(d).toMatchObject({
-      transition: 'cut', leadS: 0, leadScale: 1.03, prelude: false, preludeFrames: 3, preludeStepS: 1.5,
+      leadS: 0, leadScale: 1.03, prelude: false, preludeFrames: 3, preludeStepS: 1.5,
       timeStyle: '12h', valleys: 0, screens: 'together',
     });
+    // Decided 2026-09-05: a camera change dips through black, the same camera dissolves.
+    expect(d).toMatchObject({ transition: 'dip', fadeS: 1.5, sameCameraFadeS: 1.5 });
     // and still every solo dial
-    expect(d).toMatchObject({ dwellS: 20, offsetS: 10, fadeS: 0, qualityFloor: 0.55, mix: 2 });
+    expect(d).toMatchObject({ dwellS: 20, offsetS: 10, qualityFloor: 0.55, mix: 2 });
   });
   it('keys are unique and every enum default is one of its options', () => {
     const keys = SOLO2_SETTINGS_SCHEMA.map((k) => k.key);

--- a/app/lib/solo2/settingsSchema.test.ts
+++ b/app/lib/solo2/settingsSchema.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest';
+import { schemaDefaults } from '@/app/lib/settings/schema';
+import { SOLO_SETTINGS_SCHEMA } from '@/app/lib/solo/settingsSchema';
+import { SOLO2_NAMESPACE, SOLO2_SETTINGS_SCHEMA, dialsFrom2 } from './settingsSchema';
+
+describe('solo2 settings schema', () => {
+  it('is its own namespace', () => {
+    expect(SOLO2_NAMESPACE).toBe('solo2');
+  });
+  it('carries every solo dial with the same default and section', () => {
+    for (const k of SOLO_SETTINGS_SCHEMA) {
+      const mine = SOLO2_SETTINGS_SCHEMA.find((x) => x.key === k.key);
+      expect(mine, k.key).toBeDefined();
+      expect(mine!.default).toBe(k.default);
+      expect(mine!.section).toBe(k.section);
+    }
+  });
+  it('the additions default to solo\'s behaviour, except the time caption', () => {
+    const d = dialsFrom2(schemaDefaults(SOLO2_SETTINGS_SCHEMA));
+    expect(d).toMatchObject({
+      transition: 'cut', leadS: 0, leadScale: 1.03, prelude: false, preludeFrames: 3, preludeStepS: 1.5,
+      timeStyle: '12h', valleys: 0, screens: 'together',
+    });
+    // and still every solo dial
+    expect(d).toMatchObject({ dwellS: 20, offsetS: 10, fadeS: 0, qualityFloor: 0.55, mix: 2 });
+  });
+  it('keys are unique and every enum default is one of its options', () => {
+    const keys = SOLO2_SETTINGS_SCHEMA.map((k) => k.key);
+    expect(new Set(keys).size).toBe(keys.length);
+    for (const k of SOLO2_SETTINGS_SCHEMA) {
+      if (k.kind === 'enum') expect(k.options).toContain(k.default);
+    }
+  });
+});

--- a/app/lib/solo2/settingsSchema.ts
+++ b/app/lib/solo2/settingsSchema.ts
@@ -1,4 +1,4 @@
-import type { SettingsSchema, SettingsValues } from '@/app/lib/settings/schema';
+import type { NumberKnob, SettingsSchema, SettingsValues } from '@/app/lib/settings/schema';
 import { SOLO_SETTINGS_SCHEMA } from '@/app/lib/solo/settingsSchema';
 import { dialsFrom } from '@/app/lib/solo/settingsSchema';
 import type { Screens, Solo2Dials, TimeStyle, Transition } from './types';
@@ -21,11 +21,16 @@ export const SOLO2_SETTINGS_SCHEMA: SettingsSchema = [
   solo('dwellS'),
   solo('offsetS'),
   {
-    key: 'transition', kind: 'enum', options: ['cut', 'crossfade', 'dip'], default: 'cut',
-    label: 'transition', section: 'glass',
-    description: 'How a frame gives way to the next. Cut is instant; crossfade dissolves over the fade time; dip goes through black in the same time.',
+    key: 'transition', kind: 'enum', options: ['cut', 'crossfade', 'dip'], default: 'dip',
+    label: 'camera change', section: 'glass',
+    description: 'How a frame gives way to one from a different camera. Cut is instant; crossfade dissolves over the fade time; dip goes through black in the same time.',
   },
-  { ...solo('fadeS'), description: 'How long a crossfade or dip takes. Ignored by cut.' },
+  { ...(solo('fadeS') as NumberKnob), default: 1.5, description: 'How long a camera change takes: the whole dissolve, or the dip down plus up. Ignored by cut.' },
+  {
+    key: 'sameCameraFadeS', kind: 'number', min: 0, max: 5, step: 0.5, default: 1.5,
+    label: 'same-camera fade (s)', section: 'glass',
+    description: 'Dissolve between two frames of the same camera: each prelude step, and a change to a later frame of the camera on glass. Never through black. 0 is a cut.',
+  },
   {
     key: 'leadS', kind: 'number', min: 0, max: 10, step: 0.5, default: 0,
     label: 'lead (s)', section: 'glass',
@@ -49,7 +54,7 @@ export const SOLO2_SETTINGS_SCHEMA: SettingsSchema = [
   {
     key: 'preludeStepS', kind: 'number', min: 0.5, max: 5, step: 0.5, default: 1.5,
     label: 'prelude step (s)', section: 'glass',
-    description: 'How long each prelude frame is held. Steps are hard cuts: a time-lapse reads as cuts.',
+    description: 'How long each prelude frame is held. Frames dissolve into the next over the same-camera fade, capped at this step.',
   },
   solo('showPlace'),
   {
@@ -85,6 +90,7 @@ export function dialsFrom2(values: SettingsValues): Solo2Dials {
   return {
     ...dialsFrom(values),
     transition: values.transition as Transition,
+    sameCameraFadeS: values.sameCameraFadeS as number,
     leadS: values.leadS as number,
     leadScale: values.leadScale as number,
     prelude: values.prelude as boolean,

--- a/app/lib/solo2/settingsSchema.ts
+++ b/app/lib/solo2/settingsSchema.ts
@@ -1,0 +1,97 @@
+import type { SettingsSchema, SettingsValues } from '@/app/lib/settings/schema';
+import { SOLO_SETTINGS_SCHEMA } from '@/app/lib/solo/settingsSchema';
+import { dialsFrom } from '@/app/lib/solo/settingsSchema';
+import type { Screens, Solo2Dials, TimeStyle, Transition } from './types';
+
+export const SOLO2_NAMESPACE = 'solo2';
+
+const solo = (key: string) => {
+  const knob = SOLO_SETTINGS_SCHEMA.find((k) => k.key === key);
+  if (!knob) throw new Error(`solo schema has no ${key}`);
+  return knob;
+};
+
+/**
+ * solo's dials plus the solo2 additions, in the order the rail shows them.
+ * Every added dial defaults to solo's behaviour except `timeStyle`, which
+ * defaults to the 12-hour clock because the time is the point (spec §1).
+ */
+export const SOLO2_SETTINGS_SCHEMA: SettingsSchema = [
+  // ---- glass ----
+  solo('dwellS'),
+  solo('offsetS'),
+  {
+    key: 'transition', kind: 'enum', options: ['cut', 'crossfade', 'dip'], default: 'cut',
+    label: 'transition', section: 'glass',
+    description: 'How a frame gives way to the next. Cut is instant; crossfade dissolves over the fade time; dip goes through black in the same time.',
+  },
+  { ...solo('fadeS'), description: 'How long a crossfade or dip takes. Ignored by cut.' },
+  {
+    key: 'leadS', kind: 'number', min: 0, max: 10, step: 0.5, default: 0,
+    label: 'lead (s)', section: 'glass',
+    description: 'For this long before each change, the frame on glass slowly pushes in. Stillness means now; motion means change is coming. 0 is off.',
+  },
+  {
+    key: 'leadScale', kind: 'number', min: 1, max: 1.1, step: 0.01, default: 1.03,
+    label: 'lead scale', section: 'glass',
+    description: 'How far the push goes by the moment of the change. 1.03 is barely felt; 1.10 is a visible zoom.',
+  },
+  {
+    key: 'prelude', kind: 'boolean', default: false,
+    label: 'prelude', section: 'glass',
+    description: 'Before the chosen frame, show the same camera\'s earlier frames in order, so the sun visibly drops into the picture.',
+  },
+  {
+    key: 'preludeFrames', kind: 'number', min: 1, max: 6, step: 1, default: 3,
+    label: 'prelude frames', section: 'glass',
+    description: 'At most this many earlier frames. Fewer if the camera has fewer, or if the dwell cannot fit them.',
+  },
+  {
+    key: 'preludeStepS', kind: 'number', min: 0.5, max: 5, step: 0.5, default: 1.5,
+    label: 'prelude step (s)', section: 'glass',
+    description: 'How long each prelude frame is held. Steps are hard cuts: a time-lapse reads as cuts.',
+  },
+  solo('showPlace'),
+  {
+    key: 'timeStyle', kind: 'enum', options: ['off', '12h', '12h-there', '24h', 'sun', '12h-sun'], default: '12h',
+    label: 'time', section: 'glass',
+    description: 'What follows the place on the caption: the local clock at the camera when the picture was taken (12h → "7:42 pm", 24h → "19:42"), the sun\'s height ("sun 1.2° above the horizon"), or both.',
+  },
+  solo('showScores'),
+  solo('showRank'),
+  solo('showTally'),
+  // ---- bins ----
+  solo('qualityFloor'),
+  solo('detectionFloor'),
+  solo('sunsetFloor'),
+  solo('mix'),
+  solo('repeatAllowance'),
+  {
+    key: 'valleys', kind: 'number', min: 0, max: 3, step: 1, default: 0,
+    label: 'valleys per peak', section: 'bins',
+    description: 'After each peak (best remaining), this many valleys (lowest eligible, unshown first) before the next peak. 0 is best-first throughout, as solo does.',
+  },
+  {
+    key: 'screens', kind: 'enum', options: ['together', 'alternate'], default: 'together',
+    label: 'screens', section: 'bins',
+    description: 'Together: both screens peak on the same beat. Alternate: one screen is on a peak while the other is on a valley. Needs valleys ≥ 1.',
+  },
+  solo('zoneGrace'),
+  solo('promoteNew'),
+] as const;
+
+/** Typed view of a merged `solo2` values object (mergeSettings output). */
+export function dialsFrom2(values: SettingsValues): Solo2Dials {
+  return {
+    ...dialsFrom(values),
+    transition: values.transition as Transition,
+    leadS: values.leadS as number,
+    leadScale: values.leadScale as number,
+    prelude: values.prelude as boolean,
+    preludeFrames: values.preludeFrames as number,
+    preludeStepS: values.preludeStepS as number,
+    timeStyle: values.timeStyle as TimeStyle,
+    valleys: values.valleys as number,
+    screens: values.screens as Screens,
+  };
+}

--- a/app/lib/solo2/types.ts
+++ b/app/lib/solo2/types.ts
@@ -1,0 +1,31 @@
+import type { SoloDials } from '@/app/lib/solo/types';
+
+/** How one frame gives way to the next (spec §4.2). */
+export type Transition = 'cut' | 'crossfade' | 'dip';
+
+/** The trailing item of the caption's second line (spec §4.5). */
+export type TimeStyle = 'off' | '12h' | '12h-there' | '24h' | 'sun' | '12h-sun';
+
+/** Whether the two screens peak on the same beat or opposite ones (spec §3). */
+export type Screens = 'together' | 'alternate';
+
+/** What a draw is inside a bar: beat 0 is the peak, the rest are valleys. */
+export type Role = 'peak' | 'valley';
+
+/**
+ * Every dial in the `solo2` namespace. A superset of solo's, so every helper
+ * that takes SoloDials accepts these. Built by settingsSchema.dialsFrom2.
+ */
+export interface Solo2Dials extends SoloDials {
+  // glass
+  transition: Transition;
+  leadS: number;
+  leadScale: number;
+  prelude: boolean;
+  preludeFrames: number;
+  preludeStepS: number;
+  timeStyle: TimeStyle;
+  // bins
+  valleys: number;
+  screens: Screens;
+}

--- a/app/lib/solo2/types.ts
+++ b/app/lib/solo2/types.ts
@@ -18,7 +18,10 @@ export type Role = 'peak' | 'valley';
  */
 export interface Solo2Dials extends SoloDials {
   // glass
+  /** Between cameras (spec §4.2). The same camera always dissolves. */
   transition: Transition;
+  /** Dissolve length between two frames of the same camera: prelude steps, and a same-camera change. 0 is a cut. */
+  sameCameraFadeS: number;
   leadS: number;
   leadScale: number;
   prelude: boolean;

--- a/app/studio/solo/DwellBudget.test.tsx
+++ b/app/studio/solo/DwellBudget.test.tsx
@@ -1,0 +1,10 @@
+import { it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { DwellBudget } from './DwellBudget';
+
+it('prints the split and turns red when the dwell cannot fit the dials', () => {
+  render(<DwellBudget dials={{ dwellS: 20, prelude: true, preludeFrames: 3, preludeStepS: 1.5, leadS: 4 }} />);
+  expect(screen.getByText('prelude 4.5 s + lead 4 s + hold 11.5 s')).toHaveStyle({ color: '#8b95a7' });
+  render(<DwellBudget dials={{ dwellS: 8, prelude: true, preludeFrames: 3, preludeStepS: 1.5, leadS: 4 }} />);
+  expect(screen.getByText(/clamped/)).toHaveStyle({ color: '#f47174' });
+});

--- a/app/studio/solo/DwellBudget.tsx
+++ b/app/studio/solo/DwellBudget.tsx
@@ -1,0 +1,22 @@
+'use client';
+
+import { describePlan, fitPlan, type PlanDials } from '@/app/lib/solo2/plan';
+
+const mono = 'ui-monospace, SFMono-Regular, Menlo, monospace';
+
+/**
+ * The dwell budget under solo2's glass dials (spec §4.1): how the dwell
+ * splits into prelude, lead and hold with the dials as set, assuming the
+ * camera has as many earlier frames as the prelude asks for. Red when the
+ * glass would have to drop something to keep the hold.
+ */
+export function DwellBudget({ dials }: { dials: PlanDials }) {
+  const plan = fitPlan(dials, dials.preludeFrames);
+  return (
+    <div title="How each dwell splits with these dials. The chosen frame always holds at least 3 s; prelude frames go first, then the lead." style={{
+      fontFamily: mono, fontSize: 11, padding: '4px 4px 0', color: plan.clamped ? '#f47174' : '#8b95a7',
+    }}>
+      {describePlan(plan)}
+    </div>
+  );
+}

--- a/app/studio/solo/EntryRow.test.tsx
+++ b/app/studio/solo/EntryRow.test.tsx
@@ -5,7 +5,7 @@ import { EntryRow } from './EntryRow';
 const e = {
   snapshotId: 7, webcamId: 3, bin: 'sunset' as const, quality: 0.91, detection: 0.88, isNew: true,
   tally: 2, enteredAt: 0, imageUrl: 'u', title: 'Pier', city: 'Lisbon', region: '', country: 'Portugal',
-  eligible: true, rank: 1,
+  eligible: true, rank: 1, capturedAt: 0, timezone: null, sunAltitudeDeg: null,
 };
 
 it('shows tally first, scores, place, and the tags', () => {

--- a/app/studio/solo/EntryRow.test.tsx
+++ b/app/studio/solo/EntryRow.test.tsx
@@ -1,6 +1,6 @@
 import { it, expect, vi } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
-import { EntryRow } from './EntryRow';
+import { EntryRow, MIN_FRAME_PX, PX_PER_S } from './EntryRow';
 
 const e = {
   snapshotId: 7, webcamId: 3, bin: 'sunset' as const, quality: 0.91, detection: 0.88, isNew: true,
@@ -30,4 +30,54 @@ it('non-sunset rows show only detection, and a click reports the entry', () => {
   expect(screen.queryByText(/q /)).toBeNull();
   fireEvent.click(screen.getByRole('button'));
   expect(onClick).toHaveBeenCalledWith(expect.objectContaining({ snapshotId: 7 }));
+});
+
+const AT = Date.UTC(2026, 8, 5, 2, 42); // 7:42 pm in Mazatlán
+const tz = { timezone: 'America/Mazatlan', region: 'BCS', country: 'Mexico' };
+
+it('a sequence stacks the earlier frames above the chosen one, each with its local time, inside one bin-coloured box', () => {
+  const onClick = vi.fn();
+  const earlier = [
+    { ...e, ...tz, snapshotId: 5, imageUrl: 'u5', capturedAt: AT - 44 * 60_000 },
+    { ...e, ...tz, snapshotId: 6, imageUrl: 'u6', capturedAt: AT - 28 * 60_000 },
+  ];
+  render(<EntryRow entry={{ ...e, ...tz, capturedAt: AT }} feed="sunset" place="queue" onClick={onClick}
+    sequence={{ earlier, stepS: 1.5, holdS: 17 }} rowS={20} />);
+  const group = screen.getByRole('group');
+  expect(group).toHaveStyle({ border: '2px solid #7ee2ac' });
+  // earlier frames first, the chosen frame last; each is its own button
+  const buttons = screen.getAllByRole('button');
+  expect(buttons).toHaveLength(3);
+  expect(buttons[0]).toHaveTextContent('6:58 pm');
+  expect(buttons[1]).toHaveTextContent('7:14 pm');
+  expect(buttons[2]).toHaveTextContent('Pier');
+  expect(buttons[2]).toHaveTextContent('7:42 pm');
+  // every frame carries a light border inside the group
+  for (const b of buttons) expect(b).toHaveStyle({ border: '1px solid #2a3242' });
+  fireEvent.click(buttons[0]);
+  expect(onClick).toHaveBeenCalledWith(expect.objectContaining({ snapshotId: 5 }));
+});
+
+it('heights are time: a prelude step, then the hold, at the shared scale, never below a legible minimum', () => {
+  const earlier = [{ ...e, snapshotId: 5, imageUrl: 'u5', capturedAt: 1 }];
+  render(<EntryRow entry={{ ...e, capturedAt: 2 }} feed="sunset" place="queue" onClick={vi.fn()}
+    sequence={{ earlier, stepS: 4, holdS: 16 }} rowS={20} />);
+  const [step, main] = screen.getAllByRole('button');
+  expect(step).toHaveStyle({ height: `${4 * PX_PER_S}px` });
+  expect(main).toHaveStyle({ minHeight: `${16 * PX_PER_S}px` });
+  render(<EntryRow entry={{ ...e, capturedAt: 2 }} feed="sunset" place="queue" onClick={vi.fn()}
+    sequence={{ earlier, stepS: 0.5, holdS: 19.5 }} rowS={20} />);
+  expect(screen.getAllByRole('button')[2]).toHaveStyle({ height: `${MIN_FRAME_PX}px` });
+});
+
+it('without a sequence the row keeps its shape, and rowS alone sets its height as time', () => {
+  render(<EntryRow entry={e} feed="sunset" place="sunset" onClick={vi.fn()} rowS={20} />);
+  const b = screen.getByRole('button');
+  expect(b).toHaveStyle({ minHeight: `${20 * PX_PER_S}px`, border: '1.5px solid #7ee2ac' });
+  expect(screen.queryByRole('group')).toBeNull();
+});
+
+it('flags a frame that an earlier queued dwell already showed inside its prelude', () => {
+  render(<EntryRow entry={e} feed="sunset" place="queue" preluded onClick={vi.fn()} />);
+  expect(screen.getByText('PRELUDE')).toBeInTheDocument();
 });

--- a/app/studio/solo/EntryRow.tsx
+++ b/app/studio/solo/EntryRow.tsx
@@ -2,10 +2,26 @@
 
 import type { EntryView } from '@/app/api/kiosk/solo/view';
 import type { Feed } from '@/app/lib/solo/types';
+import { formatTime } from '@/app/lib/solo2/caption';
 import type { Role } from '@/app/lib/solo2/types';
 
 const COLOR = { sunset: '#7ee2ac', non_sunset: '#c3cad6' } as const;
 const mono = 'ui-monospace, SFMono-Regular, Menlo, monospace';
+const LIGHT = '#2a3242';
+
+/** Height is time on the solo2 studio: this many pixels per second of glass. */
+export const PX_PER_S = 4;
+/** A prelude step shorter than this many pixels would hide its thumbnail. */
+export const MIN_FRAME_PX = 14;
+
+/** What plays before the chosen frame in one dwell, as the glass would show it. */
+export interface Sequence {
+  /** Earlier frames of the same camera, oldest first, already cut to what the dwell fits. */
+  earlier: EntryView[];
+  stepS: number;
+  /** The rest of the dwell: hold plus lead. */
+  holdS: number;
+}
 
 function Tag({ children, bg, fg, title }: { children: string; bg: string; fg: string; title: string }) {
   return (
@@ -16,11 +32,20 @@ function Tag({ children, bg, fg, title }: { children: string; bg: string; fg: st
   );
 }
 
+const clock = (e: EntryView) => formatTime('12h', e.capturedAt, e.timezone, null);
+
 /**
  * One frame, wherever it sits: a bin or the queue. The outline is always the
  * colour of the bin the frame belongs to, so the queue reads at a glance.
+ * With a `sequence` the row becomes a group: the earlier frames stacked
+ * above the chosen one in capture order, each its own light box with its
+ * local time, all inside one bin-coloured border, so a dwell that plays
+ * several pictures reads as one box. With `rowS` the row is as tall as the
+ * time it gets on glass.
  */
-export function EntryRow({ entry: e, feed, place, onGlass = false, repeat = false, cameraIndex, role, onClick }: {
+export function EntryRow({
+  entry: e, feed, place, onGlass = false, repeat = false, cameraIndex, role, sequence, rowS, preluded = false, onClick,
+}: {
   entry: EntryView;
   feed: Feed;
   place: 'sunset' | 'non_sunset' | 'queue';
@@ -29,25 +54,38 @@ export function EntryRow({ entry: e, feed, place, onGlass = false, repeat = fals
   cameraIndex?: { n: number; m: number };
   /** solo2: what this queued draw is inside its bar. */
   role?: Role;
+  /** solo2: the prelude this dwell plays first. */
+  sequence?: Sequence;
+  /** solo2: seconds this row stands for; its height follows. */
+  rowS?: number;
+  /** solo2: an earlier queued dwell already showed this frame inside its prelude. */
+  preluded?: boolean;
   onClick: (entry: EntryView) => void;
 }) {
   const scores = e.bin === 'sunset'
     ? `q ${(e.quality ?? 0).toFixed(2)} d ${e.detection.toFixed(2)}`
     : `d ${e.detection.toFixed(2)}`;
-  const placeText = [e.city, e.country].filter(Boolean).join(', ');
+  const placeText = [[e.city, e.country].filter(Boolean).join(', '), clock(e)].filter(Boolean).join(' · ');
   const title =
     `${e.title} · ${placeText}. Frame ${e.snapshotId}, ${feed} feed` +
     (place === 'queue' ? ', in the queue. ' : '. ') +
     (e.bin === 'sunset' ? 'Sunset bin, ordered by quality. ' : 'Non-sunset bin, ordered by detection. ') +
     (!e.eligible ? 'Below the floor dial; not eligible. ' : '') +
     (repeat ? 'Already appears earlier in the queue; this is a repeat showing. ' : '') +
+    (preluded ? 'Already shown inside an earlier queued frame\'s prelude; this is its own turn. ' : '') +
+    (sequence ? `Plays ${sequence.earlier.length} earlier frame${sequence.earlier.length === 1 ? '' : 's'} of this camera first, ${sequence.stepS} s each. ` : '') +
     `Shown ${e.tally} time${e.tally === 1 ? '' : 's'} today.`;
-  return (
+  const grouped = !!sequence && sequence.earlier.length > 0;
+  const ring = onGlass ? '0 0 0 2px #f5a344' : undefined;
+
+  const main = (
     <button type="button" onClick={() => onClick(e)} title={title} style={{
       display: 'grid', gridTemplateColumns: '46px 1fr', gap: 5, alignItems: 'center', width: '100%',
-      textAlign: 'left', border: `1.5px solid ${COLOR[e.bin]}`, borderRadius: 5, padding: 3, marginBottom: 4,
+      textAlign: 'left', borderRadius: 5, padding: 3, marginBottom: grouped ? 0 : 4,
+      border: grouped ? `1px solid ${LIGHT}` : `1.5px solid ${COLOR[e.bin]}`,
+      minHeight: grouped ? Math.max(0, sequence.holdS * PX_PER_S) : rowS !== undefined ? rowS * PX_PER_S : undefined,
       background: '#0e1119', fontFamily: mono, fontSize: 9.5, color: '#9aa3b2', cursor: 'pointer',
-      opacity: !e.eligible || repeat ? 0.45 : 1, boxShadow: onGlass ? '0 0 0 2px #f5a344' : undefined,
+      opacity: !e.eligible || repeat ? 0.45 : 1, boxShadow: grouped ? undefined : ring,
     }}>
       {/* eslint-disable-next-line @next/next/no-img-element */}
       <img src={e.imageUrl} alt="" style={{ width: 46, aspectRatio: '16/9', objectFit: 'cover', borderRadius: 3, display: 'block' }} />
@@ -62,6 +100,9 @@ export function EntryRow({ entry: e, feed, place, onGlass = false, repeat = fals
           {cameraIndex && (
             <Tag bg="#7ea6e2" fg="#061224" title="Same camera as another queue entry">{`CAM ${cameraIndex.n}/${cameraIndex.m}`}</Tag>
           )}
+          {preluded && (
+            <Tag bg="#5b4b8a" fg="#efe9ff" title="An earlier queued frame already shows this picture inside its prelude; this is its own turn">PRELUDE</Tag>
+          )}
           {role === 'peak' && <Tag bg="#f5a344" fg="#1a1000" title="Beat 0 of the bar: the best remaining frame">PEAK</Tag>}
           {role === 'valley' && <Tag bg="#3a4356" fg="#e5e7eb" title="A valley: the lowest eligible frame, unshown first">VALLEY</Tag>}
         </div>
@@ -69,5 +110,33 @@ export function EntryRow({ entry: e, feed, place, onGlass = false, repeat = fals
         <div style={{ color: '#6b7280', whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>{placeText}</div>
       </div>
     </button>
+  );
+
+  if (!grouped) return main;
+
+  const stepPx = Math.max(MIN_FRAME_PX, sequence.stepS * PX_PER_S);
+  return (
+    <div role="group" aria-label={`${e.title}: ${sequence.earlier.length + 1} frames in one dwell`} style={{
+      border: `2px solid ${COLOR[e.bin]}`, borderRadius: 6, padding: 3, marginBottom: 4,
+      background: '#0b0e14', boxShadow: ring, display: 'flex', flexDirection: 'column', gap: 3,
+    }}>
+      {sequence.earlier.map((f) => {
+        const t = clock(f) ?? `${Math.max(1, Math.round((e.capturedAt - f.capturedAt) / 60_000))} min earlier`;
+        return (
+          <button key={f.snapshotId} type="button" onClick={() => onClick(f)}
+            title={`${f.title} · ${t}. Frame ${f.snapshotId}, shown for ${sequence.stepS} s as part of this dwell's prelude, without a caption.`}
+            style={{
+              display: 'flex', gap: 5, alignItems: 'center', width: '100%', boxSizing: 'border-box', height: stepPx,
+              textAlign: 'left', border: `1px solid ${LIGHT}`, borderRadius: 4, padding: '0 3px',
+              background: '#0e1119', fontFamily: mono, fontSize: 9, color: '#9aa3b2', cursor: 'pointer',
+            }}>
+            {/* eslint-disable-next-line @next/next/no-img-element */}
+            <img src={f.imageUrl} alt="" style={{ height: '100%', aspectRatio: '16/9', objectFit: 'cover', borderRadius: 2, display: 'block' }} />
+            <span style={{ whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>{t}</span>
+          </button>
+        );
+      })}
+      {main}
+    </div>
   );
 }

--- a/app/studio/solo/EntryRow.tsx
+++ b/app/studio/solo/EntryRow.tsx
@@ -2,6 +2,7 @@
 
 import type { EntryView } from '@/app/api/kiosk/solo/view';
 import type { Feed } from '@/app/lib/solo/types';
+import type { Role } from '@/app/lib/solo2/types';
 
 const COLOR = { sunset: '#7ee2ac', non_sunset: '#c3cad6' } as const;
 const mono = 'ui-monospace, SFMono-Regular, Menlo, monospace';
@@ -19,13 +20,15 @@ function Tag({ children, bg, fg, title }: { children: string; bg: string; fg: st
  * One frame, wherever it sits: a bin or the queue. The outline is always the
  * colour of the bin the frame belongs to, so the queue reads at a glance.
  */
-export function EntryRow({ entry: e, feed, place, onGlass = false, repeat = false, cameraIndex, onClick }: {
+export function EntryRow({ entry: e, feed, place, onGlass = false, repeat = false, cameraIndex, role, onClick }: {
   entry: EntryView;
   feed: Feed;
   place: 'sunset' | 'non_sunset' | 'queue';
   onGlass?: boolean;
   repeat?: boolean;
   cameraIndex?: { n: number; m: number };
+  /** solo2: what this queued draw is inside its bar. */
+  role?: Role;
   onClick: (entry: EntryView) => void;
 }) {
   const scores = e.bin === 'sunset'
@@ -59,6 +62,8 @@ export function EntryRow({ entry: e, feed, place, onGlass = false, repeat = fals
           {cameraIndex && (
             <Tag bg="#7ea6e2" fg="#061224" title="Same camera as another queue entry">{`CAM ${cameraIndex.n}/${cameraIndex.m}`}</Tag>
           )}
+          {role === 'peak' && <Tag bg="#f5a344" fg="#1a1000" title="Beat 0 of the bar: the best remaining frame">PEAK</Tag>}
+          {role === 'valley' && <Tag bg="#3a4356" fg="#e5e7eb" title="A valley: the lowest eligible frame, unshown first">VALLEY</Tag>}
         </div>
         <div style={{ color: '#c3cad6', whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>{e.title}</div>
         <div style={{ color: '#6b7280', whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>{placeText}</div>

--- a/app/studio/solo/FeedColumn.test.tsx
+++ b/app/studio/solo/FeedColumn.test.tsx
@@ -9,6 +9,7 @@ const D = dialsFrom(schemaDefaults(SOLO_SETTINGS_SCHEMA));
 const entry = (id: number, bin: 'sunset' | 'non_sunset', score: number, webcamId = 100 + id): ViewEntry => ({
   snapshotId: id, webcamId, bin, quality: bin === 'sunset' ? score : null, detection: bin === 'sunset' ? 0.9 : score,
   isNew: false, tally: 0, enteredAt: id, imageUrl: `u${id}`, title: `cam${id}`, city: '', region: '', country: '',
+  capturedAt: 0, timezone: null, sunAltitudeDeg: null,
 });
 const view = (dials = D) => buildStateView({
   feed: 'sunset', dials,

--- a/app/studio/solo/FeedColumn.test.tsx
+++ b/app/studio/solo/FeedColumn.test.tsx
@@ -48,3 +48,19 @@ it('with nothing on glass the panel says so and the queue starts at the projecti
   expect(screen.getByText('nothing on glass yet')).toBeInTheDocument();
   expect(screen.getAllByText('cam9').length).toBeGreaterThan(0);
 });
+
+it('solo2 with valleys tags queued draws PEAK and VALLEY and captions the local time', async () => {
+  const { SOLO_VERSIONS } = await import('@/app/lib/solo/versions');
+  const { SOLO2_SETTINGS_SCHEMA, dialsFrom2 } = await import('@/app/lib/solo2/settingsSchema');
+  const d2 = { ...dialsFrom2(schemaDefaults(SOLO2_SETTINGS_SCHEMA)), valleys: 1 };
+  const at = Date.UTC(2026, 8, 5, 2, 42);
+  const es = [entry(1, 'sunset', 0.9), entry(2, 'sunset', 0.8), entry(3, 'sunset', 0.7)]
+    .map((e) => ({ ...e, capturedAt: at, timezone: 'America/Mazatlan', region: 'BCS', country: 'Mexico' }));
+  const v = buildStateView({ feed: 'sunrise', dials: d2, entries: es,
+    screen: { feed: 'sunrise', currentSnapshotId: 1, shownSince: 0, slot: 0, sunsetStreak: 1 },
+    nowMs: 0, admitted: { sunset: 0, nonSunset: 0 }, zone: { minDeg: -24, maxDeg: -2 }, version: SOLO_VERSIONS.solo2 });
+  render(<FeedColumn feed="sunrise" server={v} projected={v} liveDials={d2} studioDials={d2} nowMs={0} version={SOLO_VERSIONS.solo2} onSelect={vi.fn()} />);
+  expect(screen.getAllByText('VALLEY').length).toBeGreaterThan(0);
+  expect(screen.getAllByText('PEAK').length).toBeGreaterThan(0);
+  expect(screen.getByText('BCS, Mexico · 7:42 pm')).toBeInTheDocument();
+});

--- a/app/studio/solo/FeedColumn.test.tsx
+++ b/app/studio/solo/FeedColumn.test.tsx
@@ -64,3 +64,25 @@ it('solo2 with valleys tags queued draws PEAK and VALLEY and captions the local 
   expect(screen.getAllByText('PEAK').length).toBeGreaterThan(0);
   expect(screen.getByText('BCS, Mexico · 7:42 pm')).toBeInTheDocument();
 });
+
+it('solo2 with the prelude on groups a camera\'s earlier frames under the queued draw and flags their own later turns', async () => {
+  const { SOLO_VERSIONS } = await import('@/app/lib/solo/versions');
+  const { SOLO2_SETTINGS_SCHEMA, dialsFrom2 } = await import('@/app/lib/solo2/settingsSchema');
+  const d2 = { ...dialsFrom2(schemaDefaults(SOLO2_SETTINGS_SCHEMA)), prelude: true, preludeFrames: 3, repeatAllowance: 0 };
+  const at = Date.UTC(2026, 8, 5, 2, 42);
+  const cam = (id: number, score: number, minutesBefore: number) => ({
+    ...entry(id, 'sunset', score, 7), capturedAt: at - minutesBefore * 60_000, timezone: 'America/Mazatlan',
+  });
+  // Camera 7 has three frames; the best (3) is on glass with 1 and 2 as its prelude. Camera 9 is alone.
+  const es = [cam(1, 0.6, 44), cam(2, 0.7, 28), cam(3, 0.9, 0), { ...entry(4, 'sunset', 0.8, 9), capturedAt: at, timezone: 'America/Mazatlan' }];
+  const v = buildStateView({ feed: 'sunrise', dials: d2, entries: es,
+    screen: { feed: 'sunrise', currentSnapshotId: 3, shownSince: 0, slot: 0, sunsetStreak: 1 },
+    nowMs: 0, admitted: { sunset: 0, nonSunset: 0 }, zone: { minDeg: -24, maxDeg: -2 }, version: SOLO_VERSIONS.solo2 });
+  render(<FeedColumn feed="sunrise" server={v} projected={v} liveDials={d2} studioDials={d2} nowMs={0} version={SOLO_VERSIONS.solo2} onSelect={vi.fn()} />);
+  // The on-glass row is a group whose earlier frames read 6:58 pm then 7:14 pm.
+  const groups = screen.getAllByRole('group');
+  expect(groups.length).toBeGreaterThan(0);
+  expect(groups[0]).toHaveTextContent(/6:58 pm.*7:14 pm.*cam3/s);
+  // Frames 1 and 2 still get their own turn somewhere later, flagged.
+  expect(screen.getAllByText('PRELUDE').length).toBeGreaterThan(0);
+});

--- a/app/studio/solo/FeedColumn.tsx
+++ b/app/studio/solo/FeedColumn.tsx
@@ -6,8 +6,9 @@ import { nextBoundaryMs } from '@/app/lib/solo/schedule';
 import type { Feed, SoloDials } from '@/app/lib/solo/types';
 import type { SoloVersionSpec } from '@/app/lib/solo/versions';
 import { captionLines } from '@/app/lib/solo2/caption';
+import { preludePlan } from '@/app/lib/solo2/prelude';
 import type { Solo2Dials } from '@/app/lib/solo2/types';
-import { EntryRow } from './EntryRow';
+import { EntryRow, type Sequence } from './EntryRow';
 
 const mono = 'ui-monospace, SFMono-Regular, Menlo, monospace';
 const LABEL: Record<Feed, string> = { sunrise: 'Sunrise · left screen', sunset: 'Sunset · right screen' };
@@ -54,6 +55,21 @@ export function FeedColumn({ feed, server, projected, liveDials, nowMs, version,
   const showRoles = version?.name === 'solo2' && (liveDials as Partial<Solo2Dials>).valleys !== undefined
     && ((projected.dials as Partial<Solo2Dials>).valleys ?? 0) > 0;
   const roleOf = (i: number) => (showRoles && i > 0 ? projected.nextRoles[i - 1] : undefined);
+  // solo2: a row is as tall as its time on glass, and a dwell with a prelude
+  // is one group. The pool is every frame the studio holds (bins ∪ queue),
+  // which is every entry; the queue's predecessor is the "previous" frame so
+  // the group continues from it, as the glass does.
+  const d2 = version?.name === 'solo2' ? (projected.dials as Solo2Dials) : null;
+  const rowS = d2 ? d2.dwellS : undefined;
+  const all: EntryView[] = [...projected.bins.sunset, ...projected.bins.nonSunset, ...queue];
+  const seqFor = (e: EntryView, prev: EntryView | null): Sequence | undefined => {
+    if (!d2 || !d2.prelude) return undefined;
+    const { frames, plan } = preludePlan(e, all, d2, prev);
+    if (frames.length === 0) return undefined;
+    return { earlier: frames, stepS: plan.preludeStepS, holdS: plan.dwellS - frames.length * plan.preludeStepS };
+  };
+  const queueSeqs = queue.map((e, i) => seqFor(e, i > 0 ? queue[i - 1] : null));
+  const preludedInQueue = new Set(queueSeqs.flatMap((s) => s?.earlier.map((f) => f.snapshotId) ?? []));
   const cap = current && captionLines(current.entry, {
     showPlace: liveDials.showPlace, timeStyle: (liveDials as Partial<Solo2Dials>).timeStyle ?? 'off',
   });
@@ -116,13 +132,15 @@ export function FeedColumn({ feed, server, projected, liveDials, nowMs, version,
         <Bin color="#7ee2ac" title={`Sunset bin · ${projected.bins.sunset.length} waiting · ${qSun} queued`}
           hint="Frames the detection head calls a sunset, ordered by quality. Shown frames sink below unshown ones. Dimmed rows are below the quality floor.">
           {projected.bins.sunset.map((e) => (
-            <EntryRow key={e.snapshotId} entry={e} feed={feed} place="sunset" onClick={(x) => onSelect(x, feed)} />
+            <EntryRow key={e.snapshotId} entry={e} feed={feed} place="sunset" onClick={(x) => onSelect(x, feed)}
+              sequence={seqFor(e, null)} rowS={rowS} preluded={preludedInQueue.has(e.snapshotId)} />
           ))}
         </Bin>
         <Bin color="#c3cad6" title={`Non-sunset bin · ${projected.bins.nonSunset.length} waiting · ${qNon} queued`}
           hint="Frames the detection head does not call a sunset, ordered by detection probability so 'almost a sunset' is on top. Dimmed rows are below the detection floor.">
           {projected.bins.nonSunset.map((e) => (
-            <EntryRow key={e.snapshotId} entry={e} feed={feed} place="non_sunset" onClick={(x) => onSelect(x, feed)} />
+            <EntryRow key={e.snapshotId} entry={e} feed={feed} place="non_sunset" onClick={(x) => onSelect(x, feed)}
+              sequence={seqFor(e, null)} rowS={rowS} preluded={preludedInQueue.has(e.snapshotId)} />
           ))}
         </Bin>
         <Bin color="#4b5568" title="On glass + next up"
@@ -138,9 +156,12 @@ export function FeedColumn({ feed, server, projected, liveDials, nowMs, version,
             const m = camCount.get(e.webcamId) ?? 1;
             const n = (camSeen.get(e.webcamId) ?? 0) + 1;
             camSeen.set(e.webcamId, n);
+            // Flagged when a dwell above this one already played the frame inside its prelude.
+            const preluded = queueSeqs.slice(0, i).some((s) => s?.earlier.some((f) => f.snapshotId === e.snapshotId));
             return (
               <EntryRow key={`${e.snapshotId}-${i}`} entry={e} feed={feed} place="queue" onGlass={i === 0 && !!current}
-                repeat={repeat} cameraIndex={m > 1 ? { n, m } : undefined} role={roleOf(i)} onClick={(x) => onSelect(x, feed)} />
+                repeat={repeat} cameraIndex={m > 1 ? { n, m } : undefined} role={roleOf(i)} onClick={(x) => onSelect(x, feed)}
+                sequence={queueSeqs[i]} rowS={rowS} preluded={preluded} />
             );
           })}
         </Bin>

--- a/app/studio/solo/FeedColumn.tsx
+++ b/app/studio/solo/FeedColumn.tsx
@@ -4,6 +4,9 @@ import type { ReactNode } from 'react';
 import type { EntryView, StateView } from '@/app/api/kiosk/solo/view';
 import { nextBoundaryMs } from '@/app/lib/solo/schedule';
 import type { Feed, SoloDials } from '@/app/lib/solo/types';
+import type { SoloVersionSpec } from '@/app/lib/solo/versions';
+import { captionLines } from '@/app/lib/solo2/caption';
+import type { Solo2Dials } from '@/app/lib/solo2/types';
 import { EntryRow } from './EntryRow';
 
 const mono = 'ui-monospace, SFMono-Regular, Menlo, monospace';
@@ -25,13 +28,14 @@ function Bin({ color, title, hint, children }: { color: string; title: string; h
  * and the queue as the STUDIO dials would order them. Every frame appears in
  * exactly one of the three columns; the on-glass frame heads the queue.
  */
-export function FeedColumn({ feed, server, projected, liveDials, nowMs, onSelect }: {
+export function FeedColumn({ feed, server, projected, liveDials, nowMs, version, onSelect }: {
   feed: Feed;
   server: StateView;
   projected: StateView;
   liveDials: SoloDials;
   studioDials: SoloDials;
   nowMs: number;
+  version?: SoloVersionSpec;
   onSelect: (entry: EntryView, feed: Feed) => void;
 }) {
   const boundary = nextBoundaryMs(nowMs, feed, liveDials.dwellS, liveDials.offsetS);
@@ -46,15 +50,20 @@ export function FeedColumn({ feed, server, projected, liveDials, nowMs, onSelect
     !!server.next[0] && !!projected.next[0] && server.next[0].snapshotId !== projected.next[0].snapshotId;
   const qSun = queue.filter((e) => e.bin === 'sunset').length;
   const qNon = queue.length - qSun;
+  // Roles are parallel to projected.next; the on-glass frame at index 0 has none.
+  const showRoles = version?.name === 'solo2' && (liveDials as Partial<Solo2Dials>).valleys !== undefined
+    && ((projected.dials as Partial<Solo2Dials>).valleys ?? 0) > 0;
+  const roleOf = (i: number) => (showRoles && i > 0 ? projected.nextRoles[i - 1] : undefined);
+  const cap = current && captionLines(current.entry, {
+    showPlace: liveDials.showPlace, timeStyle: (liveDials as Partial<Solo2Dials>).timeStyle ?? 'off',
+  });
 
   const caption = current && (
     <>
-      {liveDials.showPlace && (
+      {cap && (
         <div style={{ position: 'absolute', left: 12, bottom: 10, color: '#fff', textShadow: '0 1px 3px #000', fontSize: 14 }}>
-          {current.entry.title}
-          <small style={{ display: 'block', fontSize: 11, opacity: 0.8 }}>
-            {[current.entry.region, current.entry.country].filter(Boolean).join(', ')}
-          </small>
+          {cap.title}
+          <small style={{ display: 'block', fontSize: 11, opacity: 0.8 }}>{cap.sub}</small>
         </div>
       )}
       <div style={{
@@ -131,7 +140,7 @@ export function FeedColumn({ feed, server, projected, liveDials, nowMs, onSelect
             camSeen.set(e.webcamId, n);
             return (
               <EntryRow key={`${e.snapshotId}-${i}`} entry={e} feed={feed} place="queue" onGlass={i === 0 && !!current}
-                repeat={repeat} cameraIndex={m > 1 ? { n, m } : undefined} onClick={(x) => onSelect(x, feed)} />
+                repeat={repeat} cameraIndex={m > 1 ? { n, m } : undefined} role={roleOf(i)} onClick={(x) => onSelect(x, feed)} />
             );
           })}
         </Bin>

--- a/app/studio/solo/RulesBox.test.tsx
+++ b/app/studio/solo/RulesBox.test.tsx
@@ -13,3 +13,13 @@ it('states the five rules with the dial values in force', () => {
   expect(screen.getByText(/Never the same frame twice/)).toBeInTheDocument();
   expect(screen.getByText(/Floors/).textContent).toContain('0.55');
 });
+
+it('solo2 with valleys states the rhythm inside rule 3; without valleys it reads like solo', async () => {
+  const { SOLO_VERSIONS } = await import('@/app/lib/solo/versions');
+  const { SOLO2_SETTINGS_SCHEMA, dialsFrom2 } = await import('@/app/lib/solo2/settingsSchema');
+  const d2 = dialsFrom2(schemaDefaults(SOLO2_SETTINGS_SCHEMA));
+  const { rerender } = render(<RulesBox dials={{ ...d2, valleys: 2, screens: 'alternate' }} version={SOLO_VERSIONS.solo2} />);
+  expect(screen.getByText(/after each peak/).textContent).toMatch(/2 valleys .* alternate/);
+  rerender(<RulesBox dials={d2} version={SOLO_VERSIONS.solo2} />);
+  expect(screen.queryByText(/after each peak/)).toBeNull();
+});

--- a/app/studio/solo/RulesBox.tsx
+++ b/app/studio/solo/RulesBox.tsx
@@ -2,6 +2,8 @@
 
 import type { ReactNode } from 'react';
 import type { SoloDials } from '@/app/lib/solo/types';
+import type { SoloVersionSpec } from '@/app/lib/solo/versions';
+import type { Solo2Dials } from '@/app/lib/solo2/types';
 
 const box = {
   fontSize: 11.5, color: '#9aa3b2', border: '1px dashed #2a3242', borderRadius: 6,
@@ -10,12 +12,16 @@ const box = {
 const B = ({ children }: { children: ReactNode }) => <b style={{ color: '#4fd1c5' }}>{children}</b>;
 
 /** Spec §4, restated with the dial values currently in force. */
-export function RulesBox({ dials: d }: { dials: SoloDials }) {
+export function RulesBox({ dials: d, version }: { dials: SoloDials; version?: SoloVersionSpec }) {
+  const d2 = version?.name === 'solo2' ? (d as Solo2Dials) : null;
+  const rhythm = d2 && d2.valleys > 0
+    ? <> after each peak, <B>{d2.valleys}</B> {d2.valleys === 1 ? 'valley' : 'valleys'} (lowest eligible, unshown first); screens <B>{d2.screens}</B></>
+    : null;
   return (
     <div style={box} title="The ordering rules, in the order they apply, with the current dial values substituted.">
       <div><B>1.</B> Lowest tier first across both bins; tier = shown tally, minus <B>{d.repeatAllowance}</B> for sunsets.</div>
       <div><B>2.</B> In a tier: <B>{d.sunsetFloor}</B>+ sunsets → sunsets only, else <B>{d.mix}</B> sunsets per non-sunset.</div>
-      <div><B>3.</B> In a bin: best score first{d.promoteNew ? ', new frames +0.10' : ''}.</div>
+      <div><B>3.</B> In a bin: best score first{d.promoteNew ? ', new frames +0.10' : ''}{rhythm ? <>;{rhythm}</> : null}.</div>
       <div><B>4.</B> Never the same frame twice in a row.</div>
       <div><B>5.</B> Floors: sunsets q ≥ <B>{d.qualityFloor.toFixed(2)}</B>, non-sunsets d ≥ <B>{d.detectionFloor.toFixed(2)}</B>.</div>
     </div>

--- a/app/studio/solo/SoloRail.test.tsx
+++ b/app/studio/solo/SoloRail.test.tsx
@@ -51,8 +51,8 @@ describe('solo2', async () => {
     const a = api2();
     render(<SoloRail api={a} deploySlot={null} version={SOLO_VERSIONS.solo2} />);
     for (const k of SOLO2_SETTINGS_SCHEMA) expect(screen.getByLabelText(k.label)).toBeInTheDocument();
-    fireEvent.change(screen.getByLabelText('transition'), { target: { value: 'dip' } });
-    expect(a.setKnob).toHaveBeenCalledWith('solo2', 'transition', 'dip');
+    fireEvent.change(screen.getByLabelText('camera change'), { target: { value: 'crossfade' } });
+    expect(a.setKnob).toHaveBeenCalledWith('solo2', 'transition', 'crossfade');
     fireEvent.change(screen.getByLabelText('valleys per peak'), { target: { value: '2' } });
     expect(a.setKnob).toHaveBeenCalledWith('solo2', 'valleys', 2);
     expect(screen.getByText('prelude 4.5 s + lead 4 s + hold 11.5 s')).toBeInTheDocument();

--- a/app/studio/solo/SoloRail.test.tsx
+++ b/app/studio/solo/SoloRail.test.tsx
@@ -1,4 +1,4 @@
-import { it, expect, vi } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { SoloRail } from './SoloRail';
 import { SOLO_SETTINGS_SCHEMA } from '@/app/lib/solo/settingsSchema';
@@ -38,4 +38,24 @@ it('reset buttons clear one section each', () => {
   render(<SoloRail api={a} deploySlot={null} />);
   fireEvent.click(screen.getByText('reset glass'));
   expect(a.resetSection).toHaveBeenCalledWith('solo', 'glass');
+});
+
+describe('solo2', async () => {
+  const { SOLO_VERSIONS } = await import('@/app/lib/solo/versions');
+  const { SOLO2_SETTINGS_SCHEMA } = await import('@/app/lib/solo2/settingsSchema');
+  const api2 = () => api({
+    effective: (ns) => (ns === 'solo2' ? mergeSettings(SOLO2_SETTINGS_SCHEMA, { prelude: true, leadS: 4 }) : { activeVersion: 'solo2', panelPreset: 'ktc-l' }),
+    diffByNamespace: { solo2: ['valleys'] },
+  });
+  it('renders every solo2 knob, selects write strings, and the budget line reads the dials', () => {
+    const a = api2();
+    render(<SoloRail api={a} deploySlot={null} version={SOLO_VERSIONS.solo2} />);
+    for (const k of SOLO2_SETTINGS_SCHEMA) expect(screen.getByLabelText(k.label)).toBeInTheDocument();
+    fireEvent.change(screen.getByLabelText('transition'), { target: { value: 'dip' } });
+    expect(a.setKnob).toHaveBeenCalledWith('solo2', 'transition', 'dip');
+    fireEvent.change(screen.getByLabelText('valleys per peak'), { target: { value: '2' } });
+    expect(a.setKnob).toHaveBeenCalledWith('solo2', 'valleys', 2);
+    expect(screen.getByText('prelude 4.5 s + lead 4 s + hold 11.5 s')).toBeInTheDocument();
+    expect(screen.getByText(/dials solo2/)).toBeInTheDocument();
+  });
 });

--- a/app/studio/solo/SoloRail.tsx
+++ b/app/studio/solo/SoloRail.tsx
@@ -1,9 +1,10 @@
 'use client';
 
 import type { ReactNode } from 'react';
-import { SOLO_NAMESPACE, SOLO_SETTINGS_SCHEMA, dialsFrom } from '@/app/lib/solo/settingsSchema';
+import { SOLO_VERSIONS, type SoloVersionSpec } from '@/app/lib/solo/versions';
+import { DwellBudget } from './DwellBudget';
 import { SHARED_NAMESPACE } from '@/app/lib/settings/sharedSchema';
-import type { KnobDescriptor } from '@/app/lib/settings/schema';
+import type { KnobDescriptor, KnobValue } from '@/app/lib/settings/schema';
 import type { StudioSettingsApi } from '../useStudioSettings';
 import { RulesBox } from './RulesBox';
 
@@ -20,7 +21,7 @@ function Control({ knob, value, differs, onChange }: {
   knob: KnobDescriptor;
   value: number | boolean | string;
   differs: boolean;
-  onChange: (v: number | boolean) => void;
+  onChange: (v: KnobValue) => void;
 }) {
   const id = `solo-${knob.key}`;
   const labelStyle = { color: '#c3cad6', fontSize: 12, fontWeight: differs ? 700 : 400, cursor: 'help' } as const;
@@ -42,7 +43,17 @@ function Control({ knob, value, differs, onChange }: {
       </div>
     );
   }
-  return null; // no enum knobs in the solo schema
+  return (
+    <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: 6, padding: '3px 4px' }}>
+      <label htmlFor={id} title={knob.description} style={labelStyle}>{knob.label}</label>
+      <select id={id} value={value as string} onChange={(e) => onChange(e.target.value)} style={{
+        background: '#1a2130', color: '#d7dce6', border: '1px solid #2a3242', borderRadius: 4,
+        padding: '2px 6px', fontSize: 12, fontFamily: mono,
+      }}>
+        {knob.options.map((o) => <option key={o} value={o}>{o}</option>)}
+      </select>
+    </div>
+  );
 }
 
 /**
@@ -50,16 +61,22 @@ function Control({ knob, value, differs, onChange }: {
  * schema's sections, a bold label wherever the studio value differs from
  * the glass, and the rules box stating §4 with the values in force.
  */
-export function SoloRail({ api, deploySlot }: { api: StudioSettingsApi; deploySlot: ReactNode }) {
-  const values = api.effective(SOLO_NAMESPACE);
+export function SoloRail({ api, deploySlot, version = SOLO_VERSIONS.solo as SoloVersionSpec }: {
+  api: StudioSettingsApi;
+  deploySlot: ReactNode;
+  version?: SoloVersionSpec;
+}) {
+  const ns = version.namespace;
+  const values = api.effective(ns);
   const shared = api.effective(SHARED_NAMESPACE);
-  const diff = new Set(api.diffByNamespace[SOLO_NAMESPACE] ?? []);
+  const diff = new Set(api.diffByNamespace[ns] ?? []);
+  const dials = version.dialsFrom(values);
   return (
     <div style={{ fontSize: 12 }}>
       {deploySlot}
       <div style={{ fontFamily: mono, color: '#8b95a7', padding: '6px 4px' }}
         title="Which version the glass runs and the panel geometry. Both are shared dials, set on /studio.">
-        glass {String(shared.activeVersion)} · panel {String(shared.panelPreset)}
+        glass {String(shared.activeVersion)} · panel {String(shared.panelPreset)} · dials {version.name}
       </div>
       {GROUPS.map((g) => (
         <section key={g.section}>
@@ -69,19 +86,20 @@ export function SoloRail({ api, deploySlot }: { api: StudioSettingsApi; deploySl
             borderLeft: `3px solid ${g.color}`, display: 'flex', justifyContent: 'space-between', cursor: 'help',
           }}>
             <span>{g.title}</span>
-            <button type="button" onClick={() => api.resetSection(SOLO_NAMESPACE, g.section)}
+            <button type="button" onClick={() => api.resetSection(ns, g.section)}
               title={`Put every ${g.section} dial back to its code default`}
               style={{ background: 'transparent', border: 0, color: g.color, fontSize: 10, cursor: 'pointer' }}>
               reset {g.section}
             </button>
           </h4>
-          {SOLO_SETTINGS_SCHEMA.filter((k) => k.section === g.section).map((k) => (
+          {version.schema.filter((k) => k.section === g.section).map((k) => (
             <Control key={k.key} knob={k} value={values[k.key]} differs={diff.has(k.key)}
-              onChange={(v) => api.setKnob(SOLO_NAMESPACE, k.key, v)} />
+              onChange={(v) => api.setKnob(ns, k.key, v)} />
           ))}
+          {g.section === 'glass' && 'leadS' in dials && <DwellBudget dials={dials} />}
         </section>
       ))}
-      <RulesBox dials={dialsFrom(values)} />
+      <RulesBox dials={dials} version={version} />
     </div>
   );
 }

--- a/app/studio/solo/SoloRail.tsx
+++ b/app/studio/solo/SoloRail.tsx
@@ -3,6 +3,7 @@
 import type { ReactNode } from 'react';
 import { SOLO_VERSIONS, type SoloVersionSpec } from '@/app/lib/solo/versions';
 import { DwellBudget } from './DwellBudget';
+import type { Solo2Dials } from '@/app/lib/solo2/types';
 import { SHARED_NAMESPACE } from '@/app/lib/settings/sharedSchema';
 import type { KnobDescriptor, KnobValue } from '@/app/lib/settings/schema';
 import type { StudioSettingsApi } from '../useStudioSettings';
@@ -96,7 +97,7 @@ export function SoloRail({ api, deploySlot, version = SOLO_VERSIONS.solo as Solo
             <Control key={k.key} knob={k} value={values[k.key]} differs={diff.has(k.key)}
               onChange={(v) => api.setKnob(ns, k.key, v)} />
           ))}
-          {g.section === 'glass' && 'leadS' in dials && <DwellBudget dials={dials} />}
+          {g.section === 'glass' && version.name === 'solo2' && <DwellBudget dials={dials as Solo2Dials} />}
         </section>
       ))}
       <RulesBox dials={dials} version={version} />

--- a/app/studio/solo/SoloStudioClient.tsx
+++ b/app/studio/solo/SoloStudioClient.tsx
@@ -9,7 +9,7 @@ import { FeedColumn } from './FeedColumn';
 import { SoloStatusStrip } from './SoloStatusStrip';
 import { useSoloState } from './useSoloState';
 import { toWebcam } from './toWebcam';
-import { SOLO_NAMESPACE, SOLO_SETTINGS_SCHEMA, dialsFrom } from '@/app/lib/solo/settingsSchema';
+import { SOLO_VERSIONS, type SoloVersionSpec } from '@/app/lib/solo/versions';
 import { mergeSettings } from '@/app/lib/settings/schema';
 import type { EntryView } from '@/app/api/kiosk/solo/view';
 import type { Feed } from '@/app/lib/solo/types';
@@ -26,12 +26,15 @@ const mono = 'ui-monospace, SFMono-Regular, Menlo, monospace';
  * re-project with those dials at once, while the panels and countdowns run
  * on the live profile, because that is what the glass runs.
  */
-export function SoloStudioClient() {
+export function SoloStudioClient({ version = SOLO_VERSIONS.solo as SoloVersionSpec }: { version?: SoloVersionSpec }) {
   const api = useStudioSettings();
-  const studioDials = dialsFrom(api.effective(SOLO_NAMESPACE));
-  const liveDials = dialsFrom(mergeSettings(SOLO_SETTINGS_SCHEMA, api.live?.namespaces?.[SOLO_NAMESPACE]));
-  const sunrise = useSoloState('sunrise', studioDials);
-  const sunset = useSoloState('sunset', studioDials);
+  const studioDials = version.dialsFrom(api.effective(version.namespace));
+  const liveDials = version.dialsFrom(mergeSettings(version.schema, api.live?.namespaces?.[version.namespace]));
+  const sunrise = useSoloState('sunrise', studioDials, version);
+  const sunset = useSoloState('sunset', studioDials, version);
+  const other = version.name === 'solo2'
+    ? { href: '/studio/solo', label: '← solo studio', title: 'The original solo kiosk\'s studio' }
+    : { href: '/studio/solo2', label: 'solo2 studio →', title: 'solo with rhythm, lead, prelude, transitions and local time' };
   const [nowMs, setNowMs] = useState(() => Date.now());
   const [selected, setSelected] = useState<{ entry: EntryView; feed: Feed } | null>(null);
 
@@ -48,19 +51,22 @@ export function SoloStudioClient() {
       <div style={{ gridColumn: '1 / -1', background: '#0e1119', borderBottom: `1px solid ${border}`, display: 'flex', alignItems: 'center' }}>
         <SoloStatusStrip nowMs={nowMs} sunrise={sunrise.server} sunset={sunset.server}
           liveRevision={api.liveRevision} diffCount={api.diffCount} zone={sunset.server?.zone ?? sunrise.server?.zone} />
-        <Link href="/studio" style={{ marginLeft: 'auto', marginRight: 12, fontSize: 11, color: '#8b95a7' }} title="The mosaic studio">
+        <Link href={other.href} style={{ marginLeft: 'auto', marginRight: 14, fontSize: 11, color: '#f5a344' }} title={other.title}>
+          {other.label}
+        </Link>
+        <Link href="/studio" style={{ marginRight: 12, fontSize: 11, color: '#8b95a7' }} title="The mosaic studio">
           ← mosaic studio
         </Link>
       </div>
       <aside style={{ background: railBg, borderRight: `1px solid ${border}`, padding: 10, overflowY: 'auto' }}>
-        <SoloRail api={api} deploySlot={<DeployButton diffCount={api.diffCount} onDeploy={api.deploy} onRevert={api.revert} />} />
+        <SoloRail api={api} version={version} deploySlot={<DeployButton diffCount={api.diffCount} onDeploy={api.deploy} onRevert={api.revert} />} />
       </aside>
       <main style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 12, padding: 12, overflowY: 'auto', minWidth: 0 }}>
         {(['sunrise', 'sunset'] as const).map((feed) => {
           const s = feed === 'sunrise' ? sunrise : sunset;
           return s.server && s.projected ? (
             <FeedColumn key={feed} feed={feed} server={s.server} projected={s.projected} liveDials={liveDials}
-              studioDials={studioDials} nowMs={nowMs} onSelect={(entry, f) => setSelected({ entry, feed: f })} />
+              studioDials={studioDials} nowMs={nowMs} version={version} onSelect={(entry, f) => setSelected({ entry, feed: f })} />
           ) : (
             <div key={feed} style={{ color: '#4b5568', fontFamily: mono, fontSize: 12 }}>{s.error ?? `loading ${feed}…`}</div>
           );

--- a/app/studio/solo/page.tsx
+++ b/app/studio/solo/page.tsx
@@ -3,12 +3,13 @@
 import { Suspense } from 'react';
 import { OwnerGate } from '@/app/components/auth/OwnerGate';
 import { SoloStudioClient } from './SoloStudioClient';
+import { SOLO_VERSIONS } from '@/app/lib/solo/versions';
 
 export default function SoloStudioPage() {
   return (
     <Suspense fallback={null}>
       <OwnerGate label="Solo studio">
-        <SoloStudioClient />
+        <SoloStudioClient version={SOLO_VERSIONS.solo} />
       </OwnerGate>
     </Suspense>
   );

--- a/app/studio/solo/toWebcam.test.ts
+++ b/app/studio/solo/toWebcam.test.ts
@@ -7,6 +7,7 @@ describe('toWebcam', () => {
       snapshotId: 88213, webcamId: 42, bin: 'sunset', quality: 0.91, detection: 0.88, isNew: false,
       tally: 1, enteredAt: 0, imageUrl: 'https://storage.googleapis.com/x.jpg', title: 'Pier',
       city: 'Lisbon', region: 'Lisboa', country: 'Portugal', eligible: true, rank: 1,
+      capturedAt: 0, timezone: null, sunAltitudeDeg: null,
     }, 'sunset');
     expect(w.frameId).toBe(88213);
     expect(w.webcamId).toBe(42);

--- a/app/studio/solo/useSoloState.ts
+++ b/app/studio/solo/useSoloState.ts
@@ -4,6 +4,7 @@ import { useMemo } from 'react';
 import useSWR from 'swr';
 import { buildStateView, type StateView } from '@/app/api/kiosk/solo/view';
 import type { Feed, SoloDials } from '@/app/lib/solo/types';
+import { SOLO_VERSIONS, type SoloVersionSpec } from '@/app/lib/solo/versions';
 
 const fetcher = (url: string) => fetch(url).then((r) => r.json());
 const POLL_MS = 5_000;
@@ -18,8 +19,8 @@ const POLL_MS = 5_000;
  * starts it at 0 and can differ from the server's own `next` by one draw.
  * FeedColumn says so when the first entries disagree.
  */
-export function useSoloState(feed: Feed, studioDials: SoloDials) {
-  const { data, error } = useSWR<StateView>(`/api/kiosk/solo/state?feed=${feed}`, fetcher, {
+export function useSoloState(feed: Feed, studioDials: SoloDials, version: SoloVersionSpec = SOLO_VERSIONS.solo as SoloVersionSpec) {
+  const { data, error } = useSWR<StateView>(`/api/kiosk/solo/state?feed=${feed}&version=${version.name}`, fetcher, {
     refreshInterval: POLL_MS,
   });
   const projected = useMemo(() => {
@@ -30,8 +31,8 @@ export function useSoloState(feed: Feed, studioDials: SoloDials) {
       : null;
     return buildStateView({
       feed, dials: studioDials, entries: data.entries, screen, nowMs: Date.now(),
-      admitted: data.lastPull.admitted, zone: data.zone,
+      admitted: data.lastPull.admitted, zone: data.zone, version,
     });
-  }, [data, feed, studioDials]);
+  }, [data, feed, studioDials, version]);
   return { server: data, projected, error: error ? String(error) : undefined };
 }

--- a/app/studio/solo2/page.tsx
+++ b/app/studio/solo2/page.tsx
@@ -1,0 +1,17 @@
+'use client';
+
+import { Suspense } from 'react';
+import { OwnerGate } from '@/app/components/auth/OwnerGate';
+import { SoloStudioClient } from '../solo/SoloStudioClient';
+import { SOLO_VERSIONS, type SoloVersionSpec } from '@/app/lib/solo/versions';
+
+/** /studio/solo2: the solo studio driving the solo2 namespace and engine (solo2 spec §5.4). */
+export default function Solo2StudioPage() {
+  return (
+    <Suspense fallback={null}>
+      <OwnerGate label="solo2 studio">
+        <SoloStudioClient version={SOLO_VERSIONS.solo2 as SoloVersionSpec} />
+      </OwnerGate>
+    </Suspense>
+  );
+}

--- a/docs/ops/pushing-an-update-to-the-glass.md
+++ b/docs/ops/pushing-an-update-to-the-glass.md
@@ -118,6 +118,26 @@ what xrandr is actually doing.
 2. `ssh pi@sunsetdisplay 'printf "ORIENTATION=portrait\n" > /home/pi/kiosk.env && sudo reboot'`
 3. Turn the monitors back. Doctor to confirm.
 
+### Solo → solo2 (and back)
+
+`solo2` (spec `docs/superpowers/specs/2026-09-04-solo2-rhythm-design.md`) is
+a second registered version beside `solo`: same bins, same schedule, same
+landscape panels, its own dials in the `solo2` namespace. Switching is
+settings only, once the build that carries it is on the glass.
+
+1. Merge and build the code that carries `solo2` in the version list.
+   `vercel ls --prod`.
+2. `bash scripts/pi/kiosk-doctor.sh --sync --reload` so both tabs run that
+   build. Without this step the dial does nothing: the tabs do not know the
+   version.
+3. In `/studio`: active version = `solo2`. Hold Deploy. Tabs pick it up
+   within a minute. Every `solo2` dial starts at `solo`'s behaviour except
+   the caption's local time, so the glass looks the same until you tune.
+4. Tune on `/studio/solo2` (valleys, screens, lead, transition, prelude,
+   time). Deploy there.
+5. Back: `/studio`, active version = `solo`. Hold Deploy. The `solo2` dials
+   stay where you left them for next time.
+
 ## When it does not work
 
 | Symptom | Meaning | Do |

--- a/docs/solutions/developer-experience/git-worktrees-for-js-and-python-repos.md
+++ b/docs/solutions/developer-experience/git-worktrees-for-js-and-python-repos.md
@@ -27,7 +27,7 @@ ln -s ~/main-repo/node_modules ~/repo-feature/node_modules
 cd ~/repo-feature && npx vitest run <path>   # works immediately
 ```
 Caveats:
-- If the branch **adds a new dependency**, run `npm install <pkg>` in the worktree — with the symlink it installs into the *shared* `node_modules`, which is fine (the package.json/lock changes stay on the branch). A *later* worktree off `main` (which lacks the dep in package.json) may need its own `npm install` to pick it up — expect a one-time install there.
+- If the branch **adds a new dependency**, run `npm install <pkg>` in the worktree. Observed 2026-09-04 (npm 10): npm does **not** install through the symlink — it replaces the worktree's `node_modules` symlink with a real, full install (~20 s, 1,300 packages) and leaves the main checkout's tree without the package. That is fine for the branch (package.json/lock changes stay on it), but after the PR merges the main checkout needs its own `npm install` before it can build or test that code. Check with `ls -ld node_modules` in the worktree if unsure which state you are in.
 - `git worktree remove --force` removes the symlink (a dir entry), **not** the real `node_modules` it points to.
 
 **Python repos — usually nothing needed** if the package is installed editable (`pip install -e`) into a shared interpreter, since `pythonpath = ["src"]` (pytest) resolves from the worktree's own `src/`. Just run `python3 -m pytest` in the worktree.

--- a/docs/superpowers/plans/2026-09-04-solo2-rhythm.md
+++ b/docs/superpowers/plans/2026-09-04-solo2-rhythm.md
@@ -1,0 +1,231 @@
+# solo2 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** A second registered kiosk version, `solo2`, that adds rhythm (peaks and valleys on a slot-derived beat), an anticipation lead, an optional same-camera prelude, transition kinds, and a local-time caption, without touching `solo`'s behaviour.
+
+**Architecture:** `solo2` is a version descriptor (`app/lib/solo/versions.ts`) that the two solo endpoints, the glass, and the studio select by name. Its engine composes `solo`'s pure helpers and adds rule 3's beat; its glass computes each dwell's stage from the wall clock through pure `plan.ts` functions; the studio pages are the existing solo studio components parametrised by the descriptor. Bins, screen state, cron, and schedule are shared and unchanged.
+
+**Tech Stack:** Next.js route handlers, Vitest (`// @vitest-environment node` for server files), React Testing Library, `tz-lookup` (+ `@types/tz-lookup`), SunCalc via `app/lib/solo/zone.ts`, the existing settings schema helpers.
+
+**Spec:** `docs/superpowers/specs/2026-09-04-solo2-rhythm-design.md`
+
+## Global Constraints
+
+- `solo`'s engine (`app/lib/solo/engine.ts`), schema, and renderer (`app/components/solo/SoloFrame.tsx`, `index.tsx`) are not modified. Additive, default-preserving changes to shared plumbing (`useSoloGlass`, `view.ts`, the endpoints, the studio components) are allowed; every existing test must keep passing unchanged.
+- Every new dial defaults to `solo`'s behaviour except `timeStyle`, which defaults to `12h`.
+- The engine and the plan helpers are pure: no `Date.now()`, no I/O, no module state.
+- Hold floor is 3 s (`MIN_HOLD_S = 3`).
+- `captured_at` is selected as `captured_at::text` and parsed as UTC (`Date.parse(text.replace(' ', 'T') + 'Z')`).
+- The client view carries no coordinates: `timezone` and `sunAltitudeDeg` are computed server-side in `toViewEntry`.
+- Work in the worktree `~/GitHub/the-sunset-webcam-map.worktrees/feat-solo2-rhythm` on branch `feat/solo2-rhythm`. Verify the branch in the same command as each commit. Stage explicit paths. Push after every commit with `GIT_TERMINAL_PROMPT=0 git -c credential.helper= -c credential.helper='!gh auth git-credential' push`.
+- `npm run test -- --run <path>` for one file; `npm run lint` and `npx tsc --noEmit` before each commit.
+
+---
+
+## File structure
+
+| path | responsibility |
+|---|---|
+| `app/lib/solo2/types.ts` | `Solo2Dials extends SoloDials`, `Transition`, `TimeStyle`, `Screens`, `Role` |
+| `app/lib/solo2/settingsSchema.ts` (+ test) | `SOLO2_NAMESPACE`, `SOLO2_SETTINGS_SCHEMA`, `dialsFrom2()` |
+| `app/lib/solo2/engine.ts` (+ test) | `beatOf`, `roleAt`, `next2`, `project2` |
+| `app/lib/solo2/plan.ts` (+ test) | `fitPlan`, `stageAt`, `MIN_HOLD_S` |
+| `app/lib/solo2/prelude.ts` (+ test) | `preludeFor` |
+| `app/lib/solo2/caption.ts` (+ test) | `formatTime`, `captionLines` |
+| `app/lib/solo/versions.ts` (+ test) | `SoloVersionSpec`, `SOLO_VERSIONS`, `resolveSoloVersion` |
+| `app/lib/solo/store.ts` | `capturedAt` on `StoredEntry` from `captured_at::text` |
+| `app/api/kiosk/solo/view.ts` (+ test) | `capturedAt`/`timezone`/`sunAltitudeDeg` on `ViewEntry`; `buildStateView` takes `version`; `nextRoles` |
+| `app/api/kiosk/solo/state/route.ts` (+ test) | `?version=` |
+| `app/api/kiosk/solo/advance/route.ts` (+ test) | `body.version` |
+| `app/components/solo/useSoloGlass.ts` (+ test) | optional `version`; returns `entries`, `nextEntries` |
+| `app/components/solo2/Solo2Frame.tsx` (+ test) | layers, transition, lead, prelude, caption |
+| `app/components/solo2/useStage.ts` (+ test) | clock-driven stage from `plan.ts` |
+| `app/components/solo2/index.tsx` (+ test) | the registered renderer |
+| `app/components/mosaic/registry.ts` (+ test) | register `solo2` |
+| `app/studio/solo/*` | take a `SoloVersionSpec`; enum control; budget line; PEAK/VALLEY tags; caption via `captionLines` |
+| `app/studio/solo2/page.tsx` | `/studio/solo2` |
+| `docs/ops/pushing-an-update-to-the-glass.md` | a line on switching to `solo2` |
+
+---
+
+### Task 1: Types and settings schema
+
+**Files:**
+- Create: `app/lib/solo2/types.ts`, `app/lib/solo2/settingsSchema.ts`, `app/lib/solo2/settingsSchema.test.ts`
+
+**Interfaces:**
+- Produces:
+  ```ts
+  export type Transition = 'cut' | 'crossfade' | 'dip';
+  export type TimeStyle = 'off' | '12h' | '12h-there' | '24h' | 'sun' | '12h-sun';
+  export type Screens = 'together' | 'alternate';
+  export type Role = 'peak' | 'valley';
+  export interface Solo2Dials extends SoloDials {
+    transition: Transition; leadS: number; leadScale: number;
+    prelude: boolean; preludeFrames: number; preludeStepS: number;
+    timeStyle: TimeStyle; valleys: number; screens: Screens;
+  }
+  export const SOLO2_NAMESPACE = 'solo2';
+  export const SOLO2_SETTINGS_SCHEMA: SettingsSchema;
+  export function dialsFrom2(values: SettingsValues): Solo2Dials;
+  ```
+- Schema order (glass): dwellS, offsetS, transition, fadeS, leadS, leadScale, prelude, preludeFrames, preludeStepS, showPlace, timeStyle, showScores, showRank, showTally. (bins): qualityFloor, detectionFloor, sunsetFloor, mix, repeatAllowance, valleys, screens, zoneGrace, promoteNew. Ranges per spec §3–§4.
+
+- [ ] Test: every `solo` key is present with the same default; the new keys default to `cut`, 0, 1.03, false, 3, 1.5, `12h`, 0, `together`; `dialsFrom2(schemaDefaults(...))` typed shape.
+- [ ] Implement; run; commit `feat(solo2): dials`.
+
+### Task 2: Engine with the beat
+
+**Files:**
+- Create: `app/lib/solo2/engine.ts`, `app/lib/solo2/engine.test.ts`
+
+**Interfaces:**
+- Consumes: `isEligible`, `tierOf`, `rankScore`, `afterShowing` from `app/lib/solo/engine`.
+- Produces:
+  ```ts
+  export function beatOf(slot: number, feed: Feed, d: Pick<Solo2Dials,'valleys'|'screens'>): number;
+  export function roleAt(slot: number, feed: Feed, d: Solo2Dials): Role;   // beat 0 → 'peak'
+  export function next2(entries: BinEntry[], d: Solo2Dials, state: ScreenState, slot: number, feed: Feed): BinEntry | null;
+  export function project2(entries: BinEntry[], d: Solo2Dials, state: ScreenState, n: number, firstSlot: number, feed: Feed): BinEntry[];
+  ```
+- Valley comparator: `a.tally - b.tally || rankScore(a) - rankScore(b) || a.enteredAt - b.enteredAt || a.snapshotId - b.snapshotId`.
+
+- [ ] Tests: valleys 0 reproduces the three `solo` allowance fixtures; 21 sunsets, valleys 1, together → `S1 S21 S2 S20 S3 S19`; valleys 2 → `S1 S21 S20 S2 S19 S18`; alternate: sunset feed at slot 0 is a valley and slot 1 a peak; a valley prefers an unshown low frame over a shown lower one; rule 4 on a valley with two frames; non-sunsets still arrive through mix with valleys 1; `beatOf` negative slots wrap to 0..period-1.
+- [ ] Implement; run; commit `feat(solo2): engine — peaks and valleys on a slot-derived beat`.
+
+### Task 3: Plan helpers (`fitPlan`, `stageAt`)
+
+**Files:**
+- Create: `app/lib/solo2/plan.ts`, `app/lib/solo2/plan.test.ts`
+
+**Interfaces:**
+```ts
+export const MIN_HOLD_S = 3;
+export interface DwellPlan { dwellS: number; preludeFrames: number; preludeStepS: number; leadS: number; holdS: number; clamped: boolean }
+export function fitPlan(d: Pick<Solo2Dials,'dwellS'|'prelude'|'preludeFrames'|'preludeStepS'|'leadS'>, available: number): DwellPlan;
+export type Stage = { layer: 'prelude'; index: number } | { layer: 'main'; leadProgress: number };
+export function stageAt(elapsedMs: number, p: DwellPlan): Stage;
+```
+- `available` = prelude frames actually available for this entry; `preludeFrames` in the result = `min(dial, available)` when `prelude` on, else 0. Drop frames (oldest first = reduce the count) until `holdS ≥ MIN_HOLD_S`; then shorten `leadS`; `clamped` true if anything was reduced.
+
+- [ ] Tests: fits as-is; drops prelude frames one at a time; shortens lead after prelude is gone; prelude off → 0 frames; `stageAt` before `k·t` → prelude index; after → main with `leadProgress` 0 until `dwell − lead`, linear to 1 at `dwell`, clamped ≥ 0 and ≤ 1; negative elapsed → first stage.
+- [ ] Implement; run; commit `feat(solo2): dwell plan and clock-driven stage`.
+
+### Task 4: Prelude and caption helpers
+
+**Files:**
+- Create: `app/lib/solo2/prelude.ts` (+ test), `app/lib/solo2/caption.ts` (+ test)
+
+**Interfaces:**
+```ts
+// prelude.ts — generic over anything with webcamId, snapshotId, capturedAt
+export function preludeFor<T extends { webcamId: number; snapshotId: number; capturedAt: number }>(entry: T, entries: T[], max: number): T[];
+// caption.ts
+export function formatTime(style: TimeStyle, capturedAt: number, timezone: string | null, sunAltitudeDeg: number | null): string | null;
+export function captionLines(entry: { title: string; region: string; country: string; capturedAt: number; timezone: string | null; sunAltitudeDeg: number | null }, d: Pick<Solo2Dials,'showPlace'|'timeStyle'>): { title: string; sub: string } | null;
+```
+- `formatTime` uses `new Intl.DateTimeFormat('en-US', { timeZone, hour: 'numeric', minute: '2-digit', hour12 })` and lower-cases `AM/PM`. `sun` → `sun 1.2° above the horizon` / `below`. Null timezone → the sun part only if asked, else null.
+
+- [ ] Tests: same camera only, earlier only, order, last `max`, alone → `[]`; each style string for `2026-09-05T02:42:00Z` in `America/Mazatlan` (7:42 pm); `24h` → `19:42`; `off` → null; null timezone with `12h` → null; `captionLines` joins `region, country · time` and omits the dot when no time.
+- [ ] Implement; run; commit `feat(solo2): prelude and caption helpers`.
+
+### Task 5: Version descriptors
+
+**Files:**
+- Create: `app/lib/solo/versions.ts` (+ test)
+
+**Interfaces:**
+```ts
+export interface SoloVersionSpec<D extends SoloDials = SoloDials> {
+  name: 'solo' | 'solo2'; namespace: string; schema: SettingsSchema;
+  dialsFrom(values: SettingsValues): D;
+  project(entries: BinEntry[], d: D, state: ScreenState, n: number, firstSlot: number, feed: Feed): BinEntry[];
+  next(entries: BinEntry[], d: D, state: ScreenState, slot: number, feed: Feed): BinEntry | null;
+  roleAt(slot: number, feed: Feed, d: D): Role;   // solo: always 'peak'
+}
+export const SOLO_VERSIONS: { solo: SoloVersionSpec<SoloDials>; solo2: SoloVersionSpec<Solo2Dials> };
+export type SoloVersionName = keyof typeof SOLO_VERSIONS;
+export function resolveSoloVersion(raw: string | null | undefined): SoloVersionSpec | null; // undefined/null/'' → solo; unknown → null
+```
+- Client-safe: no `server-only`, no store imports.
+
+- [ ] Tests: resolve default/known/unknown; `solo.project` ignores the slot and equals `project`; `solo2.roleAt` follows `beatOf`.
+- [ ] Implement; run; commit.
+
+### Task 6: Store and view
+
+**Files:**
+- Modify: `app/lib/solo/store.ts` (`captured_at::text as captured_at`, `capturedAt: number` on `StoredEntry`, parser `parseUtcText`), `app/api/kiosk/solo/view.ts` (+ test)
+
+**Interfaces:**
+- `ViewEntry` gains `capturedAt: number; timezone: string | null; sunAltitudeDeg: number | null`.
+- `toViewEntry(e: StoredEntry)` computes `timezone = tzLookup(e.lat, e.lng)` (try/catch → null) and `sunAltitudeDeg = sunAltitudeDeg(new Date(e.capturedAt), e.lat, e.lng)`.
+- `buildStateView(input & { version?: SoloVersionSpec })` — default `SOLO_VERSIONS.solo`; `firstSlot = schedule.slot + 1`; `StateView.nextRoles: Role[]`.
+- Existing test fixtures gain the three fields via a helper default (tests that build `ViewEntry` objects need `capturedAt: 0, timezone: null, sunAltitudeDeg: null`).
+
+- [ ] Tests: `parseUtcText('2026-09-05 03:34:28.703')` = `Date.UTC(2026,8,5,3,34,28,703)`; `toViewEntry` sets a timezone for Cabo (`America/Mazatlan`) and a finite altitude; `buildStateView` with `solo2` and valleys 1 yields alternating roles and the `S1 S21` order; default keeps every existing assertion.
+- [ ] Implement; run whole `app/api/kiosk/solo` and `app/lib/solo`; commit.
+
+### Task 7: Endpoints take a version
+
+**Files:**
+- Modify: `state/route.ts`, `advance/route.ts` (+ their tests)
+
+- `state`: `resolveSoloVersion(searchParams.get('version'))`, 400 `version must be solo or solo2` on null. Dials from `version.dialsFrom(mergeSettings(version.schema, profile?.namespaces[version.namespace]))`. Pass `version` to `buildStateView`.
+- `advance`: same from `body.version`; `version.next(entries, dials, state, slot, feed)`.
+
+- [ ] Tests: `?version=solo2` reads the `solo2` namespace (`dwellS: 9` there vs 30 in `solo`) and returns `nextRoles`; unknown → 400; missing → solo as before; advance with `solo2` valleys 1 at an odd slot draws the valley.
+- [ ] Implement; run; commit.
+
+### Task 8: Glass hook gains version and entries
+
+**Files:**
+- Modify: `app/components/solo/useSoloGlass.ts` (+ test)
+
+- `useSoloGlass({ feed, dials, drive, dozing, version = 'solo' })`; URL `&version=`, body `version`. Return adds `entries: ViewEntry[]` and `nextEntries: EntryView[]` (the full `next` list). Existing return fields unchanged.
+
+- [ ] Tests: default calls omit nothing the old test asserted (`body` equality → update to include `version: 'solo'`); `version: 'solo2'` appears in URL and body; `entries` surfaces the view's entries.
+- [ ] Implement; run; commit.
+
+### Task 9: `solo2` renderer
+
+**Files:**
+- Create: `app/components/solo2/useStage.ts` (+ test), `Solo2Frame.tsx` (+ test), `index.tsx` (+ test)
+- Modify: `app/components/mosaic/registry.ts` (+ test)
+
+**Interfaces:**
+```ts
+// useStage.ts
+export function useStage(plan: DwellPlan, startMs: number, tickMs = 250): Stage;   // startMs = boundaryMs − dwell
+// Solo2Frame.tsx
+export function Solo2Frame(p: { entry: EntryView; prelude: EntryView[]; previous: EntryView | null; stage: Stage; plan: DwellPlan; dials: Solo2Dials; width: number; height: number }): JSX.Element;
+```
+- Layers, bottom to top: previous image (if transition ≠ cut and a previous exists); for `dip`, a black div animating `opacity 0→1` over `fadeS/2`; the top image (prelude[index] or entry) with `crossfade` animation over `fadeS`, or for `dip` an animation with `animation-delay: fadeS/2`; `key` on the top image = its `snapshotId` so a change re-runs the animation; prelude steps swap `src` under the same key (no animation) — implement as `key={'top'}` + `src` change for prelude and `key={entry.snapshotId}` on the entry into the dwell.
+- Lead: when `stage.layer === 'main'` and `plan.leadS > 0`, style `animation: solo2-lead ${leadS}s linear forwards; animation-delay: -${leadProgress*leadS}s` with keyframes `to { transform: scale(leadScale) }`.
+- Overlays only when `stage.layer === 'main'`: caption from `captionLines`, scores/rank/tally exactly as `SoloFrame`.
+- `index.tsx`: `dialsFrom2(mergeSettings(SOLO2_SETTINGS_SCHEMA, props.settings))`; `useSoloGlass({ ..., version: 'solo2' })`; `prelude = dials.prelude ? preludeFor(current, entries, dials.preludeFrames) : []`; `plan = fitPlan(dials, prelude.length)`; `startMs = boundaryMs − dwellS*1000`; `stage = useStage(plan, startMs)`; preload `next[0]` and its prelude.
+- Registry: `solo2: Solo2Kiosk`, schemas `solo2: SOLO2_SETTINGS_SCHEMA`.
+
+- [ ] Tests: `useStage` with fake timers walks prelude → main → lead; `Solo2Frame` prelude stage shows no caption, main stage shows `Lisboa, Portugal · 7:42 pm`; `dip` renders the black layer; `cut` renders no previous; lead sets the animation; `index` passes `version: 'solo2'` and `drive/dozing`; registry has `solo2` and `SHARED_SCHEMA` activeVersion options include it.
+- [ ] Implement; run; commit.
+
+### Task 10: Studio parametrised by version, `/studio/solo2`
+
+**Files:**
+- Modify: `app/studio/solo/SoloStudioClient.tsx`, `SoloRail.tsx`, `RulesBox.tsx`, `FeedColumn.tsx`, `EntryRow.tsx`, `useSoloState.ts`, `page.tsx` (+ tests)
+- Create: `app/studio/solo2/page.tsx`, `app/studio/solo/DwellBudget.tsx` (+ test)
+
+- `SoloStudioClient({ version })`, `SoloRail({ api, deploySlot, version })`, `useSoloState(feed, dials, version)` (URL `&version=`; projection via `buildStateView({ ..., version })`), `RulesBox({ dials, version })` — for `solo2` rule 3 reads `In a bin: best first; after each peak, N valleys (lowest eligible) · screens together|alternate`; `FeedColumn` gets `roles={projected.nextRoles}` and passes `role` to `EntryRow`, which renders a `PEAK`/`VALLEY` tag only when `version.name === 'solo2' && valleys > 0`; the panel caption uses `captionLines` when the dials carry `timeStyle`.
+- `Control` renders `kind === 'enum'` as `<select>`; `setKnob` receives the string.
+- `DwellBudget({ dials })` under the glass group for `solo2`: `prelude 4.5 s + lead 4 s + hold 11.5 s`, red + ` (clamped)` when `fitPlan(dials, dials.preludeFrames).clamped`.
+- Each studio's strip links to the other (`solo2 studio →` / `← solo studio`).
+
+- [ ] Tests: rail renders every `solo2` knob incl. selects and writes strings; budget line values and clamp; feed column shows PEAK/VALLEY tags with valleys 1; existing solo studio tests unchanged.
+- [ ] Implement; run whole `app/studio/solo`; commit.
+
+### Task 11: Docs, lint, full suite, PR
+
+- [ ] `docs/ops/pushing-an-update-to-the-glass.md`: a short "solo2" note (merge → build → doctor reload → active version `solo2` → tune on `/studio/solo2`; back is the same dial).
+- [ ] `npm run lint`, `npx tsc --noEmit`, `npm run test -- --run`.
+- [ ] Commit; push; open the PR with the spec summary, the dial table, the on-glass procedure, and the `npm install` note for the main checkout.

--- a/docs/superpowers/specs/2026-09-04-solo2-rhythm-design.md
+++ b/docs/superpowers/specs/2026-09-04-solo2-rhythm-design.md
@@ -1,0 +1,317 @@
+# solo2 — rhythm, anticipation, prelude, and local time for the solo kiosk
+
+**Date:** 2026-09-04
+**Status:** Design agreed in conversation (2026-09-04 evening); built overnight
+as one PR for the operator to look at on 2026-09-05.
+**Predecessor:** `2026-09-04-solo-kiosk-design.md` (the `solo` version: bins,
+the five rules, the schedule, the glass, `/studio/solo`). Everything there
+still holds; this document only states what `solo2` adds.
+**Show:** opening night Fri 2026-09-12, freeze Wed 2026-09-10.
+
+---
+
+## 1. What this is
+
+A second registered version, **`solo2`**, beside `solo`. It reads the same
+server-owned bins and the same screen state, and the shared `activeVersion`
+dial switches the glass between the two. `solo` is not edited: its engine,
+renderer, and namespace stay as shipped, so refining the original remains
+possible on its own branch.
+
+`solo2` takes four ideas from feed design and keeps only the ones that hold
+without a viewer identity:
+
+1. **Rhythm.** Best-first within a tier is a monotone decline. `solo2`
+   alternates **peaks** (best remaining) with **valleys** (lowest eligible),
+   so a one-minute viewer sees a high and a low instead of three near-equal
+   tops. The beat is derived from the schedule slot, so the two screens can
+   peak **together** or **alternate** without talking to each other.
+2. **Anticipation.** A frame is perfectly still while it is "now". In the
+   last seconds of its dwell it starts a slow push (scale 1.00 → 1.03), and
+   the next frame lands still again. Stillness means now; motion means
+   change is coming.
+3. **Prelude.** Optionally, the chosen frame is preceded by its own camera's
+   earlier archived frames in capture order, held briefly each, arriving at
+   the chosen frame which then holds. The sun visibly drops into the picture
+   the engine picked. A glass dial: it changes how a frame is shown, never
+   which frame.
+4. **Local time.** The caption's second line gains the time it was at that
+   place when the picture was taken, in that place's clock: `Baja
+   California Sur, Mexico · 7:42 pm`. Several phrasings are dials so the
+   operator can pick one on the studio.
+
+Every new dial defaults to `solo`'s behaviour (rhythm off, lead 0, prelude
+off, cut transition), with one exception: the time caption defaults to
+`7:42 pm`, because that is the point. The branch is therefore reversible on
+the glass by dials as well as by git.
+
+Not in scope, decided 2026-09-04: call-and-response between screens (most
+coupling, first thing to break on a tab reload), same-camera deduplication
+(still parked from the predecessor), scenes for this mode.
+
+### Fixed directives, restated
+
+- One frame fills the screen. Never a grid.
+- The score shown for a frame is the score of **that exact picture**. Prelude
+  frames carry no caption and no score; overlays mount with the chosen frame.
+- **The best sunsets lead each bar.** Peaks are drawn best-first exactly as
+  `solo` draws everything; valleys are the rhythm between them. With valleys
+  at 0 the rule is `solo`'s rule 3 verbatim.
+- Nothing ever silently drops out of the bins.
+
+---
+
+## 2. Vocabulary (extends the predecessor's §2)
+
+- **Beat** — the position of a draw inside a bar, derived from the schedule
+  slot. Beat 0 is the peak; beats 1…N are valleys.
+- **Bar** — `valleys + 1` consecutive draws on one screen: one peak, then
+  the valleys.
+- **Peak** — the draw that takes the head of the pool (best remaining).
+- **Valley** — a draw that takes the tail of the pool: the lowest eligible
+  score, preferring unshown frames.
+- **Prelude** — the same camera's earlier archived frames shown before the
+  chosen frame, in capture order.
+- **Lead** — the final seconds of a dwell during which the frame on glass
+  pushes in, announcing the change.
+- **Hold** — the part of a dwell during which the chosen frame sits still
+  with its caption: `dwell − prelude − lead`.
+
+---
+
+## 3. The ordering rules in `solo2`
+
+Rules 1, 2, 4 and 5 are the predecessor's, unchanged. Rule 3 becomes:
+
+3. **Within a bin, peaks best-first, valleys worst-first, on a beat.**
+   `period = valleys + 1`. For a draw at schedule slot `s` on feed `f`,
+   `beat = (s − phase(f)) mod period`, with `phase(sunrise) = 0` and
+   `phase(sunset) = 0` when **screens** is `together`, `⌊period / 2⌋` when
+   it is `alternate`.
+   - Beat 0 (**peak**): the pool sorted as `solo` sorts it — tally
+     ascending, score descending (promote-new bonus included), then
+     `entered_at`, then id — and the head is drawn.
+   - Beat ≥ 1 (**valley**): the pool sorted tally ascending, score
+     **ascending**, then `entered_at`, then id — and the head is drawn. Tally
+     stays first so a valley still prefers a picture nobody has seen.
+   Dials: **valleys** (0–3, default 0), **screens** (`together` |
+   `alternate`, default `together`). At valleys 0 every draw is a peak and
+   the rule is `solo`'s.
+
+The pool a beat draws from is still chosen by rules 1 and 2, so non-sunsets
+keep arriving through **mix** exactly as before; they are simply the deepest
+valleys. Rule 4 still forbids the frame on glass.
+
+Worked case, 21 sunsets `S1…S21` by descending quality, one tier, valleys 1,
+screens together: sunrise draws `S1, S21, S2, S20, S3, S19 …`. With screens
+`alternate` the sunset screen, whose slot at the same wall-clock moment is
+the same index, draws `S21', S1', S20', S2' …` from its own bin, so at any
+moment one screen is on a peak and the other on a valley.
+
+The beat is a function of the slot, not of screen memory, so:
+
+- a reload lands on the same beat the schedule says;
+- the studio's projection knows the beat of every queued draw and can label
+  it;
+- the two screens need no channel between them, which is the predecessor's
+  §6.2 philosophy kept.
+
+The engine stays pure. `next2(entries, dials, state, slot)` and
+`project2(entries, dials, state, n, firstSlot)`; the first projected draw is
+at `slotFor(now) + 1`, the next boundary.
+
+---
+
+## 4. The glass in `solo2`
+
+### 4.1 Timeline of one dwell
+
+For a dwell `D` beginning at boundary `B`, with `k` prelude frames, step
+`t`, and lead `L`:
+
+| from | what |
+|---|---|
+| `B` | transition (per dial) into prelude frame 1 if `k > 0`, else into the chosen frame |
+| `B + i·t` | hard cut to prelude frame `i + 1` |
+| `B + k·t` | hard cut to the chosen frame; caption and score overlays mount now |
+| `B + D − L` | the chosen frame begins a linear push from scale 1.00 to **lead scale** |
+| `B + D` | the next dwell begins; the incoming frame is at scale 1.00 |
+
+Prelude steps are hard cuts on purpose: a time-lapse reads as cuts.
+
+The stage is computed from the wall clock, not from timers chained since
+mount: `stageAt(elapsedMs, plan)` is a pure function, so a tab that reloads
+mid-dwell joins at the right step, and the studio can draw the same timeline.
+
+**Dwell budget.** `hold = D − k·t − L` must be at least **3 s**. If it is
+not, the glass drops prelude frames from the oldest until it is; if there is
+still no room, it shortens the lead. The studio prints the budget under the
+glass dials and turns it red when clamped. The rule lives in one pure
+function (`fitPlan`) used by both.
+
+### 4.2 Transition
+
+**transition** (`cut` | `crossfade` | `dip`, default `cut`), with **fade**
+(0–10 s, default 0) as its duration:
+
+- `cut` — what `solo` ships.
+- `crossfade` — the previous frame underneath, the incoming fades in over
+  `fade`. Reads as a double exposure for the whole duration; kept as an
+  option.
+- `dip` — the previous frame fades to black over `fade / 2`, then the
+  incoming fades up from black over `fade / 2`. What photo slideshows use.
+
+### 4.3 Lead
+
+**lead** (0–10 s, default 0) and **lead scale** (1.00–1.10, default 1.03).
+A CSS animation on the top layer, started by the clock-driven stage with a
+negative `animation-delay` equal to the time already elapsed in the lead, so
+a late-joining tab is in sync.
+
+### 4.4 Prelude
+
+**prelude** (boolean, default off), **prelude frames** (1–6, default 3),
+**prelude step** (0.5–5 s, default 1.5).
+
+The prelude of a frame is a pure function over the entries the state
+endpoint already returns: `preludeFor(entry, entries, max)` = the other
+entries with the same camera, captured earlier, sorted by capture time, the
+last `max` of them. No new query. Frames below a floor are fine as prelude
+(they are earlier pictures of the same scene); frames removed from the bins
+are not returned by the endpoint and simply shorten the prelude. Frames the
+cron never archived (detection below 0.20) were never pictures we hold.
+
+The glass preloads the prelude of the projected next frame along with the
+frame itself.
+
+### 4.5 Caption and the time
+
+**place + country** stays. A new **time** dial (enum, default `12h`) sets
+the second line's trailing item:
+
+| option | rendered |
+|---|---|
+| `off` | `Baja California Sur, Mexico` |
+| `12h` | `Baja California Sur, Mexico · 7:42 pm` |
+| `12h there` | `Baja California Sur, Mexico · 7:42 pm there` |
+| `24h` | `Baja California Sur, Mexico · 19:42` |
+| `sun` | `Baja California Sur, Mexico · sun 1.2° above the horizon` |
+| `12h + sun` | `Baja California Sur, Mexico · 7:42 pm · sun 1.2° above the horizon` |
+
+The time is the picture's `captured_at` rendered in the camera's IANA zone.
+No camera has a zone stored, so it is resolved from `lat`/`lng` with
+`tz-lookup` (pure, in-memory, ~150 KB) on the server when the view is
+built. Solar altitude for the `sun` phrasing is `sunAltitudeDeg` from
+`app/lib/solo/zone.ts`, also computed server-side. The client view gains
+`capturedAt` (ms), `timezone` (IANA), and `sunAltitudeDeg`; it still carries
+no coordinates. Rendering uses `Intl.DateTimeFormat` with `timeZone`.
+
+The caption is rendered by one helper, `captionLines(entry, dials)`, used by
+the glass and by the studio's panel preview, so the studio shows the glass's
+words.
+
+Gotcha, recorded so nobody debugs it twice: `webcam_snapshots.captured_at`
+is `timestamp without time zone` holding UTC. The Neon driver parses a naive
+timestamp as **client-local**, which is correct on Vercel (UTC) and seven
+hours off on a Mac. The store selects `captured_at::text` and parses it as
+UTC explicitly.
+
+---
+
+## 5. Delivery
+
+### 5.1 Versions
+
+`app/lib/solo/versions.ts` (client-safe) exports a descriptor per version:
+
+```ts
+interface SoloVersionSpec {
+  name: 'solo' | 'solo2';
+  namespace: string;
+  schema: SettingsSchema;
+  dialsFrom(values): SoloDials | Solo2Dials;
+  engine: { isEligible, project(entries, dials, state, n, firstSlot), roleAt?(slot, feed, dials) };
+  rules(dials): ReactNode[];   // the rules box lines
+}
+```
+
+`solo`'s descriptor wraps the existing engine (ignoring the slot).
+`solo2`'s lives in `app/lib/solo2/` (`settingsSchema.ts`, `engine.ts`,
+`plan.ts` for `fitPlan`/`stageAt`, `prelude.ts`, `caption.ts`). `solo2`'s
+engine imports `solo`'s pure helpers (`isEligible`, `tierOf`, `rankScore`)
+rather than copying them; `solo`'s files are not modified.
+
+### 5.2 Endpoints
+
+Both endpoints gain a `version` parameter (`?version=` on GET state,
+`version` in the POST advance body), default `solo`, unknown → 400. It
+selects the namespace whose dials are read and the engine that runs.
+`buildStateView` takes the descriptor. The screen state table is shared:
+only one version is on glass at a time, and the slot is the same schedule.
+
+Additions to the view: `EntryView.capturedAt`, `timezone`, `sunAltitudeDeg`;
+`StateView.nextRoles: ('peak' | 'valley')[]` parallel to `next` (all
+`peak` for `solo`).
+
+No migration.
+
+### 5.3 The renderer
+
+`app/components/solo2/`: `index.tsx` registered as version `solo2` in
+`MOSAIC_VERSIONS` and `MOSAIC_SETTINGS_SCHEMAS` (which also adds it to the
+`activeVersion` options automatically), `Solo2Frame.tsx` (layers,
+transition, lead, prelude, caption), and the clock-driven stage. The glass
+loop `useSoloGlass` gains an optional `version` and returns `entries`; the
+`solo` renderer's behaviour is unchanged.
+
+### 5.4 The studio
+
+`/studio/solo2`, owner-gated, is the same page as `/studio/solo` with the
+`solo2` descriptor: `SoloStudioClient`, `SoloRail`, `FeedColumn`,
+`RulesBox` take the descriptor instead of importing `solo`'s constants.
+Additions:
+
+- enum dials render as a `<select>`;
+- under the glass group, the dwell budget line
+  (`prelude 4.5 s + lead 4 s + hold 11.5 s`), red when clamped;
+- queue rows carry a **PEAK** / **VALLEY** tag from `nextRoles`;
+- the panel preview's caption uses `captionLines`, so it shows the time;
+- the rules box states rule 3 with valleys and screens substituted;
+- each studio links to the other.
+
+### 5.5 Putting it on the glass
+
+Code, then settings, as `docs/ops/pushing-an-update-to-the-glass.md` says:
+
+1. Merge; wait for the production build.
+2. `bash scripts/pi/kiosk-doctor.sh --sync --reload` so both tabs load a
+   build that contains `solo2`.
+3. On `/studio`, set **active version** to `solo2`, Deploy. The tabs pick it
+   up within a minute. Back to `solo` is the same dial.
+4. Tune on `/studio/solo2`; Deploy.
+
+---
+
+## 6. Testing
+
+- Engine: valleys 0 reproduces every `solo` fixture; valleys 1 on 21
+  sunsets gives `S1, S21, S2, S20 …`; valleys 2 gives one peak then two
+  valleys; `alternate` puts the sunset screen's peak on the opposite beat;
+  a valley prefers an unshown frame over a lower-scored shown one; rule 4
+  holds on valleys; non-sunsets still arrive through mix.
+- `fitPlan`: drops prelude frames oldest-first until hold ≥ 3 s, then
+  shortens lead; `stageAt`: prelude index by elapsed time, main frame after
+  `k·t`, lead progress in the last `L`, clamped at both ends.
+- `preludeFor`: same camera only, earlier captures only, capture order,
+  last `max`, empty when alone.
+- `captionLines`: each time option's exact string; a `null` timezone falls
+  back to `off`; the `sun` phrasing above and below the horizon.
+- View: `nextRoles` parallel to `next`; `capturedAt` parsed as UTC from the
+  text column.
+- Endpoints: `version=solo2` reads the `solo2` namespace and runs the beat;
+  unknown version → 400; default stays `solo`.
+- Registry: `solo2` registered and present in the `activeVersion` options.
+- Renderer: prelude frames carry no caption; caption mounts with the chosen
+  frame; the transition kinds render their layers; a dial change re-plans.
+- Studio: enum control writes a string; the budget line reads the plan;
+  PEAK/VALLEY tags appear on queue rows.

--- a/docs/superpowers/specs/2026-09-04-solo2-rhythm-design.md
+++ b/docs/superpowers/specs/2026-09-04-solo2-rhythm-design.md
@@ -1,8 +1,11 @@
 # solo2 — rhythm, anticipation, prelude, and local time for the solo kiosk
 
-**Date:** 2026-09-04
+**Date:** 2026-09-04, amended 2026-09-05 (dissolves, studio groups)
 **Status:** Design agreed in conversation (2026-09-04 evening); built overnight
-as one PR for the operator to look at on 2026-09-05.
+as one PR for the operator to look at on 2026-09-05. The 09-05 review asked
+for two changes, folded into the same PR: the prelude dissolves instead of
+cutting (§4.1, §4.2, §4.4), and the studio groups a dwell's frames into one
+box whose height is time (§5.4).
 **Predecessor:** `2026-09-04-solo-kiosk-design.md` (the `solo` version: bins,
 the five rules, the schedule, the glass, `/studio/solo`). Everything there
 still holds; this document only states what `solo2` adds.
@@ -41,9 +44,12 @@ without a viewer identity:
    operator can pick one on the studio.
 
 Every new dial defaults to `solo`'s behaviour (rhythm off, lead 0, prelude
-off, cut transition), with one exception: the time caption defaults to
-`7:42 pm`, because that is the point. The branch is therefore reversible on
-the glass by dials as well as by git.
+off), with two exceptions: the time caption defaults to `7:42 pm`, because
+that is the point, and the transitions default to a dissolve (decided
+2026-09-05: a camera change dips through black over 1.5 s, the same camera
+crossfades over 1.5 s). `solo`'s hard cut is one dial away (**camera
+change** = cut, **same-camera fade** = 0). The branch is therefore
+reversible on the glass by dials as well as by git.
 
 Not in scope, decided 2026-09-04: call-and-response between screens (most
 coupling, first thing to break on a tab reload), same-camera deduplication
@@ -131,13 +137,25 @@ For a dwell `D` beginning at boundary `B`, with `k` prelude frames, step
 
 | from | what |
 |---|---|
-| `B` | transition (per dial) into prelude frame 1 if `k > 0`, else into the chosen frame |
-| `B + i·t` | hard cut to prelude frame `i + 1` |
-| `B + k·t` | hard cut to the chosen frame; caption and score overlays mount now |
+| `B` | arrival (§4.2) into prelude frame 1 if `k > 0`, else into the chosen frame |
+| `B + i·t` | prelude frame `i + 1` dissolves in over the **same-camera fade** (capped at `t`) |
+| `B + k·t` | the chosen frame dissolves in the same way; caption and score overlays mount now |
 | `B + D − L` | the chosen frame begins a linear push from scale 1.00 to **lead scale** |
 | `B + D` | the next dwell begins; the incoming frame is at scale 1.00 |
 
-Prelude steps are hard cuts on purpose: a time-lapse reads as cuts.
+Prelude steps were hard cuts in the first build ("a time-lapse reads as
+cuts"). Reversed 2026-09-05: the point of the prelude is the sun visibly
+dropping, and a dissolve between two frames of the same camera is the
+closest thing to that motion without inventing any. The whole sequence
+(prelude frames, then the chosen frame) is stacked as layers in capture
+order; each layer becomes opaque when the clock-driven stage reaches it,
+with a CSS opacity transition of the same-camera fade. A reloaded tab
+renders every reached layer opaque at once and joins in the right place.
+
+The prelude **continues from the frame on glass** when that frame is the
+same camera: `preludeFor` takes an `afterMs` and keeps only captures after
+it, so a camera drawn twice in a row plays forward rather than rewinding
+past the picture the viewer just saw.
 
 The stage is computed from the wall clock, not from timers chained since
 mount: `stageAt(elapsedMs, plan)` is a pure function, so a tab that reloads
@@ -149,17 +167,27 @@ still no room, it shortens the lead. The studio prints the budget under the
 glass dials and turns it red when clamped. The rule lives in one pure
 function (`fitPlan`) used by both.
 
-### 4.2 Transition
+### 4.2 Arrival: the same camera dissolves, a camera change dips
 
-**transition** (`cut` | `crossfade` | `dip`, default `cut`), with **fade**
-(0–10 s, default 0) as its duration:
+How a dwell arrives depends on whether the camera changed (`arrival()` in
+`Solo2Frame.tsx`, pure, so the studio can say the same):
 
-- `cut` — what `solo` ships.
-- `crossfade` — the previous frame underneath, the incoming fades in over
-  `fade`. Reads as a double exposure for the whole duration; kept as an
-  option.
-- `dip` — the previous frame fades to black over `fade / 2`, then the
-  incoming fades up from black over `fade / 2`. What photo slideshows use.
+- **Same camera as the frame on glass** — always a crossfade, over
+  **same-camera fade** (0–5 s, default 1.5). Never through black: the
+  viewer is watching one sunset continue. 0 is a cut.
+- **A different camera** — **camera change** (`cut` | `crossfade` | `dip`,
+  default `dip`), with **fade** (0–10 s, default 1.5) as its duration:
+  - `cut` — what `solo` ships.
+  - `crossfade` — the previous frame underneath, the incoming fades in over
+    `fade`. Reads as a double exposure for the whole duration; kept as an
+    option.
+  - `dip` — the previous frame fades to black over `fade / 2`, then the
+    incoming fades up from black over `fade / 2`. What photo slideshows
+    use, and the default: black between cameras says "another place".
+
+The same-camera fade is also the dissolve inside the prelude (§4.1). One
+dial, one meaning: how long two pictures of the same scene take to become
+each other.
 
 ### 4.3 Lead
 
@@ -174,9 +202,12 @@ a late-joining tab is in sync.
 **prelude step** (0.5–5 s, default 1.5).
 
 The prelude of a frame is a pure function over the entries the state
-endpoint already returns: `preludeFor(entry, entries, max)` = the other
-entries with the same camera, captured earlier, sorted by capture time, the
-last `max` of them. No new query. Frames below a floor are fine as prelude
+endpoint already returns: `preludeFor(entry, entries, max, afterMs?)` = the
+other entries with the same camera, captured earlier (and after `afterMs`
+when given), sorted by capture time, the last `max` of them. No new query.
+`preludePlan(entry, entries, dials, previous?)` wraps it with `fitPlan` and
+returns the frames the budget actually keeps, newest kept, so the renderer
+and the studio never disagree about which frames play. Frames below a floor are fine as prelude
 (they are earlier pictures of the same scene); frames removed from the bins
 are not returned by the endpoint and simply shorten the prelude. Frames the
 cron never archived (detection below 0.20) were never pictures we hold.
@@ -275,6 +306,25 @@ Additions:
 - under the glass group, the dwell budget line
   (`prelude 4.5 s + lead 4 s + hold 11.5 s`), red when clamped;
 - queue rows carry a **PEAK** / **VALLEY** tag from `nextRoles`;
+- **height is time** (added 2026-09-05): on `/studio/solo2` every row in the
+  bins and the queue is as tall as its time on glass, 4 px per second, so
+  the column reads as a timeline. Dwell, prelude step and lead are the
+  dials that set it; the row is a projection of them, not a dial of its own;
+- **a dwell is one box** (added 2026-09-05): with the prelude dial on, a
+  frame that will play earlier frames of its camera first becomes a group:
+  the earlier frames stacked above the chosen one in capture order, each a
+  light-bordered strip (thumbnail + local time, e.g. `6:58 pm`, `7:14 pm`)
+  as tall as a prelude step, then the chosen frame with its usual
+  annotations and the time on its place line, all inside one thick
+  bin-coloured border (green sunset, grey non-sunset). Queue rows continue
+  from their predecessor as the glass does; bin rows show the full prelude
+  a draw would get. Every frame in the group is clickable and opens its own
+  detail;
+- **PRELUDE** tag (added 2026-09-05): a frame that an earlier queued dwell
+  already shows inside its prelude carries the tag when it comes back for
+  its own turn, in the queue or in a bin. This makes the parked same-camera
+  dedup question visible without deciding it: the tag is how often a
+  viewer sees a picture twice;
 - the panel preview's caption uses `captionLines`, so it shows the time;
 - the rules box states rule 3 with valleys and screens substituted;
 - each studio links to the other.
@@ -312,6 +362,18 @@ Code, then settings, as `docs/ops/pushing-an-update-to-the-glass.md` says:
   unknown version → 400; default stays `solo`.
 - Registry: `solo2` registered and present in the `activeVersion` options.
 - Renderer: prelude frames carry no caption; caption mounts with the chosen
-  frame; the transition kinds render their layers; a dial change re-plans.
+  frame; the transition kinds render their layers; a dial change re-plans;
+  the sequence is stacked with opacity by stage and a transition of the
+  same-camera fade capped at the step (0 is `none`); a same-camera previous
+  frame crossfades over the same-camera fade even when the camera-change
+  dial says dip; the defaults dip between cameras.
+- `preludePlan`: keeps the newest frames when the budget clamps; continues
+  after a same-camera previous frame; ignores another camera's.
+- Studio rows: a sequence renders as a group with the bin-coloured border,
+  one light-bordered button per frame with its local time; heights follow
+  the step and the hold at `PX_PER_S`, never below `MIN_FRAME_PX`; a row
+  without a sequence keeps its shape and takes `rowS` as its height; the
+  PRELUDE tag; FeedColumn groups the on-glass row and flags the earlier
+  frames' own turns.
 - Studio: enum control writes a string; the budget line reads the plan;
   PEAK/VALLEY tags appear on queue rows.

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,6 +40,7 @@
         "solar-calculator": "^0.3.0",
         "suncalc": "^1.9.0",
         "swr": "^2.3.6",
+        "tz-lookup": "^6.1.25",
         "uuid": "^13.0.0",
         "zustand": "^5.0.8"
       },
@@ -54,6 +55,7 @@
         "@types/react": "^19",
         "@types/react-dom": "^19",
         "@types/suncalc": "^1.9.2",
+        "@types/tz-lookup": "^6.1.2",
         "@vitejs/plugin-react": "^4.7.0",
         "eslint": "^9",
         "eslint-config-next": "15.4.6",
@@ -6498,6 +6500,13 @@
       "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/@types/tz-lookup": {
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/@types/tz-lookup/-/tz-lookup-6.1.2.tgz",
+      "integrity": "sha512-9y31Xf/8FHXrCHjvVjGZLcsayAa6ABNc8bZlk6MPOQLLlr41tICSqW3TRPRIx2nodbzdKs5N7ipHWBrUsWUiAA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.39.0",
@@ -16322,6 +16331,12 @@
       "engines": {
         "node": ">=12.17"
       }
+    },
+    "node_modules/tz-lookup": {
+      "version": "6.1.25",
+      "resolved": "https://registry.npmjs.org/tz-lookup/-/tz-lookup-6.1.25.tgz",
+      "integrity": "sha512-fFewT9o1uDzsW1QnUU1ValqaihFnwiUiiHr1S79/fxOzKXYYvX+EHeRnpvQJ9B3Qg67wPXT6QF2Esc4pFOrvLg==",
+      "license": "CC0-1.0"
     },
     "node_modules/uglify-js": {
       "version": "3.19.3",

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "solar-calculator": "^0.3.0",
     "suncalc": "^1.9.0",
     "swr": "^2.3.6",
+    "tz-lookup": "^6.1.25",
     "uuid": "^13.0.0",
     "zustand": "^5.0.8"
   },
@@ -63,6 +64,7 @@
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "@types/suncalc": "^1.9.2",
+    "@types/tz-lookup": "^6.1.2",
     "@vitejs/plugin-react": "^4.7.0",
     "eslint": "^9",
     "eslint-config-next": "15.4.6",


### PR DESCRIPTION
## solo2 — rhythm, anticipation, prelude, transitions, local time

A second registered kiosk version, **`solo2`**, beside `solo`. Same bins, same schedule, same screen state; the shared **active version** dial switches the glass between the two. `solo`'s engine, schema and renderer are untouched, so refining the original stays possible on its own branch.

Spec: `docs/superpowers/specs/2026-09-04-solo2-rhythm-design.md` · Plan: `docs/superpowers/plans/2026-09-04-solo2-rhythm.md`

### What it adds

| idea | dial(s) | default |
|---|---|---|
| **Rhythm** — peaks (best remaining) alternate with valleys (lowest eligible, unshown first), on a beat derived from the schedule slot | `valleys per peak` 0–3, `screens` together / alternate | 0, together (= solo) |
| **Lead** — the frame pushes in slowly over the last seconds of its dwell; the next lands still | `lead (s)` 0–10, `lead scale` 1.00–1.10 | 0, 1.03 |
| **Prelude** — the same camera's earlier frames, in capture order, before the chosen frame | `prelude`, `prelude frames` 1–6, `prelude step (s)` | off, 3, 1.5 |
| **Transition** — cut, crossfade, or dip through black | `transition`, `fade (s)` | cut |
| **Local time** on the caption's second line | `time`: off / `7:42 pm` / `7:42 pm there` / `19:42` / `sun 1.2° above the horizon` / both | `7:42 pm` |

Every dial defaults to `solo`'s behaviour except the time, so the branch is reversible on the glass by dials as well as by git.

"Screens: alternate" puts the sunset screen's peak on the opposite beat from the sunrise screen's with no channel between the tabs — both read the same clock. Call-and-response was dropped as agreed.

### Where things live

- `app/lib/solo2/` — dials, the beat engine (composes solo's helpers), `fitPlan`/`stageAt` (dwell budget, clock-driven stage), `preludeFor`, `captionLines`.
- `app/lib/solo/versions.ts` — one descriptor per version; the two endpoints take `version` (default `solo`, unknown → 400).
- `app/components/solo2/` — the renderer, registered as `solo2` (which also puts it in the active-version options).
- `/studio/solo2` — the solo studio parametrised by version: enum dials as selects, a dwell-budget line (red when clamped), PEAK/VALLEY tags on queued draws, the caption preview shows the time. Each studio links to the other.
- The view now carries `capturedAt`, `timezone` (from lat/lng via `tz-lookup`, computed server-side), `sunAltitudeDeg`, and `nextRoles`.

### Gotchas recorded

- `webcam_snapshots.captured_at` is a naive timestamp holding UTC; the Neon driver parses it client-local (7 h off on a Mac). The store selects `::text` and parses as UTC.
- `npm install` in a worktree **replaced** the `node_modules` symlink with a real install. The main checkout needs `npm install` after this merges (`tz-lookup`, `@types/tz-lookup`). Noted in the worktrees doc.
- Two pre-existing `tsc` errors in untouched test files (`app/api/cameras/[id]/snapshot/route.test.ts`, `sweepHealth.test.ts`); `next build` and Vitest are green.

### Putting it on the glass

Runbook section added: `docs/ops/pushing-an-update-to-the-glass.md` → "Solo → solo2 (and back)". Merge → build → `kiosk-doctor.sh --sync --reload` → `/studio` active version = `solo2` → tune on `/studio/solo2`.

### Verification

- `npm run test -- --run`: 272 files, 2120 tests green (incl. 60+ new).
- `npm run build`: green.
- Not yet done: a signed-in look at `/studio/solo2` and a glass session. That is the point of the morning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0125sgxgU6Co8b9ZQqCTzSw2


## Added 2026-09-05 after the first look

- **The prelude dissolves.** Each prelude step, and the step into the chosen frame, crossfades over a new `same-camera fade (s)` dial (default 1.5 s, capped at the step, 0 = cut). Renamed `transition` to `camera change`; it and `fade (s)` now default to a 1.5 s dip through black. A change to a later frame of the camera already on glass dissolves too, and its prelude continues from that frame instead of rewinding.
- **The studio groups a dwell as one box.** With the prelude on, a frame's earlier pictures stack vertically above it, each a light-bordered strip with its local time, inside one thick bin-coloured border. Rows are as tall as their time on glass (4 px/s).
- **PRELUDE flag.** A frame an earlier queued dwell already showed inside its prelude is tagged when it comes back for its own turn. Makes the parked dedup question visible without deciding it.
