### PR TITLE
fix(solo): age bins against every ring that swept, not only the guaranteed ones

### DIFF
--- a/app/api/cron/update-cameras/lib/binAdmission.test.ts
+++ b/app/api/cron/update-cameras/lib/binAdmission.test.ts
@@ -8,6 +8,7 @@ const listActiveEntries = vi.fn();
 const markSeen = vi.fn();
 const markOutOfZone = vi.fn();
 const removeStale = vi.fn();
+const saveSweptZone = vi.fn();
 vi.mock('server-only', () => ({}));
 vi.mock('@/app/lib/solo/store', () => ({
   insertEntry: (...a: unknown[]) => insertEntry(...a),
@@ -17,6 +18,7 @@ vi.mock('@/app/lib/solo/store', () => ({
   markSeen: (...a: unknown[]) => markSeen(...a),
   markOutOfZone: (...a: unknown[]) => markOutOfZone(...a),
   removeStale: (...a: unknown[]) => removeStale(...a),
+  saveSweptZone: (...a: unknown[]) => saveSweptZone(...a),
 }));
 
 import { decideBin, enterBins, maintainBins, BIN_ADMIT_DETECTION_FLOOR } from './binAdmission';
@@ -87,6 +89,22 @@ describe('maintainBins', () => {
     expect(removeStale).toHaveBeenCalledWith('sunset', { grace: 2, maxAgeHours: 24 });
     expect(removeStale).toHaveBeenCalledWith('sunrise', { grace: 2, maxAgeHours: 24 });
     expect(out).toEqual({ leftZone: 0, expired: 0 });
+  });
+  it('records the zone it aged entries against, so the state route shows the same band', async () => {
+    listActiveEntries.mockResolvedValue([]);
+    const wide = { minDeg: -39.75, maxDeg: 13.75 };
+    await maintainBins({ now: seattleDusk, zone: wide, grace: 2 });
+    expect(saveSweptZone).toHaveBeenCalledWith(wide);
+  });
+  it('a golden-hour camera the escalation ring admitted is in zone when the zone includes that ring', async () => {
+    // Honolulu at 17:06Z on 2026-09-05: sun at +10.8 and rising. Evicted
+    // under the guaranteed-rings zone (-24..-2); kept under the swept one.
+    const honolulu = entry('sunrise', 7, 21.29701, -157.86688);
+    listActiveEntries.mockImplementation(async (feed: string) => (feed === 'sunrise' ? [honolulu] : []));
+    const at = new Date('2026-09-05T17:06:38Z');
+    await maintainBins({ now: at, zone: { minDeg: -24, maxDeg: 13.75 }, grace: 2 });
+    expect(markSeen).toHaveBeenCalledWith('sunrise', [7]);
+    expect(markOutOfZone).toHaveBeenCalledWith('sunrise', []);
   });
   it('absence from a poll is not a reason: only zone membership drives the counters', async () => {
     listActiveEntries.mockImplementation(async (feed: string) =>

--- a/app/api/cron/update-cameras/lib/binAdmission.ts
+++ b/app/api/cron/update-cameras/lib/binAdmission.ts
@@ -7,6 +7,7 @@ import {
   markOutOfZone,
   markSeen,
   removeStale,
+  saveSweptZone,
 } from '@/app/lib/solo/store';
 import { inFeedZone, type Zone } from '@/app/lib/solo/zone';
 import type { BinKind, Feed } from '@/app/lib/solo/types';
@@ -72,6 +73,12 @@ export async function enterBins(
  * Removal is by zone, not by absence. Every active entry is checked against
  * where its camera's sun is right now; a poll that simply did not return the
  * camera changes nothing.
+ *
+ * `zone` must be the band the sweep actually gathered from this tick
+ * (sweepGeometry.sweptZone), escalation rings included: admission takes any
+ * camera the sweep returned, and a narrower zone here evicts what an
+ * escalation ring just brought in. The zone used is recorded so the state
+ * route can show the same band.
  */
 export async function maintainBins(opts: {
   now: Date;
@@ -79,6 +86,7 @@ export async function maintainBins(opts: {
   grace: number;
 }): Promise<{ leftZone: number; expired: number }> {
   const totals = { leftZone: 0, expired: 0 };
+  await saveSweptZone(opts.zone);
   for (const feed of FEEDS) {
     const entries = await listActiveEntries(feed);
     const seen = new Set<number>();

--- a/app/api/cron/update-cameras/lib/sweepGeometry.test.ts
+++ b/app/api/cron/update-cameras/lib/sweepGeometry.test.ts
@@ -7,10 +7,30 @@ vi.mock('@/app/lib/db', () => ({
     sqlMock(strings, ...values),
 }));
 
-import { coverageSpan, sweepGeometry, upsertSweepGeometry } from './sweepGeometry';
+import { coverageSpan, sweepGeometry, sweptZone, upsertSweepGeometry } from './sweepGeometry';
 
 beforeEach(() => {
   sqlMock.mockReset();
+});
+
+describe('sweptZone', () => {
+  it('is the base ring alone when only the base ring swept', () => {
+    expect(sweptZone([0])).toEqual({ minDeg: -24, maxDeg: -2 });
+  });
+
+  it('includes every ring that swept this tick, escalations included', () => {
+    // The 2026-09-05 sunrise bug: the sweep escalated to +15.75 for a thin
+    // sunrise feed and admitted golden-hour cameras at +1..+11, but the
+    // removal zone counted only the guaranteed rings (-24..-2), so every one
+    // of them was evicted three ticks later. Admission and removal must read
+    // the same band.
+    expect(sweptZone([0, 15.75, -15.75])).toEqual({ minDeg: -39.75, maxDeg: 13.75 });
+  });
+
+  it('always contains the base ring, even if telemetry omitted it', () => {
+    expect(sweptZone([15.75])).toEqual({ minDeg: -24, maxDeg: 13.75 });
+    expect(sweptZone([])).toEqual({ minDeg: -24, maxDeg: -2 });
+  });
 });
 
 describe('coverageSpan', () => {

--- a/app/api/cron/update-cameras/lib/sweepGeometry.ts
+++ b/app/api/cron/update-cameras/lib/sweepGeometry.ts
@@ -60,6 +60,24 @@ export function coverageSpan(
   };
 }
 
+/**
+ * The band the solo bins are aged against: every ring that swept THIS tick,
+ * escalations included, not only the guaranteed ones.
+ *
+ * Admission takes any camera the sweep returned, so removal has to accept
+ * the same band or the two disagree whenever a thin feed escalates. On
+ * 2026-09-05 the sunrise terminator sat over the Pacific, the feed escalated
+ * to +15.75 every tick, and every golden-hour camera it admitted (+1 to +11
+ * degrees) was evicted as out of the -24..-2 guaranteed zone three ticks
+ * later. The base ring is always included so a telemetry gap cannot narrow
+ * the zone below what the sweep always covers.
+ */
+export function sweptZone(ringOffsetsDeg: readonly number[]): { minDeg: number; maxDeg: number } {
+  const offsets = [...new Set([0, ...ringOffsetsDeg])];
+  const { min, max } = coverageSpan(offsets.map((o) => TERMINATOR_SUN_ALTITUDE_DEG + o));
+  return { minDeg: min, maxDeg: max };
+}
+
 export function sweepGeometry(forcedOffsets: readonly number[]): SweepGeometry {
   const guaranteed = [0, ...forcedOffsets];
   const { min: coverageMinDeg, max: coverageMaxDeg } = coverageSpan(

--- a/app/api/cron/update-cameras/route.test.ts
+++ b/app/api/cron/update-cameras/route.test.ts
@@ -73,10 +73,11 @@ vi.mock('./lib/dbOperations', () => ({
   insertWindyDisagreementSnapshot: (...a: unknown[]) =>
     insertWindyDisagreementSnapshotMock(...a),
 }));
+const maintainBinsMock = vi.fn(async () => ({ leftZone: 0, expired: 0 }));
 vi.mock('./lib/binAdmission', () => ({
   decideBin: () => null,
   enterBins: async () => ({ sunset: 0, nonSunset: 0, duplicates: 0 }),
-  maintainBins: async () => ({ leftZone: 0, expired: 0 }),
+  maintainBins: (...a: unknown[]) => maintainBinsMock(...(a as [])),
 }));
 vi.mock('@/app/lib/settings/liveSettings', () => ({
   getLiveSettingsCached: async () => null,
@@ -650,6 +651,26 @@ describe('GET /api/cron/update-cameras', () => {
     expect(upsertSweepGeometryMock.mock.calls[0][1]).toMatchObject({
       forcedOffsetsDeg: '',
     });
+    expect(maintainBinsMock).toHaveBeenCalledWith(
+      expect.objectContaining({ zone: { minDeg: -24, maxDeg: -2 } }),
+    );
+  });
+
+  it('ages the bins against every ring that swept, not only the guaranteed ones', async () => {
+    // A thin sunrise feed escalates to +15.75 and -15.75; the cameras those
+    // rings admit must be inside the zone the same tick checks them against.
+    classifyMock.mockReturnValue({
+      sunrise: Array.from(
+        { length: TERMINATOR_CAMERA_FLOOR - 1 },
+        (_, i) => ({ webcamId: `thin-${i}` }),
+      ),
+      sunset: HEALTHY_CLASSIFY_RESULT.sunset,
+    });
+    const res = await GET(makeReq());
+    expect(res.status).toBe(200);
+    expect(maintainBinsMock).toHaveBeenCalledWith(
+      expect.objectContaining({ zone: { minDeg: -39.75, maxDeg: 13.75 } }),
+    );
   });
 
   it('sweeps the day-side ring on a healthy tick when the switch is on', async () => {

--- a/app/api/cron/update-cameras/route.ts
+++ b/app/api/cron/update-cameras/route.ts
@@ -47,7 +47,7 @@ import {
   upsertSweepStats,
   type RingGateCounts,
 } from './lib/sweepStats';
-import { sweepGeometry, upsertSweepGeometry } from './lib/sweepGeometry';
+import { sweepGeometry, sweptZone, upsertSweepGeometry } from './lib/sweepGeometry';
 import {
   upsertWebcams,
   getWebcamIdMap,
@@ -400,11 +400,13 @@ export async function GET(req: Request) {
   try {
     const live = await getLiveSettingsCached();
     const dials = dialsFrom(mergeSettings(SOLO_SETTINGS_SCHEMA, live?.namespaces[SOLO_NAMESPACE]));
-    const geometry = sweepGeometry(forcedOffsets);
     const admitted = await enterBins(admissions);
+    // The rings that swept THIS tick, escalations included. The guaranteed
+    // geometry (sweepGeometry) is narrower whenever a thin feed escalated,
+    // and aging against it evicts what the escalation ring just admitted.
     const removed = await maintainBins({
       now: new Date(),
-      zone: { minDeg: geometry.coverageMinDeg, maxDeg: geometry.coverageMaxDeg },
+      zone: sweptZone(sweep.telemetry.rings.map((r) => r.offsetDeg)),
       grace: dials.zoneGrace,
     });
     bins = { admitted, removed };

--- a/app/api/kiosk/solo/advance/route.test.ts
+++ b/app/api/kiosk/solo/advance/route.test.ts
@@ -6,6 +6,7 @@ const getScreenState = vi.fn();
 const commitAdvance = vi.fn();
 const countAdmittedSince = vi.fn();
 const getLiveSettingsCached = vi.fn();
+const getSweptZone = vi.fn();
 vi.mock('server-only', () => ({}));
 // sweepGeometry's module pulls in the Neon client; the route only uses its pure half.
 vi.mock('@/app/lib/db', () => ({ sql: vi.fn() }));
@@ -15,6 +16,7 @@ vi.mock('@/app/lib/solo/store', () => ({
   getScreenState: (...a: unknown[]) => getScreenState(...a),
   commitAdvance: (...a: unknown[]) => commitAdvance(...a),
   countAdmittedSince: (...a: unknown[]) => countAdmittedSince(...a),
+  getSweptZone: (...a: unknown[]) => getSweptZone(...a),
 }));
 vi.mock('@/app/lib/settings/liveSettings', () => ({ getLiveSettingsCached: () => getLiveSettingsCached() }));
 
@@ -37,12 +39,20 @@ beforeEach(() => {
   getScreenState.mockResolvedValue(null);
   commitAdvance.mockResolvedValue(true);
   countAdmittedSince.mockResolvedValue({ sunset: 0, nonSunset: 0 });
+  getSweptZone.mockResolvedValue(null);
 });
 afterEach(() => {
   vi.useRealTimers();
 });
 
 describe('POST /api/kiosk/solo/advance', () => {
+  it('echoes the zone the cron last aged entries against, falling back to the guaranteed rings', async () => {
+    expect((await (await post({ feed: 'sunrise', slot: 50_000_000 })).json()).zone)
+      .toEqual({ minDeg: -24, maxDeg: -2 });
+    getSweptZone.mockResolvedValue({ minDeg: -39.75, maxDeg: 13.75 });
+    expect((await (await post({ feed: 'sunrise', slot: 50_000_000 })).json()).zone)
+      .toEqual({ minDeg: -39.75, maxDeg: 13.75 });
+  });
   it('rejects bad bodies', async () => {
     expect((await post({})).status).toBe(400);
     expect((await post({ feed: 'sunrise', slot: 'x' })).status).toBe(400);

--- a/app/api/kiosk/solo/advance/route.ts
+++ b/app/api/kiosk/solo/advance/route.ts
@@ -4,7 +4,7 @@ import { mergeSettings } from '@/app/lib/settings/schema';
 import { afterShowing, next } from '@/app/lib/solo/engine';
 import { slotFor } from '@/app/lib/solo/schedule';
 import { SOLO_NAMESPACE, SOLO_SETTINGS_SCHEMA, dialsFrom } from '@/app/lib/solo/settingsSchema';
-import { commitAdvance, countAdmittedSince, getScreenState, listActiveEntries } from '@/app/lib/solo/store';
+import { commitAdvance, countAdmittedSince, getScreenState, getSweptZone, listActiveEntries } from '@/app/lib/solo/store';
 import { isFlagEnabled, SWEEP_FORCE_DAY_RING } from '@/app/lib/runtimeFlags';
 import { sweepGeometry } from '@/app/api/cron/update-cameras/lib/sweepGeometry';
 import { TERMINATOR_DAY_SIDE_OFFSETS_DEG } from '@/app/lib/masterConfig';
@@ -64,12 +64,15 @@ export async function POST(request: Request) {
       }
     }
   }
-  const [admitted, forcedDayRing] = await Promise.all([
+  const [admitted, sweptZone, forcedDayRing] = await Promise.all([
     countAdmittedSince(feed, nowMs - LAST_PULL_WINDOW_MS),
+    getSweptZone(),
     isFlagEnabled(SWEEP_FORCE_DAY_RING),
   ]);
+  // Same source as the state route: the zone the cron last used, else the
+  // guaranteed rings.
   const geometry = sweepGeometry(forcedDayRing ? TERMINATOR_DAY_SIDE_OFFSETS_DEG : []);
-  const zone = { minDeg: geometry.coverageMinDeg, maxDeg: geometry.coverageMaxDeg };
+  const zone = sweptZone ?? { minDeg: geometry.coverageMinDeg, maxDeg: geometry.coverageMaxDeg };
   return NextResponse.json({
     advanced,
     ...buildStateView({ feed, dials, entries: entries.map(toViewEntry), screen, nowMs, admitted, zone }),

--- a/app/api/kiosk/solo/state/route.test.ts
+++ b/app/api/kiosk/solo/state/route.test.ts
@@ -8,6 +8,7 @@ const getScreenState = vi.fn();
 const countAdmittedSince = vi.fn();
 const getLiveSettingsCached = vi.fn();
 const getProfileSettings = vi.fn();
+const getSweptZone = vi.fn();
 vi.mock('server-only', () => ({}));
 // sweepGeometry's module pulls in the Neon client; the route only uses its pure half.
 vi.mock('@/app/lib/db', () => ({ sql: vi.fn() }));
@@ -17,6 +18,7 @@ vi.mock('@/app/lib/solo/store', () => ({
   listActiveEntries: (...a: unknown[]) => listActiveEntries(...a),
   getScreenState: (...a: unknown[]) => getScreenState(...a),
   countAdmittedSince: (...a: unknown[]) => countAdmittedSince(...a),
+  getSweptZone: (...a: unknown[]) => getSweptZone(...a),
 }));
 vi.mock('@/app/lib/settings/liveSettings', () => ({ getLiveSettingsCached: () => getLiveSettingsCached() }));
 vi.mock('@/app/lib/settings/store', () => ({ getProfileSettings: (p: string) => getProfileSettings(p) }));
@@ -31,16 +33,22 @@ beforeEach(() => {
   listActiveEntries.mockResolvedValue([]);
   getScreenState.mockResolvedValue(null);
   countAdmittedSince.mockResolvedValue({ sunset: 0, nonSunset: 0 });
+  getSweptZone.mockResolvedValue(null);
   getLiveSettingsCached.mockResolvedValue({ namespaces: { solo: { dwellS: 30 } }, revision: 1 });
   getProfileSettings.mockResolvedValue({ namespaces: { solo: { dwellS: 7 } }, revision: 1 });
 });
 
 describe('GET /api/kiosk/solo/state', () => {
+  it('shows the zone the cron last aged entries against', async () => {
+    getSweptZone.mockResolvedValue({ minDeg: -39.75, maxDeg: 13.75 });
+    const body = await (await get('?feed=sunrise')).json();
+    expect(body.zone).toEqual({ minDeg: -39.75, maxDeg: 13.75 });
+  });
   it('rejects a missing or unknown feed', async () => {
     expect((await get('')).status).toBe(400);
     expect((await get('?feed=noon')).status).toBe(400);
   });
-  it('live profile by default, no owner check', async () => {
+  it('live profile by default, no owner check; guaranteed-rings zone until the cron has recorded one', async () => {
     const res = await get('?feed=sunset');
     expect(res.status).toBe(200);
     const body = await res.json();

--- a/app/api/kiosk/solo/state/route.ts
+++ b/app/api/kiosk/solo/state/route.ts
@@ -4,7 +4,7 @@ import { getLiveSettingsCached } from '@/app/lib/settings/liveSettings';
 import { getProfileSettings } from '@/app/lib/settings/store';
 import { mergeSettings } from '@/app/lib/settings/schema';
 import { SOLO_NAMESPACE, SOLO_SETTINGS_SCHEMA, dialsFrom } from '@/app/lib/solo/settingsSchema';
-import { countAdmittedSince, getScreenState, listActiveEntries } from '@/app/lib/solo/store';
+import { countAdmittedSince, getScreenState, getSweptZone, listActiveEntries } from '@/app/lib/solo/store';
 import { isFlagEnabled, SWEEP_FORCE_DAY_RING } from '@/app/lib/runtimeFlags';
 import { sweepGeometry } from '@/app/api/cron/update-cameras/lib/sweepGeometry';
 import { TERMINATOR_DAY_SIDE_OFFSETS_DEG } from '@/app/lib/masterConfig';
@@ -34,15 +34,18 @@ export async function GET(request: NextRequest) {
   const dials = dialsFrom(mergeSettings(SOLO_SETTINGS_SCHEMA, profile?.namespaces[SOLO_NAMESPACE]));
 
   const nowMs = Date.now();
-  const [entries, screen, admitted, forcedDayRing] = await Promise.all([
+  const [entries, screen, admitted, sweptZone, forcedDayRing] = await Promise.all([
     listActiveEntries(feed),
     getScreenState(feed),
     countAdmittedSince(feed, nowMs - LAST_PULL_WINDOW_MS),
+    getSweptZone(),
     isFlagEnabled(SWEEP_FORCE_DAY_RING),
   ]);
-  // The same zone the cron ages entries against (binAdmission.maintainBins).
+  // The zone the cron last aged entries against (binAdmission.maintainBins),
+  // escalation rings included. Until the cron has recorded one, the
+  // guaranteed rings are the best available guess.
   const geometry = sweepGeometry(forcedDayRing ? TERMINATOR_DAY_SIDE_OFFSETS_DEG : []);
-  const zone = { minDeg: geometry.coverageMinDeg, maxDeg: geometry.coverageMaxDeg };
+  const zone = sweptZone ?? { minDeg: geometry.coverageMinDeg, maxDeg: geometry.coverageMaxDeg };
   return NextResponse.json(buildStateView({
     feed, dials, entries: entries.map(toViewEntry), screen, nowMs, admitted, zone,
   }));

--- a/app/lib/solo/store.test.ts
+++ b/app/lib/solo/store.test.ts
@@ -16,13 +16,36 @@ vi.mock('@/app/lib/db', async () => {
 import { sql } from '@/app/lib/db';
 import {
   listActiveEntries, insertEntry, removeStale, getScreenState, commitAdvance,
-  countAdmittedSince, getBinDigestSummary,
+  countAdmittedSince, getBinDigestSummary, saveSweptZone, getSweptZone,
 } from './store';
 
 const sqlMock = (sql as unknown as SqlTag).__sqlMock;
 const lastQuery = () => (sqlMock.mock.calls.at(-1)![0] as TemplateStringsArray).join('?');
 
 beforeEach(() => sqlMock.mockReset());
+
+describe('swept zone', () => {
+  it('saveSweptZone upserts the single row the cron aged entries against', async () => {
+    sqlMock.mockResolvedValueOnce([]);
+    await saveSweptZone({ minDeg: -39.75, maxDeg: 13.75 });
+    expect(lastQuery()).toMatch(/kiosk_sweep_zone/);
+    expect(sqlMock.mock.calls.at(-1)!.slice(1)).toEqual([-39.75, 13.75]);
+  });
+  it('saveSweptZone never throws: an unmigrated table must not cost the tick its bins', async () => {
+    sqlMock.mockRejectedValueOnce(new Error('relation "kiosk_sweep_zone" does not exist'));
+    await expect(saveSweptZone({ minDeg: -24, maxDeg: -2 })).resolves.toBeUndefined();
+  });
+  it('getSweptZone maps Neon strings to numbers', async () => {
+    sqlMock.mockResolvedValueOnce([{ min_deg: '-39.75', max_deg: '13.75' }]);
+    expect(await getSweptZone()).toEqual({ minDeg: -39.75, maxDeg: 13.75 });
+  });
+  it('getSweptZone is null when the table is missing or empty', async () => {
+    sqlMock.mockRejectedValueOnce(new Error('relation "kiosk_sweep_zone" does not exist'));
+    expect(await getSweptZone()).toBeNull();
+    sqlMock.mockResolvedValueOnce([]);
+    expect(await getSweptZone()).toBeNull();
+  });
+});
 
 describe('listActiveEntries', () => {
   it('maps rows into StoredEntry with numbers, not Neon strings', async () => {

--- a/app/lib/solo/store.ts
+++ b/app/lib/solo/store.ts
@@ -157,6 +157,46 @@ export async function removeStale(
   return { leftZone: leftZone.length, expired: expired.length };
 }
 
+export interface SweptZone {
+  minDeg: number;
+  maxDeg: number;
+}
+
+/**
+ * Record the zone maintainBins just aged entries against, so the state and
+ * advance routes can show the same band instead of recomputing a guess from
+ * the flag alone. Escalation rings fire per tick, and only the cron knows
+ * which ones did. Non-fatal: an unmigrated table must not cost the tick its
+ * bins.
+ */
+export async function saveSweptZone(zone: SweptZone): Promise<void> {
+  try {
+    await sql`
+      insert into kiosk_sweep_zone (id, min_deg, max_deg, updated_at)
+      values (1, ${zone.minDeg}, ${zone.maxDeg}, now())
+      on conflict (id) do update
+        set min_deg = excluded.min_deg, max_deg = excluded.max_deg, updated_at = now()
+    `;
+  } catch (error) {
+    console.warn('[solo/store] swept zone persist failed:', error);
+  }
+}
+
+/** Null when the cron has not recorded a zone yet, or the table is missing. */
+export async function getSweptZone(): Promise<SweptZone | null> {
+  try {
+    const rows = (await sql`
+      select min_deg, max_deg from kiosk_sweep_zone where id = 1
+    `) as unknown as { min_deg: string | number; max_deg: string | number }[];
+    const r = rows[0];
+    if (!r) return null;
+    return { minDeg: num(r.min_deg), maxDeg: num(r.max_deg) };
+  } catch (error) {
+    console.warn('[solo/store] swept zone read failed:', error);
+    return null;
+  }
+}
+
 export interface ScreenRow {
   feed: Feed;
   currentSnapshotId: number | null;

--- a/database/migrations/20260905_kiosk_sweep_zone.sql
+++ b/database/migrations/20260905_kiosk_sweep_zone.sql
@@ -1,0 +1,22 @@
+-- Solo kiosk: the zone the cron last aged bin entries against.
+--
+-- One row. Written by binAdmission.maintainBins every tick with the band
+-- every ring that swept THIS tick gathered from (escalations included); read
+-- by GET /api/kiosk/solo/state and POST /api/kiosk/solo/advance so the studio
+-- shows the band the bins were really checked against, not a guess from the
+-- day-ring flag. Before this the routes recomputed the guaranteed-rings zone
+-- and the cron aged against the same narrower band, which evicted every
+-- golden-hour sunrise camera the escalation ring admitted (2026-09-05).
+--
+-- Forward-only, idempotent. Both readers and the writer degrade to the
+-- guaranteed-rings zone when this table is missing, so apply order is not
+-- load-bearing, but apply it so the studio strip is honest. Apply via:
+--   node scripts/apply-migration.mjs database/migrations/20260905_kiosk_sweep_zone.sql
+--   node scripts/apply-migration.mjs database/migrations/20260905_kiosk_sweep_zone.sql --apply
+
+CREATE TABLE IF NOT EXISTS kiosk_sweep_zone (
+  id          SMALLINT PRIMARY KEY CHECK (id = 1),
+  min_deg     NUMERIC(6,2) NOT NULL,
+  max_deg     NUMERIC(6,2) NOT NULL,
+  updated_at  TIMESTAMPTZ NOT NULL DEFAULT now()
+);


### PR DESCRIPTION
## Why

The solo studio's sunrise bins were empty all day while the sunset bins held 82 frames. The cron WAS admitting sunrise frames (411 in 24 h); every one was removed as `left_zone` about 2 minutes after entering.

Cause: the sweep admits any camera it returns, escalation rings included, but `maintainBins` aged entries against the **guaranteed** band from `sweepGeometry` (base ring + forced rings). With the day-ring flag off that is -24..-2°. The sunrise terminator sat over the Pacific, the feed was under the 15-camera floor every tick, the sweep escalated to +15.75°, and every golden-hour camera it admitted (Honolulu, Lahaina, Tahiti, Alaska at +0.3..+11°) was marked out of zone on the same tick and evicted three ticks later. Sunset was unaffected only because its terminator was over Europe/Africa and never escalated; this flips with the clock.

## What

- `sweepGeometry.sweptZone(offsets)`: the band of every ring that swept **this** tick. The cron feeds it `sweep.telemetry.rings`, so admission and removal read the same band.
- `maintainBins` records the zone it used in a new one-row `kiosk_sweep_zone` table (non-fatal when unmigrated). The state and advance routes read it back, falling back to the guaranteed band until the cron has written one, so the studio strip shows the band the bins were really checked against.
- Migration `database/migrations/20260905_kiosk_sweep_zone.sql` (additive, idempotent). **Apply before merge** (dry run verified, apply is classifier-blocked for the agent): `node scripts/apply-migration.mjs database/migrations/20260905_kiosk_sweep_zone.sql --from fix/solo-zone-swept-rings --apply`. Both readers and the writer degrade to the guaranteed band if it is missing, so nothing breaks either way, only the strip stays a guess..

## Tests

- `sweptZone` covers escalations and always includes the base ring.
- Cron route: a thin sunrise feed ages the bins against -39.75..13.75, not -24..-2.
- `maintainBins`: Honolulu at 17:06Z on 2026-09-05 (+10.8°) is in zone under the swept band; the zone used is persisted.
- Store: save/get round-trip, Neon string → number, null on missing table.
- State + advance routes: persisted zone wins, guaranteed band as fallback.

Full suite: 262 files / 2069 tests green.

## Note

An escalation ring that stops firing (feed back over the floor) still narrows the zone and evicts its entries after the grace. With the day-ring flag ON (scheduled in the opening-night runbook) the +15.75 ring is guaranteed and this cannot happen for golden hour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01REQnoggvpSstsNaeXBvaQT
