### PR TITLE
fix(solo): one shared caption for every version; caption clamp; scores on the 1–5 scale; sunset floor default 1; preview + queue-row tidy

### DIFF
--- a/app/api/kiosk/solo/state/route.test.ts
+++ b/app/api/kiosk/solo/state/route.test.ts
@@ -34,7 +34,9 @@ beforeEach(() => {
   getScreenState.mockResolvedValue(null);
   countAdmittedSince.mockResolvedValue({ sunset: 0, nonSunset: 0 });
   getSweptZone.mockResolvedValue(null);
-  getLiveSettingsCached.mockResolvedValue({ namespaces: { solo: { dwellS: 30 }, solo2: { dwellS: 9, valleys: 1 } }, revision: 1 });
+  getLiveSettingsCached.mockResolvedValue({
+    namespaces: { shared: { activeVersion: 'solo', pictureHeight: 70 }, solo: { dwellS: 30, pictureHeight: 92 }, solo2: { dwellS: 9, valleys: 1 } }, revision: 1,
+  });
   getProfileSettings.mockResolvedValue({ namespaces: { solo: { dwellS: 7 } }, revision: 1 });
 });
 
@@ -56,6 +58,12 @@ describe('GET /api/kiosk/solo/state', () => {
     expect(body.dials.dwellS).toBe(9);
     expect(body.dials.valleys).toBe(1);
     expect(body.nextRoles).toEqual([]);
+  });
+  it('the caption comes from the shared namespace for either version; a caption key left in a version row is ignored', async () => {
+    expect((await (await get('?feed=sunset')).json()).dials.pictureHeight).toBe(70);
+    expect((await (await get('?feed=sunset&version=solo2')).json()).dials.pictureHeight).toBe(70);
+    getProfileSettings.mockResolvedValue({ namespaces: { solo: { pictureHeight: 92 } }, revision: 1 });
+    expect((await (await get('?feed=sunset&profile=studio')).json()).dials.pictureHeight).toBe(87);
   });
   it('live profile by default, no owner check; guaranteed-rings zone until the cron has recorded one', async () => {
     const res = await get('?feed=sunset');

--- a/app/api/kiosk/solo/state/route.ts
+++ b/app/api/kiosk/solo/state/route.ts
@@ -3,6 +3,8 @@ import { requireOwner } from '@/app/lib/owner';
 import { getLiveSettingsCached } from '@/app/lib/settings/liveSettings';
 import { getProfileSettings } from '@/app/lib/settings/store';
 import { mergeSettings } from '@/app/lib/settings/schema';
+import { SHARED_NAMESPACE } from '@/app/lib/settings/sharedSchema';
+import { withCaption } from '@/app/lib/solo/captionSchema';
 import { resolveSoloVersion } from '@/app/lib/solo/versions';
 import { countAdmittedSince, getScreenState, getSweptZone, listActiveEntries } from '@/app/lib/solo/store';
 import { isFlagEnabled, SWEEP_FORCE_DAY_RING } from '@/app/lib/runtimeFlags';
@@ -34,7 +36,10 @@ export async function GET(request: NextRequest) {
     if (denied) return denied;
   }
   const profile = studio ? await getProfileSettings('studio') : await getLiveSettingsCached();
-  const dials = version.dialsFrom(mergeSettings(version.schema, profile?.namespaces[version.namespace]));
+  // The version's own dials with the caption from the shared namespace: one caption for every solo version.
+  const dials = version.dialsFrom(withCaption(
+    mergeSettings(version.schema, profile?.namespaces[version.namespace]), profile?.namespaces[SHARED_NAMESPACE],
+  ));
 
   const nowMs = Date.now();
   const [entries, screen, admitted, sweptZone, forcedDayRing] = await Promise.all([

--- a/app/components/mosaic/types.ts
+++ b/app/components/mosaic/types.ts
@@ -58,6 +58,12 @@ export interface MosaicProps {
   at?: string | number;
   /** Merged-or-deviation knob values for THIS version's namespace (server profile). */
   settings?: Record<string, number | boolean | string>;
+  /**
+   * The SHARED namespace's values (merged or deviations), for the dials that
+   * are not a version's own: the solo versions draw their caption from it.
+   * Mosaic versions ignore it.
+   */
+  shared?: Record<string, number | boolean | string>;
 }
 
 export type MosaicComponent = (props: MosaicProps) => React.ReactNode;

--- a/app/components/solo/Caption.tsx
+++ b/app/components/solo/Caption.tsx
@@ -3,7 +3,7 @@
 import type { CSSProperties } from 'react';
 import type { SoloDials } from '@/app/lib/solo/types';
 import {
-  FONT_STACKS, captionBox, captionLines, captionScale, gray, type CaptionEntry, type Rect,
+  FONT_STACKS, LINE_HEIGHT, captionBox, captionLines, captionScale, gray, type CaptionEntry, type Rect,
 } from '@/app/lib/solo/caption';
 
 /**
@@ -12,17 +12,19 @@ import {
  * the frame. Null when the place dial is off. Everything positional comes
  * from lib/solo/caption.ts, so this is layout only.
  */
-export function Caption({ entry, dials, picture, width }: {
+export function Caption({ entry, dials, picture, width, height }: {
   entry: CaptionEntry;
   dials: SoloDials;
   /** Where the picture sits on the panel, from pictureRect. */
   picture: Rect;
   width: number;
+  /** The panel's height, so a panel-bottom caption knows where the bottom is and how far up the picture reaches. */
+  height: number;
 }) {
   const lines = captionLines(entry, dials);
   if (!lines) return null;
   const s = captionScale(width);
-  const box = captionBox(dials, picture, width);
+  const box = captionBox(dials, picture, width, height, lines);
   const overlay = dials.captionLayout === 'overlay';
   const inline = dials.timeLine === 'inline';
 
@@ -42,18 +44,18 @@ export function Caption({ entry, dials, picture, width }: {
   return (
     <div data-testid="caption" style={block}>
       <div data-testid="caption-title" style={{
-        ...line, fontSize: dials.titleSize * s, fontWeight: Number(dials.titleWeight), color: gray(dials.titleGray), lineHeight: 1.15,
+        ...line, fontSize: dials.titleSize * s, fontWeight: Number(dials.titleWeight), color: gray(dials.titleGray), lineHeight: LINE_HEIGHT.title,
       }}>
         {lines.title}
       </div>
       {(lines.place || (inline && time)) && (
-        <div data-testid="caption-place" style={{ ...line, fontSize: dials.placeSize * s, color: gray(dials.placeGray), lineHeight: 1.3 }}>
+        <div data-testid="caption-place" style={{ ...line, fontSize: dials.placeSize * s, color: gray(dials.placeGray), lineHeight: LINE_HEIGHT.place }}>
           {lines.place}
           {inline && time && lines.place ? <span style={{ color: gray(dials.timeGray) }}> · </span> : null}
           {inline ? time : null}
         </div>
       )}
-      {!inline && time && <div style={{ ...line, lineHeight: 1.3 }}>{time}</div>}
+      {!inline && time && <div style={{ ...line, lineHeight: LINE_HEIGHT.time }}>{time}</div>}
     </div>
   );
 }

--- a/app/components/solo/SoloFrame.test.tsx
+++ b/app/components/solo/SoloFrame.test.tsx
@@ -29,15 +29,16 @@ it('caption sizes are glass pixels: the dialled px on a 1920 panel, and the gray
   expect(screen.getByTestId('caption-title')).toHaveStyle({ fontSize: '21px', fontWeight: '300', color: 'rgb(181, 181, 181)' });
   expect(screen.getByTestId('caption-place')).toHaveStyle({ fontSize: '17px', color: 'rgb(145, 145, 145)' });
   expect(screen.getByTestId('caption-time')).toHaveStyle({ fontSize: '12px', color: 'rgb(117, 117, 117)' });
-  // flush with the picture's left edge, the gap above the panel's bottom edge
-  expect(screen.getByTestId('caption')).toHaveStyle({ left: '125px', bottom: '18px', maxWidth: '1671px' });
+  // flush with the picture's left edge; the panel edge would put its top at 1000.15, the gap under the picture (983) says 1001
+  expect(screen.getByTestId('caption')).toHaveStyle({ left: '125px', top: '1001px', maxWidth: '1671px' });
 });
 
 it('on a half-size panel everything halves', () => {
   render(<SoloFrame entry={e} previous={null} fadeS={0} dials={D} width={960} height={540} />);
   expect(screen.getByRole('presentation')).toHaveStyle({ width: '836px', height: '470px' });
   expect(screen.getByTestId('caption-title')).toHaveStyle({ fontSize: '10.5px' });
-  expect(screen.getByTestId('caption')).toHaveStyle({ bottom: '9px' });
+  // the picture rect rounds: 470 tall from 22 down ends at 492, plus the 9 px gap; the panel edge would say 500.075
+  expect(screen.getByTestId('caption')).toHaveStyle({ top: '501px' });
 });
 
 it('overlay layout: the picture fills the panel and the caption floats over it with a shadow', () => {
@@ -70,4 +71,11 @@ it('keeps the previous frame underneath, in the same picture box, and sets the f
   expect(imgs.map((i) => i.getAttribute('src'))).toEqual(['u0', 'u1']);
   expect(imgs[0]).toHaveStyle({ left: '125px', width: '1671px' });
   expect(imgs[1]).toHaveStyle({ transition: 'opacity 3s ease' });
+});
+
+it('a panel-bottom caption never rises into the picture: at 92 % it hangs the gap under the picture instead', () => {
+  render(<SoloFrame entry={e} previous={null} fadeS={0} dials={{ ...D, pictureHeight: 92 }} width={1920} height={1080} />);
+  // 92 % of 1080 = 994 tall, 4 % down = 43: the picture ends at 1037; the caption starts 18 below it.
+  expect(screen.getByRole('presentation')).toHaveStyle({ top: '43px', height: '994px' });
+  expect(screen.getByTestId('caption')).toHaveStyle({ top: '1055px' });
 });

--- a/app/components/solo/SoloFrame.tsx
+++ b/app/components/solo/SoloFrame.tsx
@@ -46,7 +46,7 @@ export function SoloFrame({ entry, previous, fadeS, dials, width, height }: {
         }}
       />
       <style>{'@keyframes solo-fade-in { from { opacity: 0 } to { opacity: 1 } }'}</style>
-      <Caption entry={entry} dials={dials} picture={picture} width={width} />
+      <Caption entry={entry} dials={dials} picture={picture} width={width} height={height} />
       {(dials.showScores || dials.showRank || dials.showTally) && (
         <div style={{
           position: 'absolute', right: 24 * scale, bottom: 20 * scale, color: '#fff',

--- a/app/components/solo/index.tsx
+++ b/app/components/solo/index.tsx
@@ -5,6 +5,7 @@ import type { MosaicProps } from '@/app/components/mosaic/types';
 import type { EntryView } from '@/app/api/kiosk/solo/view';
 import { mergeSettings } from '@/app/lib/settings/schema';
 import { SOLO_SETTINGS_SCHEMA, dialsFrom } from '@/app/lib/solo/settingsSchema';
+import { withCaption } from '@/app/lib/solo/captionSchema';
 import { SoloFrame } from './SoloFrame';
 import { useSoloGlass } from './useSoloGlass';
 
@@ -17,7 +18,7 @@ const mono = 'ui-monospace, SFMono-Regular, Menlo, monospace';
  * /api/kiosk/solo.
  */
 export function SoloKiosk(props: MosaicProps) {
-  const dials = dialsFrom(mergeSettings(SOLO_SETTINGS_SCHEMA, props.settings));
+  const dials = dialsFrom(withCaption(mergeSettings(SOLO_SETTINGS_SCHEMA, props.settings), props.shared));
   const glass = useSoloGlass({
     feed: props.feed,
     dials,

--- a/app/components/solo2/Solo2Frame.tsx
+++ b/app/components/solo2/Solo2Frame.tsx
@@ -110,7 +110,7 @@ export function Solo2Frame({ entry, prelude, previous, stage, plan, dials, width
           ))}
         </div>
       </div>
-      {onMain && <Caption entry={entry} dials={dials} picture={picture} width={width} />}
+      {onMain && <Caption entry={entry} dials={dials} picture={picture} width={width} height={height} />}
       {onMain && (dials.showScores || dials.showRank || dials.showTally) && (
         <div style={{
           position: 'absolute', right: 24 * scale, bottom: 20 * scale, color: '#fff',

--- a/app/components/solo2/index.tsx
+++ b/app/components/solo2/index.tsx
@@ -5,6 +5,7 @@ import type { MosaicProps } from '@/app/components/mosaic/types';
 import type { EntryView } from '@/app/api/kiosk/solo/view';
 import { mergeSettings } from '@/app/lib/settings/schema';
 import { SOLO2_SETTINGS_SCHEMA, dialsFrom2 } from '@/app/lib/solo2/settingsSchema';
+import { withCaption } from '@/app/lib/solo/captionSchema';
 import { fitPlan } from '@/app/lib/solo2/plan';
 import { preludePlan } from '@/app/lib/solo2/prelude';
 import { useSoloGlass } from '@/app/components/solo/useSoloGlass';
@@ -25,7 +26,7 @@ function preload(url: string) {
  * `version=solo2`.
  */
 export function Solo2Kiosk(props: MosaicProps) {
-  const dials = dialsFrom2(mergeSettings(SOLO2_SETTINGS_SCHEMA, props.settings));
+  const dials = dialsFrom2(withCaption(mergeSettings(SOLO2_SETTINGS_SCHEMA, props.settings), props.shared));
   const glass = useSoloGlass({
     feed: props.feed,
     dials,

--- a/app/kiosk/sunrise/page.tsx
+++ b/app/kiosk/sunrise/page.tsx
@@ -60,6 +60,7 @@ function SunriseKioskContent() {
         dozing={dozing}
         search={queryString}
         settings={liveSettings?.namespaces[versionName]}
+        shared={liveSettings?.namespaces.shared}
       />
       <KioskDozeOverlay dozing={dozing} />
     </>

--- a/app/kiosk/sunset/page.tsx
+++ b/app/kiosk/sunset/page.tsx
@@ -60,6 +60,7 @@ function SunsetKioskContent() {
         dozing={dozing}
         search={queryString}
         settings={liveSettings?.namespaces[versionName]}
+        shared={liveSettings?.namespaces.shared}
       />
       <KioskDozeOverlay dozing={dozing} />
     </>

--- a/app/lib/settings/sharedSchema.test.ts
+++ b/app/lib/settings/sharedSchema.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest';
 import { SHARED_SCHEMA, SHARED_NAMESPACE } from './sharedSchema';
 import { schemaDefaults } from './schema';
 import { DEFAULT_MOSAIC_VERSION } from '@/app/components/mosaic/registry';
+import { CAPTION_SCHEMA } from '@/app/lib/solo/captionSchema';
 
 describe('SHARED_SCHEMA', () => {
   it('activeVersion defaults to the registry pin so an empty DB changes nothing', () => {
@@ -11,6 +12,11 @@ describe('SHARED_SCHEMA', () => {
     const knob = SHARED_SCHEMA.find((k) => k.key === 'panelPreset');
     expect(knob?.kind).toBe('enum');
     expect(knob && 'options' in knob ? [...knob.options] : []).toEqual(['dell', 'ktc', 'dell-l', 'ktc-l']);
+  });
+  it('carries every caption knob, so one caption serves every solo version', () => {
+    for (const k of CAPTION_SCHEMA) expect(SHARED_SCHEMA.find((x) => x.key === k.key)).toBe(k);
+    const keys = SHARED_SCHEMA.map((k) => k.key);
+    expect(new Set(keys).size).toBe(keys.length);
   });
   it('exports the namespace constant used by storage rows', () => {
     expect(SHARED_NAMESPACE).toBe('shared');

--- a/app/lib/settings/sharedSchema.ts
+++ b/app/lib/settings/sharedSchema.ts
@@ -1,6 +1,7 @@
 import { SettingsSchema } from './schema';
 import { MOSAIC_VERSIONS, DEFAULT_MOSAIC_VERSION } from '@/app/components/mosaic/registry';
 import { PANEL_PRESETS, DEFAULT_PANEL_PRESET } from '@/app/kiosk/panelPreview';
+import { CAPTION_SCHEMA } from '@/app/lib/solo/captionSchema';
 
 export const SHARED_NAMESPACE = 'shared';
 
@@ -13,6 +14,8 @@ const describePanels = (): string =>
  * Shared settings apply across all mosaic versions and the UI.
  * activeVersion selects which mosaic to render (?v= param default).
  * panelPreset selects the physical screen dimensions for the kiosk.
+ * The caption section (captionSchema.ts) is the solo kiosk's caption, one
+ * set for every solo version; /studio/solo dials it, /studio hides it.
  */
 export const SHARED_SCHEMA: SettingsSchema = [
   {
@@ -35,4 +38,5 @@ export const SHARED_SCHEMA: SettingsSchema = [
     description: `Panel size: ${describePanels()}. Both physical screens share one geometry.`,
     section: 'glass',
   },
+  ...CAPTION_SCHEMA,
 ] as const;

--- a/app/lib/solo/caption.test.ts
+++ b/app/lib/solo/caption.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { captionBox, captionLines, displayTitle, formatTime, gray, pictureRect } from './caption';
+import { captionBox, captionHeight, captionLines, displayTitle, formatTime, gray, pictureRect } from './caption';
 
 // 02:42 UTC on 2026-09-05 is 7:42 pm the evening before in Mazatlán (UTC−7).
 const AT = Date.UTC(2026, 8, 5, 2, 42);
@@ -91,24 +91,59 @@ describe('pictureRect', () => {
   });
 });
 
+describe('captionHeight', () => {
+  const d = { titleSize: 21, placeSize: 17, timeSize: 12, lineGap: 0, timeLine: 'own' as const };
+  const lines = { place: 'Norrbotten County, Sweden', time: '7:42 pm there' };
+  it('adds the lines that will exist at the glass line heights, plus the gaps between them, at scale', () => {
+    // title 21 × 1.15 + place 17 × 1.3 + time 12 × 1.3
+    expect(captionHeight(d, lines, 1)).toBeCloseTo(61.85);
+    expect(captionHeight(d, { place: '', time: '' }, 1)).toBeCloseTo(21 * 1.15);
+    expect(captionHeight(d, { place: '', time: '7:42 pm' }, 1)).toBeCloseTo(21 * 1.15 + 12 * 1.3);
+    expect(captionHeight({ ...d, lineGap: 4 }, lines, 1)).toBeCloseTo(61.85 + 8);
+    expect(captionHeight(d, lines, 0.5)).toBeCloseTo(61.85 / 2);
+  });
+  it('an inline time shares the place line, and makes one when there is no place', () => {
+    expect(captionHeight({ ...d, timeLine: 'inline' }, lines, 1)).toBeCloseTo(21 * 1.15 + 17 * 1.3);
+    expect(captionHeight({ ...d, timeLine: 'inline' }, { place: '', time: '7:42 pm' }, 1)).toBeCloseTo(21 * 1.15 + 17 * 1.3);
+  });
+});
+
 describe('captionBox', () => {
-  const pic = { left: 125, top: 43, width: 1671, height: 940 };
-  const d = { captionLayout: 'inset' as const, captionAnchor: 'panel-bottom' as const, captionAlign: 'picture' as const, captionGap: 18 };
-  it('panel-bottom + picture: the gap above the panel edge, flush with the picture', () => {
-    expect(captionBox(d, pic, 1920)).toEqual({ left: 125, maxWidth: 1671, bottom: 18, textAlign: 'left' });
+  const pic = { left: 125, top: 43, width: 1671, height: 940 }; // pictureRect at 87 % on 1920 × 1080
+  const d = {
+    captionLayout: 'inset' as const, captionAnchor: 'panel-bottom' as const, captionAlign: 'picture' as const, captionGap: 18,
+    titleSize: 21, placeSize: 17, timeSize: 12, lineGap: 0, timeLine: 'own' as const,
+  };
+  const lines = { place: 'Norrbotten County, Sweden', time: '7:42 pm there' };
+  const capH = 61.85; // captionHeight(d, lines, 1)
+  it('panel-bottom + picture: the gap above the panel edge, flush with the picture, when the picture leaves room', () => {
+    const short = pictureRect({ captionLayout: 'inset', pictureHeight: 80, pictureTop: 4 }, 1920, 1080);
+    const box = captionBox(d, short, 1920, 1080, lines);
+    expect(box).toMatchObject({ left: short.left, maxWidth: short.width, textAlign: 'left' });
+    expect(box.top).toBeCloseTo(1080 - 18 - capH);
+    expect(box.bottom).toBeUndefined();
+  });
+  it('a panel-bottom caption never rises into the picture: it sits no higher than the gap below the picture', () => {
+    // At 87 % the panel edge would put the caption's top at 1000.15; the picture ends at 983, so the gap wins by less than a pixel.
+    expect(captionBox(d, pic, 1920, 1080, lines)).toEqual({ left: 125, maxWidth: 1671, top: 1001, textAlign: 'left' });
+    // At 92 % (the glass on 2026-09-05) the panel edge would put it 37 px into the picture; it hangs under the picture instead.
+    const tall = pictureRect({ captionLayout: 'inset', pictureHeight: 92, pictureTop: 4 }, 1920, 1080);
+    expect(tall.top + tall.height).toBe(1037);
+    expect(captionBox(d, tall, 1920, 1080, lines)).toMatchObject({ top: 1037 + 18 });
   });
   it('under-picture hangs the gap below the picture', () => {
-    expect(captionBox({ ...d, captionAnchor: 'under-picture' }, pic, 1920)).toMatchObject({ top: 43 + 940 + 18 });
+    expect(captionBox({ ...d, captionAnchor: 'under-picture' }, pic, 1920, 1080, lines)).toMatchObject({ top: 43 + 940 + 18 });
   });
   it('center spans the panel; panel sits at the glass margin', () => {
-    expect(captionBox({ ...d, captionAlign: 'center' }, pic, 1920)).toEqual({ left: 0, width: 1920, textAlign: 'center', bottom: 18 });
-    expect(captionBox({ ...d, captionAlign: 'panel' }, pic, 1920)).toMatchObject({ left: 24, textAlign: 'left' });
+    expect(captionBox({ ...d, captionAlign: 'center' }, pic, 1920, 1080, lines)).toEqual({ left: 0, width: 1920, textAlign: 'center', top: 1001 });
+    expect(captionBox({ ...d, captionAlign: 'panel' }, pic, 1920, 1080, lines)).toMatchObject({ left: 24, textAlign: 'left' });
   });
-  it('the gap is in glass pixels: half on a half-width panel', () => {
-    expect(captionBox(d, pictureRect({ captionLayout: 'inset', pictureHeight: 87, pictureTop: 4 }, 960, 540), 960)).toMatchObject({ bottom: 9 });
+  it('the gap and the caption are in glass pixels: everything halves on a half-size panel', () => {
+    const half = pictureRect({ captionLayout: 'inset', pictureHeight: 80, pictureTop: 4 }, 960, 540);
+    expect(captionBox(d, half, 960, 540, lines).top).toBeCloseTo((1080 - 18 - capH) / 2);
   });
   it('overlay tucks into the picture corner whatever the dials say', () => {
-    expect(captionBox({ ...d, captionLayout: 'overlay', captionAlign: 'center' }, pic, 1920)).toEqual({ left: 24, bottom: 20, textAlign: 'left', maxWidth: 1872 });
+    expect(captionBox({ ...d, captionLayout: 'overlay', captionAlign: 'center' }, pic, 1920, 1080, lines)).toEqual({ left: 24, bottom: 20, textAlign: 'left', maxWidth: 1872 });
   });
 });
 

--- a/app/lib/solo/caption.ts
+++ b/app/lib/solo/caption.ts
@@ -132,25 +132,52 @@ export interface CaptionBox {
   textAlign: 'left' | 'center';
 }
 
+/** Line heights the caption draws with, as multiples of each line's font size. Caption.tsx uses these. */
+export const LINE_HEIGHT = { title: 1.15, place: 1.3, time: 1.3 } as const;
+
 /**
- * Where the caption block sits, given the picture. Under-picture hangs it
- * `captionGap` below the picture; panel-bottom keeps it that far above the
- * panel's bottom edge. Overlay ignores both and tucks it inside the picture.
+ * How tall the caption block will be, in CSS pixels at scale `s`: the lines
+ * that will exist (the title always; the place line when there is a place or
+ * an inline time; the time on its own line unless inline) at the line heights
+ * Caption draws with, plus the line gap between them.
+ */
+export function captionHeight(
+  d: Pick<SoloDials, 'titleSize' | 'placeSize' | 'timeSize' | 'lineGap' | 'timeLine'>,
+  lines: Pick<CaptionLines, 'place' | 'time'>, s: number,
+): number {
+  const inline = d.timeLine === 'inline';
+  const heights = [d.titleSize * LINE_HEIGHT.title];
+  if (lines.place || (inline && lines.time)) heights.push(d.placeSize * LINE_HEIGHT.place);
+  if (!inline && lines.time) heights.push(d.timeSize * LINE_HEIGHT.time);
+  return (heights.reduce((a, b) => a + b, 0) + d.lineGap * (heights.length - 1)) * s;
+}
+
+/**
+ * Where the caption block sits, given the picture and the panel. Under-picture
+ * hangs it `captionGap` below the picture. Panel-bottom keeps it that far
+ * above the panel's bottom edge, but never higher than under-picture would
+ * put it: a picture too tall for the caption pushes the caption down rather
+ * than the caption rising into the picture (the glass on 2026-09-05, at
+ * pictureHeight 92, drew the caption 37 px over the picture's foot). When the
+ * panel cannot hold both, the caption leaves the panel, which the studio
+ * preview shows for what it is: a picture dial set too tall. Overlay ignores
+ * all of this and tucks the caption inside the picture.
  */
 export function captionBox(
-  d: Pick<SoloDials, 'captionLayout' | 'captionAnchor' | 'captionAlign' | 'captionGap'>,
-  picture: Rect, width: number,
+  d: Pick<SoloDials, 'captionLayout' | 'captionAnchor' | 'captionAlign' | 'captionGap' | 'titleSize' | 'placeSize' | 'timeSize' | 'lineGap' | 'timeLine'>,
+  picture: Rect, width: number, height: number, lines: Pick<CaptionLines, 'place' | 'time'>,
 ): CaptionBox {
   const s = captionScale(width);
   if (d.captionLayout === 'overlay') return { left: 24 * s, bottom: 20 * s, textAlign: 'left', maxWidth: width - 48 * s };
   const gap = d.captionGap * s;
-  const vertical = d.captionAnchor === 'under-picture'
-    ? { top: picture.top + picture.height + gap }
-    : { bottom: gap };
+  const underPicture = picture.top + picture.height + gap;
+  const top = d.captionAnchor === 'under-picture'
+    ? underPicture
+    : Math.max(height - gap - captionHeight(d, lines, s), underPicture);
   switch (d.captionAlign) {
-    case 'center': return { left: 0, width, textAlign: 'center', ...vertical };
-    case 'panel': return { left: 24 * s, maxWidth: width - 48 * s, textAlign: 'left', ...vertical };
-    default: return { left: picture.left, maxWidth: picture.width, textAlign: 'left', ...vertical };
+    case 'center': return { left: 0, width, textAlign: 'center', top };
+    case 'panel': return { left: 24 * s, maxWidth: width - 48 * s, textAlign: 'left', top };
+    default: return { left: picture.left, maxWidth: picture.width, textAlign: 'left', top };
   }
 }
 

--- a/app/lib/solo/captionSchema.test.ts
+++ b/app/lib/solo/captionSchema.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from 'vitest';
+import { CAPTION_SCHEMA, CAPTION_SECTION, captionDialsFrom, withCaption } from './captionSchema';
+import { mergeSettings, schemaDefaults } from '@/app/lib/settings/schema';
+
+describe('CAPTION_SCHEMA', () => {
+  it('defaults are the 2026-09-05 mockup', () => {
+    expect(captionDialsFrom(schemaDefaults(CAPTION_SCHEMA))).toEqual({
+      captionLayout: 'inset', pictureHeight: 87, pictureTop: 4,
+      captionAnchor: 'panel-bottom', captionAlign: 'picture', captionGap: 18,
+      font: 'system', titleClean: 'compass',
+      titleSize: 21, titleWeight: '300', titleGray: 71,
+      placeSize: 17, placeGray: 57, lineGap: 0,
+      timeStyle: '12h-there', timeLine: 'own', timeSize: 12, timeGray: 46,
+    });
+  });
+
+  it('every knob is in the caption section, keys are unique, and every default is legal', () => {
+    const keys = CAPTION_SCHEMA.map((k) => k.key);
+    expect(new Set(keys).size).toBe(keys.length);
+    for (const k of CAPTION_SCHEMA) {
+      expect(k.section).toBe(CAPTION_SECTION);
+      if (k.kind === 'enum') expect(k.options, k.key).toContain(k.default);
+      if (k.kind === 'number') {
+        expect(k.default, k.key).toBeGreaterThanOrEqual(k.min);
+        expect(k.default, k.key).toBeLessThanOrEqual(k.max);
+      }
+    }
+  });
+});
+
+describe('withCaption', () => {
+  const own = { dwellS: 5, mix: 2 };
+  it('lays the shared caption over a version\'s values, from deviations or merged values alike', () => {
+    expect(withCaption(own, { pictureHeight: 70, activeVersion: 'solo' })).toMatchObject({ dwellS: 5, mix: 2, pictureHeight: 70, captionGap: 18 });
+    const merged = mergeSettings(CAPTION_SCHEMA, { pictureHeight: 70 });
+    expect(withCaption(own, merged).pictureHeight).toBe(70);
+    expect('activeVersion' in withCaption(own, { pictureHeight: 70, activeVersion: 'solo' })).toBe(false);
+  });
+  it('without shared values the caption is at its defaults; a caption key in the version values does not win', () => {
+    expect(withCaption(own).pictureHeight).toBe(87);
+    expect(withCaption({ ...own, pictureHeight: 92 }, {}).pictureHeight).toBe(87);
+    expect(withCaption({ ...own, pictureHeight: 92 }, { pictureHeight: 70 }).pictureHeight).toBe(70);
+  });
+});

--- a/app/lib/solo/captionSchema.ts
+++ b/app/lib/solo/captionSchema.ts
@@ -1,0 +1,150 @@
+import { mergeSettings } from '@/app/lib/settings/schema';
+import type { SettingsSchema, SettingsValues } from '@/app/lib/settings/schema';
+import type {
+  CaptionAlign, CaptionAnchor, CaptionDials, CaptionFont, CaptionLayout, TimeLine, TimeStyle, TitleClean, TitleWeight,
+} from './types';
+
+/** The rail section every caption knob sits in. */
+export const CAPTION_SECTION = 'caption';
+
+/**
+ * The caption dials: the picture's frame on black and the words beneath it.
+ *
+ * They live in the SHARED settings namespace (sharedSchema.ts spreads them
+ * in), not in a version's, because the glass draws one caption whichever
+ * solo engine picks the frame. Each version carrying its own copy let the two
+ * drift: on 2026-09-05 the live `solo` row said pictureHeight 92 while
+ * `solo2` sat at the default 87, so the solo2 studio previewed a caption the
+ * glass, running solo, never drew. A stored caption key in a version's row
+ * is now unknown to that version's schema and is dropped on merge.
+ *
+ * Defaults are the values dialled in on the 2026-09-05 mockup. Sizes are
+ * glass pixels on a 1920-wide panel; grays are percent of white.
+ */
+export const CAPTION_SCHEMA: SettingsSchema = [
+  {
+    key: 'captionLayout', kind: 'enum', options: ['inset', 'overlay'], default: 'inset',
+    label: 'layout', section: CAPTION_SECTION,
+    description: 'Inset: the picture sits smaller on black with the caption beneath it. Overlay: the picture fills the panel and the caption floats over it.',
+  },
+  {
+    key: 'pictureHeight', kind: 'number', min: 60, max: 100, step: 1, default: 87,
+    label: 'picture height (%)', section: CAPTION_SECTION,
+    description: 'How tall the inset picture is, as a percent of the panel. It keeps the panel\'s shape and sits centred. The caption never rises into it: a picture too tall for the caption pushes the caption down, and past what the panel can hold, off it.',
+  },
+  {
+    key: 'pictureTop', kind: 'number', min: 0, max: 12, step: 0.5, default: 4,
+    label: 'picture top margin (%)', section: CAPTION_SECTION,
+    description: 'Black above the inset picture, as a percent of the panel height.',
+  },
+  {
+    key: 'captionAnchor', kind: 'enum', options: ['panel-bottom', 'under-picture'], default: 'panel-bottom',
+    label: 'caption sits', section: CAPTION_SECTION,
+    description: 'panel-bottom: the gap above the bottom edge of the panel, but never higher than the gap below the picture. under-picture: the gap below the picture.',
+  },
+  {
+    key: 'captionAlign', kind: 'enum', options: ['picture', 'center', 'panel'], default: 'picture',
+    label: 'caption aligned to', section: CAPTION_SECTION,
+    description: 'Flush with the picture\'s left edge, centred on the panel, or at the panel\'s left margin.',
+  },
+  {
+    key: 'captionGap', kind: 'number', min: 0, max: 80, step: 2, default: 18,
+    label: 'gap (px)', section: CAPTION_SECTION,
+    description: 'Space between the caption and whatever it is anchored to.',
+  },
+  {
+    key: 'font', kind: 'enum', options: ['system', 'geist', 'sans', 'serif', 'mono'], default: 'system',
+    label: 'font', section: CAPTION_SECTION,
+    description: 'system: whatever the Pi has. geist: the site\'s face. sans: Source Sans 3. serif: Source Serif 4. mono: Geist Mono.',
+  },
+  {
+    key: 'titleClean', kind: 'enum', options: ['compass', 'raw', 'comma', 'dot', 'spot'], default: 'compass',
+    label: '“›” in titles', section: CAPTION_SECTION,
+    description: 'Windy titles read "City › Compass: Spot". compass drops the "› Compass" part; comma / dot keep it with a quieter separator; spot shows only the spot name and moves the city down to the place line; raw shows the title as sent.',
+  },
+  {
+    key: 'titleSize', kind: 'number', min: 10, max: 60, step: 1, default: 21,
+    label: 'title size (px)', section: CAPTION_SECTION,
+    description: 'The camera name.',
+  },
+  {
+    key: 'titleWeight', kind: 'enum', options: ['300', '400', '500', '600'], default: '300',
+    label: 'title weight', section: CAPTION_SECTION,
+    description: '300 light, 400 regular, 500 medium, 600 semibold.',
+  },
+  {
+    key: 'titleGray', kind: 'number', min: 40, max: 100, step: 1, default: 71,
+    label: 'title gray (%)', section: CAPTION_SECTION,
+    description: '100 is white.',
+  },
+  {
+    key: 'placeSize', kind: 'number', min: 8, max: 40, step: 1, default: 17,
+    label: 'place size (px)', section: CAPTION_SECTION,
+    description: 'The region and country line.',
+  },
+  {
+    key: 'placeGray', kind: 'number', min: 30, max: 100, step: 1, default: 57,
+    label: 'place gray (%)', section: CAPTION_SECTION,
+    description: '100 is white.',
+  },
+  {
+    key: 'lineGap', kind: 'number', min: 0, max: 24, step: 1, default: 0,
+    label: 'line gap (px)', section: CAPTION_SECTION,
+    description: 'Extra space between the caption\'s lines.',
+  },
+  {
+    key: 'timeStyle', kind: 'enum', options: ['off', '12h', '12h-there', '24h', 'sun', '12h-sun'], default: '12h-there',
+    label: 'time', section: CAPTION_SECTION,
+    description: 'The local clock at the camera when the picture was taken (12h → "7:42 pm", 12h-there → "7:42 pm there", 24h → "19:42"), the sun\'s height ("sun 1.2° above the horizon"), or both.',
+  },
+  {
+    key: 'timeLine', kind: 'enum', options: ['own', 'inline'], default: 'own',
+    label: 'time placement', section: CAPTION_SECTION,
+    description: 'own: the time on its own line under the place. inline: after the place with a middle dot.',
+  },
+  {
+    key: 'timeSize', kind: 'number', min: 8, max: 32, step: 1, default: 12,
+    label: 'time size (px)', section: CAPTION_SECTION,
+    description: 'The time line.',
+  },
+  {
+    key: 'timeGray', kind: 'number', min: 20, max: 90, step: 1, default: 46,
+    label: 'time gray (%)', section: CAPTION_SECTION,
+    description: '100 would be white; keep it quieter than the place.',
+  },
+] as const;
+
+/** Typed view of merged caption values (mergeSettings over CAPTION_SCHEMA). */
+export function captionDialsFrom(values: SettingsValues): CaptionDials {
+  return {
+    captionLayout: values.captionLayout as CaptionLayout,
+    pictureHeight: values.pictureHeight as number,
+    pictureTop: values.pictureTop as number,
+    captionAnchor: values.captionAnchor as CaptionAnchor,
+    captionAlign: values.captionAlign as CaptionAlign,
+    captionGap: values.captionGap as number,
+    font: values.font as CaptionFont,
+    titleClean: values.titleClean as TitleClean,
+    titleSize: values.titleSize as number,
+    titleWeight: values.titleWeight as TitleWeight,
+    titleGray: values.titleGray as number,
+    placeSize: values.placeSize as number,
+    placeGray: values.placeGray as number,
+    lineGap: values.lineGap as number,
+    timeStyle: values.timeStyle as TimeStyle,
+    timeLine: values.timeLine as TimeLine,
+    timeSize: values.timeSize as number,
+    timeGray: values.timeGray as number,
+  };
+}
+
+/**
+ * A version's merged values with the caption laid over them from the shared
+ * namespace (its deviations or its merged values; both sanitize the same, and
+ * nothing else in `shared` is a caption key). Every SoloDials a surface draws
+ * with goes through this, so the glass, the state route and both studios
+ * caption alike. Without `shared` the caption is at its defaults.
+ */
+export function withCaption(values: SettingsValues, shared?: SettingsValues): SettingsValues {
+  return { ...values, ...mergeSettings(CAPTION_SCHEMA, shared) };
+}

--- a/app/lib/solo/settingsSchema.test.ts
+++ b/app/lib/solo/settingsSchema.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { SOLO_SETTINGS_SCHEMA, SOLO_NAMESPACE, dialsFrom } from './settingsSchema';
+import { withCaption } from './captionSchema';
 import { schemaDefaults, mergeSettings } from '@/app/lib/settings/schema';
 
 describe('SOLO_SETTINGS_SCHEMA', () => {
@@ -14,7 +15,7 @@ describe('SOLO_SETTINGS_SCHEMA', () => {
       rest: 4, promoteNew: true, zoneGrace: 2,
       dwellS: 20, offsetS: 10, fadeS: 0,
       showPlace: true, showScores: false, showRank: false, showTally: false,
-      // the caption as dialled in on 2026-09-05
+      // the caption as dialled in on 2026-09-05, at its defaults because no shared values were laid over
       captionLayout: 'inset', pictureHeight: 87, pictureTop: 4,
       captionAnchor: 'panel-bottom', captionAlign: 'picture', captionGap: 18,
       font: 'system', titleClean: 'compass',
@@ -24,10 +25,18 @@ describe('SOLO_SETTINGS_SCHEMA', () => {
     });
   });
 
-  it('every knob sits in the glass, bins or caption section', () => {
+  it('every knob sits in the glass or bins section; the caption section is the shared namespace\'s', () => {
     for (const knob of SOLO_SETTINGS_SCHEMA) {
-      expect(['glass', 'bins', 'caption']).toContain(knob.section);
+      expect(['glass', 'bins']).toContain(knob.section);
     }
+  });
+
+  it('a caption key stored in the solo namespace (before 2026-09-05) is dropped; the shared namespace supplies it', () => {
+    expect(SOLO_SETTINGS_SCHEMA.find((k) => k.key === 'pictureHeight')).toBeUndefined();
+    const own = mergeSettings(SOLO_SETTINGS_SCHEMA, { pictureHeight: 92, dwellS: 5 });
+    expect('pictureHeight' in own).toBe(false);
+    expect(dialsFrom(own).pictureHeight).toBe(87);
+    expect(dialsFrom(withCaption(own, { pictureHeight: 70, activeVersion: 'solo' }))).toMatchObject({ pictureHeight: 70, dwellS: 5, captionGap: 18 });
   });
 
   it('keys are unique and every enum default is one of its options', () => {
@@ -42,8 +51,8 @@ describe('SOLO_SETTINGS_SCHEMA', () => {
     }
   });
 
-  it('dialsFrom reads merged deviations', () => {
-    const merged = mergeSettings(SOLO_SETTINGS_SCHEMA, { rest: 7, dwellS: 5, titleGray: 90, font: 'serif' });
+  it('dialsFrom reads merged deviations, the caption from the shared values laid over them', () => {
+    const merged = withCaption(mergeSettings(SOLO_SETTINGS_SCHEMA, { rest: 7, dwellS: 5 }), { titleGray: 90, font: 'serif' });
     const d = dialsFrom(merged);
     expect(d.rest).toBe(7);
     expect(d.dwellS).toBe(5);

--- a/app/lib/solo/settingsSchema.ts
+++ b/app/lib/solo/settingsSchema.ts
@@ -1,15 +1,16 @@
+import { mergeSettings } from '@/app/lib/settings/schema';
 import type { SettingsSchema, SettingsValues } from '@/app/lib/settings/schema';
-import type {
-  CaptionAlign, CaptionAnchor, CaptionFont, CaptionLayout, SoloDials, TimeLine, TimeStyle, TitleClean, TitleWeight,
-} from './types';
+import { CAPTION_SCHEMA, captionDialsFrom } from './captionSchema';
+import type { SoloDials } from './types';
 
 export const SOLO_NAMESPACE = 'solo';
 
 /**
- * Every solo dial. Three sections, and the studio colours them differently:
- * 'glass' changes what the screen draws, 'bins' changes which frame comes
- * next (spec §6.4), 'caption' is the picture's frame and the words beneath
- * it. Defaults ARE the behaviour with no settings row.
+ * Every dial in the `solo` namespace. Two sections, and the studio colours
+ * them differently: 'glass' changes what the screen draws, 'bins' changes
+ * which frame comes next (spec §6.4). The caption dials are the shared
+ * namespace's (captionSchema.ts), so every solo version draws one caption.
+ * Defaults ARE the behaviour with no settings row.
  */
 export const SOLO_SETTINGS_SCHEMA: SettingsSchema = [
   // ---- glass ----
@@ -84,102 +85,15 @@ export const SOLO_SETTINGS_SCHEMA: SettingsSchema = [
     label: 'promote new frames', section: 'bins',
     description: 'A newer frame from a camera already in the bin gets +0.10 on its score until first shown.',
   },
-  // ---- caption ----
-  // Defaults are the values dialled in on the 2026-09-05 mockup. Sizes are
-  // glass pixels on a 1920-wide panel; grays are percent of white.
-  {
-    key: 'captionLayout', kind: 'enum', options: ['inset', 'overlay'], default: 'inset',
-    label: 'layout', section: 'caption',
-    description: 'Inset: the picture sits smaller on black with the caption beneath it. Overlay: the picture fills the panel and the caption floats over it.',
-  },
-  {
-    key: 'pictureHeight', kind: 'number', min: 60, max: 100, step: 1, default: 87,
-    label: 'picture height (%)', section: 'caption',
-    description: 'How tall the inset picture is, as a percent of the panel. It keeps the panel\'s shape and sits centred.',
-  },
-  {
-    key: 'pictureTop', kind: 'number', min: 0, max: 12, step: 0.5, default: 4,
-    label: 'picture top margin (%)', section: 'caption',
-    description: 'Black above the inset picture, as a percent of the panel height.',
-  },
-  {
-    key: 'captionAnchor', kind: 'enum', options: ['panel-bottom', 'under-picture'], default: 'panel-bottom',
-    label: 'caption sits', section: 'caption',
-    description: 'panel-bottom: the gap above the bottom edge of the panel. under-picture: the gap below the picture.',
-  },
-  {
-    key: 'captionAlign', kind: 'enum', options: ['picture', 'center', 'panel'], default: 'picture',
-    label: 'caption aligned to', section: 'caption',
-    description: 'Flush with the picture\'s left edge, centred on the panel, or at the panel\'s left margin.',
-  },
-  {
-    key: 'captionGap', kind: 'number', min: 0, max: 80, step: 2, default: 18,
-    label: 'gap (px)', section: 'caption',
-    description: 'Space between the caption and whatever it is anchored to.',
-  },
-  {
-    key: 'font', kind: 'enum', options: ['system', 'geist', 'sans', 'serif', 'mono'], default: 'system',
-    label: 'font', section: 'caption',
-    description: 'system: whatever the Pi has. geist: the site\'s face. sans: Source Sans 3. serif: Source Serif 4. mono: Geist Mono.',
-  },
-  {
-    key: 'titleClean', kind: 'enum', options: ['compass', 'raw', 'comma', 'dot', 'spot'], default: 'compass',
-    label: '“›” in titles', section: 'caption',
-    description: 'Windy titles read "City › Compass: Spot". compass drops the "› Compass" part; comma / dot keep it with a quieter separator; spot shows only the spot name and moves the city down to the place line; raw shows the title as sent.',
-  },
-  {
-    key: 'titleSize', kind: 'number', min: 10, max: 60, step: 1, default: 21,
-    label: 'title size (px)', section: 'caption',
-    description: 'The camera name.',
-  },
-  {
-    key: 'titleWeight', kind: 'enum', options: ['300', '400', '500', '600'], default: '300',
-    label: 'title weight', section: 'caption',
-    description: '300 light, 400 regular, 500 medium, 600 semibold.',
-  },
-  {
-    key: 'titleGray', kind: 'number', min: 40, max: 100, step: 1, default: 71,
-    label: 'title gray (%)', section: 'caption',
-    description: '100 is white.',
-  },
-  {
-    key: 'placeSize', kind: 'number', min: 8, max: 40, step: 1, default: 17,
-    label: 'place size (px)', section: 'caption',
-    description: 'The region and country line.',
-  },
-  {
-    key: 'placeGray', kind: 'number', min: 30, max: 100, step: 1, default: 57,
-    label: 'place gray (%)', section: 'caption',
-    description: '100 is white.',
-  },
-  {
-    key: 'lineGap', kind: 'number', min: 0, max: 24, step: 1, default: 0,
-    label: 'line gap (px)', section: 'caption',
-    description: 'Extra space between the caption\'s lines.',
-  },
-  {
-    key: 'timeStyle', kind: 'enum', options: ['off', '12h', '12h-there', '24h', 'sun', '12h-sun'], default: '12h-there',
-    label: 'time', section: 'caption',
-    description: 'The local clock at the camera when the picture was taken (12h → "7:42 pm", 12h-there → "7:42 pm there", 24h → "19:42"), the sun\'s height ("sun 1.2° above the horizon"), or both.',
-  },
-  {
-    key: 'timeLine', kind: 'enum', options: ['own', 'inline'], default: 'own',
-    label: 'time placement', section: 'caption',
-    description: 'own: the time on its own line under the place. inline: after the place with a middle dot.',
-  },
-  {
-    key: 'timeSize', kind: 'number', min: 8, max: 32, step: 1, default: 12,
-    label: 'time size (px)', section: 'caption',
-    description: 'The time line.',
-  },
-  {
-    key: 'timeGray', kind: 'number', min: 20, max: 90, step: 1, default: 46,
-    label: 'time gray (%)', section: 'caption',
-    description: '100 would be white; keep it quieter than the place.',
-  },
 ] as const;
 
-/** Typed view of a merged `solo` values object (mergeSettings output). */
+/**
+ * Typed view of a merged `solo` values object (mergeSettings output), with
+ * the caption read from the same object. Surfaces pass `withCaption(values,
+ * shared)` so the caption is the shared namespace's; without those keys the
+ * caption sits at its defaults (the engine never draws, and tests build
+ * dials from `schemaDefaults(SOLO_SETTINGS_SCHEMA)`).
+ */
 export function dialsFrom(values: SettingsValues): SoloDials {
   return {
     qualityFloor: values.qualityFloor as number,
@@ -196,23 +110,6 @@ export function dialsFrom(values: SettingsValues): SoloDials {
     showScores: values.showScores as boolean,
     showRank: values.showRank as boolean,
     showTally: values.showTally as boolean,
-    captionLayout: values.captionLayout as CaptionLayout,
-    pictureHeight: values.pictureHeight as number,
-    pictureTop: values.pictureTop as number,
-    captionAnchor: values.captionAnchor as CaptionAnchor,
-    captionAlign: values.captionAlign as CaptionAlign,
-    captionGap: values.captionGap as number,
-    font: values.font as CaptionFont,
-    titleClean: values.titleClean as TitleClean,
-    titleSize: values.titleSize as number,
-    titleWeight: values.titleWeight as TitleWeight,
-    titleGray: values.titleGray as number,
-    placeSize: values.placeSize as number,
-    placeGray: values.placeGray as number,
-    lineGap: values.lineGap as number,
-    timeStyle: values.timeStyle as TimeStyle,
-    timeLine: values.timeLine as TimeLine,
-    timeSize: values.timeSize as number,
-    timeGray: values.timeGray as number,
+    ...captionDialsFrom(mergeSettings(CAPTION_SCHEMA, values)),
   };
 }

--- a/app/lib/solo/types.ts
+++ b/app/lib/solo/types.ts
@@ -39,26 +39,14 @@ export type TitleClean = 'raw' | 'comma' | 'dot' | 'compass' | 'spot';
 export type TitleWeight = '300' | '400' | '500' | '600';
 export type CaptionFont = 'system' | 'geist' | 'sans' | 'serif' | 'mono';
 
-/** Every dial in the `solo` namespace, typed. Built by settingsSchema.dialsFrom. */
-export interface SoloDials {
-  // bins group — change which frame comes next
-  qualityFloor: number;
-  detectionFloor: number;
-  sunsetFloor: number;
-  mix: number;
-  rest: number;
-  promoteNew: boolean;
-  zoneGrace: number;
-  // glass group — change what the screen draws
-  dwellS: number;
-  offsetS: number;
-  fadeS: number;
-  showPlace: boolean;
-  showScores: boolean;
-  showRank: boolean;
-  showTally: boolean;
-  // caption group — the picture's frame and the words beneath it.
-  // Sizes are glass pixels on a 1920-wide panel; grays are percent of white.
+/**
+ * The caption group — the picture's frame and the words beneath it. These
+ * dials live in the SHARED settings namespace (captionSchema.ts), one set
+ * for every solo version, and are laid over a version's own values by
+ * `withCaption`. Sizes are glass pixels on a 1920-wide panel; grays are
+ * percent of white.
+ */
+export interface CaptionDials {
   captionLayout: CaptionLayout;
   pictureHeight: number;
   pictureTop: number;
@@ -77,6 +65,29 @@ export interface SoloDials {
   timeLine: TimeLine;
   timeSize: number;
   timeGray: number;
+}
+
+/**
+ * Every dial a solo surface draws with: the `solo` namespace's own two
+ * groups plus the shared caption. Built by settingsSchema.dialsFrom.
+ */
+export interface SoloDials extends CaptionDials {
+  // bins group — change which frame comes next
+  qualityFloor: number;
+  detectionFloor: number;
+  sunsetFloor: number;
+  mix: number;
+  rest: number;
+  promoteNew: boolean;
+  zoneGrace: number;
+  // glass group — change what the screen draws
+  dwellS: number;
+  offsetS: number;
+  fadeS: number;
+  showPlace: boolean;
+  showScores: boolean;
+  showRank: boolean;
+  showTally: boolean;
 }
 
 /** What one screen remembers between draws (rules 2 and 4). */

--- a/app/lib/solo2/settingsSchema.test.ts
+++ b/app/lib/solo2/settingsSchema.test.ts
@@ -26,6 +26,10 @@ describe('solo2 settings schema', () => {
     // and still every solo dial
     expect(d).toMatchObject({ dwellS: 20, offsetS: 10, qualityFloor: 0.55, mix: 2 });
   });
+  it('has no caption knobs of its own: the shared namespace carries them', () => {
+    expect(SOLO2_SETTINGS_SCHEMA.some((k) => k.section === 'caption')).toBe(false);
+    expect(dialsFrom2(schemaDefaults(SOLO2_SETTINGS_SCHEMA)).pictureHeight).toBe(87);
+  });
   it('keys are unique and every enum default is one of its options', () => {
     const keys = SOLO2_SETTINGS_SCHEMA.map((k) => k.key);
     expect(new Set(keys).size).toBe(keys.length);

--- a/app/lib/solo2/settingsSchema.ts
+++ b/app/lib/solo2/settingsSchema.ts
@@ -14,7 +14,9 @@ const solo = (key: string) => {
 /**
  * solo's dials plus the solo2 additions, in the order the rail shows them.
  * Every added dial defaults to solo's behaviour; the fade and the dissolves
- * are the exceptions decided 2026-09-05. The caption dials are solo's.
+ * are the exceptions decided 2026-09-05. The caption dials are not here:
+ * they are the shared namespace's (captionSchema.ts), one set for every
+ * solo version.
  */
 export const SOLO2_SETTINGS_SCHEMA: SettingsSchema = [
   // ---- glass ----
@@ -78,8 +80,6 @@ export const SOLO2_SETTINGS_SCHEMA: SettingsSchema = [
   },
   solo('zoneGrace'),
   solo('promoteNew'),
-  // ---- caption ---- (all solo's; the time dial included)
-  ...SOLO_SETTINGS_SCHEMA.filter((k) => k.section === 'caption'),
 ] as const;
 
 /** Typed view of a merged `solo2` values object (mergeSettings output). */

--- a/app/studio/PreviewPane.tsx
+++ b/app/studio/PreviewPane.tsx
@@ -46,6 +46,7 @@ export function PreviewPane({
   panelPresetLabel,
   versionName,
   settings,
+  shared,
   scenes = [],
   sceneSource = { kind: 'live' },
   onSceneSourceChange,
@@ -64,6 +65,8 @@ export function PreviewPane({
   panelPresetLabel: string;
   versionName: string;
   settings?: SettingsValues;
+  /** The shared namespace's values; the solo versions draw their caption from it. */
+  shared?: SettingsValues;
   scenes?: SceneSummary[];
   sceneSource?: SceneSource;
   onSceneSourceChange?: (source: SceneSource) => void;
@@ -347,6 +350,7 @@ export function PreviewPane({
                   peerWebcams={peerOf(feed)}
                   search=""
                   settings={settings}
+                  shared={shared}
                   driveSchedule={false}
                   at={at}
                   onSelect={setSelected}

--- a/app/studio/StudioClient.tsx
+++ b/app/studio/StudioClient.tsx
@@ -237,6 +237,7 @@ export function StudioClient() {
           panelPresetLabel={panelPresetLabel}
           versionName={versionName}
           settings={previewSettings}
+          shared={sharedSettings}
           scenes={scenes}
           sceneSource={sceneSource}
           onSceneSourceChange={setSceneSource}

--- a/app/studio/StudioRail.tsx
+++ b/app/studio/StudioRail.tsx
@@ -3,6 +3,7 @@
 import { useMemo, type ReactNode } from 'react';
 import { LevaPanel, useCreateStore, useControls, folder, button } from 'leva';
 import { SHARED_NAMESPACE, SHARED_SCHEMA } from '@/app/lib/settings/sharedSchema';
+import { CAPTION_SECTION } from '@/app/lib/solo/captionSchema';
 import { MOSAIC_SETTINGS_SCHEMAS } from '@/app/components/mosaic/registry';
 import { buildFolderSpecs, type LevaFolderSpec } from './levaConfig';
 import type { KnobValue, SettingsSchema } from '@/app/lib/settings/schema';
@@ -94,10 +95,11 @@ export function StudioRail({
   const versionOptions = activeVersionKnob?.kind === 'enum' ? activeVersionKnob.options : [];
   const activeVersion = (sharedValues.activeVersion as string) ?? versionOptions[0] ?? 'v1';
 
-  // The top <select> owns activeVersion — everything else in SHARED_SCHEMA
-  // (currently just panelPreset, both in section 'glass') is dial-controlled.
+  // The top <select> owns activeVersion — everything else in SHARED_SCHEMA's
+  // glass section (currently just panelPreset) is dial-controlled here. The
+  // shared caption section is the solo kiosk's and is dialled on /studio/solo.
   const sharedSchema = useMemo(
-    () => SHARED_SCHEMA.filter((k) => k.key !== 'activeVersion'),
+    () => SHARED_SCHEMA.filter((k) => k.key !== 'activeVersion' && k.section !== CAPTION_SECTION),
     []
   );
   const versionSchema: SettingsSchema = MOSAIC_SETTINGS_SCHEMAS[activeVersion] ?? [];

--- a/app/studio/solo/EntryRow.test.tsx
+++ b/app/studio/solo/EntryRow.test.tsx
@@ -1,5 +1,5 @@
 import { it, expect, vi } from 'vitest';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, cleanup } from '@testing-library/react';
 import { EntryRow, MIN_FRAME_PX, PX_PER_S } from './EntryRow';
 
 const e = {
@@ -17,11 +17,14 @@ it('shows tally first, scores, place, and the tags', () => {
   expect(screen.getByText(/Lisbon, Portugal/)).toBeInTheDocument();
 });
 
-it('marks ineligible frames FLOOR and repeats as repeat', () => {
+it('dims an ineligible frame and tags it FLOOR; a repeat keeps full strength and is tagged REPEAT', () => {
   render(<EntryRow entry={{ ...e, eligible: false, isNew: false }} feed="sunset" place="sunset" onClick={vi.fn()} />);
   expect(screen.getByText('FLOOR')).toBeInTheDocument();
+  expect(screen.getByRole('button')).toHaveStyle({ opacity: '0.45' });
+  cleanup();
   render(<EntryRow entry={e} feed="sunset" place="queue" repeat onClick={vi.fn()} />);
-  expect(screen.getByText(/repeat/)).toBeInTheDocument();
+  expect(screen.getByText('REPEAT')).toBeInTheDocument();
+  expect(screen.getByRole('button')).toHaveStyle({ opacity: '1' });
 });
 
 it('non-sunset rows show only detection, and a click reports the entry', () => {

--- a/app/studio/solo/EntryRow.tsx
+++ b/app/studio/solo/EntryRow.tsx
@@ -41,7 +41,9 @@ const clock = (e: EntryView) => formatTime('12h', e.capturedAt, e.timezone, null
  * above the chosen one in capture order, each its own light box with its
  * local time, all inside one bin-coloured border, so a dwell that plays
  * several pictures reads as one box. With `rowS` the row is as tall as the
- * time it gets on glass.
+ * time it gets on glass. Dimming means the frame will not be shown (it is
+ * below a floor); a repeat IS shown again, so it keeps full strength and a
+ * red tag says so.
  */
 export function EntryRow({
   entry: e, feed, place, onGlass = false, repeat = false, cameraIndex, role, sequence, rowS, preluded = false, onClick,
@@ -85,7 +87,7 @@ export function EntryRow({
       border: grouped ? `1px solid ${LIGHT}` : `1.5px solid ${COLOR[e.bin]}`,
       minHeight: grouped ? Math.max(0, sequence.holdS * PX_PER_S) : rowS !== undefined ? rowS * PX_PER_S : undefined,
       background: '#0e1119', fontFamily: mono, fontSize: 9.5, color: '#9aa3b2', cursor: 'pointer',
-      opacity: !e.eligible || repeat ? 0.45 : 1, boxShadow: grouped ? undefined : ring,
+      opacity: e.eligible ? 1 : 0.45, boxShadow: grouped ? undefined : ring,
     }}>
       {/* eslint-disable-next-line @next/next/no-img-element */}
       <img src={e.imageUrl} alt="" style={{ width: 46, aspectRatio: '16/9', objectFit: 'cover', borderRadius: 3, display: 'block' }} />
@@ -93,10 +95,11 @@ export function EntryRow({
         <span style={{ fontWeight: e.tally > 0 ? 800 : 500, color: e.tally > 0 ? '#e5e7eb' : '#6b7280' }}>
           shown ×{e.tally}
         </span>
-        {' · '}{scores}{repeat ? ' · repeat' : ''}
+        {' · '}{scores}
         <div style={{ marginTop: 2 }}>
           {e.isNew && <Tag bg="#f5a344" fg="#1a1000" title="Newer frame from a camera already in the bin">NEW</Tag>}
           {!e.eligible && <Tag bg="#3a4356" fg="#e5e7eb" title="Below the floor dial">FLOOR</Tag>}
+          {repeat && <Tag bg="#8b2e2e" fg="#ffe1e1" title="Already earlier in this queue; the rest dial let it come round again">REPEAT</Tag>}
           {cameraIndex && (
             <Tag bg="#7ea6e2" fg="#061224" title="Same camera as another queue entry">{`CAM ${cameraIndex.n}/${cameraIndex.m}`}</Tag>
           )}

--- a/app/studio/solo/SoloRail.test.tsx
+++ b/app/studio/solo/SoloRail.test.tsx
@@ -2,13 +2,15 @@ import { describe, it, expect, vi } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { SoloRail } from './SoloRail';
 import { SOLO_SETTINGS_SCHEMA } from '@/app/lib/solo/settingsSchema';
+import { CAPTION_SCHEMA } from '@/app/lib/solo/captionSchema';
+import { SHARED_SCHEMA } from '@/app/lib/settings/sharedSchema';
 import { mergeSettings } from '@/app/lib/settings/schema';
 import type { StudioSettingsApi } from '../useStudioSettings';
 
 function api(over: Partial<StudioSettingsApi> = {}): StudioSettingsApi {
   return {
     loading: false, studio: undefined, live: undefined, lastPollAt: null, liveRevision: 3,
-    effective: (ns) => (ns === 'solo' ? mergeSettings(SOLO_SETTINGS_SCHEMA, {}) : { activeVersion: 'v1', panelPreset: 'dell' }),
+    effective: (ns) => (ns === 'solo' ? mergeSettings(SOLO_SETTINGS_SCHEMA, {}) : mergeSettings(SHARED_SCHEMA, { activeVersion: 'v1', panelPreset: 'dell' })),
     setKnob: vi.fn(), resetSection: vi.fn(), applyNamespace: () => [],
     diffByNamespace: { solo: ['mix'] }, diffCount: 1,
     deploy: async () => {}, revert: async () => {}, deployedAtMs: null, droppedKeys: [],
@@ -20,29 +22,25 @@ function api(over: Partial<StudioSettingsApi> = {}): StudioSettingsApi {
 it('the dials tab renders every glass and bins knob under its group and marks the differing one; caption knobs wait on their tab', () => {
   render(<SoloRail api={api()} deploySlot={<span>DEPLOY</span>} />);
   expect(screen.getByText('DEPLOY')).toBeInTheDocument();
-  for (const k of SOLO_SETTINGS_SCHEMA) {
-    if (k.section === 'caption') expect(screen.queryByLabelText(k.label)).toBeNull();
-    else expect(screen.getByLabelText(k.label)).toBeInTheDocument();
-  }
+  for (const k of SOLO_SETTINGS_SCHEMA) expect(screen.getByLabelText(k.label)).toBeInTheDocument();
+  for (const k of CAPTION_SCHEMA) expect(screen.queryByLabelText(k.label)).toBeNull();
   expect(screen.getByText('mix (sunsets per non-sunset)')).toHaveStyle({ fontWeight: 700 });
   expect(screen.getByText('dwell (s)')).toHaveStyle({ fontWeight: 400 });
   expect(screen.getByRole('tab', { name: 'Dials' })).toHaveAttribute('aria-selected', 'true');
 });
 
-it('the caption tab renders every caption knob and nothing else; selects write strings; reset clears the section', () => {
-  const a = api({ diffByNamespace: { solo: ['titleGray'] } });
+it('the caption tab renders every caption knob, bound to the shared namespace, and nothing else; reset clears that section', () => {
+  const a = api({ diffByNamespace: { shared: ['titleGray'] } });
   render(<SoloRail api={a} deploySlot={null} tab="caption" />);
-  for (const k of SOLO_SETTINGS_SCHEMA) {
-    if (k.section === 'caption') expect(screen.getByLabelText(k.label)).toBeInTheDocument();
-    else expect(screen.queryByLabelText(k.label)).toBeNull();
-  }
+  for (const k of CAPTION_SCHEMA) expect(screen.getByLabelText(k.label)).toBeInTheDocument();
+  for (const k of SOLO_SETTINGS_SCHEMA) expect(screen.queryByLabelText(k.label)).toBeNull();
   expect(screen.getByText('title gray (%)')).toHaveStyle({ fontWeight: 700 });
   fireEvent.change(screen.getByLabelText('font'), { target: { value: 'serif' } });
-  expect(a.setKnob).toHaveBeenCalledWith('solo', 'font', 'serif');
+  expect(a.setKnob).toHaveBeenCalledWith('shared', 'font', 'serif');
   fireEvent.change(screen.getByLabelText('title size (px)'), { target: { value: '14' } });
-  expect(a.setKnob).toHaveBeenCalledWith('solo', 'titleSize', 14);
+  expect(a.setKnob).toHaveBeenCalledWith('shared', 'titleSize', 14);
   fireEvent.click(screen.getByText('reset caption'));
-  expect(a.resetSection).toHaveBeenCalledWith('solo', 'caption');
+  expect(a.resetSection).toHaveBeenCalledWith('shared', 'caption');
   expect(screen.queryByText(/reset glass/)).toBeNull();
 });
 
@@ -73,15 +71,13 @@ describe('solo2', async () => {
   const { SOLO_VERSIONS } = await import('@/app/lib/solo/versions');
   const { SOLO2_SETTINGS_SCHEMA } = await import('@/app/lib/solo2/settingsSchema');
   const api2 = () => api({
-    effective: (ns) => (ns === 'solo2' ? mergeSettings(SOLO2_SETTINGS_SCHEMA, { prelude: true, leadS: 4 }) : { activeVersion: 'solo2', panelPreset: 'ktc-l' }),
+    effective: (ns) => (ns === 'solo2' ? mergeSettings(SOLO2_SETTINGS_SCHEMA, { prelude: true, leadS: 4 }) : mergeSettings(SHARED_SCHEMA, { activeVersion: 'solo2', panelPreset: 'ktc-l' })),
     diffByNamespace: { solo2: ['valleys'] },
   });
   it('renders every solo2 knob, selects write strings, and the budget line reads the dials', () => {
     const a = api2();
     const { rerender } = render(<SoloRail api={a} deploySlot={null} version={SOLO_VERSIONS.solo2} />);
-    for (const k of SOLO2_SETTINGS_SCHEMA) {
-      if (k.section !== 'caption') expect(screen.getByLabelText(k.label)).toBeInTheDocument();
-    }
+    for (const k of SOLO2_SETTINGS_SCHEMA) expect(screen.getByLabelText(k.label)).toBeInTheDocument();
     fireEvent.change(screen.getByLabelText('camera change'), { target: { value: 'crossfade' } });
     expect(a.setKnob).toHaveBeenCalledWith('solo2', 'transition', 'crossfade');
     fireEvent.change(screen.getByLabelText('valleys per peak'), { target: { value: '2' } });
@@ -89,10 +85,8 @@ describe('solo2', async () => {
     expect(screen.getByText('prelude 4.5 s + lead 4 s + hold 11.5 s')).toBeInTheDocument();
     expect(screen.getByText(/dials solo2/)).toBeInTheDocument();
     rerender(<SoloRail api={a} deploySlot={null} version={SOLO_VERSIONS.solo2} tab="caption" />);
-    for (const k of SOLO2_SETTINGS_SCHEMA) {
-      if (k.section === 'caption') expect(screen.getByLabelText(k.label)).toBeInTheDocument();
-    }
+    for (const k of CAPTION_SCHEMA) expect(screen.getByLabelText(k.label)).toBeInTheDocument();
     fireEvent.change(screen.getByLabelText('time'), { target: { value: '24h' } });
-    expect(a.setKnob).toHaveBeenCalledWith('solo2', 'timeStyle', '24h');
+    expect(a.setKnob).toHaveBeenCalledWith('shared', 'timeStyle', '24h');
   });
 });

--- a/app/studio/solo/SoloRail.tsx
+++ b/app/studio/solo/SoloRail.tsx
@@ -5,6 +5,7 @@ import { SOLO_VERSIONS, type SoloVersionSpec } from '@/app/lib/solo/versions';
 import { DwellBudget } from './DwellBudget';
 import type { Solo2Dials } from '@/app/lib/solo2/types';
 import { SHARED_NAMESPACE } from '@/app/lib/settings/sharedSchema';
+import { CAPTION_SCHEMA, CAPTION_SECTION, withCaption } from '@/app/lib/solo/captionSchema';
 import type { KnobDescriptor, KnobValue } from '@/app/lib/settings/schema';
 import type { StudioSettingsApi } from '../useStudioSettings';
 import { RulesBox } from './RulesBox';
@@ -21,8 +22,8 @@ const GROUPS = [
     hint: 'These change what the screens draw. They never change which frame comes next.' },
   { section: 'bins', tab: 'dials', title: 'Bins · the ordering algorithm', color: '#4fd1c5',
     hint: 'These change which frame comes next. The queue re-runs the moment one moves.' },
-  { section: 'caption', tab: 'caption', title: 'Caption · the picture and its words', color: '#c4a7f7',
-    hint: 'Sizes are glass pixels on a 1920-wide panel; grays are percent of white. Deploy sends them to the glass like any other dial.' },
+  { section: CAPTION_SECTION, tab: 'caption', title: 'Caption · the picture and its words', color: '#c4a7f7',
+    hint: 'Sizes are glass pixels on a 1920-wide panel; grays are percent of white. Shared by every solo version, so the glass draws one caption whichever engine runs. Deploy sends them to the glass like any other dial.' },
 ] as const;
 
 const mono = 'ui-monospace, SFMono-Regular, Menlo, monospace';
@@ -83,7 +84,13 @@ export function SoloRail({ api, deploySlot, version = SOLO_VERSIONS.solo as Solo
   const values = api.effective(ns);
   const shared = api.effective(SHARED_NAMESPACE);
   const diff = new Set(api.diffByNamespace[ns] ?? []);
-  const dials = version.dialsFrom(values);
+  const sharedDiff = new Set(api.diffByNamespace[SHARED_NAMESPACE] ?? []);
+  const dials = version.dialsFrom(withCaption(values, shared));
+  // The caption group is the shared namespace's: one caption for every solo
+  // version, whichever the glass runs. The other groups are this version's.
+  const groupOf = (section: string) => section === CAPTION_SECTION
+    ? { ns: SHARED_NAMESPACE, knobs: CAPTION_SCHEMA, values: shared, diff: sharedDiff }
+    : { ns, knobs: version.schema.filter((k) => k.section === section), values, diff };
   return (
     <div style={{ fontSize: 12 }}>
       {deploySlot}
@@ -103,27 +110,30 @@ export function SoloRail({ api, deploySlot, version = SOLO_VERSIONS.solo as Solo
           </button>
         ))}
       </div>
-      {GROUPS.filter((g) => g.tab === tab).map((g) => (
-        <section key={g.section}>
-          <h4 title={g.hint} style={{
-            margin: '10px 0 6px', fontSize: 11, letterSpacing: '.06em', textTransform: 'uppercase',
-            padding: '4px 8px', borderRadius: 4, background: `${g.color}22`, color: g.color,
-            borderLeft: `3px solid ${g.color}`, display: 'flex', justifyContent: 'space-between', cursor: 'help',
-          }}>
-            <span>{g.title}</span>
-            <button type="button" onClick={() => api.resetSection(ns, g.section)}
-              title={`Put every ${g.section} dial back to its code default`}
-              style={{ background: 'transparent', border: 0, color: g.color, fontSize: 10, cursor: 'pointer' }}>
-              reset {g.section}
-            </button>
-          </h4>
-          {version.schema.filter((k) => k.section === g.section).map((k) => (
-            <Control key={k.key} knob={k} value={values[k.key]} differs={diff.has(k.key)}
-              onChange={(v) => api.setKnob(ns, k.key, v)} />
-          ))}
-          {g.section === 'glass' && version.name === 'solo2' && <DwellBudget dials={dials as Solo2Dials} />}
-        </section>
-      ))}
+      {GROUPS.filter((g) => g.tab === tab).map((g) => {
+        const grp = groupOf(g.section);
+        return (
+          <section key={g.section}>
+            <h4 title={g.hint} style={{
+              margin: '10px 0 6px', fontSize: 11, letterSpacing: '.06em', textTransform: 'uppercase',
+              padding: '4px 8px', borderRadius: 4, background: `${g.color}22`, color: g.color,
+              borderLeft: `3px solid ${g.color}`, display: 'flex', justifyContent: 'space-between', cursor: 'help',
+            }}>
+              <span>{g.title}</span>
+              <button type="button" onClick={() => api.resetSection(grp.ns, g.section)}
+                title={`Put every ${g.section} dial back to its code default`}
+                style={{ background: 'transparent', border: 0, color: g.color, fontSize: 10, cursor: 'pointer' }}>
+                reset {g.section}
+              </button>
+            </h4>
+            {grp.knobs.map((k) => (
+              <Control key={k.key} knob={k} value={grp.values[k.key]} differs={grp.diff.has(k.key)}
+                onChange={(v) => api.setKnob(grp.ns, k.key, v)} />
+            ))}
+            {g.section === 'glass' && version.name === 'solo2' && <DwellBudget dials={dials as Solo2Dials} />}
+          </section>
+        );
+      })}
       {tab === 'dials' && <RulesBox dials={dials} version={version} />}
     </div>
   );

--- a/app/studio/solo/SoloStudioClient.tsx
+++ b/app/studio/solo/SoloStudioClient.tsx
@@ -13,6 +13,7 @@ import { useSoloState } from './useSoloState';
 import { toWebcam } from './toWebcam';
 import { SOLO_VERSIONS, type SoloVersionSpec } from '@/app/lib/solo/versions';
 import { mergeSettings } from '@/app/lib/settings/schema';
+import { withCaption } from '@/app/lib/solo/captionSchema';
 import { SHARED_NAMESPACE } from '@/app/lib/settings/sharedSchema';
 import { PANEL_PRESETS } from '@/app/kiosk/panelPreview';
 import type { EntryView } from '@/app/api/kiosk/solo/view';
@@ -32,8 +33,12 @@ const mono = 'ui-monospace, SFMono-Regular, Menlo, monospace';
  */
 export function SoloStudioClient({ version = SOLO_VERSIONS.solo as SoloVersionSpec }: { version?: SoloVersionSpec }) {
   const api = useStudioSettings();
-  const studioDials = version.dialsFrom(api.effective(version.namespace));
-  const liveDials = version.dialsFrom(mergeSettings(version.schema, api.live?.namespaces?.[version.namespace]));
+  // The version's own dials with the caption from the shared namespace: one caption for every solo version.
+  const shared = api.effective(SHARED_NAMESPACE);
+  const studioDials = version.dialsFrom(withCaption(api.effective(version.namespace), shared));
+  const liveDials = version.dialsFrom(withCaption(
+    mergeSettings(version.schema, api.live?.namespaces?.[version.namespace]), api.live?.namespaces?.[SHARED_NAMESPACE],
+  ));
   const sunrise = useSoloState('sunrise', studioDials, version);
   const sunset = useSoloState('sunset', studioDials, version);
   const other = version.name === 'solo2'
@@ -44,7 +49,7 @@ export function SoloStudioClient({ version = SOLO_VERSIONS.solo as SoloVersionSp
   // Which rail page is up. The caption page swaps the queue columns for the
   // screens drawn with the studio dials, so a caption dial shows its effect.
   const [tab, setTab] = useState<RailTab>('dials');
-  const panelPreset = String(api.effective(SHARED_NAMESPACE).panelPreset ?? '');
+  const panelPreset = String(shared.panelPreset ?? '');
   const panel = PANEL_PRESETS[panelPreset] ?? PANEL_PRESETS['dell-l'];
 
   useEffect(() => {

--- a/docs/solutions/integration-issues/per-version-dial-copies-drift.md
+++ b/docs/solutions/integration-issues/per-version-dial-copies-drift.md
@@ -1,0 +1,61 @@
+---
+title: Solo caption dials duplicated per version namespace drifted, so the studio previewed a caption the glass never drew
+date: 2026-09-05
+category: docs/solutions/integration-issues
+module: kiosk-solo-settings
+problem_type: integration_issue
+component: settings-namespaces
+symptoms:
+  - "On the glass the solo caption overlapped the foot of the picture; the /studio/solo2 caption preview showed it clear"
+  - "kiosk_settings had `solo` at pictureHeight 92 (live and studio) while `solo2` sat at the schema default 87; the glass ran `solo`"
+  - "A panel-bottom caption at pictureHeight 92 on a 1920×1080 panel started at y≈1000 while the picture ended at 1037"
+root_cause: duplicated_state
+resolution_type: refactor
+severity: medium
+tags: [kiosk, solo, solo2, settings, namespaces, caption, studio, shared-schema]
+---
+
+# Per-version copies of a shared dial drift
+
+## What happened
+
+`solo` and `solo2` each carried the full caption section in their own
+settings namespace (`SOLO2_SETTINGS_SCHEMA` spread solo's caption knobs in).
+The glass draws one caption whichever engine picks the frame, so the two
+copies described one thing. Jesse dialled `pictureHeight` to 92 in the solo
+studio and deployed; the solo2 studio, reading its own namespace, previewed
+87. Looking at that preview, the caption looked fine; on the glass, running
+`solo` at 92, the panel-bottom caption rose 37 px into the picture.
+
+A second, independent bug made the overlap possible at all:
+`captionBox` placed a panel-bottom caption at a fixed distance above the
+panel edge with no regard for where the picture ended.
+
+## Fix
+
+1. **One namespace for one thing.** The caption knobs moved to
+   `app/lib/solo/captionSchema.ts` and are spread into `SHARED_SCHEMA`
+   (section `caption`). Version schemas no longer carry them; a caption key
+   left in a version row is unknown to that schema and is dropped on merge.
+   Every builder of `SoloDials` goes through `withCaption(versionValues,
+   sharedValues)`: the two glass renderers (via a new `shared` prop on
+   `MosaicProps`), the state route, and both studio pages.
+2. **Clamp the caption.** `captionBox` now takes the panel height and the
+   caption's lines, and a panel-bottom caption sits at
+   `max(panelBottom − gap − captionHeight, pictureBottom + gap)`. A picture
+   too tall for the caption pushes the caption down; past what the panel can
+   hold the caption leaves the panel, which the studio preview shows for what
+   it is (a picture dial set too tall) instead of hiding it inside the
+   picture.
+
+## Lesson
+
+When two versions share a renderer, the dials that renderer reads belong in
+the shared namespace, not in each version's. The tell is a schema that
+spreads another schema's section into itself. The studio "matches the glass"
+only if it reads the same namespace the glass reads; a preview that reads a
+sibling copy is not a preview.
+
+After this change the previously deployed `pictureHeight: 92` in the `solo`
+rows is inert; the glass falls back to the mockup default 87 until the shared
+caption is dialled and deployed from /studio/solo.


### PR DESCRIPTION
## Why

The glass caption overlapped the foot of the picture while the studio preview showed it clear. Two causes, both fixed here:

1. **Caption dials were duplicated per version namespace.** `solo` and `solo2` each carried the whole caption section, so they drifted: live `solo` had `pictureHeight: 92` (deployed, the glass runs `solo`) while `solo2` sat at the default 87. The solo2 studio previewed a caption the glass never drew.
2. **`captionBox` let a panel-bottom caption rise into the picture.** It sat a fixed gap above the panel edge with no regard for where the picture ended. At 92 % on 1920×1080 the caption's top landed at y≈1000 while the picture ended at 1037.

Then Jesse's studio feedback from the same afternoon, folded in as separate commits: scores read on the 1–5 scale he knows, the sunset floor defaults to "every sunset", the caption preview is no longer full width, and queue rows dim only when a frame will not be shown.

## What changed

- **Caption knobs live in the shared namespace.** New `app/lib/solo/captionSchema.ts` holds the caption section; `SHARED_SCHEMA` spreads it in; `SOLO_SETTINGS_SCHEMA` and `SOLO2_SETTINGS_SCHEMA` no longer carry it. `withCaption(versionValues, sharedValues)` lays the shared caption over a version's values, and every `SoloDials` builder goes through it: both glass renderers (via a new `shared` prop on `MosaicProps`, passed by the kiosk pages and the studio preview pane), the state route, and both studio pages. The solo studio's Caption tab now writes to `shared`; the mosaic studio hides the shared caption section.
- **Panel-bottom caption is clamped.** `captionBox` takes the panel height and the caption's lines; panel-bottom sits at `max(panelBottom − gap − captionHeight, pictureBottom + gap)`. A too-tall picture pushes the caption down rather than the caption rising into the picture. The line heights the caption draws with are constants in `caption.ts` so the estimate and the render cannot drift.
- **Scores on the rubric's scale.** New `app/lib/solo/scores.ts`: quality 0–1 is shown as the 1–5 rating (`1 + 4q`, so 0.75 = 4.0); detection is the binary head's probability that the frame is a sunset at all, not a rating, so it reads as a percent. One `scoreLine` (`rating 4.6 · sunset 88%`, or `sunset 12%` for a non-sunset) is used by the studio rows, the on-glass score overlay, the feed column, and the rules box.
- **`ratingFloor` replaces `qualityFloor`.** Dialled 1–5, default **1**: every sunset-bin frame is eligible, because a poor sunset is still a sunset. Stored 0–1 quality is compared through `qualityOf(rating)`. No deployed row carried `qualityFloor`, and a stale key is dropped on merge. The non-sunset floor keeps its 0–1 key and is labelled as a sunset-probability floor.
- **Caption preview side by side.** The two screens take one studio column each instead of stacking at full width.
- **Studio queue rows: dim only FLOOR.** A repeat is shown again, so it keeps full strength and gets a red `REPEAT` tag instead of the `· repeat` text and 45 % opacity.
- Lesson written up in `docs/solutions/integration-issues/per-version-dial-copies-drift.md`; the solo spec's rule 5 restated.

## Effect on the deployed dials (read before merging)

No migration. The `pictureHeight: 92` stored in the `solo` rows (live and studio) becomes an unknown key to the solo schema and is dropped on merge, so after deploy the glass draws the caption at the mockup default 87, which is inside the clamp. If 92 is wanted back, dial it on /studio/solo → Caption (it now writes to `shared`) and Deploy; the preview will show the caption hanging under the picture and running off the panel at that height, which is what 92 actually means on a 16:9 panel with a three-line caption.

The sunset bin's floor drops from quality 0.55 (rating 3.2) to rating 1 by default. Frames that were waiting below the old floor become eligible on deploy.

## Verification

- `npx vitest run`: 281 files, 2234 tests pass.
- `npx tsc --noEmit`: clean outside the repo's pre-existing jest-dom typing noise in test files.
- `npx eslint` over the touched directories: clean.
- New tests: `captionHeight`, the clamp at 87 % (1001) and 92 % (1055), `withCaption` precedence, the shared schema carrying every caption knob, the solo schema dropping a stored caption key, the state route reading the caption from `shared` for either version, the solo rail binding the Caption tab to `shared`, the score line and rating conversions, the rating floor at its default admitting a 0.0 sunset, EntryRow opacity per tag.
- Not verified on the glass or in a signed-in /studio session. After merge: `bash scripts/pi/kiosk-doctor.sh --sync --reload`, then check the Caption tab on /studio/solo and /studio/solo2 show the same values and the same preview.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015ovyDJa6YyLdzBQAUyqPuC
