### PR TITLE
feat(studio): deploy history — every Deploy is a numbered snapshot you can load back

### DIFF
--- a/app/api/kiosk/deploys/[id]/load/route.test.ts
+++ b/app/api/kiosk/deploys/[id]/load/route.test.ts
@@ -1,0 +1,45 @@
+// @vitest-environment node
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NextRequest, NextResponse } from 'next/server';
+
+const requireOwnerMock = vi.fn();
+vi.mock('@/app/lib/owner', () => ({ requireOwner: () => requireOwnerMock() }));
+const loadMock = vi.fn();
+vi.mock('@/app/lib/settings/deploys', () => ({
+  loadDeployIntoStudio: (id: number) => loadMock(id),
+}));
+
+import { POST } from './route';
+
+const req = () => new NextRequest('http://test/api/kiosk/deploys/7/load', { method: 'POST' });
+const params = (id: string) => ({ params: Promise.resolve({ id }) });
+
+describe('POST /api/kiosk/deploys/[id]/load', () => {
+  beforeEach(() => {
+    requireOwnerMock.mockReset();
+    loadMock.mockReset();
+    requireOwnerMock.mockResolvedValue(null);
+  });
+  it('rejects non-owners', async () => {
+    requireOwnerMock.mockResolvedValueOnce(NextResponse.json({ error: 'Forbidden' }, { status: 403 }));
+    expect((await POST(req(), params('7'))).status).toBe(403);
+    expect(loadMock).not.toHaveBeenCalled();
+  });
+  it('400 on a bad id', async () => {
+    expect((await POST(req(), params('0'))).status).toBe(400);
+  });
+  it('404 when the deploy does not exist', async () => {
+    loadMock.mockResolvedValueOnce(null);
+    expect((await POST(req(), params('99'))).status).toBe(404);
+  });
+  it('loads into the studio and reports the dropped keys', async () => {
+    const out = {
+      studio: { namespaces: { v1: { floorPx: 140 } }, revision: 2 },
+      dropped: [{ namespace: 'v1', key: 'ghost', reason: 'unknown' }],
+    };
+    loadMock.mockResolvedValueOnce(out);
+    const res = await POST(req(), params('7'));
+    expect(loadMock).toHaveBeenCalledWith(7);
+    expect(await res.json()).toEqual(out);
+  });
+});

--- a/app/api/kiosk/deploys/[id]/load/route.ts
+++ b/app/api/kiosk/deploys/[id]/load/route.ts
@@ -1,0 +1,26 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { requireOwner } from '@/app/lib/owner';
+import { loadDeployIntoStudio } from '@/app/lib/settings/deploys';
+import { parseDeployId } from '../../parseId';
+
+export const dynamic = 'force-dynamic';
+export const runtime = 'nodejs';
+
+/**
+ * Put a recorded deploy into the STUDIO profile so it can be previewed and
+ * then deployed. The glass is untouched: only Deploy changes live.
+ */
+export async function POST(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const denied = await requireOwner();
+  if (denied) return denied;
+  const id = parseDeployId((await params).id);
+  if (id === null) {
+    return NextResponse.json({ error: 'id must be a positive integer' }, { status: 400 });
+  }
+  const out = await loadDeployIntoStudio(id);
+  if (!out) return NextResponse.json({ error: 'no such deploy' }, { status: 404 });
+  return NextResponse.json(out);
+}

--- a/app/api/kiosk/deploys/[id]/route.test.ts
+++ b/app/api/kiosk/deploys/[id]/route.test.ts
@@ -1,0 +1,51 @@
+// @vitest-environment node
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NextRequest, NextResponse } from 'next/server';
+
+const requireOwnerMock = vi.fn();
+vi.mock('@/app/lib/owner', () => ({ requireOwner: () => requireOwnerMock() }));
+const relabelMock = vi.fn();
+vi.mock('@/app/lib/settings/deploys', () => ({
+  relabelDeploy: (id: number, l: unknown) => relabelMock(id, l),
+}));
+
+import { PATCH } from './route';
+
+const req = (body: unknown) =>
+  new NextRequest('http://test/api/kiosk/deploys/7', {
+    method: 'PATCH',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+const params = (id: string) => ({ params: Promise.resolve({ id }) });
+
+describe('PATCH /api/kiosk/deploys/[id]', () => {
+  beforeEach(() => {
+    requireOwnerMock.mockReset();
+    relabelMock.mockReset();
+    requireOwnerMock.mockResolvedValue(null);
+  });
+  it('rejects non-owners', async () => {
+    requireOwnerMock.mockResolvedValueOnce(NextResponse.json({ error: 'Forbidden' }, { status: 403 }));
+    expect((await PATCH(req({ label: 'x' }), params('7'))).status).toBe(403);
+  });
+  it('400 on a bad id, a non-string label, or a label over 60 chars', async () => {
+    expect((await PATCH(req({ label: 'x' }), params('seven'))).status).toBe(400);
+    expect((await PATCH(req({ label: 5 }), params('7'))).status).toBe(400);
+    expect((await PATCH(req({ label: 'x'.repeat(61) }), params('7'))).status).toBe(400);
+    expect(relabelMock).not.toHaveBeenCalled();
+  });
+  it('renames, and null clears the label', async () => {
+    relabelMock.mockResolvedValueOnce(true);
+    const res = await PATCH(req({ label: ' opening night ' }), params('7'));
+    expect(relabelMock).toHaveBeenCalledWith(7, 'opening night');
+    expect(await res.json()).toEqual({ ok: true });
+    relabelMock.mockResolvedValueOnce(true);
+    await PATCH(req({ label: null }), params('7'));
+    expect(relabelMock).toHaveBeenLastCalledWith(7, null);
+  });
+  it('404 when the deploy does not exist', async () => {
+    relabelMock.mockResolvedValueOnce(false);
+    expect((await PATCH(req({ label: 'x' }), params('99'))).status).toBe(404);
+  });
+});

--- a/app/api/kiosk/deploys/[id]/route.ts
+++ b/app/api/kiosk/deploys/[id]/route.ts
@@ -1,0 +1,42 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { requireOwner } from '@/app/lib/owner';
+import { relabelDeploy } from '@/app/lib/settings/deploys';
+import { parseDeployId } from '../parseId';
+
+export const dynamic = 'force-dynamic';
+export const runtime = 'nodejs';
+
+const LABEL_MAX = 60;
+
+/** Rename a deploy. `{ label: null }` clears it. */
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const denied = await requireOwner();
+  if (denied) return denied;
+  const id = parseDeployId((await params).id);
+  if (id === null) {
+    return NextResponse.json({ error: 'id must be a positive integer' }, { status: 400 });
+  }
+  let body: { label?: unknown };
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: 'invalid JSON' }, { status: 400 });
+  }
+  const raw = body?.label;
+  if (raw !== null && typeof raw !== 'string') {
+    return NextResponse.json({ error: 'label must be a string or null' }, { status: 400 });
+  }
+  if (typeof raw === 'string' && raw.length > LABEL_MAX) {
+    return NextResponse.json(
+      { error: `label must be at most ${LABEL_MAX} characters` },
+      { status: 400 },
+    );
+  }
+  const label = typeof raw === 'string' && raw.trim() ? raw.trim() : null;
+  const found = await relabelDeploy(id, label);
+  if (!found) return NextResponse.json({ error: 'no such deploy' }, { status: 404 });
+  return NextResponse.json({ ok: true });
+}

--- a/app/api/kiosk/deploys/parseId.ts
+++ b/app/api/kiosk/deploys/parseId.ts
@@ -1,0 +1,8 @@
+/**
+ * A deploy id from the URL: a positive integer, or null. Route files may only
+ * export handler fields, so this lives beside them.
+ */
+export function parseDeployId(raw: string): number | null {
+  const id = Number(raw);
+  return Number.isInteger(id) && id > 0 ? id : null;
+}

--- a/app/api/kiosk/deploys/route.test.ts
+++ b/app/api/kiosk/deploys/route.test.ts
@@ -1,0 +1,29 @@
+// @vitest-environment node
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NextResponse } from 'next/server';
+
+const requireOwnerMock = vi.fn();
+vi.mock('@/app/lib/owner', () => ({ requireOwner: () => requireOwnerMock() }));
+const listDeploysMock = vi.fn();
+vi.mock('@/app/lib/settings/deploys', () => ({ listDeploys: () => listDeploysMock() }));
+
+import { GET } from './route';
+
+describe('GET /api/kiosk/deploys', () => {
+  beforeEach(() => {
+    requireOwnerMock.mockReset();
+    listDeploysMock.mockReset();
+  });
+  it('rejects non-owners', async () => {
+    requireOwnerMock.mockResolvedValueOnce(NextResponse.json({ error: 'Forbidden' }, { status: 403 }));
+    expect((await GET()).status).toBe(403);
+    expect(listDeploysMock).not.toHaveBeenCalled();
+  });
+  it('returns the list', async () => {
+    requireOwnerMock.mockResolvedValueOnce(null);
+    listDeploysMock.mockResolvedValueOnce([{ id: 1, label: null, namespaces: {}, deployedAt: 'T' }]);
+    expect(await (await GET()).json()).toEqual({
+      deploys: [{ id: 1, label: null, namespaces: {}, deployedAt: 'T' }],
+    });
+  });
+});

--- a/app/api/kiosk/deploys/route.ts
+++ b/app/api/kiosk/deploys/route.ts
@@ -1,0 +1,13 @@
+import { NextResponse } from 'next/server';
+import { requireOwner } from '@/app/lib/owner';
+import { listDeploys } from '@/app/lib/settings/deploys';
+
+export const dynamic = 'force-dynamic';
+export const runtime = 'nodejs';
+
+/** Every recorded Deploy, newest first (spec §2.3). */
+export async function GET() {
+  const denied = await requireOwner();
+  if (denied) return denied;
+  return NextResponse.json({ deploys: await listDeploys() });
+}

--- a/app/api/kiosk/settings/deploy/route.test.ts
+++ b/app/api/kiosk/settings/deploy/route.test.ts
@@ -12,6 +12,11 @@ vi.mock('@/app/lib/settings/store', () => ({
   copyProfile: (f: unknown, t: unknown) => copyProfileMock(f, t),
 }));
 
+const recordDeployMock = vi.fn();
+vi.mock('@/app/lib/settings/deploys', () => ({
+  recordDeploy: (live: unknown, label: unknown) => recordDeployMock(live, label),
+}));
+
 const setKioskLiveSettingsCacheMock = vi.fn();
 vi.mock('@/app/lib/cache', () => ({
   setKioskLiveSettingsCache: (s: unknown) => setKioskLiveSettingsCacheMock(s),
@@ -30,6 +35,7 @@ describe('POST /api/kiosk/settings/deploy', () => {
     requireOwnerMock.mockReset();
     copyProfileMock.mockReset();
     setKioskLiveSettingsCacheMock.mockReset();
+    recordDeployMock.mockReset();
   });
 
   it('rejects non-owners', async () => {
@@ -55,6 +61,39 @@ describe('POST /api/kiosk/settings/deploy', () => {
     expect(copyProfileMock).toHaveBeenCalledWith('studio', 'live');
     expect(setKioskLiveSettingsCacheMock).toHaveBeenCalledWith(liveSettings);
     const body = await res.json();
-    expect(body).toEqual({ live: liveSettings });
+    expect(body).toEqual({ live: liveSettings, deploy: null });
+  });
+
+  it('records the copied profile and returns the deploy row', async () => {
+    requireOwnerMock.mockResolvedValueOnce(null);
+    const live = { namespaces: { v1: { floorPx: 140 } }, revision: 4 };
+    copyProfileMock.mockResolvedValueOnce(live);
+    recordDeployMock.mockResolvedValueOnce({ id: 7, label: 'opening night', namespaces: live.namespaces, deployedAt: 'T' });
+    const res = await POST(new Request('http://test/api/kiosk/settings/deploy', {
+      method: 'POST', headers: { 'content-type': 'application/json' }, body: JSON.stringify({ label: 'opening night' }),
+    }));
+    expect(res.status).toBe(200);
+    expect(recordDeployMock).toHaveBeenCalledWith(live, 'opening night');
+    expect(await res.json()).toEqual({
+      live, deploy: { id: 7, label: 'opening night', namespaces: live.namespaces, deployedAt: 'T' },
+    });
+  });
+
+  it('a bodiless POST still deploys, with no label, and a failed record comes back as null', async () => {
+    requireOwnerMock.mockResolvedValueOnce(null);
+    const live = { namespaces: {}, revision: 5 };
+    copyProfileMock.mockResolvedValueOnce(live);
+    recordDeployMock.mockResolvedValueOnce(null);
+    const res = await POST();
+    expect(recordDeployMock).toHaveBeenCalledWith(live, null);
+    expect(await res.json()).toEqual({ live, deploy: null });
+  });
+
+  it('clips a label to 60 characters', async () => {
+    requireOwnerMock.mockResolvedValueOnce(null);
+    copyProfileMock.mockResolvedValueOnce({ namespaces: {}, revision: 6 });
+    recordDeployMock.mockResolvedValueOnce(null);
+    await POST(new Request('http://test/x', { method: 'POST', body: JSON.stringify({ label: 'x'.repeat(80) }) }));
+    expect(recordDeployMock.mock.calls[0][1]).toHaveLength(60);
   });
 });

--- a/app/api/kiosk/settings/deploy/route.test.ts
+++ b/app/api/kiosk/settings/deploy/route.test.ts
@@ -55,6 +55,7 @@ describe('POST /api/kiosk/settings/deploy', () => {
     };
     requireOwnerMock.mockResolvedValueOnce(null);
     copyProfileMock.mockResolvedValueOnce(liveSettings);
+    recordDeployMock.mockResolvedValueOnce(null);
 
     const res = await POST(reqPost());
     expect(res.status).toBe(200);

--- a/app/api/kiosk/settings/deploy/route.test.ts
+++ b/app/api/kiosk/settings/deploy/route.test.ts
@@ -42,7 +42,7 @@ describe('POST /api/kiosk/settings/deploy', () => {
     requireOwnerMock.mockResolvedValueOnce(
       NextResponse.json({ error: 'Forbidden' }, { status: 403 }),
     );
-    const res = await POST();
+    const res = await POST(reqPost());
     expect(res.status).toBe(403);
     expect(copyProfileMock).not.toHaveBeenCalled();
     expect(setKioskLiveSettingsCacheMock).not.toHaveBeenCalled();
@@ -85,7 +85,7 @@ describe('POST /api/kiosk/settings/deploy', () => {
     const live = { namespaces: {}, revision: 5 };
     copyProfileMock.mockResolvedValueOnce(live);
     recordDeployMock.mockResolvedValueOnce(null);
-    const res = await POST();
+    const res = await POST(reqPost());
     expect(recordDeployMock).toHaveBeenCalledWith(live, null);
     expect(await res.json()).toEqual({ live, deploy: null });
   });

--- a/app/api/kiosk/settings/deploy/route.ts
+++ b/app/api/kiosk/settings/deploy/route.ts
@@ -1,15 +1,35 @@
 import { NextResponse } from 'next/server';
 import { requireOwner } from '@/app/lib/owner';
 import { copyProfile } from '@/app/lib/settings/store';
+import { recordDeploy } from '@/app/lib/settings/deploys';
 import { setKioskLiveSettingsCache } from '@/app/lib/cache';
 
 export const dynamic = 'force-dynamic';
 export const runtime = 'nodejs';
 
-export async function POST() {
+const LABEL_MAX = 60;
+
+/** Optional `{ label }`. No body, or a malformed one, is a deploy with no label. */
+async function labelOf(request?: Request): Promise<string | null> {
+  if (!request) return null;
+  try {
+    const body = (await request.json()) as { label?: unknown };
+    return typeof body?.label === 'string' && body.label.trim()
+      ? body.label.trim().slice(0, LABEL_MAX)
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+export async function POST(request?: Request) {
   const denied = await requireOwner();
   if (denied) return denied;
+  const label = await labelOf(request);
   const live = await copyProfile('studio', 'live');
   await setKioskLiveSettingsCache(live);
-  return NextResponse.json({ live });
+  // History is bookkeeping: it must not fail the deploy, and `null` is how
+  // the studio learns it was not written instead of assuming it was.
+  const deploy = await recordDeploy(live, label);
+  return NextResponse.json({ live, deploy });
 }

--- a/app/api/kiosk/settings/deploy/route.ts
+++ b/app/api/kiosk/settings/deploy/route.ts
@@ -10,8 +10,7 @@ export const runtime = 'nodejs';
 const LABEL_MAX = 60;
 
 /** Optional `{ label }`. No body, or a malformed one, is a deploy with no label. */
-async function labelOf(request?: Request): Promise<string | null> {
-  if (!request) return null;
+async function labelOf(request: Request): Promise<string | null> {
   try {
     const body = (await request.json()) as { label?: unknown };
     return typeof body?.label === 'string' && body.label.trim()
@@ -22,7 +21,7 @@ async function labelOf(request?: Request): Promise<string | null> {
   }
 }
 
-export async function POST(request?: Request) {
+export async function POST(request: Request) {
   const denied = await requireOwner();
   if (denied) return denied;
   const label = await labelOf(request);

--- a/app/lib/settings/deploys.test.ts
+++ b/app/lib/settings/deploys.test.ts
@@ -1,0 +1,127 @@
+// @vitest-environment node
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+type SqlTag = {
+  (strings: TemplateStringsArray, ...values: unknown[]): unknown;
+  transaction: unknown;
+  __sqlMock: ReturnType<typeof vi.fn>;
+  __txnMock: ReturnType<typeof vi.fn>;
+};
+
+vi.mock('@/app/lib/db', async () => {
+  const sqlMockFn = vi.fn();
+  const txnMockFn = vi.fn();
+  const tag = (strings: TemplateStringsArray, ...values: unknown[]) => sqlMockFn(strings, ...values);
+  const t = tag as unknown as SqlTag;
+  t.transaction = txnMockFn;
+  t.__sqlMock = sqlMockFn;
+  t.__txnMock = txnMockFn;
+  return { sql: tag };
+});
+
+vi.mock('@/app/components/mosaic/registry', () => ({
+  MOSAIC_VERSIONS: { v1: {} },
+  DEFAULT_MOSAIC_VERSION: 'v1',
+  MOSAIC_SETTINGS_SCHEMAS: {
+    v1: [{ key: 'floorPx', kind: 'number', min: 20, max: 800, step: 10, default: 100, label: 'floor', description: '', section: 's' }],
+  },
+}));
+
+import { recordDeploy, listDeploys, loadDeployIntoStudio, relabelDeploy } from './deploys';
+import { sql } from '@/app/lib/db';
+
+const sqlMock = (sql as unknown as SqlTag).__sqlMock;
+const txnMock = (sql as unknown as SqlTag).__txnMock;
+const text = (call: unknown[]) => (call[0] as TemplateStringsArray).join('?');
+/** Answer each statement by a fragment of its text; anything else (the transaction's DELETE/INSERT tags) gets undefined. */
+const byStatement = (answers: Record<string, unknown[]>) =>
+  sqlMock.mockImplementation((strings: TemplateStringsArray) => {
+    const t = strings.join('?');
+    const hit = Object.keys(answers).find((k) => t.includes(k));
+    return hit ? Promise.resolve(answers[hit]) : undefined;
+  });
+
+beforeEach(() => {
+  sqlMock.mockReset();
+  txnMock.mockReset();
+  vi.spyOn(console, 'warn').mockImplementation(() => {});
+});
+
+describe('recordDeploy', () => {
+  it('inserts the whole profile and returns the row', async () => {
+    sqlMock.mockResolvedValueOnce([
+      { id: 7, label: null, namespaces: { v1: { floorPx: 140 } }, deployed_at: '2026-09-05T18:30:00.000Z' },
+    ]);
+    const row = await recordDeploy({ namespaces: { v1: { floorPx: 140 } }, revision: 3 }, null);
+    expect(row).toEqual({
+      id: 7, label: null, namespaces: { v1: { floorPx: 140 } }, deployedAt: '2026-09-05T18:30:00.000Z',
+    });
+    expect(text(sqlMock.mock.calls[0])).toContain('INSERT INTO kiosk_deploys');
+    expect(sqlMock.mock.calls[0][2]).toBe(JSON.stringify({ v1: { floorPx: 140 } }));
+  });
+  it('returns null instead of throwing when the table is missing', async () => {
+    sqlMock.mockRejectedValueOnce(new Error('relation "kiosk_deploys" does not exist'));
+    expect(await recordDeploy({ namespaces: {}, revision: 1 })).toBeNull();
+  });
+});
+
+describe('listDeploys', () => {
+  it('maps rows newest first and defaults the limit to 50', async () => {
+    sqlMock.mockResolvedValueOnce([
+      { id: 2, label: 'b', namespaces: {}, deployed_at: '2026-09-05T18:30:00.000Z' },
+      { id: 1, label: null, namespaces: {}, deployed_at: '2026-09-05T17:00:00.000Z' },
+    ]);
+    const rows = await listDeploys();
+    expect(rows.map((r) => r.id)).toEqual([2, 1]);
+    expect(text(sqlMock.mock.calls[0])).toContain('ORDER BY id DESC');
+    expect(sqlMock.mock.calls[0][1]).toBe(50);
+  });
+  it('returns [] when the read fails', async () => {
+    sqlMock.mockRejectedValueOnce(new Error('nope'));
+    expect(await listDeploys()).toEqual([]);
+  });
+});
+
+describe('loadDeployIntoStudio', () => {
+  it('returns null for an unknown id', async () => {
+    sqlMock.mockResolvedValueOnce([]);
+    expect(await loadDeployIntoStudio(99)).toBeNull();
+    expect(txnMock).not.toHaveBeenCalled();
+  });
+  it('replaces the studio profile wholesale, sanitizing through the current schema and naming what it dropped', async () => {
+    // The transaction's tagged calls also go through sqlMock, so answer by statement, not by order.
+    byStatement({
+      'SELECT namespaces': [{ namespaces: { v1: { floorPx: 140, ghost: 1 }, gone: { x: 2 } } }],
+      'SELECT namespace, data': [{ namespace: 'v1', data: { floorPx: 140 }, revision: 1 }],
+    });
+    const out = await loadDeployIntoStudio(7);
+    expect(out?.studio).toEqual({ namespaces: { v1: { floorPx: 140 } }, revision: 1 });
+    expect(out?.dropped).toEqual([
+      { namespace: 'v1', key: 'ghost', reason: 'unknown' },
+      { namespace: 'gone', key: 'x', reason: 'unknown' },
+    ]);
+    const [statements] = txnMock.mock.calls[0];
+    expect(statements).toHaveLength(2); // DELETE every studio row, then one INSERT per surviving namespace
+    const deleteCall = sqlMock.mock.calls.find((c) =>
+      text(c).includes("DELETE FROM kiosk_settings WHERE profile = 'studio'"));
+    expect(deleteCall).toBeDefined();
+    const insertCall = sqlMock.mock.calls.find((c) => text(c).includes('INSERT INTO kiosk_settings'));
+    expect(insertCall?.[1]).toBe('v1');
+    expect(insertCall?.[2]).toBe(JSON.stringify({ floorPx: 140 }));
+  });
+  it('a namespace whose every value is at default is not written back', async () => {
+    byStatement({ 'SELECT namespaces': [{ namespaces: { v1: { floorPx: 100 } } }], 'SELECT namespace, data': [] });
+    const out = await loadDeployIntoStudio(3);
+    expect(out?.studio).toEqual({ namespaces: {}, revision: 0 });
+    expect(txnMock.mock.calls[0][0]).toHaveLength(1);
+  });
+});
+
+describe('relabelDeploy', () => {
+  it('true when a row changed, false when none did', async () => {
+    sqlMock.mockResolvedValueOnce([{ id: 7 }]);
+    expect(await relabelDeploy(7, 'opening night')).toBe(true);
+    sqlMock.mockResolvedValueOnce([]);
+    expect(await relabelDeploy(8, null)).toBe(false);
+  });
+});

--- a/app/lib/settings/deploys.ts
+++ b/app/lib/settings/deploys.ts
@@ -1,0 +1,123 @@
+import 'server-only';
+import { sql } from '@/app/lib/db';
+import { getProfileSettings, type ProfileSettings } from './store';
+import {
+  droppedKeys,
+  sanitizeValues,
+  stripDefaults,
+  type DroppedKey,
+  type SettingsValues,
+} from './schema';
+import { schemaFor } from './knownSchemas';
+
+/** One studio Deploy, the whole profile as it was copied to live (spec §2.1). */
+export interface DeployRow {
+  id: number;
+  label: string | null;
+  namespaces: Record<string, SettingsValues>;
+  deployedAt: string;
+}
+
+export type DroppedDeployKey = DroppedKey & { namespace: string };
+
+interface Row {
+  id: number;
+  label: string | null;
+  namespaces: Record<string, SettingsValues>;
+  deployed_at: string | Date;
+}
+
+function toRow(r: Row): DeployRow {
+  return {
+    id: Number(r.id),
+    label: r.label,
+    namespaces: r.namespaces,
+    deployedAt: new Date(r.deployed_at).toISOString(),
+  };
+}
+
+/**
+ * Record the profile Deploy just copied. Never throws: history failing to
+ * write must not fail the deploy, and the null return is how the route says
+ * so instead of hiding it.
+ */
+export async function recordDeploy(
+  live: ProfileSettings,
+  label?: string | null,
+): Promise<DeployRow | null> {
+  try {
+    const rows = (await sql`
+      INSERT INTO kiosk_deploys (label, namespaces)
+      VALUES (${label ?? null}, ${JSON.stringify(live.namespaces)}::jsonb)
+      RETURNING id, label, namespaces, deployed_at
+    `) as unknown as Row[];
+    return toRow(rows[0]);
+  } catch (error) {
+    console.warn('[deploys] recordDeploy failed:', error);
+    return null;
+  }
+}
+
+export async function listDeploys(limit = 50): Promise<DeployRow[]> {
+  try {
+    const rows = (await sql`
+      SELECT id, label, namespaces, deployed_at FROM kiosk_deploys ORDER BY id DESC LIMIT ${limit}
+    `) as unknown as Row[];
+    return rows.map(toRow);
+  } catch (error) {
+    console.warn('[deploys] listDeploys failed:', error);
+    return [];
+  }
+}
+
+/**
+ * Replace the studio profile with a snapshot. Wholesale: a studio namespace
+ * the snapshot never had is deleted, otherwise a stale deviation would
+ * survive underneath the restore. Every namespace is read through its
+ * current schema and the casualties are returned by name (schemas drift).
+ * Delete-all-then-insert rather than a NOT IN list so no array parameter
+ * crosses the driver; studio revisions restart at 1, which nothing reads.
+ */
+export async function loadDeployIntoStudio(
+  id: number,
+): Promise<{ studio: ProfileSettings; dropped: DroppedDeployKey[] } | null> {
+  const rows = (await sql`
+    SELECT namespaces FROM kiosk_deploys WHERE id = ${id}
+  `) as unknown as Pick<Row, 'namespaces'>[];
+  if (!rows[0]) return null;
+
+  const dropped: DroppedDeployKey[] = [];
+  const clean: Record<string, SettingsValues> = {};
+  for (const [namespace, values] of Object.entries(rows[0].namespaces ?? {})) {
+    const schema = schemaFor(namespace);
+    if (!schema) {
+      for (const key of Object.keys(values ?? {})) dropped.push({ namespace, key, reason: 'unknown' });
+      continue;
+    }
+    for (const d of droppedKeys(schema, values)) dropped.push({ namespace, ...d });
+    const deviations = stripDefaults(schema, sanitizeValues(schema, values));
+    if (Object.keys(deviations).length > 0) clean[namespace] = deviations;
+  }
+
+  await sql.transaction([
+    sql`DELETE FROM kiosk_settings WHERE profile = 'studio'`,
+    ...Object.entries(clean).map(
+      ([namespace, deviations]) => sql`
+        INSERT INTO kiosk_settings (profile, namespace, data)
+        VALUES ('studio', ${namespace}, ${JSON.stringify(deviations)}::jsonb)
+        ON CONFLICT (profile, namespace)
+        DO UPDATE SET data = EXCLUDED.data,
+                      revision = kiosk_settings.revision + 1,
+                      updated_at = now()
+      `,
+    ),
+  ]);
+  return { studio: await getProfileSettings('studio'), dropped };
+}
+
+export async function relabelDeploy(id: number, label: string | null): Promise<boolean> {
+  const rows = (await sql`
+    UPDATE kiosk_deploys SET label = ${label} WHERE id = ${id} RETURNING id
+  `) as unknown as { id: number }[];
+  return rows.length > 0;
+}

--- a/app/lib/settings/knownSchemas.ts
+++ b/app/lib/settings/knownSchemas.ts
@@ -1,0 +1,11 @@
+import type { SettingsSchema } from './schema';
+import { SHARED_NAMESPACE, SHARED_SCHEMA } from './sharedSchema';
+import { MOSAIC_SETTINGS_SCHEMAS } from '@/app/components/mosaic/registry';
+
+/** The schema a namespace's deviations are read through, or null for a namespace this build does not know. */
+export function schemaFor(namespace: string): SettingsSchema | null {
+  if (namespace === SHARED_NAMESPACE) return SHARED_SCHEMA;
+  return MOSAIC_SETTINGS_SCHEMAS[namespace] ?? null;
+}
+
+export const KNOWN_NAMESPACES: string[] = [SHARED_NAMESPACE, ...Object.keys(MOSAIC_SETTINGS_SCHEMAS)];

--- a/app/studio/DeployButton.test.tsx
+++ b/app/studio/DeployButton.test.tsx
@@ -81,7 +81,7 @@ describe('DeployButton', () => {
   it('revert button is disabled when in sync', () => {
     render(<DeployButton diffCount={0} onDeploy={vi.fn()} onRevert={vi.fn()} />);
 
-    const revertButton = screen.getByRole('button', { name: /revert to glass/i });
+    const revertButton = screen.getByRole('button', { name: /discard changes/i });
     expect(revertButton).toBeDisabled();
   });
 
@@ -89,7 +89,7 @@ describe('DeployButton', () => {
     const onRevert = vi.fn().mockResolvedValue(undefined);
     render(<DeployButton diffCount={1} onDeploy={vi.fn()} onRevert={onRevert} />);
 
-    const revertButton = screen.getByRole('button', { name: /revert to glass/i });
+    const revertButton = screen.getByRole('button', { name: /discard changes/i });
     expect(revertButton).not.toBeDisabled();
 
     fireEvent.click(revertButton);
@@ -103,7 +103,7 @@ describe('DeployButton', () => {
       .mockResolvedValueOnce(undefined);
     render(<DeployButton diffCount={2} onDeploy={vi.fn()} onRevert={onRevert} />);
 
-    const revertButton = screen.getByRole('button', { name: /revert to glass/i });
+    const revertButton = screen.getByRole('button', { name: /discard changes/i });
 
     fireEvent.click(revertButton);
     await act(async () => {
@@ -124,7 +124,7 @@ describe('DeployButton', () => {
 
     expect(onRevert).toHaveBeenCalledTimes(2);
     expect(screen.queryByText('revert failed — try again')).not.toBeInTheDocument();
-    expect(screen.getByText('↩ revert to glass')).toBeInTheDocument();
+    expect(screen.getByText('↩ discard changes')).toBeInTheDocument();
   });
 
   it('compact variant renders DEPLOY and an N differ chip', () => {

--- a/app/studio/DeployButton.tsx
+++ b/app/studio/DeployButton.tsx
@@ -252,7 +252,7 @@ export function DeployButton({
           opacity: inSync ? 0.35 : 1,
         }}
       >
-        {revertFailed ? 'revert failed — try again' : '↩ revert to glass'}
+        {revertFailed ? 'revert failed — try again' : '↩ discard changes'}
       </button>
     </div>
   );

--- a/app/studio/DeployHistory.test.tsx
+++ b/app/studio/DeployHistory.test.tsx
@@ -1,0 +1,88 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import type { StudioSettingsApi } from './useStudioSettings';
+import type { DeployRow } from '@/app/lib/settings/deploys';
+
+vi.mock('@/app/components/mosaic/registry', () => ({
+  MOSAIC_VERSIONS: { v1: {} },
+  DEFAULT_MOSAIC_VERSION: 'v1',
+  MOSAIC_SETTINGS_SCHEMAS: {
+    v1: [{ key: 'floorPx', kind: 'number', min: 20, max: 800, step: 10, default: 100, label: 'floor', description: '', section: 's' }],
+  },
+}));
+
+import { DeployHistory } from './DeployHistory';
+
+const deploys: DeployRow[] = [
+  { id: 2, label: 'opening night', namespaces: { v1: { floorPx: 140 } }, deployedAt: '2026-09-05T18:30:00.000Z' },
+  { id: 1, label: null, namespaces: {}, deployedAt: '2026-09-05T17:00:00.000Z' },
+];
+
+function api(over: Partial<StudioSettingsApi> = {}): StudioSettingsApi {
+  return {
+    loading: false,
+    studio: { namespaces: { v1: { floorPx: 140 } }, revision: 1 },
+    live: { namespaces: {}, revision: 1 },
+    lastPollAt: null, liveRevision: 1,
+    effective: () => ({}), setKnob: vi.fn(), resetSection: vi.fn(), applyNamespace: () => [],
+    diffByNamespace: {}, diffCount: 1,
+    deploy: async () => {}, revert: async () => {}, deployedAtMs: null, droppedKeys: [],
+    deploys, loadDeploy: vi.fn(async () => []), relabelDeploy: vi.fn(async () => {}), lastDeployRecorded: null,
+    ...over,
+  };
+}
+
+describe('DeployHistory', () => {
+  it('lists deploys newest first with number, label, summary, and the glass/studio badges', () => {
+    render(<DeployHistory api={api()} />);
+    const rows = screen.getAllByRole('listitem');
+    expect(rows[0]).toHaveTextContent('#2');
+    expect(rows[0]).toHaveTextContent('opening night');
+    expect(rows[0]).toHaveTextContent('floorPx 140');
+    expect(rows[0]).toHaveTextContent('studio');
+    expect(rows[1]).toHaveTextContent('#1');
+    expect(rows[1]).toHaveTextContent('first recorded');
+    expect(rows[1]).toHaveTextContent('glass');
+    expect(rows[0]).not.toHaveTextContent('glass');
+  });
+
+  it('clicking a row loads it into the studio and reports a partial fit', async () => {
+    const loadDeploy = vi.fn(async () => [{ namespace: 'v1', key: 'ghost', reason: 'unknown' as const }]);
+    render(<DeployHistory api={api({ loadDeploy, deploys: [{ ...deploys[0], namespaces: { v1: { floorPx: 140, ghost: 1 } } }] })} />);
+    await act(async () => { fireEvent.click(screen.getByRole('button', { name: /load deploy #2/i })); });
+    expect(loadDeploy).toHaveBeenCalledWith(2);
+    expect(screen.getByText('loaded, 1 of 2 keys fit the current schema')).toBeInTheDocument();
+  });
+
+  it('a 404 on load reads as gone', async () => {
+    const loadDeploy = vi.fn(async () => { throw new Error('load deploy failed: 404'); });
+    render(<DeployHistory api={api({ loadDeploy })} />);
+    await act(async () => { fireEvent.click(screen.getByRole('button', { name: /load deploy #1/i })); });
+    expect(screen.getByText('gone')).toBeInTheDocument();
+  });
+
+  it('the label is edited inline: Enter saves, Escape cancels', async () => {
+    const relabelDeploy = vi.fn(async () => {});
+    render(<DeployHistory api={api({ relabelDeploy })} />);
+    fireEvent.click(screen.getByRole('button', { name: /label deploy #1/i }));
+    const input = screen.getByRole('textbox');
+    fireEvent.change(input, { target: { value: 'before the show' } });
+    await act(async () => { fireEvent.keyDown(input, { key: 'Enter' }); });
+    expect(relabelDeploy).toHaveBeenCalledWith(1, 'before the show');
+    fireEvent.click(screen.getByRole('button', { name: /label deploy #2/i }));
+    fireEvent.keyDown(screen.getByRole('textbox'), { key: 'Escape' });
+    expect(screen.queryByRole('textbox')).toBeNull();
+    expect(relabelDeploy).toHaveBeenCalledTimes(1);
+  });
+
+  it('says when the last deploy was not recorded', () => {
+    render(<DeployHistory api={api({ lastDeployRecorded: false })} />);
+    expect(screen.getByText(/history not recorded/)).toBeInTheDocument();
+  });
+
+  it('renders nothing but the heading when there are no deploys', () => {
+    render(<DeployHistory api={api({ deploys: [] })} />);
+    expect(screen.getByText('deploys')).toBeInTheDocument();
+    expect(screen.queryAllByRole('listitem')).toHaveLength(0);
+  });
+});

--- a/app/studio/DeployHistory.tsx
+++ b/app/studio/DeployHistory.tsx
@@ -1,0 +1,141 @@
+'use client';
+
+import { useState } from 'react';
+import type { StudioSettingsApi } from './useStudioSettings';
+import type { DeployRow } from '@/app/lib/settings/deploys';
+import { profileEquals, summarize } from './deploySummary';
+
+const mono = 'ui-monospace, SFMono-Regular, Menlo, monospace';
+const LABEL_MAX = 60;
+
+function when(iso: string): string {
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return '';
+  return d.toLocaleString(undefined, { month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit' });
+}
+
+function keyCount(row: DeployRow): number {
+  return Object.values(row.namespaces).reduce((n, values) => n + Object.keys(values ?? {}).length, 0);
+}
+
+function Badge({ children, color }: { children: string; color: string }) {
+  return (
+    <span style={{
+      fontSize: 9, fontWeight: 700, padding: '1px 5px', borderRadius: 999, marginLeft: 4,
+      border: `1px solid ${color}`, color, textTransform: 'uppercase', letterSpacing: '.04em',
+    }}>{children}</span>
+  );
+}
+
+/**
+ * Every recorded Deploy, newest first, under the Deploy button (spec §2.5).
+ * Click a row to put that deploy into the studio; Deploy then sends it to
+ * the glass. Nothing here touches live.
+ */
+export function DeployHistory({ api }: { api: StudioSettingsApi }) {
+  const { deploys, studio, live, loadDeploy, relabelDeploy, lastDeployRecorded } = api;
+  const [editing, setEditing] = useState<{ id: number; draft: string } | null>(null);
+  const [note, setNote] = useState<{ id: number; text: string } | null>(null);
+
+  const load = async (row: DeployRow) => {
+    setNote(null);
+    try {
+      const dropped = await loadDeploy(row.id);
+      if (dropped.length > 0) {
+        const total = keyCount(row);
+        setNote({ id: row.id, text: `loaded, ${total - dropped.length} of ${total} keys fit the current schema` });
+      }
+    } catch (e) {
+      setNote({ id: row.id, text: /404/.test(String(e)) ? 'gone' : 'load failed' });
+    }
+  };
+
+  const saveLabel = async () => {
+    if (!editing) return;
+    const label = editing.draft.trim().slice(0, LABEL_MAX) || null;
+    setEditing(null);
+    try {
+      await relabelDeploy(editing.id, label);
+    } catch {
+      setNote({ id: editing.id, text: 'rename failed' });
+    }
+  };
+
+  return (
+    <section style={{ marginTop: 10, fontFamily: mono, fontSize: 11 }}>
+      <h4
+        style={{ margin: '0 0 4px', fontSize: 10, letterSpacing: '.06em', textTransform: 'uppercase', color: '#8b95a7', cursor: 'help' }}
+        title="Every Deploy, newest first. Click one to load it into the studio; Deploy then sends it to the glass."
+      >
+        deploys
+      </h4>
+      {lastDeployRecorded === false && (
+        <div style={{ color: '#e5484d', marginBottom: 4 }}>history not recorded (table missing?)</div>
+      )}
+      <ul style={{ listStyle: 'none', margin: 0, padding: 0, maxHeight: 260, overflowY: 'auto' }}>
+        {deploys.map((row, i) => {
+          const onGlass = profileEquals(row.namespaces, live?.namespaces);
+          const inStudio = profileEquals(row.namespaces, studio?.namespaces);
+          const isEditing = editing?.id === row.id;
+          return (
+            <li key={row.id} style={{ borderTop: '1px solid #1d2432', padding: '4px 0' }}>
+              <div style={{ display: 'flex', alignItems: 'baseline', gap: 6 }}>
+                <button
+                  type="button"
+                  onClick={() => void load(row)}
+                  aria-label={`load deploy #${row.id} into the studio`}
+                  title="Load into the studio (undeployed studio edits are discarded)"
+                  style={{
+                    background: 'transparent', border: 0, padding: 0, color: '#e5e7eb', fontFamily: mono,
+                    fontSize: 11, cursor: 'pointer', textAlign: 'left', flex: 1, minWidth: 0,
+                  }}
+                >
+                  <b style={{ color: '#f5a344' }}>#{row.id}</b>
+                  <span style={{ color: '#6b7280', marginLeft: 6 }}>{when(row.deployedAt)}</span>
+                  <span style={{ display: 'block', color: '#9aa3b2', whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>
+                    {summarize(row, deploys[i + 1])}
+                  </span>
+                </button>
+                <span style={{ whiteSpace: 'nowrap' }}>
+                  {onGlass && <Badge color="#7ee2ac">glass</Badge>}
+                  {inStudio && <Badge color="#f5a344">studio</Badge>}
+                </span>
+              </div>
+              {isEditing ? (
+                <input
+                  autoFocus
+                  value={editing.draft}
+                  maxLength={LABEL_MAX}
+                  aria-label={`label for deploy #${row.id}`}
+                  onChange={(e) => setEditing({ id: row.id, draft: e.target.value })}
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter') void saveLabel();
+                    if (e.key === 'Escape') setEditing(null);
+                  }}
+                  style={{
+                    width: '100%', marginTop: 2, background: '#0b0e14', color: '#e5e7eb', border: '1px solid #2a3242',
+                    borderRadius: 4, fontFamily: mono, fontSize: 11, padding: '2px 4px',
+                  }}
+                />
+              ) : (
+                <button
+                  type="button"
+                  onClick={() => setEditing({ id: row.id, draft: row.label ?? '' })}
+                  aria-label={`label deploy #${row.id}`}
+                  title="Click to rename"
+                  style={{
+                    background: 'transparent', border: 0, padding: 0, color: row.label ? '#c3cad6' : '#4b5568',
+                    fontFamily: mono, fontSize: 11, cursor: 'text', fontStyle: row.label ? 'normal' : 'italic',
+                  }}
+                >
+                  {row.label ?? 'add a label'}
+                </button>
+              )}
+              {note?.id === row.id && <div style={{ color: '#f5a344', marginTop: 2 }}>{note.text}</div>}
+            </li>
+          );
+        })}
+      </ul>
+    </section>
+  );
+}

--- a/app/studio/StudioClient.tsx
+++ b/app/studio/StudioClient.tsx
@@ -9,6 +9,7 @@ import { MapMosaicModeToggle } from '@/app/components/MapMosaicModeToggle';
 import { useStudioSettings } from './useStudioSettings';
 import { useSceneWebcams, type SceneSource } from './useSceneWebcams';
 import { DeployButton } from './DeployButton';
+import { DeployHistory } from './DeployHistory';
 import { StatusStrip } from './StatusStrip';
 import { resolveMosaicName } from '@/app/components/mosaic/registry';
 import { mergeSettings } from '@/app/lib/settings/schema';
@@ -189,11 +190,14 @@ export function StudioClient() {
             api={settingsApi}
             onCollapse={() => setRailCollapsed(true)}
             deploySlot={
-              <DeployButton
-                diffCount={settingsApi.diffCount}
-                onDeploy={settingsApi.deploy}
-                onRevert={settingsApi.revert}
-              />
+              <>
+                <DeployButton
+                  diffCount={settingsApi.diffCount}
+                  onDeploy={settingsApi.deploy}
+                  onRevert={settingsApi.revert}
+                />
+                <DeployHistory api={settingsApi} />
+              </>
             }
           />
           <div

--- a/app/studio/deploySummary.test.ts
+++ b/app/studio/deploySummary.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('@/app/components/mosaic/registry', () => ({
+  MOSAIC_VERSIONS: { v1: {} },
+  DEFAULT_MOSAIC_VERSION: 'v1',
+  MOSAIC_SETTINGS_SCHEMAS: {
+    v1: [
+      { key: 'floorPx', kind: 'number', min: 20, max: 800, step: 10, default: 100, label: 'floor', description: '', section: 's' },
+      { key: 'gate', kind: 'number', min: 0, max: 1, step: 0.01, default: 0.5, label: 'gate', description: '', section: 's' },
+      { key: 'label', kind: 'boolean', default: false, label: 'label', description: '', section: 's' },
+      { key: 'ceilingPx', kind: 'number', min: 100, max: 2000, step: 10, default: 1000, label: 'ceiling', description: '', section: 's' },
+    ],
+  },
+}));
+
+import { summarize, profileEquals, formatValue } from './deploySummary';
+
+const row = (id: number, namespaces: Record<string, Record<string, number | boolean | string>>) =>
+  ({ id, label: null, namespaces, deployedAt: 'T' });
+
+describe('formatValue', () => {
+  it('integers plain, fractions to two places, booleans on/off, strings as-is', () => {
+    expect(formatValue(140)).toBe('140');
+    expect(formatValue(0.549999)).toBe('0.55');
+    expect(formatValue(true)).toBe('on');
+    expect(formatValue('solo')).toBe('solo');
+  });
+});
+
+describe('summarize', () => {
+  it('the first recorded deploy says so', () => {
+    expect(summarize(row(1, { v1: { floorPx: 140 } }), undefined)).toBe('first recorded');
+  });
+  it('lists what changed against the previous deploy with the new values', () => {
+    expect(summarize(row(2, { v1: { floorPx: 140, gate: 0.18 } }), row(1, { v1: { floorPx: 140 } }))).toBe('gate 0.18');
+  });
+  it('a namespace going back to defaults reads as its keys returning to default values', () => {
+    expect(summarize(row(2, {}), row(1, { v1: { floorPx: 140 } }))).toBe('floorPx 100');
+  });
+  it('caps at three and counts the rest', () => {
+    expect(summarize(row(2, { v1: { floorPx: 140, gate: 0.18, label: true, ceilingPx: 1100 } }), row(1, {})))
+      .toBe('floorPx 140 · gate 0.18 · label on · +1');
+  });
+  it('an identical redeploy says no dial changes', () => {
+    expect(summarize(row(2, { v1: { floorPx: 140 } }), row(1, { v1: { floorPx: 140 } }))).toBe('no dial changes');
+  });
+});
+
+describe('profileEquals', () => {
+  it('compares effective values per known namespace, so defaults and absent rows are equal', () => {
+    expect(profileEquals({ v1: { floorPx: 100 } }, {})).toBe(true);
+    expect(profileEquals({ v1: { floorPx: 140 } }, { v1: { floorPx: 140 } })).toBe(true);
+    expect(profileEquals({ v1: { floorPx: 140 } }, undefined)).toBe(false);
+  });
+  it('ignores namespaces this build does not know', () => {
+    expect(profileEquals({ gone: { x: 1 } }, {})).toBe(true);
+  });
+});

--- a/app/studio/deploySummary.ts
+++ b/app/studio/deploySummary.ts
@@ -1,0 +1,47 @@
+import { diffKeys, mergeSettings, type KnobValue, type SettingsValues } from '@/app/lib/settings/schema';
+import { KNOWN_NAMESPACES, schemaFor } from '@/app/lib/settings/knownSchemas';
+import type { DeployRow } from '@/app/lib/settings/deploys';
+
+const SUMMARY_MAX = 3;
+
+export function formatValue(v: KnobValue): string {
+  if (typeof v === 'boolean') return v ? 'on' : 'off';
+  if (typeof v === 'number') return Number.isInteger(v) ? String(v) : v.toFixed(2);
+  return v;
+}
+
+/**
+ * What a deploy changed against the one before it: up to three `key value`
+ * pairs then `+n`. Read through the current schemas, so a namespace that
+ * vanished reads as its keys returning to their defaults.
+ */
+export function summarize(row: DeployRow, previous: DeployRow | undefined): string {
+  if (!previous) return 'first recorded';
+  const changes: string[] = [];
+  for (const namespace of KNOWN_NAMESPACES) {
+    const schema = schemaFor(namespace);
+    if (!schema) continue;
+    const now = mergeSettings(schema, row.namespaces[namespace]);
+    for (const key of diffKeys(schema, previous.namespaces[namespace], row.namespaces[namespace])) {
+      changes.push(`${key} ${formatValue(now[key])}`);
+    }
+  }
+  if (changes.length === 0) return 'no dial changes';
+  const shown = changes.slice(0, SUMMARY_MAX);
+  if (changes.length > SUMMARY_MAX) shown.push(`+${changes.length - SUMMARY_MAX}`);
+  return shown.join(' · ');
+}
+
+/** Effective-value equality over every namespace this build knows. */
+export function profileEquals(
+  a: Record<string, SettingsValues> | undefined,
+  b: Record<string, SettingsValues> | undefined,
+): boolean {
+  if (!a || !b) return false;
+  for (const namespace of KNOWN_NAMESPACES) {
+    const schema = schemaFor(namespace);
+    if (!schema) continue;
+    if (diffKeys(schema, a[namespace], b[namespace]).length > 0) return false;
+  }
+  return true;
+}

--- a/app/studio/solo/SoloRail.test.tsx
+++ b/app/studio/solo/SoloRail.test.tsx
@@ -12,6 +12,7 @@ function api(over: Partial<StudioSettingsApi> = {}): StudioSettingsApi {
     setKnob: vi.fn(), resetSection: vi.fn(), applyNamespace: () => [],
     diffByNamespace: { solo: ['mix'] }, diffCount: 1,
     deploy: async () => {}, revert: async () => {}, deployedAtMs: null, droppedKeys: [],
+    deploys: [], loadDeploy: async () => [], relabelDeploy: async () => {}, lastDeployRecorded: null,
     ...over,
   };
 }

--- a/app/studio/solo/SoloStudioClient.tsx
+++ b/app/studio/solo/SoloStudioClient.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from 'react';
 import Link from 'next/link';
 import { useStudioSettings } from '../useStudioSettings';
 import { DeployButton } from '../DeployButton';
+import { DeployHistory } from '../DeployHistory';
 import { SoloRail } from './SoloRail';
 import { FeedColumn } from './FeedColumn';
 import { SoloStatusStrip } from './SoloStatusStrip';
@@ -53,7 +54,12 @@ export function SoloStudioClient() {
         </Link>
       </div>
       <aside style={{ background: railBg, borderRight: `1px solid ${border}`, padding: 10, overflowY: 'auto' }}>
-        <SoloRail api={api} deploySlot={<DeployButton diffCount={api.diffCount} onDeploy={api.deploy} onRevert={api.revert} />} />
+        <SoloRail api={api} deploySlot={
+          <>
+            <DeployButton diffCount={api.diffCount} onDeploy={api.deploy} onRevert={api.revert} />
+            <DeployHistory api={api} />
+          </>
+        } />
       </aside>
       <main style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 12, padding: 12, overflowY: 'auto', minWidth: 0 }}>
         {(['sunrise', 'sunset'] as const).map((feed) => {

--- a/app/studio/useStudioSettings.test.tsx
+++ b/app/studio/useStudioSettings.test.tsx
@@ -588,4 +588,72 @@ describe('useStudioSettings.applyNamespace — restoring a saved dial set', () =
     act(() => { dropped = result.current.applyNamespace('nope', { a: 1 }); });
     expect(dropped).toEqual([]);
   });
+
+  it('exposes the deploy list from /api/kiosk/deploys and [] before it loads', async () => {
+    const deploys = [{ id: 2, label: null, namespaces: { v1: { floorPx: 140 } }, deployedAt: 'T' }];
+    fetchMock = vi.fn(async (url: string) => ({
+      ok: true,
+      json: async () => (url === '/api/kiosk/deploys' ? { deploys } : settingsResponse({}, {})),
+    }));
+    vi.stubGlobal('fetch', fetchMock);
+    const { result } = renderHook(() => useStudioSettings(), { wrapper });
+    expect(result.current.deploys).toEqual([]);
+    await act(async () => { await vi.advanceTimersByTimeAsync(0); });
+    expect(result.current.deploys).toEqual(deploys);
+  });
+
+  it('loadDeploy replaces the studio profile, drops the local overlay, and returns the dropped keys', async () => {
+    const loaded = { namespaces: { v1: { floorPx: 200 } }, revision: 9 };
+    fetchMock = vi.fn(async (url: string, init?: RequestInit) => {
+      if (url === '/api/kiosk/deploys/7/load') {
+        return { ok: true, json: async () => ({ studio: loaded, dropped: [{ namespace: 'v1', key: 'ghost', reason: 'unknown' }] }) };
+      }
+      if (url === '/api/kiosk/deploys') return { ok: true, json: async () => ({ deploys: [] }) };
+      if (init?.method === 'PATCH') return { ok: true, json: async () => ({ revision: 2 }) };
+      return { ok: true, json: async () => settingsResponse({}, {}) };
+    });
+    vi.stubGlobal('fetch', fetchMock);
+    const { result } = renderHook(() => useStudioSettings(), { wrapper });
+    await act(async () => { await vi.advanceTimersByTimeAsync(0); });
+    act(() => { result.current.setKnob('v1', 'floorPx', 140); }); // a pending, un-flushed edit
+    let dropped: unknown;
+    await act(async () => { dropped = await result.current.loadDeploy(7); });
+    expect(dropped).toEqual([{ namespace: 'v1', key: 'ghost', reason: 'unknown' }]);
+    expect(result.current.effective('v1').floorPx).toBe(200);
+    await act(async () => { await vi.advanceTimersByTimeAsync(1000); });
+    expect(fetchMock.mock.calls.some(([, init]) => (init as RequestInit | undefined)?.method === 'PATCH')).toBe(false);
+  });
+
+  it('deploy(label) posts the label and remembers whether history was recorded', async () => {
+    fetchMock = vi.fn(async (url: string) => {
+      if (url === '/api/kiosk/settings/deploy') {
+        return { ok: true, json: async () => ({ live: { namespaces: {}, revision: 3 }, deploy: null }) };
+      }
+      if (url === '/api/kiosk/deploys') return { ok: true, json: async () => ({ deploys: [] }) };
+      return { ok: true, json: async () => settingsResponse({ floorPx: 140 }, {}) };
+    });
+    vi.stubGlobal('fetch', fetchMock);
+    const { result } = renderHook(() => useStudioSettings(), { wrapper });
+    await act(async () => { await vi.advanceTimersByTimeAsync(0); });
+    expect(result.current.lastDeployRecorded).toBeNull();
+    await act(async () => { await result.current.deploy('opening night'); });
+    const call = fetchMock.mock.calls.find(([u]) => u === '/api/kiosk/settings/deploy');
+    expect(JSON.parse(String((call?.[1] as RequestInit).body))).toEqual({ label: 'opening night' });
+    expect(result.current.lastDeployRecorded).toBe(false);
+  });
+
+  it('relabelDeploy PATCHes the label', async () => {
+    fetchMock = vi.fn(async (url: string) => {
+      if (url === '/api/kiosk/deploys') return { ok: true, json: async () => ({ deploys: [] }) };
+      if (url === '/api/kiosk/deploys/7') return { ok: true, json: async () => ({ ok: true }) };
+      return { ok: true, json: async () => settingsResponse({}, {}) };
+    });
+    vi.stubGlobal('fetch', fetchMock);
+    const { result } = renderHook(() => useStudioSettings(), { wrapper });
+    await act(async () => { await vi.advanceTimersByTimeAsync(0); });
+    await act(async () => { await result.current.relabelDeploy(7, 'opening night'); });
+    const call = fetchMock.mock.calls.find(([u]) => u === '/api/kiosk/deploys/7');
+    expect((call?.[1] as RequestInit).method).toBe('PATCH');
+    expect(JSON.parse(String((call?.[1] as RequestInit).body))).toEqual({ label: 'opening night' });
+  });
 });

--- a/app/studio/useStudioSettings.ts
+++ b/app/studio/useStudioSettings.ts
@@ -13,12 +13,13 @@ import {
   type SettingsSchema,
   type SettingsValues,
 } from '@/app/lib/settings/schema';
-import { SHARED_NAMESPACE, SHARED_SCHEMA } from '@/app/lib/settings/sharedSchema';
-import { MOSAIC_SETTINGS_SCHEMAS } from '@/app/components/mosaic/registry';
+import { schemaFor, KNOWN_NAMESPACES } from '@/app/lib/settings/knownSchemas';
 import type { ProfileSettings } from '@/app/lib/settings/store';
+import type { DeployRow, DroppedDeployKey } from '@/app/lib/settings/deploys';
 
 const DEBOUNCE_MS = 400;
 const SETTINGS_URL = '/api/kiosk/settings';
+const DEPLOYS_URL = '/api/kiosk/deploys';
 
 interface SettingsResponse {
   studio: ProfileSettings;
@@ -45,18 +46,18 @@ export interface StudioSettingsApi {
   applyNamespace: (namespace: string, deviations: SettingsValues) => DroppedKey[];
   diffByNamespace: Record<string, string[]>; // diffKeys(schema, studio[ns], live[ns]) per known ns
   diffCount: number; // total across namespaces — the badge number
-  deploy: () => Promise<void>;
+  deploy: (label?: string) => Promise<void>;
   revert: () => Promise<void>;
+  /** Recorded deploys, newest first. [] until the first fetch lands. */
+  deploys: DeployRow[];
+  /** Put a recorded deploy into the studio profile (the glass is untouched). Returns the keys the current schema could not take. */
+  loadDeploy: (id: number) => Promise<DroppedDeployKey[]>;
+  relabelDeploy: (id: number, label: string | null) => Promise<void>;
+  /** Whether the last deploy this session was written to history; null before any deploy. */
+  lastDeployRecorded: boolean | null;
   deployedAtMs: number | null; // Date.now() at last successful deploy this session
   droppedKeys: DroppedKey[]; // keys the last PATCH per namespace could not store
 }
-
-function schemaFor(namespace: string): SettingsSchema | null {
-  if (namespace === SHARED_NAMESPACE) return SHARED_SCHEMA;
-  return MOSAIC_SETTINGS_SCHEMAS[namespace] ?? null;
-}
-
-const KNOWN_NAMESPACES = [SHARED_NAMESPACE, ...Object.keys(MOSAIC_SETTINGS_SCHEMAS)];
 
 const fetcher = (url: string) => fetch(url).then((r) => r.json());
 
@@ -70,6 +71,12 @@ export function useStudioSettings(): StudioSettingsApi {
   const { data, isLoading, mutate } = useSWR<SettingsResponse>(SETTINGS_URL, fetcher, {
     refreshInterval: 30_000,
   });
+  const { data: deploysData, mutate: mutateDeploys } = useSWR<{ deploys: DeployRow[] }>(
+    DEPLOYS_URL,
+    fetcher,
+    { refreshInterval: 30_000 }
+  );
+  const [lastDeployRecorded, setLastDeployRecorded] = useState<boolean | null>(null);
 
   // Per-namespace optimistic overlay: full local deviation set for a
   // namespace once it has been touched this session, keyed by namespace.
@@ -265,19 +272,28 @@ export function useStudioSettings(): StudioSettingsApi {
     [diffByNamespace]
   );
 
-  const deploy = useCallback(async () => {
-    await flushPending();
-    const res = await fetch('/api/kiosk/settings/deploy', { method: 'POST' });
-    if (!res.ok) {
-      throw new Error(`deploy failed: ${res.status}`);
-    }
-    const json = (await res.json()) as { live: ProfileSettings };
-    await mutate(
-      (current) => (current ? { ...current, live: json.live } : current),
-      { revalidate: false }
-    );
-    setDeployedAtMs(Date.now());
-  }, [flushPending, mutate]);
+  const deploy = useCallback(
+    async (label?: string) => {
+      await flushPending();
+      const res = await fetch('/api/kiosk/settings/deploy', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(label ? { label } : {}),
+      });
+      if (!res.ok) {
+        throw new Error(`deploy failed: ${res.status}`);
+      }
+      const json = (await res.json()) as { live: ProfileSettings; deploy: DeployRow | null };
+      await mutate(
+        (current) => (current ? { ...current, live: json.live } : current),
+        { revalidate: false }
+      );
+      setDeployedAtMs(Date.now());
+      setLastDeployRecorded(json.deploy != null);
+      void mutateDeploys();
+    },
+    [flushPending, mutate, mutateDeploys]
+  );
 
   const revert = useCallback(async () => {
     cancelPending();
@@ -294,6 +310,42 @@ export function useStudioSettings(): StudioSettingsApi {
     setOverlay({});
   }, [cancelPending, mutate]);
 
+  // Same shape as revert(): the studio profile is replaced by the server,
+  // so pending debounced edits are discarded, not sent on top of it.
+  const loadDeploy = useCallback(
+    async (id: number): Promise<DroppedDeployKey[]> => {
+      cancelPending();
+      const res = await fetch(`${DEPLOYS_URL}/${id}/load`, { method: 'POST' });
+      if (!res.ok) {
+        throw new Error(`load deploy failed: ${res.status}`);
+      }
+      const json = (await res.json()) as { studio: ProfileSettings; dropped: DroppedDeployKey[] };
+      await mutate(
+        (current) => (current ? { ...current, studio: json.studio } : current),
+        { revalidate: false }
+      );
+      overlayRef.current = {};
+      setOverlay({});
+      return json.dropped;
+    },
+    [cancelPending, mutate]
+  );
+
+  const relabelDeploy = useCallback(
+    async (id: number, label: string | null) => {
+      const res = await fetch(`${DEPLOYS_URL}/${id}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ label }),
+      });
+      if (!res.ok) {
+        throw new Error(`relabel failed: ${res.status}`);
+      }
+      void mutateDeploys();
+    },
+    [mutateDeploys]
+  );
+
   return {
     loading: isLoading,
     studio,
@@ -308,6 +360,10 @@ export function useStudioSettings(): StudioSettingsApi {
     diffCount,
     deploy,
     revert,
+    deploys: deploysData?.deploys ?? [],
+    loadDeploy,
+    relabelDeploy,
+    lastDeployRecorded,
     deployedAtMs,
     droppedKeys,
   };

--- a/database/migrations/20260905_kiosk_deploys.sql
+++ b/database/migrations/20260905_kiosk_deploys.sql
@@ -1,0 +1,26 @@
+-- kiosk_deploys: one row per studio Deploy (spec:
+-- docs/superpowers/specs/2026-09-05-studio-deploy-history-and-solo-preview-design.md §2.1).
+-- `namespaces` is { namespace: deviations }, the same deviations-only blobs
+-- kiosk_settings.data holds, captured exactly as they were copied to live.
+-- Loading a row back sanitizes each namespace through its current schema, so
+-- adding/renaming/removing knobs never needs a migration here either.
+--
+-- Seeds deploy #1 from the current live profile when the table is empty, so
+-- "what was on the glass before deploy history" is recoverable from day one.
+--
+-- Forward-only, idempotent. Apply via:
+--   node scripts/apply-migration.mjs database/migrations/20260905_kiosk_deploys.sql
+--   node scripts/apply-migration.mjs database/migrations/20260905_kiosk_deploys.sql --apply
+
+CREATE TABLE IF NOT EXISTS kiosk_deploys (
+  id           SERIAL PRIMARY KEY,
+  label        TEXT,
+  namespaces   JSONB NOT NULL,
+  deployed_at  TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+INSERT INTO kiosk_deploys (label, namespaces)
+SELECT 'before deploy history', COALESCE(jsonb_object_agg(namespace, data), '{}'::jsonb)
+FROM kiosk_settings
+WHERE profile = 'live'
+  AND NOT EXISTS (SELECT 1 FROM kiosk_deploys);

--- a/docs/superpowers/plans/2026-09-05-studio-deploy-history.md
+++ b/docs/superpowers/plans/2026-09-05-studio-deploy-history.md
@@ -1,0 +1,1438 @@
+# Studio Deploy History Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Every studio Deploy records a numbered snapshot of the whole profile; the rail lists them, and any one can be loaded back into the studio for preview and redeploy.
+
+**Architecture:** One new table (`kiosk_deploys`) written by the existing deploy route; a small server store module; three owner-gated routes; four additions to `useStudioSettings`; one pure summary helper; one `DeployHistory` component rendered under the Deploy button in both studios. Loading a deploy touches only the studio profile. The glass changes only on Deploy.
+
+**Tech Stack:** Next.js 15 app router, Neon `sql` tag (`@/app/lib/db`), SWR, Vitest + Testing Library.
+
+**Spec:** `docs/superpowers/specs/2026-09-05-studio-deploy-history-and-solo-preview-design.md` (Part A only; Part B waits for PR #134 and gets its own plan).
+
+## Global Constraints
+
+- Worktree: `~/GitHub/the-sunset-webcam-map.worktrees/feat-deploy-history`, branch `feat/deploy-history`. Verify the branch in the same command as every commit. Stage explicit paths.
+- These are **deploys** numbered `#n`, never "versions".
+- Label max 60 characters.
+- History failing to write must never fail Deploy, and must never be hidden: the response carries `deploy: null` and the rail says so.
+- Migration `database/migrations/20260905_kiosk_deploys.sql` is applied by Jesse (`--apply` is classifier-blocked) **before** the PR merges.
+- Run tests with `npx vitest run <path>`; the whole suite with `npm run test`; lint with `npm run lint`.
+- Commit trailer on every commit:
+  ```
+  Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>
+  Claude-Session: https://claude.ai/code/session_01UBj3NHsZ13Cw7aWr2sQaRt
+  ```
+
+---
+
+## File map
+
+| file | responsibility |
+|---|---|
+| `database/migrations/20260905_kiosk_deploys.sql` | create `kiosk_deploys`, seed deploy #1 from live |
+| `app/lib/settings/knownSchemas.ts` | `schemaFor(namespace)` + `KNOWN_NAMESPACES`, shared by store, hook, summary |
+| `app/lib/settings/deploys.ts` (+ test) | record / list / load-into-studio / relabel |
+| `app/api/kiosk/settings/deploy/route.ts` (+ test) | records the snapshot after the copy |
+| `app/api/kiosk/deploys/route.ts` (+ test) | GET list |
+| `app/api/kiosk/deploys/[id]/route.ts` (+ test) | PATCH label |
+| `app/api/kiosk/deploys/[id]/load/route.ts` (+ test) | POST load into studio |
+| `app/studio/useStudioSettings.ts` (+ test) | `deploys`, `deploy(label?)`, `loadDeploy`, `relabelDeploy`, `lastDeployRecorded` |
+| `app/studio/deploySummary.ts` (+ test) | `summarize(row, previous)`, `profileEquals(a, b)`, `formatValue` |
+| `app/studio/DeployHistory.tsx` (+ test) | the list under the Deploy button |
+| `app/studio/DeployButton.tsx` | "↩ revert to glass" → "↩ discard changes" |
+| `app/studio/StudioClient.tsx`, `app/studio/solo/SoloStudioClient.tsx` | render `DeployHistory` in the deploy slot |
+| `app/studio/solo/SoloRail.test.tsx` | fixture gains the new api fields |
+
+---
+
+### Task 1: Migration
+
+**Files:**
+- Create: `database/migrations/20260905_kiosk_deploys.sql`
+
+- [ ] **Step 1: Write the migration**
+
+```sql
+-- kiosk_deploys: one row per studio Deploy (spec:
+-- docs/superpowers/specs/2026-09-05-studio-deploy-history-and-solo-preview-design.md §2.1).
+-- `namespaces` is { namespace: deviations }, the same deviations-only blobs
+-- kiosk_settings.data holds, captured exactly as they were copied to live.
+-- Loading a row back sanitizes each namespace through its current schema, so
+-- adding/renaming/removing knobs never needs a migration here either.
+--
+-- Seeds deploy #1 from the current live profile when the table is empty, so
+-- "what was on the glass before deploy history" is recoverable from day one.
+--
+-- Forward-only, idempotent. Apply via:
+--   node scripts/apply-migration.mjs database/migrations/20260905_kiosk_deploys.sql
+--   node scripts/apply-migration.mjs database/migrations/20260905_kiosk_deploys.sql --apply
+
+CREATE TABLE IF NOT EXISTS kiosk_deploys (
+  id           SERIAL PRIMARY KEY,
+  label        TEXT,
+  namespaces   JSONB NOT NULL,
+  deployed_at  TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+INSERT INTO kiosk_deploys (label, namespaces)
+SELECT 'before deploy history', COALESCE(jsonb_object_agg(namespace, data), '{}'::jsonb)
+FROM kiosk_settings
+WHERE profile = 'live'
+  AND NOT EXISTS (SELECT 1 FROM kiosk_deploys);
+```
+
+- [ ] **Step 2: Dry-run it (prints statements, applies nothing)**
+
+Run: `node scripts/apply-migration.mjs database/migrations/20260905_kiosk_deploys.sql`
+Expected: `2 statement(s)` listed, no errors. Note: `npm run migrate:status` will now list it as PENDING; that is correct until Jesse applies it.
+
+- [ ] **Step 3: Commit**
+
+```bash
+[ "$(git rev-parse --abbrev-ref HEAD)" = feat/deploy-history ] && \
+git add database/migrations/20260905_kiosk_deploys.sql && \
+git commit -m "feat(settings): kiosk_deploys table, seeded from the live profile"
+```
+
+---
+
+### Task 2: Shared schema lookup
+
+**Files:**
+- Create: `app/lib/settings/knownSchemas.ts`
+
+**Interfaces:**
+- Produces: `schemaFor(namespace: string): SettingsSchema | null`, `KNOWN_NAMESPACES: string[]`
+
+- [ ] **Step 1: Write the module**
+
+```ts
+import type { SettingsSchema } from './schema';
+import { SHARED_NAMESPACE, SHARED_SCHEMA } from './sharedSchema';
+import { MOSAIC_SETTINGS_SCHEMAS } from '@/app/components/mosaic/registry';
+
+/** The schema a namespace's deviations are read through, or null for a namespace this build does not know. */
+export function schemaFor(namespace: string): SettingsSchema | null {
+  if (namespace === SHARED_NAMESPACE) return SHARED_SCHEMA;
+  return MOSAIC_SETTINGS_SCHEMAS[namespace] ?? null;
+}
+
+export const KNOWN_NAMESPACES: string[] = [SHARED_NAMESPACE, ...Object.keys(MOSAIC_SETTINGS_SCHEMAS)];
+```
+
+- [ ] **Step 2: Type-check and commit**
+
+Run: `npx tsc --noEmit -p . 2>&1 | head -5`
+Expected: no output.
+
+```bash
+[ "$(git rev-parse --abbrev-ref HEAD)" = feat/deploy-history ] && \
+git add app/lib/settings/knownSchemas.ts && \
+git commit -m "refactor(settings): one schemaFor for every namespace reader"
+```
+
+---
+
+### Task 3: Deploys store
+
+**Files:**
+- Create: `app/lib/settings/deploys.ts`
+- Test: `app/lib/settings/deploys.test.ts`
+
+**Interfaces:**
+- Consumes: `schemaFor` (Task 2), `getProfileSettings`, `sql`
+- Produces:
+  ```ts
+  interface DeployRow { id: number; label: string | null; namespaces: Record<string, SettingsValues>; deployedAt: string }
+  type DroppedDeployKey = DroppedKey & { namespace: string }
+  recordDeploy(live: ProfileSettings, label?: string | null): Promise<DeployRow | null>
+  listDeploys(limit?: number): Promise<DeployRow[]>
+  loadDeployIntoStudio(id: number): Promise<{ studio: ProfileSettings; dropped: DroppedDeployKey[] } | null>
+  relabelDeploy(id: number, label: string | null): Promise<boolean>
+  ```
+
+- [ ] **Step 1: Write the failing tests**
+
+```ts
+// @vitest-environment node
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+type SqlTag = {
+  (strings: TemplateStringsArray, ...values: unknown[]): unknown;
+  transaction: unknown;
+  __sqlMock: ReturnType<typeof vi.fn>;
+  __txnMock: ReturnType<typeof vi.fn>;
+};
+
+vi.mock('@/app/lib/db', async () => {
+  const sqlMockFn = vi.fn();
+  const txnMockFn = vi.fn();
+  const tag = (strings: TemplateStringsArray, ...values: unknown[]) => sqlMockFn(strings, ...values);
+  const t = tag as unknown as SqlTag;
+  t.transaction = txnMockFn;
+  t.__sqlMock = sqlMockFn;
+  t.__txnMock = txnMockFn;
+  return { sql: tag };
+});
+
+vi.mock('@/app/components/mosaic/registry', () => ({
+  MOSAIC_SETTINGS_SCHEMAS: {
+    v1: [{ key: 'floorPx', kind: 'number', min: 20, max: 800, step: 10, default: 100, label: 'floor', description: '', section: 's' }],
+  },
+}));
+
+import { recordDeploy, listDeploys, loadDeployIntoStudio, relabelDeploy } from './deploys';
+import { sql } from '@/app/lib/db';
+
+const sqlMock = (sql as unknown as SqlTag).__sqlMock;
+const txnMock = (sql as unknown as SqlTag).__txnMock;
+const text = (call: unknown[]) => (call[0] as TemplateStringsArray).join('?');
+
+beforeEach(() => {
+  sqlMock.mockReset();
+  txnMock.mockReset();
+  vi.spyOn(console, 'warn').mockImplementation(() => {});
+});
+
+describe('recordDeploy', () => {
+  it('inserts the whole profile and returns the row', async () => {
+    sqlMock.mockResolvedValueOnce([{ id: 7, label: null, namespaces: { v1: { floorPx: 140 } }, deployed_at: '2026-09-05T18:30:00.000Z' }]);
+    const row = await recordDeploy({ namespaces: { v1: { floorPx: 140 } }, revision: 3 }, null);
+    expect(row).toEqual({ id: 7, label: null, namespaces: { v1: { floorPx: 140 } }, deployedAt: '2026-09-05T18:30:00.000Z' });
+    expect(text(sqlMock.mock.calls[0])).toContain('INSERT INTO kiosk_deploys');
+    expect(sqlMock.mock.calls[0][2]).toBe(JSON.stringify({ v1: { floorPx: 140 } }));
+  });
+  it('returns null instead of throwing when the table is missing', async () => {
+    sqlMock.mockRejectedValueOnce(new Error('relation "kiosk_deploys" does not exist'));
+    expect(await recordDeploy({ namespaces: {}, revision: 1 })).toBeNull();
+  });
+});
+
+describe('listDeploys', () => {
+  it('maps rows newest first and defaults the limit to 50', async () => {
+    sqlMock.mockResolvedValueOnce([{ id: 2, label: 'b', namespaces: {}, deployed_at: 'B' }, { id: 1, label: null, namespaces: {}, deployed_at: 'A' }]);
+    const rows = await listDeploys();
+    expect(rows.map((r) => r.id)).toEqual([2, 1]);
+    expect(text(sqlMock.mock.calls[0])).toContain('ORDER BY id DESC');
+    expect(sqlMock.mock.calls[0][1]).toBe(50);
+  });
+  it('returns [] when the read fails', async () => {
+    sqlMock.mockRejectedValueOnce(new Error('nope'));
+    expect(await listDeploys()).toEqual([]);
+  });
+});
+
+describe('loadDeployIntoStudio', () => {
+  it('returns null for an unknown id', async () => {
+    sqlMock.mockResolvedValueOnce([]);
+    expect(await loadDeployIntoStudio(99)).toBeNull();
+    expect(txnMock).not.toHaveBeenCalled();
+  });
+  it('replaces the studio profile wholesale, sanitizing through the current schema and naming what it dropped', async () => {
+    sqlMock.mockResolvedValueOnce([{ namespaces: { v1: { floorPx: 140, ghost: 1 }, gone: { x: 2 } } }]);
+    sqlMock.mockResolvedValueOnce([{ namespace: 'v1', data: { floorPx: 140 }, revision: 1 }]); // getProfileSettings after the write
+    const out = await loadDeployIntoStudio(7);
+    expect(out?.studio).toEqual({ namespaces: { v1: { floorPx: 140 } }, revision: 1 });
+    expect(out?.dropped).toEqual([
+      { namespace: 'v1', key: 'ghost', reason: 'unknown' },
+      { namespace: 'gone', key: 'x', reason: 'unknown' },
+    ]);
+    const [statements] = txnMock.mock.calls[0];
+    expect(statements).toHaveLength(2); // DELETE every studio row, then one INSERT per surviving namespace
+    const deleteCall = sqlMock.mock.calls.find((c) => text(c).includes("DELETE FROM kiosk_settings WHERE profile = 'studio'"));
+    expect(deleteCall).toBeDefined();
+    const insertCall = sqlMock.mock.calls.find((c) => text(c).includes('INSERT INTO kiosk_settings'));
+    expect(insertCall?.[1]).toBe('v1');
+    expect(insertCall?.[2]).toBe(JSON.stringify({ floorPx: 140 }));
+  });
+  it('a namespace whose every value is at default is not written back', async () => {
+    sqlMock.mockResolvedValueOnce([{ namespaces: { v1: { floorPx: 100 } } }]);
+    sqlMock.mockResolvedValueOnce([]);
+    const out = await loadDeployIntoStudio(3);
+    expect(out?.studio).toEqual({ namespaces: {}, revision: 0 });
+    expect(txnMock.mock.calls[0][0]).toHaveLength(1);
+  });
+});
+
+describe('relabelDeploy', () => {
+  it('true when a row changed, false when none did', async () => {
+    sqlMock.mockResolvedValueOnce([{ id: 7 }]);
+    expect(await relabelDeploy(7, 'opening night')).toBe(true);
+    sqlMock.mockResolvedValueOnce([]);
+    expect(await relabelDeploy(8, null)).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `npx vitest run app/lib/settings/deploys.test.ts`
+Expected: FAIL, cannot resolve `./deploys`.
+
+- [ ] **Step 3: Write the store**
+
+```ts
+import 'server-only';
+import { sql } from '@/app/lib/db';
+import { getProfileSettings, type ProfileSettings } from './store';
+import { droppedKeys, sanitizeValues, stripDefaults, type DroppedKey, type SettingsValues } from './schema';
+import { schemaFor } from './knownSchemas';
+
+/** One studio Deploy, the whole profile as it was copied to live (spec §2.1). */
+export interface DeployRow {
+  id: number;
+  label: string | null;
+  namespaces: Record<string, SettingsValues>;
+  deployedAt: string;
+}
+
+export type DroppedDeployKey = DroppedKey & { namespace: string };
+
+interface Row { id: number; label: string | null; namespaces: Record<string, SettingsValues>; deployed_at: string | Date }
+
+function toRow(r: Row): DeployRow {
+  return { id: Number(r.id), label: r.label, namespaces: r.namespaces, deployedAt: new Date(r.deployed_at).toISOString() };
+}
+
+/**
+ * Record the profile Deploy just copied. Never throws: history failing to
+ * write must not fail the deploy, and the null return is how the route says
+ * so instead of hiding it.
+ */
+export async function recordDeploy(live: ProfileSettings, label?: string | null): Promise<DeployRow | null> {
+  try {
+    const rows = (await sql`
+      INSERT INTO kiosk_deploys (label, namespaces)
+      VALUES (${label ?? null}, ${JSON.stringify(live.namespaces)}::jsonb)
+      RETURNING id, label, namespaces, deployed_at
+    `) as unknown as Row[];
+    return toRow(rows[0]);
+  } catch (error) {
+    console.warn('[deploys] recordDeploy failed:', error);
+    return null;
+  }
+}
+
+export async function listDeploys(limit = 50): Promise<DeployRow[]> {
+  try {
+    const rows = (await sql`
+      SELECT id, label, namespaces, deployed_at FROM kiosk_deploys ORDER BY id DESC LIMIT ${limit}
+    `) as unknown as Row[];
+    return rows.map(toRow);
+  } catch (error) {
+    console.warn('[deploys] listDeploys failed:', error);
+    return [];
+  }
+}
+
+/**
+ * Replace the studio profile with a snapshot. Wholesale: a studio namespace
+ * the snapshot never had is deleted, otherwise a stale deviation would
+ * survive underneath the restore. Every namespace is read through its
+ * current schema and the casualties are returned by name (schemas drift).
+ * Delete-all-then-insert rather than a NOT IN list so no array parameter
+ * crosses the driver; studio revisions restart at 1, which nothing reads.
+ */
+export async function loadDeployIntoStudio(
+  id: number,
+): Promise<{ studio: ProfileSettings; dropped: DroppedDeployKey[] } | null> {
+  const rows = (await sql`SELECT namespaces FROM kiosk_deploys WHERE id = ${id}`) as unknown as Pick<Row, 'namespaces'>[];
+  if (!rows[0]) return null;
+
+  const dropped: DroppedDeployKey[] = [];
+  const clean: Record<string, SettingsValues> = {};
+  for (const [namespace, values] of Object.entries(rows[0].namespaces ?? {})) {
+    const schema = schemaFor(namespace);
+    if (!schema) {
+      for (const key of Object.keys(values ?? {})) dropped.push({ namespace, key, reason: 'unknown' });
+      continue;
+    }
+    for (const d of droppedKeys(schema, values)) dropped.push({ namespace, ...d });
+    const deviations = stripDefaults(schema, sanitizeValues(schema, values));
+    if (Object.keys(deviations).length > 0) clean[namespace] = deviations;
+  }
+
+  await sql.transaction([
+    sql`DELETE FROM kiosk_settings WHERE profile = 'studio'`,
+    ...Object.entries(clean).map(
+      ([namespace, deviations]) => sql`
+        INSERT INTO kiosk_settings (profile, namespace, data)
+        VALUES ('studio', ${namespace}, ${JSON.stringify(deviations)}::jsonb)
+        ON CONFLICT (profile, namespace)
+        DO UPDATE SET data = EXCLUDED.data, revision = kiosk_settings.revision + 1, updated_at = now()
+      `,
+    ),
+  ]);
+  return { studio: await getProfileSettings('studio'), dropped };
+}
+
+export async function relabelDeploy(id: number, label: string | null): Promise<boolean> {
+  const rows = (await sql`
+    UPDATE kiosk_deploys SET label = ${label} WHERE id = ${id} RETURNING id
+  `) as unknown as { id: number }[];
+  return rows.length > 0;
+}
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `npx vitest run app/lib/settings/deploys.test.ts`
+Expected: 8 passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+[ "$(git rev-parse --abbrev-ref HEAD)" = feat/deploy-history ] && \
+git add app/lib/settings/deploys.ts app/lib/settings/deploys.test.ts && \
+git commit -m "feat(settings): deploys store — record, list, load into studio, relabel"
+```
+
+---
+
+### Task 4: Deploy route records the snapshot
+
+**Files:**
+- Modify: `app/api/kiosk/settings/deploy/route.ts`
+- Test: `app/api/kiosk/settings/deploy/route.test.ts`
+
+**Interfaces:**
+- Consumes: `recordDeploy` (Task 3)
+- Produces: response `{ live: ProfileSettings; deploy: DeployRow | null }`; `POST(request?: Request)` accepts an optional JSON body `{ label?: string }`.
+
+- [ ] **Step 1: Add the failing tests**
+
+Add to the existing mocks at the top of the test file:
+
+```ts
+const recordDeployMock = vi.fn();
+vi.mock('@/app/lib/settings/deploys', () => ({
+  recordDeploy: (live: unknown, label: unknown) => recordDeployMock(live, label),
+}));
+```
+
+Add `recordDeployMock.mockReset();` to the `beforeEach`, then append these cases inside the `describe`:
+
+```ts
+  it('records the copied profile and returns the deploy row', async () => {
+    requireOwnerMock.mockResolvedValueOnce(null);
+    const live = { namespaces: { v1: { floorPx: 140 } }, revision: 4 };
+    copyProfileMock.mockResolvedValueOnce(live);
+    recordDeployMock.mockResolvedValueOnce({ id: 7, label: 'opening night', namespaces: live.namespaces, deployedAt: 'T' });
+    const res = await POST(new Request('http://test/api/kiosk/settings/deploy', {
+      method: 'POST', headers: { 'content-type': 'application/json' }, body: JSON.stringify({ label: 'opening night' }),
+    }));
+    expect(res.status).toBe(200);
+    expect(recordDeployMock).toHaveBeenCalledWith(live, 'opening night');
+    expect(await res.json()).toEqual({ live, deploy: { id: 7, label: 'opening night', namespaces: live.namespaces, deployedAt: 'T' } });
+  });
+
+  it('a bodiless POST still deploys, with no label, and a failed record comes back as null', async () => {
+    requireOwnerMock.mockResolvedValueOnce(null);
+    const live = { namespaces: {}, revision: 5 };
+    copyProfileMock.mockResolvedValueOnce(live);
+    recordDeployMock.mockResolvedValueOnce(null);
+    const res = await POST();
+    expect(recordDeployMock).toHaveBeenCalledWith(live, null);
+    expect(await res.json()).toEqual({ live, deploy: null });
+  });
+
+  it('clips a label to 60 characters', async () => {
+    requireOwnerMock.mockResolvedValueOnce(null);
+    copyProfileMock.mockResolvedValueOnce({ namespaces: {}, revision: 6 });
+    recordDeployMock.mockResolvedValueOnce(null);
+    await POST(new Request('http://test/x', { method: 'POST', body: JSON.stringify({ label: 'x'.repeat(80) }) }));
+    expect(recordDeployMock.mock.calls[0][1]).toHaveLength(60);
+  });
+```
+
+- [ ] **Step 2: Run to verify the new cases fail**
+
+Run: `npx vitest run app/api/kiosk/settings/deploy/route.test.ts`
+Expected: the three new cases FAIL (`recordDeployMock` not called / `deploy` missing); the existing ones still pass.
+
+- [ ] **Step 3: Update the route**
+
+```ts
+import { NextResponse } from 'next/server';
+import { requireOwner } from '@/app/lib/owner';
+import { copyProfile } from '@/app/lib/settings/store';
+import { recordDeploy } from '@/app/lib/settings/deploys';
+import { setKioskLiveSettingsCache } from '@/app/lib/cache';
+
+export const dynamic = 'force-dynamic';
+export const runtime = 'nodejs';
+
+const LABEL_MAX = 60;
+
+/** Optional `{ label }`. No body, or a malformed one, is a deploy with no label. */
+async function labelOf(request?: Request): Promise<string | null> {
+  if (!request) return null;
+  try {
+    const body = (await request.json()) as { label?: unknown };
+    return typeof body?.label === 'string' && body.label.trim() ? body.label.trim().slice(0, LABEL_MAX) : null;
+  } catch {
+    return null;
+  }
+}
+
+export async function POST(request?: Request) {
+  const denied = await requireOwner();
+  if (denied) return denied;
+  const label = await labelOf(request);
+  const live = await copyProfile('studio', 'live');
+  await setKioskLiveSettingsCache(live);
+  // History is bookkeeping: it must not fail the deploy, and `null` is how
+  // the studio learns it was not written instead of assuming it was.
+  const deploy = await recordDeploy(live, label);
+  return NextResponse.json({ live, deploy });
+}
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `npx vitest run app/api/kiosk/settings/deploy/route.test.ts`
+Expected: all passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+[ "$(git rev-parse --abbrev-ref HEAD)" = feat/deploy-history ] && \
+git add app/api/kiosk/settings/deploy/route.ts app/api/kiosk/settings/deploy/route.test.ts && \
+git commit -m "feat(settings): Deploy records a kiosk_deploys snapshot and returns it"
+```
+
+---
+
+### Task 5: Deploys routes — list, relabel, load
+
+**Files:**
+- Create: `app/api/kiosk/deploys/route.ts`, `app/api/kiosk/deploys/route.test.ts`
+- Create: `app/api/kiosk/deploys/[id]/route.ts`, `app/api/kiosk/deploys/[id]/route.test.ts`
+- Create: `app/api/kiosk/deploys/[id]/load/route.ts`, `app/api/kiosk/deploys/[id]/load/route.test.ts`
+- Create: `app/api/kiosk/deploys/parseId.ts`
+
+**Interfaces:**
+- Consumes: `listDeploys`, `relabelDeploy`, `loadDeployIntoStudio` (Task 3)
+- Produces: `GET /api/kiosk/deploys → { deploys }`; `PATCH /api/kiosk/deploys/:id { label } → { ok: true }`; `POST /api/kiosk/deploys/:id/load → { studio, dropped }`.
+
+- [ ] **Step 1: Write the failing tests**
+
+`app/api/kiosk/deploys/route.test.ts`:
+
+```ts
+// @vitest-environment node
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NextResponse } from 'next/server';
+
+const requireOwnerMock = vi.fn();
+vi.mock('@/app/lib/owner', () => ({ requireOwner: () => requireOwnerMock() }));
+const listDeploysMock = vi.fn();
+vi.mock('@/app/lib/settings/deploys', () => ({ listDeploys: () => listDeploysMock() }));
+
+import { GET } from './route';
+
+describe('GET /api/kiosk/deploys', () => {
+  beforeEach(() => { requireOwnerMock.mockReset(); listDeploysMock.mockReset(); });
+  it('rejects non-owners', async () => {
+    requireOwnerMock.mockResolvedValueOnce(NextResponse.json({ error: 'Forbidden' }, { status: 403 }));
+    expect((await GET()).status).toBe(403);
+    expect(listDeploysMock).not.toHaveBeenCalled();
+  });
+  it('returns the list', async () => {
+    requireOwnerMock.mockResolvedValueOnce(null);
+    listDeploysMock.mockResolvedValueOnce([{ id: 1, label: null, namespaces: {}, deployedAt: 'T' }]);
+    expect(await (await GET()).json()).toEqual({ deploys: [{ id: 1, label: null, namespaces: {}, deployedAt: 'T' }] });
+  });
+});
+```
+
+`app/api/kiosk/deploys/[id]/route.test.ts`:
+
+```ts
+// @vitest-environment node
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NextResponse } from 'next/server';
+import { NextRequest } from 'next/server';
+
+const requireOwnerMock = vi.fn();
+vi.mock('@/app/lib/owner', () => ({ requireOwner: () => requireOwnerMock() }));
+const relabelMock = vi.fn();
+vi.mock('@/app/lib/settings/deploys', () => ({ relabelDeploy: (id: number, l: unknown) => relabelMock(id, l) }));
+
+import { PATCH } from './route';
+
+const req = (body: unknown) => new NextRequest('http://test/api/kiosk/deploys/7', {
+  method: 'PATCH', headers: { 'content-type': 'application/json' }, body: JSON.stringify(body),
+});
+const params = (id: string) => ({ params: Promise.resolve({ id }) });
+
+describe('PATCH /api/kiosk/deploys/[id]', () => {
+  beforeEach(() => { requireOwnerMock.mockReset(); relabelMock.mockReset(); requireOwnerMock.mockResolvedValue(null); });
+  it('rejects non-owners', async () => {
+    requireOwnerMock.mockResolvedValueOnce(NextResponse.json({ error: 'Forbidden' }, { status: 403 }));
+    expect((await PATCH(req({ label: 'x' }), params('7'))).status).toBe(403);
+  });
+  it('400 on a bad id, a non-string label, or a label over 60 chars', async () => {
+    expect((await PATCH(req({ label: 'x' }), params('seven'))).status).toBe(400);
+    expect((await PATCH(req({ label: 5 }), params('7'))).status).toBe(400);
+    expect((await PATCH(req({ label: 'x'.repeat(61) }), params('7'))).status).toBe(400);
+    expect(relabelMock).not.toHaveBeenCalled();
+  });
+  it('renames, and null clears the label', async () => {
+    relabelMock.mockResolvedValueOnce(true);
+    const res = await PATCH(req({ label: ' opening night ' }), params('7'));
+    expect(relabelMock).toHaveBeenCalledWith(7, 'opening night');
+    expect(await res.json()).toEqual({ ok: true });
+    relabelMock.mockResolvedValueOnce(true);
+    await PATCH(req({ label: null }), params('7'));
+    expect(relabelMock).toHaveBeenLastCalledWith(7, null);
+  });
+  it('404 when the deploy does not exist', async () => {
+    relabelMock.mockResolvedValueOnce(false);
+    expect((await PATCH(req({ label: 'x' }), params('99'))).status).toBe(404);
+  });
+});
+```
+
+`app/api/kiosk/deploys/[id]/load/route.test.ts`:
+
+```ts
+// @vitest-environment node
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NextResponse } from 'next/server';
+import { NextRequest } from 'next/server';
+
+const requireOwnerMock = vi.fn();
+vi.mock('@/app/lib/owner', () => ({ requireOwner: () => requireOwnerMock() }));
+const loadMock = vi.fn();
+vi.mock('@/app/lib/settings/deploys', () => ({ loadDeployIntoStudio: (id: number) => loadMock(id) }));
+
+import { POST } from './route';
+
+const req = () => new NextRequest('http://test/api/kiosk/deploys/7/load', { method: 'POST' });
+const params = (id: string) => ({ params: Promise.resolve({ id }) });
+
+describe('POST /api/kiosk/deploys/[id]/load', () => {
+  beforeEach(() => { requireOwnerMock.mockReset(); loadMock.mockReset(); requireOwnerMock.mockResolvedValue(null); });
+  it('rejects non-owners', async () => {
+    requireOwnerMock.mockResolvedValueOnce(NextResponse.json({ error: 'Forbidden' }, { status: 403 }));
+    expect((await POST(req(), params('7'))).status).toBe(403);
+    expect(loadMock).not.toHaveBeenCalled();
+  });
+  it('400 on a bad id', async () => {
+    expect((await POST(req(), params('0'))).status).toBe(400);
+  });
+  it('404 when the deploy does not exist', async () => {
+    loadMock.mockResolvedValueOnce(null);
+    expect((await POST(req(), params('99'))).status).toBe(404);
+  });
+  it('loads into the studio and reports the dropped keys', async () => {
+    const out = { studio: { namespaces: { v1: { floorPx: 140 } }, revision: 2 }, dropped: [{ namespace: 'v1', key: 'ghost', reason: 'unknown' }] };
+    loadMock.mockResolvedValueOnce(out);
+    const res = await POST(req(), params('7'));
+    expect(loadMock).toHaveBeenCalledWith(7);
+    expect(await res.json()).toEqual(out);
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `npx vitest run app/api/kiosk/deploys`
+Expected: FAIL, modules not found.
+
+- [ ] **Step 3: Write the routes**
+
+`app/api/kiosk/deploys/parseId.ts`:
+
+```ts
+/** A deploy id from the URL: a positive integer, or null. Route files may only export handler fields, so this lives beside them. */
+export function parseDeployId(raw: string): number | null {
+  const id = Number(raw);
+  return Number.isInteger(id) && id > 0 ? id : null;
+}
+```
+
+`app/api/kiosk/deploys/route.ts`:
+
+```ts
+import { NextResponse } from 'next/server';
+import { requireOwner } from '@/app/lib/owner';
+import { listDeploys } from '@/app/lib/settings/deploys';
+
+export const dynamic = 'force-dynamic';
+export const runtime = 'nodejs';
+
+/** Every recorded Deploy, newest first (spec §2.3). */
+export async function GET() {
+  const denied = await requireOwner();
+  if (denied) return denied;
+  return NextResponse.json({ deploys: await listDeploys() });
+}
+```
+
+`app/api/kiosk/deploys/[id]/route.ts`:
+
+```ts
+import { NextRequest, NextResponse } from 'next/server';
+import { requireOwner } from '@/app/lib/owner';
+import { relabelDeploy } from '@/app/lib/settings/deploys';
+import { parseDeployId } from '../parseId';
+
+export const dynamic = 'force-dynamic';
+export const runtime = 'nodejs';
+
+const LABEL_MAX = 60;
+
+/** Rename a deploy. `{ label: null }` clears it. */
+export async function PATCH(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const denied = await requireOwner();
+  if (denied) return denied;
+  const id = parseDeployId((await params).id);
+  if (id === null) return NextResponse.json({ error: 'id must be a positive integer' }, { status: 400 });
+  let body: { label?: unknown };
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: 'invalid JSON' }, { status: 400 });
+  }
+  const raw = body?.label;
+  if (raw !== null && typeof raw !== 'string') {
+    return NextResponse.json({ error: 'label must be a string or null' }, { status: 400 });
+  }
+  if (typeof raw === 'string' && raw.length > LABEL_MAX) {
+    return NextResponse.json({ error: `label must be at most ${LABEL_MAX} characters` }, { status: 400 });
+  }
+  const label = typeof raw === 'string' && raw.trim() ? raw.trim() : null;
+  const found = await relabelDeploy(id, label);
+  if (!found) return NextResponse.json({ error: 'no such deploy' }, { status: 404 });
+  return NextResponse.json({ ok: true });
+}
+```
+
+`app/api/kiosk/deploys/[id]/load/route.ts`:
+
+```ts
+import { NextRequest, NextResponse } from 'next/server';
+import { requireOwner } from '@/app/lib/owner';
+import { loadDeployIntoStudio } from '@/app/lib/settings/deploys';
+import { parseDeployId } from '../../parseId';
+
+export const dynamic = 'force-dynamic';
+export const runtime = 'nodejs';
+
+/**
+ * Put a recorded deploy into the STUDIO profile so it can be previewed and
+ * then deployed. The glass is untouched: only Deploy changes live.
+ */
+export async function POST(_request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const denied = await requireOwner();
+  if (denied) return denied;
+  const id = parseDeployId((await params).id);
+  if (id === null) return NextResponse.json({ error: 'id must be a positive integer' }, { status: 400 });
+  const out = await loadDeployIntoStudio(id);
+  if (!out) return NextResponse.json({ error: 'no such deploy' }, { status: 404 });
+  return NextResponse.json(out);
+}
+```
+
+- [ ] **Step 4: Run to verify they pass**
+
+Run: `npx vitest run app/api/kiosk/deploys`
+Expected: 10 passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+[ "$(git rev-parse --abbrev-ref HEAD)" = feat/deploy-history ] && \
+git add app/api/kiosk/deploys && \
+git commit -m "feat(api): kiosk deploys — list, relabel, load into studio"
+```
+
+---
+
+### Task 6: Hook additions
+
+**Files:**
+- Modify: `app/studio/useStudioSettings.ts`
+- Test: `app/studio/useStudioSettings.test.tsx`
+- Modify: `app/studio/solo/SoloRail.test.tsx` (fixture gains the new fields)
+
+**Interfaces:**
+- Consumes: `schemaFor`, `KNOWN_NAMESPACES` (Task 2); types `DeployRow`, `DroppedDeployKey` (Task 3)
+- Produces, on `StudioSettingsApi`:
+  ```ts
+  deploys: DeployRow[];
+  deploy: (label?: string) => Promise<void>;
+  loadDeploy: (id: number) => Promise<DroppedDeployKey[]>;
+  relabelDeploy: (id: number, label: string | null) => Promise<void>;
+  lastDeployRecorded: boolean | null;
+  ```
+
+- [ ] **Step 1: Add the failing tests**
+
+Append inside the `describe('useStudioSettings')` block. `settingsResponse` and `wrapper` already exist in the file.
+
+```ts
+  it('exposes the deploy list from /api/kiosk/deploys and [] before it loads', async () => {
+    const deploys = [{ id: 2, label: null, namespaces: { v1: { floorPx: 140 } }, deployedAt: 'T' }];
+    fetchMock = vi.fn(async (url: string) => ({
+      ok: true,
+      json: async () => (url === '/api/kiosk/deploys' ? { deploys } : settingsResponse({}, {})),
+    }));
+    vi.stubGlobal('fetch', fetchMock);
+    const { result } = renderHook(() => useStudioSettings(), { wrapper });
+    expect(result.current.deploys).toEqual([]);
+    await act(async () => { await vi.advanceTimersByTimeAsync(0); });
+    expect(result.current.deploys).toEqual(deploys);
+  });
+
+  it('loadDeploy replaces the studio profile, drops the local overlay, and returns the dropped keys', async () => {
+    const loaded = { namespaces: { v1: { floorPx: 200 } }, revision: 9 };
+    fetchMock = vi.fn(async (url: string, init?: RequestInit) => {
+      if (url === '/api/kiosk/deploys/7/load') {
+        return { ok: true, json: async () => ({ studio: loaded, dropped: [{ namespace: 'v1', key: 'ghost', reason: 'unknown' }] }) };
+      }
+      if (url === '/api/kiosk/deploys') return { ok: true, json: async () => ({ deploys: [] }) };
+      if (init?.method === 'PATCH') return { ok: true, json: async () => ({ revision: 2 }) };
+      return { ok: true, json: async () => settingsResponse({}, {}) };
+    });
+    vi.stubGlobal('fetch', fetchMock);
+    const { result } = renderHook(() => useStudioSettings(), { wrapper });
+    await act(async () => { await vi.advanceTimersByTimeAsync(0); });
+    act(() => { result.current.setKnob('v1', 'floorPx', 140); }); // a pending, un-flushed edit
+    let dropped: unknown;
+    await act(async () => { dropped = await result.current.loadDeploy(7); });
+    expect(dropped).toEqual([{ namespace: 'v1', key: 'ghost', reason: 'unknown' }]);
+    expect(result.current.effective('v1').floorPx).toBe(200);
+    await act(async () => { await vi.advanceTimersByTimeAsync(1000); });
+    expect(fetchMock.mock.calls.some(([, init]) => (init as RequestInit | undefined)?.method === 'PATCH')).toBe(false);
+  });
+
+  it('deploy(label) posts the label and remembers whether history was recorded', async () => {
+    fetchMock = vi.fn(async (url: string) => {
+      if (url === '/api/kiosk/settings/deploy') {
+        return { ok: true, json: async () => ({ live: { namespaces: {}, revision: 3 }, deploy: null }) };
+      }
+      if (url === '/api/kiosk/deploys') return { ok: true, json: async () => ({ deploys: [] }) };
+      return { ok: true, json: async () => settingsResponse({ floorPx: 140 }, {}) };
+    });
+    vi.stubGlobal('fetch', fetchMock);
+    const { result } = renderHook(() => useStudioSettings(), { wrapper });
+    await act(async () => { await vi.advanceTimersByTimeAsync(0); });
+    expect(result.current.lastDeployRecorded).toBeNull();
+    await act(async () => { await result.current.deploy('opening night'); });
+    const call = fetchMock.mock.calls.find(([u]) => u === '/api/kiosk/settings/deploy');
+    expect(JSON.parse(String((call?.[1] as RequestInit).body))).toEqual({ label: 'opening night' });
+    expect(result.current.lastDeployRecorded).toBe(false);
+  });
+
+  it('relabelDeploy PATCHes the label', async () => {
+    fetchMock = vi.fn(async (url: string) => {
+      if (url === '/api/kiosk/deploys') return { ok: true, json: async () => ({ deploys: [] }) };
+      if (url === '/api/kiosk/deploys/7') return { ok: true, json: async () => ({ ok: true }) };
+      return { ok: true, json: async () => settingsResponse({}, {}) };
+    });
+    vi.stubGlobal('fetch', fetchMock);
+    const { result } = renderHook(() => useStudioSettings(), { wrapper });
+    await act(async () => { await vi.advanceTimersByTimeAsync(0); });
+    await act(async () => { await result.current.relabelDeploy(7, 'opening night'); });
+    const call = fetchMock.mock.calls.find(([u]) => u === '/api/kiosk/deploys/7');
+    expect((call?.[1] as RequestInit).method).toBe('PATCH');
+    expect(JSON.parse(String((call?.[1] as RequestInit).body))).toEqual({ label: 'opening night' });
+  });
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `npx vitest run app/studio/useStudioSettings.test.tsx`
+Expected: the four new cases FAIL (`deploys` undefined, `loadDeploy is not a function`, …). If an EXISTING deploy test asserts the fetch init is exactly `{ method: 'POST' }`, it will start failing in Step 3; loosen it to check `method` only.
+
+- [ ] **Step 3: Update the hook**
+
+Replace the private `schemaFor` and `KNOWN_NAMESPACES` in the hook with:
+
+```ts
+import { schemaFor, KNOWN_NAMESPACES } from '@/app/lib/settings/knownSchemas';
+import type { DeployRow, DroppedDeployKey } from '@/app/lib/settings/deploys';
+```
+
+(delete the local `function schemaFor` and `const KNOWN_NAMESPACES`; keep the `SHARED_NAMESPACE`/`MOSAIC_SETTINGS_SCHEMAS` imports only if something else in the file still uses them, otherwise remove them so lint stays clean).
+
+Add to `StudioSettingsApi`, after `revert`:
+
+```ts
+  /** Recorded deploys, newest first. [] until the first fetch lands. */
+  deploys: DeployRow[];
+  /** Put a recorded deploy into the studio profile (the glass is untouched). Returns the keys the current schema could not take. */
+  loadDeploy: (id: number) => Promise<DroppedDeployKey[]>;
+  relabelDeploy: (id: number, label: string | null) => Promise<void>;
+  /** Whether the last deploy this session was written to history; null before any deploy. */
+  lastDeployRecorded: boolean | null;
+```
+
+and change `deploy`'s type to `deploy: (label?: string) => Promise<void>;`.
+
+Add the constant `const DEPLOYS_URL = '/api/kiosk/deploys';` next to `SETTINGS_URL`, and inside the hook, after the settings `useSWR`:
+
+```ts
+  const { data: deploysData, mutate: mutateDeploys } = useSWR<{ deploys: DeployRow[] }>(DEPLOYS_URL, fetcher, {
+    refreshInterval: 30_000,
+  });
+  const [lastDeployRecorded, setLastDeployRecorded] = useState<boolean | null>(null);
+```
+
+Replace `deploy`:
+
+```ts
+  const deploy = useCallback(
+    async (label?: string) => {
+      await flushPending();
+      const res = await fetch('/api/kiosk/settings/deploy', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(label ? { label } : {}),
+      });
+      if (!res.ok) {
+        throw new Error(`deploy failed: ${res.status}`);
+      }
+      const json = (await res.json()) as { live: ProfileSettings; deploy: DeployRow | null };
+      await mutate(
+        (current) => (current ? { ...current, live: json.live } : current),
+        { revalidate: false }
+      );
+      setDeployedAtMs(Date.now());
+      setLastDeployRecorded(json.deploy != null);
+      void mutateDeploys();
+    },
+    [flushPending, mutate, mutateDeploys]
+  );
+```
+
+Add after `revert`:
+
+```ts
+  // Same shape as revert(): the studio profile is replaced by the server,
+  // so pending debounced edits are discarded, not sent on top of it.
+  const loadDeploy = useCallback(
+    async (id: number): Promise<DroppedDeployKey[]> => {
+      cancelPending();
+      const res = await fetch(`${DEPLOYS_URL}/${id}/load`, { method: 'POST' });
+      if (!res.ok) {
+        throw new Error(`load deploy failed: ${res.status}`);
+      }
+      const json = (await res.json()) as { studio: ProfileSettings; dropped: DroppedDeployKey[] };
+      await mutate(
+        (current) => (current ? { ...current, studio: json.studio } : current),
+        { revalidate: false }
+      );
+      overlayRef.current = {};
+      setOverlay({});
+      return json.dropped;
+    },
+    [cancelPending, mutate]
+  );
+
+  const relabelDeploy = useCallback(
+    async (id: number, label: string | null) => {
+      const res = await fetch(`${DEPLOYS_URL}/${id}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ label }),
+      });
+      if (!res.ok) {
+        throw new Error(`relabel failed: ${res.status}`);
+      }
+      void mutateDeploys();
+    },
+    [mutateDeploys]
+  );
+```
+
+Return the new fields: `deploys: deploysData?.deploys ?? [], loadDeploy, relabelDeploy, lastDeployRecorded`.
+
+Then in `app/studio/solo/SoloRail.test.tsx`, extend the `api()` fixture:
+
+```ts
+    deploy: async () => {}, revert: async () => {}, deployedAtMs: null, droppedKeys: [],
+    deploys: [], loadDeploy: async () => [], relabelDeploy: async () => {}, lastDeployRecorded: null,
+```
+
+- [ ] **Step 4: Run to verify they pass, plus the type check**
+
+Run: `npx vitest run app/studio/useStudioSettings.test.tsx app/studio/solo/SoloRail.test.tsx && npx tsc --noEmit -p . 2>&1 | head -5`
+Expected: all passed; tsc silent. (`import type` from a `server-only` module is erased at compile time, exactly as the existing `ProfileSettings` import is.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+[ "$(git rev-parse --abbrev-ref HEAD)" = feat/deploy-history ] && \
+git add app/studio/useStudioSettings.ts app/studio/useStudioSettings.test.tsx app/studio/solo/SoloRail.test.tsx && \
+git commit -m "feat(studio): useStudioSettings learns deploys, loadDeploy, relabelDeploy"
+```
+
+---
+
+### Task 7: Summary helper
+
+**Files:**
+- Create: `app/studio/deploySummary.ts`
+- Test: `app/studio/deploySummary.test.ts`
+
+**Interfaces:**
+- Consumes: `schemaFor`, `KNOWN_NAMESPACES` (Task 2), `DeployRow` (Task 3)
+- Produces:
+  ```ts
+  formatValue(v: KnobValue): string
+  summarize(row: DeployRow, previous: DeployRow | undefined): string
+  profileEquals(a: Record<string, SettingsValues> | undefined, b: Record<string, SettingsValues> | undefined): boolean
+  ```
+
+- [ ] **Step 1: Write the failing tests**
+
+```ts
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('@/app/components/mosaic/registry', () => ({
+  MOSAIC_SETTINGS_SCHEMAS: {
+    v1: [
+      { key: 'floorPx', kind: 'number', min: 20, max: 800, step: 10, default: 100, label: 'floor', description: '', section: 's' },
+      { key: 'gate', kind: 'number', min: 0, max: 1, step: 0.01, default: 0.5, label: 'gate', description: '', section: 's' },
+      { key: 'label', kind: 'boolean', default: false, label: 'label', description: '', section: 's' },
+      { key: 'ceilingPx', kind: 'number', min: 100, max: 2000, step: 10, default: 1000, label: 'ceiling', description: '', section: 's' },
+    ],
+  },
+}));
+
+import { summarize, profileEquals, formatValue } from './deploySummary';
+
+const row = (id: number, namespaces: Record<string, Record<string, number | boolean | string>>) =>
+  ({ id, label: null, namespaces, deployedAt: 'T' });
+
+describe('formatValue', () => {
+  it('integers plain, fractions to two places, booleans on/off, strings as-is', () => {
+    expect(formatValue(140)).toBe('140');
+    expect(formatValue(0.549999)).toBe('0.55');
+    expect(formatValue(true)).toBe('on');
+    expect(formatValue('solo')).toBe('solo');
+  });
+});
+
+describe('summarize', () => {
+  it('the first recorded deploy says so', () => {
+    expect(summarize(row(1, { v1: { floorPx: 140 } }), undefined)).toBe('first recorded');
+  });
+  it('lists what changed against the previous deploy with the new values', () => {
+    expect(summarize(row(2, { v1: { floorPx: 140, gate: 0.18 } }), row(1, { v1: { floorPx: 140 } }))).toBe('gate 0.18');
+  });
+  it('a namespace going back to defaults reads as its keys returning to default values', () => {
+    expect(summarize(row(2, {}), row(1, { v1: { floorPx: 140 } }))).toBe('floorPx 100');
+  });
+  it('caps at three and counts the rest', () => {
+    expect(summarize(row(2, { v1: { floorPx: 140, gate: 0.18, label: true, ceilingPx: 1100 } }), row(1, {}))).toBe('floorPx 140 · gate 0.18 · label on · +1');
+  });
+  it('an identical redeploy says no dial changes', () => {
+    expect(summarize(row(2, { v1: { floorPx: 140 } }), row(1, { v1: { floorPx: 140 } }))).toBe('no dial changes');
+  });
+});
+
+describe('profileEquals', () => {
+  it('compares effective values per known namespace, so defaults and absent rows are equal', () => {
+    expect(profileEquals({ v1: { floorPx: 100 } }, {})).toBe(true);
+    expect(profileEquals({ v1: { floorPx: 140 } }, { v1: { floorPx: 140 } })).toBe(true);
+    expect(profileEquals({ v1: { floorPx: 140 } }, undefined)).toBe(false);
+  });
+  it('ignores namespaces this build does not know', () => {
+    expect(profileEquals({ gone: { x: 1 } }, {})).toBe(true);
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `npx vitest run app/studio/deploySummary.test.ts`
+Expected: FAIL, cannot resolve `./deploySummary`.
+
+- [ ] **Step 3: Write the helper**
+
+```ts
+import { diffKeys, mergeSettings, type KnobValue, type SettingsValues } from '@/app/lib/settings/schema';
+import { KNOWN_NAMESPACES, schemaFor } from '@/app/lib/settings/knownSchemas';
+import type { DeployRow } from '@/app/lib/settings/deploys';
+
+const SUMMARY_MAX = 3;
+
+export function formatValue(v: KnobValue): string {
+  if (typeof v === 'boolean') return v ? 'on' : 'off';
+  if (typeof v === 'number') return Number.isInteger(v) ? String(v) : v.toFixed(2);
+  return v;
+}
+
+/**
+ * What a deploy changed against the one before it: up to three `key value`
+ * pairs then `+n`. Read through the current schemas, so a namespace that
+ * vanished reads as its keys returning to their defaults.
+ */
+export function summarize(row: DeployRow, previous: DeployRow | undefined): string {
+  if (!previous) return 'first recorded';
+  const changes: string[] = [];
+  for (const namespace of KNOWN_NAMESPACES) {
+    const schema = schemaFor(namespace);
+    if (!schema) continue;
+    const now = mergeSettings(schema, row.namespaces[namespace]);
+    for (const key of diffKeys(schema, previous.namespaces[namespace], row.namespaces[namespace])) {
+      changes.push(`${key} ${formatValue(now[key])}`);
+    }
+  }
+  if (changes.length === 0) return 'no dial changes';
+  const shown = changes.slice(0, SUMMARY_MAX);
+  if (changes.length > SUMMARY_MAX) shown.push(`+${changes.length - SUMMARY_MAX}`);
+  return shown.join(' · ');
+}
+
+/** Effective-value equality over every namespace this build knows. */
+export function profileEquals(
+  a: Record<string, SettingsValues> | undefined,
+  b: Record<string, SettingsValues> | undefined,
+): boolean {
+  if (!a || !b) return false;
+  for (const namespace of KNOWN_NAMESPACES) {
+    const schema = schemaFor(namespace);
+    if (!schema) continue;
+    if (diffKeys(schema, a[namespace], b[namespace]).length > 0) return false;
+  }
+  return true;
+}
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `npx vitest run app/studio/deploySummary.test.ts`
+Expected: 8 passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+[ "$(git rev-parse --abbrev-ref HEAD)" = feat/deploy-history ] && \
+git add app/studio/deploySummary.ts app/studio/deploySummary.test.ts && \
+git commit -m "feat(studio): deploy summary — what changed since the previous deploy"
+```
+
+---
+
+### Task 8: DeployHistory component, wired into both studios
+
+**Files:**
+- Create: `app/studio/DeployHistory.tsx`
+- Test: `app/studio/DeployHistory.test.tsx`
+- Modify: `app/studio/DeployButton.tsx` (label rename)
+- Modify: `app/studio/StudioClient.tsx:190-197` and `app/studio/solo/SoloStudioClient.tsx:58` (deploy slot)
+
+**Interfaces:**
+- Consumes: `StudioSettingsApi` (Task 6), `summarize`/`profileEquals` (Task 7)
+- Produces: `DeployHistory({ api }: { api: StudioSettingsApi })`
+
+- [ ] **Step 1: Write the failing tests**
+
+```tsx
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import type { StudioSettingsApi } from './useStudioSettings';
+import type { DeployRow } from '@/app/lib/settings/deploys';
+
+vi.mock('@/app/components/mosaic/registry', () => ({
+  MOSAIC_SETTINGS_SCHEMAS: {
+    v1: [{ key: 'floorPx', kind: 'number', min: 20, max: 800, step: 10, default: 100, label: 'floor', description: '', section: 's' }],
+  },
+}));
+
+import { DeployHistory } from './DeployHistory';
+
+const deploys: DeployRow[] = [
+  { id: 2, label: 'opening night', namespaces: { v1: { floorPx: 140 } }, deployedAt: '2026-09-05T18:30:00.000Z' },
+  { id: 1, label: null, namespaces: {}, deployedAt: '2026-09-05T17:00:00.000Z' },
+];
+
+function api(over: Partial<StudioSettingsApi> = {}): StudioSettingsApi {
+  return {
+    loading: false,
+    studio: { namespaces: { v1: { floorPx: 140 } }, revision: 1 },
+    live: { namespaces: {}, revision: 1 },
+    lastPollAt: null, liveRevision: 1,
+    effective: () => ({}), setKnob: vi.fn(), resetSection: vi.fn(), applyNamespace: () => [],
+    diffByNamespace: {}, diffCount: 1,
+    deploy: async () => {}, revert: async () => {}, deployedAtMs: null, droppedKeys: [],
+    deploys, loadDeploy: vi.fn(async () => []), relabelDeploy: vi.fn(async () => {}), lastDeployRecorded: null,
+    ...over,
+  };
+}
+
+describe('DeployHistory', () => {
+  it('lists deploys newest first with number, label, summary, and the glass/studio badges', () => {
+    render(<DeployHistory api={api()} />);
+    const rows = screen.getAllByRole('listitem');
+    expect(rows[0]).toHaveTextContent('#2');
+    expect(rows[0]).toHaveTextContent('opening night');
+    expect(rows[0]).toHaveTextContent('floorPx 140');
+    expect(rows[0]).toHaveTextContent('studio');
+    expect(rows[1]).toHaveTextContent('#1');
+    expect(rows[1]).toHaveTextContent('first recorded');
+    expect(rows[1]).toHaveTextContent('glass');
+    expect(rows[0]).not.toHaveTextContent('glass');
+  });
+
+  it('clicking a row loads it into the studio and reports a partial fit', async () => {
+    const loadDeploy = vi.fn(async () => [{ namespace: 'v1', key: 'ghost', reason: 'unknown' as const }]);
+    render(<DeployHistory api={api({ loadDeploy, deploys: [{ ...deploys[0], namespaces: { v1: { floorPx: 140, ghost: 1 } } }] })} />);
+    await act(async () => { fireEvent.click(screen.getByRole('button', { name: /load deploy #2/i })); });
+    expect(loadDeploy).toHaveBeenCalledWith(2);
+    expect(screen.getByText('loaded, 1 of 2 keys fit the current schema')).toBeInTheDocument();
+  });
+
+  it('a 404 on load reads as gone', async () => {
+    const loadDeploy = vi.fn(async () => { throw new Error('load deploy failed: 404'); });
+    render(<DeployHistory api={api({ loadDeploy })} />);
+    await act(async () => { fireEvent.click(screen.getByRole('button', { name: /load deploy #1/i })); });
+    expect(screen.getByText('gone')).toBeInTheDocument();
+  });
+
+  it('the label is edited inline: Enter saves, Escape cancels', async () => {
+    const relabelDeploy = vi.fn(async () => {});
+    render(<DeployHistory api={api({ relabelDeploy })} />);
+    fireEvent.click(screen.getByRole('button', { name: /label deploy #1/i }));
+    const input = screen.getByRole('textbox');
+    fireEvent.change(input, { target: { value: 'before the show' } });
+    await act(async () => { fireEvent.keyDown(input, { key: 'Enter' }); });
+    expect(relabelDeploy).toHaveBeenCalledWith(1, 'before the show');
+    fireEvent.click(screen.getByRole('button', { name: /label deploy #2/i }));
+    fireEvent.keyDown(screen.getByRole('textbox'), { key: 'Escape' });
+    expect(screen.queryByRole('textbox')).toBeNull();
+    expect(relabelDeploy).toHaveBeenCalledTimes(1);
+  });
+
+  it('says when the last deploy was not recorded', () => {
+    render(<DeployHistory api={api({ lastDeployRecorded: false })} />);
+    expect(screen.getByText(/history not recorded/)).toBeInTheDocument();
+  });
+
+  it('renders nothing but the heading when there are no deploys', () => {
+    render(<DeployHistory api={api({ deploys: [] })} />);
+    expect(screen.getByText('deploys')).toBeInTheDocument();
+    expect(screen.queryAllByRole('listitem')).toHaveLength(0);
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `npx vitest run app/studio/DeployHistory.test.tsx`
+Expected: FAIL, cannot resolve `./DeployHistory`.
+
+- [ ] **Step 3: Write the component**
+
+```tsx
+'use client';
+
+import { useState } from 'react';
+import type { StudioSettingsApi } from './useStudioSettings';
+import type { DeployRow } from '@/app/lib/settings/deploys';
+import { profileEquals, summarize } from './deploySummary';
+
+const mono = 'ui-monospace, SFMono-Regular, Menlo, monospace';
+const LABEL_MAX = 60;
+
+function when(iso: string): string {
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return '';
+  return d.toLocaleString(undefined, { month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit' });
+}
+
+function keyCount(row: DeployRow): number {
+  return Object.values(row.namespaces).reduce((n, values) => n + Object.keys(values ?? {}).length, 0);
+}
+
+function Badge({ children, color }: { children: string; color: string }) {
+  return (
+    <span style={{
+      fontSize: 9, fontWeight: 700, padding: '1px 5px', borderRadius: 999, marginLeft: 4,
+      border: `1px solid ${color}`, color, textTransform: 'uppercase', letterSpacing: '.04em',
+    }}>{children}</span>
+  );
+}
+
+/**
+ * Every recorded Deploy, newest first, under the Deploy button (spec §2.5).
+ * Click a row to put that deploy into the studio; Deploy then sends it to
+ * the glass. Nothing here touches live.
+ */
+export function DeployHistory({ api }: { api: StudioSettingsApi }) {
+  const { deploys, studio, live, loadDeploy, relabelDeploy, lastDeployRecorded } = api;
+  const [editing, setEditing] = useState<{ id: number; draft: string } | null>(null);
+  const [note, setNote] = useState<{ id: number; text: string } | null>(null);
+
+  const load = async (row: DeployRow) => {
+    setNote(null);
+    try {
+      const dropped = await loadDeploy(row.id);
+      if (dropped.length > 0) {
+        const total = keyCount(row);
+        setNote({ id: row.id, text: `loaded, ${total - dropped.length} of ${total} keys fit the current schema` });
+      }
+    } catch (e) {
+      setNote({ id: row.id, text: /404/.test(String(e)) ? 'gone' : 'load failed' });
+    }
+  };
+
+  const saveLabel = async () => {
+    if (!editing) return;
+    const label = editing.draft.trim().slice(0, LABEL_MAX) || null;
+    setEditing(null);
+    try {
+      await relabelDeploy(editing.id, label);
+    } catch {
+      setNote({ id: editing.id, text: 'rename failed' });
+    }
+  };
+
+  return (
+    <section style={{ marginTop: 10, fontFamily: mono, fontSize: 11 }}>
+      <h4 style={{ margin: '0 0 4px', fontSize: 10, letterSpacing: '.06em', textTransform: 'uppercase', color: '#8b95a7' }}
+        title="Every Deploy, newest first. Click one to load it into the studio; Deploy then sends it to the glass.">
+        deploys
+      </h4>
+      {lastDeployRecorded === false && (
+        <div style={{ color: '#e5484d', marginBottom: 4 }}>history not recorded (table missing?)</div>
+      )}
+      <ul style={{ listStyle: 'none', margin: 0, padding: 0, maxHeight: 260, overflowY: 'auto' }}>
+        {deploys.map((row, i) => {
+          const onGlass = profileEquals(row.namespaces, live?.namespaces);
+          const inStudio = profileEquals(row.namespaces, studio?.namespaces);
+          const isEditing = editing?.id === row.id;
+          return (
+            <li key={row.id} style={{ borderTop: '1px solid #1d2432', padding: '4px 0' }}>
+              <div style={{ display: 'flex', alignItems: 'baseline', gap: 6 }}>
+                <button type="button" onClick={() => void load(row)} aria-label={`load deploy #${row.id} into the studio`}
+                  title="Load into the studio (undeployed studio edits are discarded)"
+                  style={{ background: 'transparent', border: 0, padding: 0, color: '#e5e7eb', fontFamily: mono, fontSize: 11, cursor: 'pointer', textAlign: 'left', flex: 1, minWidth: 0 }}>
+                  <b style={{ color: '#f5a344' }}>#{row.id}</b>
+                  <span style={{ color: '#6b7280', marginLeft: 6 }}>{when(row.deployedAt)}</span>
+                  <span style={{ display: 'block', color: '#9aa3b2', whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>
+                    {summarize(row, deploys[i + 1])}
+                  </span>
+                </button>
+                <span style={{ whiteSpace: 'nowrap' }}>
+                  {onGlass && <Badge color="#7ee2ac">glass</Badge>}
+                  {inStudio && <Badge color="#f5a344">studio</Badge>}
+                </span>
+              </div>
+              {isEditing ? (
+                <input autoFocus value={editing.draft} maxLength={LABEL_MAX} aria-label={`label for deploy #${row.id}`}
+                  onChange={(e) => setEditing({ id: row.id, draft: e.target.value })}
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter') void saveLabel();
+                    if (e.key === 'Escape') setEditing(null);
+                  }}
+                  onBlur={() => setEditing(null)}
+                  style={{ width: '100%', marginTop: 2, background: '#0b0e14', color: '#e5e7eb', border: '1px solid #2a3242', borderRadius: 4, fontFamily: mono, fontSize: 11, padding: '2px 4px' }} />
+              ) : (
+                <button type="button" onClick={() => setEditing({ id: row.id, draft: row.label ?? '' })}
+                  aria-label={`label deploy #${row.id}`} title="Click to rename"
+                  style={{ background: 'transparent', border: 0, padding: 0, color: row.label ? '#c3cad6' : '#4b5568', fontFamily: mono, fontSize: 11, cursor: 'text', fontStyle: row.label ? 'normal' : 'italic' }}>
+                  {row.label ?? 'add a label'}
+                </button>
+              )}
+              {note?.id === row.id && <div style={{ color: '#f5a344', marginTop: 2 }}>{note.text}</div>}
+            </li>
+          );
+        })}
+      </ul>
+    </section>
+  );
+}
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `npx vitest run app/studio/DeployHistory.test.tsx`
+Expected: 6 passed. If the Escape case fails because `onBlur` fired first, that is fine behaviour but the test asserts `relabelDeploy` was called once, which still holds; if the textbox lingers, remove the `onBlur` handler (Escape and Enter are the two exits the spec names).
+
+- [ ] **Step 5: Rename the revert button and wire the component in**
+
+In `app/studio/DeployButton.tsx`, change the last button's text:
+
+```tsx
+        {revertFailed ? 'revert failed — try again' : '↩ discard changes'}
+```
+
+Run: `grep -rn "revert to glass" app --include='*.tsx' --include='*.ts'` and update any test string to `discard changes`.
+
+In `app/studio/StudioClient.tsx`, the full-rail deploy slot (around line 190) becomes:
+
+```tsx
+            deploySlot={
+              <>
+                <DeployButton
+                  diffCount={settingsApi.diffCount}
+                  onDeploy={settingsApi.deploy}
+                  onRevert={settingsApi.revert}
+                />
+                <DeployHistory api={settingsApi} />
+              </>
+            }
+```
+
+with `import { DeployHistory } from './DeployHistory';` beside the `DeployButton` import. Leave the compact pill (around line 285) alone.
+
+In `app/studio/solo/SoloStudioClient.tsx` line 58:
+
+```tsx
+        <SoloRail api={api} deploySlot={<><DeployButton diffCount={api.diffCount} onDeploy={api.deploy} onRevert={api.revert} /><DeployHistory api={api} /></>} />
+```
+
+with `import { DeployHistory } from '../DeployHistory';`.
+
+- [ ] **Step 6: Run the whole suite, lint, and type-check**
+
+Run: `npm run test 2>&1 | tail -6 && npm run lint 2>&1 | tail -3 && npx tsc --noEmit -p . 2>&1 | head -5`
+Expected: all tests pass, lint clean, tsc silent.
+
+- [ ] **Step 7: Commit**
+
+```bash
+[ "$(git rev-parse --abbrev-ref HEAD)" = feat/deploy-history ] && \
+git add app/studio/DeployHistory.tsx app/studio/DeployHistory.test.tsx app/studio/DeployButton.tsx app/studio/StudioClient.tsx app/studio/solo/SoloStudioClient.tsx && \
+git commit -m "feat(studio): deploy history under the Deploy button; revert reads as discard changes"
+```
+
+---
+
+### Task 9: Smoke on a dev server, spec touch-up, PR
+
+**Files:**
+- Modify: `docs/superpowers/specs/2026-09-05-studio-deploy-history-and-solo-preview-design.md` §2.5 (two wording fixes below)
+
+- [ ] **Step 1: Spec wording matches what was built**
+
+In §2.5 replace the sentence about namespaces appearing/disappearing (`… is listed as \`v4 reset\``) with: "A namespace that disappears reads as its keys returning to their default values." Replace "the row shows `gone` and the list revalidates" in §4 with "the row shows `gone`; the list refreshes within 30 s."
+
+- [ ] **Step 2: Dev-server smoke (the table does not exist yet in prod, so this exercises the null path)**
+
+Run: `npm run dev` (it picks a free port; note it), then in another command:
+
+```bash
+curl -s -o /dev/null -w '%{http_code}\n' http://localhost:<port>/api/kiosk/deploys
+```
+
+Expected: `403` (owner gate), which proves the route mounts. Open `/studio` signed in: the rail shows the `deploys` heading with no rows and the button reads "↩ discard changes". Stop the dev server.
+
+- [ ] **Step 3: Commit, push, open the PR**
+
+```bash
+[ "$(git rev-parse --abbrev-ref HEAD)" = feat/deploy-history ] && \
+git add docs/superpowers/specs/2026-09-05-studio-deploy-history-and-solo-preview-design.md && \
+git commit -m "docs(spec): deploy history wording matches the build" && \
+git push -u origin feat/deploy-history
+```
+
+PR title: `feat(studio): deploy history — every Deploy is a numbered snapshot you can load back`. Body: the spec's §1 in three sentences, the migration line Jesse must run before merging (`node scripts/apply-migration.mjs database/migrations/20260905_kiosk_deploys.sql --apply`), and a note that Part B (solo preview) follows PR #134 in its own PR.

--- a/docs/superpowers/specs/2026-09-05-studio-deploy-history-and-solo-preview-design.md
+++ b/docs/superpowers/specs/2026-09-05-studio-deploy-history-and-solo-preview-design.md
@@ -126,8 +126,9 @@ Each row, newest first, monospace:
 
 - **Summary** is what changed **against the previous deploy**: up to three
   `key value` pairs, then `+n`. Computed client-side from consecutive
-  snapshots with `diffKeys` per namespace; a namespace that appears or
-  disappears is listed as `v4 reset`. Deploy #1 shows `first recorded`.
+  snapshots with `diffKeys` per namespace; a namespace that disappears
+  reads as its keys returning to their default values. Deploy #1 shows
+  `first recorded`; an identical redeploy shows `no dial changes`.
 - **`glass` badge** on the row whose snapshot equals the live profile
   (deviation-equality per namespace, not "the newest id": a failed record
   would otherwise mislabel). **`studio` badge** on the row equal to the
@@ -198,8 +199,8 @@ starts now (`feat/deploy-history`).
 
 - History write fails → Deploy still succeeds; response says
   `deploy: null`; rail shows "history not recorded".
-- Load of a missing id → 404 → rail row shows `gone` and the list
-  revalidates.
+- Load of a missing id → 404 → rail row shows `gone`; the list refreshes
+  within 30 s.
 - Load with schema drift → keys dropped and counted in the response, never
   silently.
 - Preview with an empty queue → panel shows "nothing eligible with these

--- a/docs/superpowers/specs/2026-09-05-studio-deploy-history-and-solo-preview-design.md
+++ b/docs/superpowers/specs/2026-09-05-studio-deploy-history-and-solo-preview-design.md
@@ -1,0 +1,235 @@
+# Studio deploy history + solo preview on studio dials — design
+
+**Date:** 2026-09-05
+**Status:** approved in conversation, this is the written form
+**Builds on:** `2026-08-30-kiosk-studio-control-and-mosaic-v2-design.md` (the
+studio/live profiles and Deploy), `2026-09-04-solo-kiosk-design.md` §6.4 (the
+solo studio)
+
+## 1. What this is
+
+Two changes to the studio, one principle:
+
+> The studio previews what we WANT the glass to show. Deploy sends it. Every
+> deploy is kept, so any earlier one can be loaded back into the studio,
+> previewed again, and redeployed.
+
+1. **Deploy history.** Every Deploy records a numbered snapshot of the whole
+   profile it copied to live. The rail lists them. Loading one puts it in
+   the studio profile (preview first); Deploy sends it to the glass.
+   Rollback is nothing special: load an older deploy, Deploy.
+2. **Solo preview on studio dials.** `/studio/solo` currently draws its panel
+   from the live profile and says so; the fade dial does nothing there. It
+   changes to the mosaic studio's convention: the panel is a local
+   simulation on the studio dials, and the live truth shrinks to one line.
+
+### Naming, decided
+
+- These are **deploys**, numbered `#1, #2, …`, with an optional label. They
+  are **not** versions. A version (`v1 … v4`, `solo`, `solo2`) is a
+  renderer with its own dial set; a deploy is a take of dial values across
+  every namespace, the active version included. "solo v3" would collide
+  with the renderer names the day `solo3` exists.
+- A deploy snapshots the **whole profile**, not one namespace. Deploy already
+  copies every namespace; a snapshot that held only solo dials could not
+  restore what was actually on the glass.
+- The existing "↩ revert to glass" button becomes **"↩ discard changes"**.
+  It still copies live → studio. "Rollback" now means load + Deploy.
+
+## 2. Part A — deploy history
+
+### 2.1 Data: `kiosk_deploys` (new table)
+
+```sql
+CREATE TABLE IF NOT EXISTS kiosk_deploys (
+  id           SERIAL PRIMARY KEY,            -- the deploy number shown in the rail
+  label        TEXT,                          -- optional, renameable
+  namespaces   JSONB NOT NULL,                -- { namespace: deviations } exactly as copied to live
+  deployed_at  TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+```
+
+`namespaces` stores deviations from code defaults, the same blob shape
+`kiosk_settings.data` uses, so schema drift is handled the same way: a key
+the current schema does not know is dropped on load and named in the
+response (mirrors `applyNamespace`'s "restored 9 of 11").
+
+The migration seeds **deploy #1** from the current live profile when the
+table is empty, so "what was on the glass before this feature" is
+recoverable from day one:
+
+```sql
+INSERT INTO kiosk_deploys (label, namespaces)
+SELECT 'before deploy history', COALESCE(jsonb_object_agg(namespace, data), '{}'::jsonb)
+FROM kiosk_settings WHERE profile = 'live'
+  AND NOT EXISTS (SELECT 1 FROM kiosk_deploys);
+```
+
+Forward-only, idempotent. Applied by Jesse with
+`node scripts/apply-migration.mjs database/migrations/20260905_kiosk_deploys.sql --apply`
+before the PR merges (ledger rule).
+
+### 2.2 Store: `app/lib/settings/deploys.ts`
+
+| function | does |
+|---|---|
+| `recordDeploy(live: ProfileSettings, label?: string): Promise<DeployRow>` | inserts one row from the profile Deploy just copied |
+| `listDeploys(limit = 50): Promise<DeployRow[]>` | newest first |
+| `loadDeployIntoStudio(id): Promise<{ studio: ProfileSettings; dropped: DroppedKey[] } \| null>` | replaces the studio profile wholesale with the snapshot (delete rows not in it, upsert the rest, one transaction), sanitizing each namespace through its current schema; unknown namespaces are dropped and named; `null` when the id does not exist |
+| `relabelDeploy(id, label: string \| null): Promise<boolean>` | rename; false when missing |
+
+`DeployRow = { id, label, namespaces, deployedAt }`.
+
+Missing table: `recordDeploy` and `listDeploys` catch and warn, returning
+`null` / `[]`. Deploy must never fail because history could not be written,
+but it must not pretend either (§2.3).
+
+### 2.3 Routes (all owner-gated, `force-dynamic`, nodejs)
+
+| route | change |
+|---|---|
+| `POST /api/kiosk/settings/deploy` | after `copyProfile` + cache warm, `recordDeploy(live, body.label?)`. Response gains `deploy: DeployRow \| null`. `null` means history was not recorded; the client shows it. |
+| `GET /api/kiosk/deploys` | `{ deploys: DeployRow[] }` |
+| `POST /api/kiosk/deploys/[id]/load` | `loadDeployIntoStudio`. 404 when missing. `{ studio, dropped }`. |
+| `PATCH /api/kiosk/deploys/[id]` | `{ label }` → `{ ok: true }`; 404 when missing; 400 on a non-string/over-60-char label. |
+
+Loading touches only the studio profile. The glass changes only on Deploy,
+which is the point: preview, then send.
+
+### 2.4 Client: `useStudioSettings` additions
+
+```ts
+deploys: DeployRow[];                       // SWR on GET /api/kiosk/deploys, refresh 30 s
+deploy: (label?: string) => Promise<void>;  // unchanged signature for existing callers
+loadDeploy: (id: number) => Promise<DroppedKey[]>;
+relabelDeploy: (id: number, label: string | null) => Promise<void>;
+lastDeployRecorded: boolean | null;         // null until a deploy happens this session
+```
+
+`loadDeploy` behaves like `revert`: cancel pending PATCHes, POST, replace
+`studio` in the SWR cache, clear the optimistic overlay, then revalidate
+`deploys` (badges depend on it). `deploy` revalidates `deploys` after the
+POST.
+
+### 2.5 UI: `DeployHistory` (one component, both rails)
+
+Rendered under the `DeployButton` in `StudioRail` (mosaic) and `SoloRail`.
+Reads only from the hook.
+
+Each row, newest first, monospace:
+
+```
+#7  11:41  solo   fade 1.5 · dwell 14 · offset 4        [glass] [studio]
+#6  11:30  solo   activeVersion solo                     
+#5  10:02  v4     gate 0.55 · +2
+```
+
+- **Summary** is what changed **against the previous deploy**: up to three
+  `key value` pairs, then `+n`. Computed client-side from consecutive
+  snapshots with `diffKeys` per namespace; a namespace that appears or
+  disappears is listed as `v4 reset`. Deploy #1 shows `first recorded`.
+- **`glass` badge** on the row whose snapshot equals the live profile
+  (deviation-equality per namespace, not "the newest id": a failed record
+  would otherwise mislabel). **`studio` badge** on the row equal to the
+  current studio profile.
+- **Label** is inline-editable on click (text input, Enter saves, Esc
+  cancels, 60 chars max). Shown after the number when set.
+- **Click the row body → load into studio.** Same weight as "discard
+  changes" today (no hold): the only thing lost is undeployed studio edits,
+  which is exactly what revert already discards without ceremony. After
+  load, the row shows the `studio` badge and Deploy arms if it differs from
+  live. If keys were dropped, one line under the row: `loaded, 9 of 11 keys
+  fit the current schema`.
+- 50 rows max, scrolling inside the rail.
+- When the last deploy of this session came back with `deploy: null`, one
+  line above the list: `history not recorded (table missing?)`.
+
+Status strip (both studios) is unchanged except the revert label rename.
+
+## 3. Part B — solo preview on studio dials
+
+### 3.1 What changes on `/studio/solo`
+
+Today the panel is an `<img>` of the server's current frame with the live
+overlays and a live countdown, captioned "as deployed". It becomes:
+
+- The real `SoloFrame` component, fed by a **local play loop** on the
+  **studio** dials: studio dwell + offset clock, studio fade, studio
+  overlays (place, scores, rank, tally).
+- It plays through the projected queue column top to bottom, cycling. The
+  row it is showing gets the orange outline the on-glass row has today; the
+  server's on-glass row gets a small `glass` tag instead, so both facts stay
+  visible without competing.
+- The header countdown ("next frame in N s") runs on the studio clock.
+- The live truth moves to the status strip, one item per feed:
+  `glass ↑ Bourail · 12 s` — the frame on glass and the seconds to its next
+  change, on the live clock.
+
+Nothing the preview does touches the server: no advance POST, no tally
+bump. The glass keeps advancing on its own.
+
+### 3.2 `useSoloPreview(feed, order: EntryView[], dials: SoloDials)`
+
+Pure client hook, sibling to `useSoloGlass` but with no fetches.
+
+- State: `index` into `order`, `previous: EntryView | null`.
+- A timer armed with `msUntilBoundary(now, feed, dials.dwellS, dials.offsetS)`;
+  on fire, `previous = order[index]`, `index = (index + 1) % order.length`,
+  re-arm. Re-armed whenever `dwellS`/`offsetS` change (same pattern as
+  `useSoloGlass`).
+- When `order` changes (dial move, 5 s poll): if the entry at `index` is
+  still in the new order, keep following it (find it by `snapshotId`);
+  otherwise reset to 0. This stops a poll from yanking the preview back to
+  the top every five seconds.
+- Returns `{ current, previous, index, boundaryMs }`.
+- `previous` is set in the same state update as `current` (derived, not in a
+  trailing effect), so the crossfade's underlay is right on its first frame.
+  The glass renderer's trailing-effect version of this is a known nit,
+  fixed in Part B by the same derivation (`app/components/solo/index.tsx`).
+
+### 3.3 Ordering constraint
+
+PR #134 (`feat/solo2-rhythm`) touches every file under `app/studio/solo/`.
+Part B lands **after** #134 merges, in its own worktree
+(`feat/solo-studio-preview`). Part A touches none of those files and
+starts now (`feat/deploy-history`).
+
+## 4. Error handling
+
+- History write fails → Deploy still succeeds; response says
+  `deploy: null`; rail shows "history not recorded".
+- Load of a missing id → 404 → rail row shows `gone` and the list
+  revalidates.
+- Load with schema drift → keys dropped and counted in the response, never
+  silently.
+- Preview with an empty queue → panel shows "nothing eligible with these
+  dials" (the projected queue is empty exactly when `project()` returns
+  nothing).
+
+## 5. Testing
+
+- `deploys.test.ts`: record/list/load/relabel against the mocked `sql`
+  (existing `store.test.ts` pattern), including the missing-table path
+  returning `null`/`[]`, the wholesale replace (a studio namespace absent
+  from the snapshot is deleted), and drift dropping.
+- Route tests for the four endpoints: owner gate, 404s, 400 on bad label,
+  deploy response carrying `deploy`.
+- `useStudioSettings.test.tsx`: `loadDeploy` clears the overlay and
+  replaces `studio`; `deploy()` revalidates `deploys`.
+- `DeployHistory.test.tsx`: summary text against the previous deploy,
+  badges from profile equality, inline relabel, load click, `history not
+  recorded` line.
+- `useSoloPreview.test.tsx` (Part B): fake timers; advances on the studio
+  clock; follows an entry across an order change; resets when it vanishes;
+  `previous` correct on the first render after a change.
+- Migration: `migrate:status` lists it; dry-run output in the PR.
+
+## 6. Out of scope
+
+- One-click "redeploy #n" that skips the studio. Preview-first is the
+  principle; two clicks is the cost.
+- Per-namespace history or diffs between arbitrary pairs of deploys.
+- Pruning old deploys. Fifty rows of JSONB a day is nothing.
+- Recording who deployed. There is one owner.
+- Snapshotting bins, scenes or frames. Deploys are dial values only;
+  scenes (`kiosk_scenes`) already cover frames.


### PR DESCRIPTION
## What

Every studio **Deploy** now records a numbered snapshot of the whole profile it copied to live. Both studios list them under the Deploy button. Click one to load it into the studio (preview first), then Deploy to send it to the glass. Rollback is nothing special: load an older deploy, Deploy.

They are **deploys** (`#1, #2, …`, optional label), not versions. A version (`v1…v4`, `solo`, `solo2`) is a renderer; a deploy is a take of dial values across every namespace, the active version included.

"↩ revert to glass" reads "↩ discard changes" now, so it stops competing with "rollback".

## Migration — apply BEFORE merging

```
node scripts/apply-migration.mjs database/migrations/20260905_kiosk_deploys.sql --apply
```

Creates `kiosk_deploys` and seeds **deploy #1** from the current live profile. Until it is applied, Deploy still works: the response carries `deploy: null` and the rail says "history not recorded" instead of pretending.

## Pieces

- `app/lib/settings/deploys.ts` — record / list / load-into-studio / relabel (load is a wholesale replace, sanitized through the current schemas; dropped keys are named).
- `POST /api/kiosk/settings/deploy` now records; `GET /api/kiosk/deploys`, `PATCH /api/kiosk/deploys/:id`, `POST /api/kiosk/deploys/:id/load`. All owner-gated.
- `useStudioSettings`: `deploys`, `deploy(label?)`, `loadDeploy`, `relabelDeploy`, `lastDeployRecorded`.
- `DeployHistory` component: summary vs the previous deploy, `glass` / `studio` badges by profile equality, inline relabel, 50 rows.
- Spec: `docs/superpowers/specs/2026-09-05-studio-deploy-history-and-solo-preview-design.md`. Part B (solo studio preview on studio dials) follows PR #134 in its own PR.

## Verified

- 2108 tests pass (34 new). Lint clean. Migration dry-run prints 2 statements.
- Dev server: the three routes mount and answer 401 unsigned; `/studio` renders.
- Not yet: a signed-in look at the rail — Jesse's smoke after applying the migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UBj3NHsZ13Cw7aWr2sQaRt
