### PR TITLE
feat(solo): scores on the 1–5 scale, rating floor default 1, caption preview side by side (the two commits #139 merged without)

### DIFF
--- a/app/api/kiosk/solo/advance/route.test.ts
+++ b/app/api/kiosk/solo/advance/route.test.ts
@@ -88,6 +88,8 @@ describe('POST /api/kiosk/solo/advance', () => {
     expect(commitAdvance).not.toHaveBeenCalled();
   });
   it('reports advanced:false when nothing is eligible', async () => {
+    // The default rating floor (1) admits every sunset; a floor of 3 puts a 0.1 (rating 1.4) below it.
+    getLiveSettingsCached.mockResolvedValue({ namespaces: { solo: { ratingFloor: 3 } }, revision: 1 });
     listActiveEntries.mockResolvedValue([entry(1, 0.1)]);
     const res = await post({ feed: 'sunrise', slot: 50_000_000 });
     expect((await res.json()).advanced).toBe(false);

--- a/app/api/kiosk/solo/view.test.ts
+++ b/app/api/kiosk/solo/view.test.ts
@@ -3,7 +3,7 @@ import { buildStateView, parseFeed, toViewEntry, type ViewEntry } from './view';
 import { dialsFrom, SOLO_SETTINGS_SCHEMA } from '@/app/lib/solo/settingsSchema';
 import { schemaDefaults } from '@/app/lib/settings/schema';
 
-const D = dialsFrom(schemaDefaults(SOLO_SETTINGS_SCHEMA));
+const D = { ...dialsFrom(schemaDefaults(SOLO_SETTINGS_SCHEMA)), ratingFloor: 3.2 }; // quality 0.55: a 0.1 sunset is below it
 const ZONE = { minDeg: -24, maxDeg: -2 };
 const stored = (id: number, bin: 'sunset' | 'non_sunset', score: number, tally = 0): ViewEntry => ({
   snapshotId: id, webcamId: 100 + id, bin,

--- a/app/components/solo/SoloFrame.test.tsx
+++ b/app/components/solo/SoloFrame.test.tsx
@@ -21,7 +21,7 @@ it('by default: the picture inset on black, the tidied title, the place, and the
   expect(screen.getByTestId('caption-place')).toHaveTextContent('Split-Dalmatia County, Croatia');
   expect(screen.getByTestId('caption-time')).toHaveTextContent('7:42 pm there');
   expect(screen.queryByText(/shown/)).toBeNull();
-  expect(screen.queryByText(/q 0\.91/)).toBeNull();
+  expect(screen.queryByText(/rating 4\.6/)).toBeNull();
 });
 
 it('caption sizes are glass pixels: the dialled px on a 1920 panel, and the grays are percent of white', () => {
@@ -59,7 +59,7 @@ it('draws scores, rank, and tally when dialled on; hides the caption when the pl
   render(<SoloFrame entry={e} previous={null} fadeS={0}
     dials={{ ...D, showPlace: false, showScores: true, showRank: true, showTally: true }} width={1920} height={1080} />);
   expect(screen.queryByTestId('caption')).toBeNull();
-  expect(screen.getByText(/q 0\.91 · d 0\.88/)).toBeInTheDocument();
+  expect(screen.getByText(/rating 4\.6 · sunset 88%/)).toBeInTheDocument();
   expect(screen.getByText(/sunset bin #3/)).toBeInTheDocument();
   expect(screen.getByText(/×2/)).toBeInTheDocument();
 });

--- a/app/components/solo/SoloFrame.tsx
+++ b/app/components/solo/SoloFrame.tsx
@@ -3,6 +3,7 @@
 import type { EntryView } from '@/app/api/kiosk/solo/view';
 import type { SoloDials } from '@/app/lib/solo/types';
 import { pictureRect } from '@/app/lib/solo/caption';
+import { scoreLine } from '@/app/lib/solo/scores';
 import { Caption } from './Caption';
 
 const mono = 'ui-monospace, SFMono-Regular, Menlo, monospace';
@@ -55,7 +56,7 @@ export function SoloFrame({ entry, previous, fadeS, dials, width, height }: {
           {dials.showTally && <div>shown <b style={{ color: '#f5a344' }}>×{entry.tally}</b></div>}
           {dials.showRank && <div>{entry.bin === 'sunset' ? 'sunset' : 'non-sunset'} bin #{entry.rank}</div>}
           {dials.showScores && (
-            <div>{entry.bin === 'sunset' ? `q ${(entry.quality ?? 0).toFixed(2)} · ` : ''}d {entry.detection.toFixed(2)}</div>
+            <div>{scoreLine(entry)}</div>
           )}
         </div>
       )}

--- a/app/components/solo2/Solo2Frame.test.tsx
+++ b/app/components/solo2/Solo2Frame.test.tsx
@@ -23,7 +23,7 @@ it('main stage: the chosen frame inset on black with place and local time, no sc
   expect(screen.getByText('Pier')).toBeInTheDocument();
   expect(screen.getByText('Baja California Sur, Mexico')).toBeInTheDocument();
   expect(screen.getByTestId('caption-time')).toHaveTextContent('7:42 pm there');
-  expect(screen.queryByText(/q 0\.91/)).toBeNull();
+  expect(screen.queryByText(/rating 4\.6/)).toBeNull();
 });
 
 it('prelude stage: an earlier frame with no caption and no scores', () => {

--- a/app/components/solo2/Solo2Frame.tsx
+++ b/app/components/solo2/Solo2Frame.tsx
@@ -2,6 +2,7 @@
 
 import type { EntryView } from '@/app/api/kiosk/solo/view';
 import { pictureRect } from '@/app/lib/solo/caption';
+import { scoreLine } from '@/app/lib/solo/scores';
 import { Caption } from '@/app/components/solo/Caption';
 import type { DwellPlan, Stage } from '@/app/lib/solo2/plan';
 import type { Solo2Dials } from '@/app/lib/solo2/types';
@@ -119,7 +120,7 @@ export function Solo2Frame({ entry, prelude, previous, stage, plan, dials, width
           {dials.showTally && <div>shown <b style={{ color: '#f5a344' }}>×{entry.tally}</b></div>}
           {dials.showRank && <div>{entry.bin === 'sunset' ? 'sunset' : 'non-sunset'} bin #{entry.rank}</div>}
           {dials.showScores && (
-            <div>{entry.bin === 'sunset' ? `q ${(entry.quality ?? 0).toFixed(2)} · ` : ''}d {entry.detection.toFixed(2)}</div>
+            <div>{scoreLine(entry)}</div>
           )}
         </div>
       )}

--- a/app/lib/solo/engine.test.ts
+++ b/app/lib/solo/engine.test.ts
@@ -7,7 +7,7 @@ import { schemaDefaults } from '@/app/lib/settings/schema';
 
 const D: SoloDials = {
   ...dialsFrom(schemaDefaults(SOLO_SETTINGS_SCHEMA)),
-  qualityFloor: 0.55, detectionFloor: 0.3, sunsetFloor: 6, mix: 2,
+  ratingFloor: 3.2, detectionFloor: 0.3, sunsetFloor: 6, mix: 2, // 3.2 on the 1–5 scale is quality 0.55
   rest: 4, promoteNew: true, zoneGrace: 2,
   dwellS: 20, offsetS: 10, fadeS: 0,
   showPlace: true, showScores: false, showRank: false, showTally: false,
@@ -153,9 +153,10 @@ describe('rule 4: never twice in a row', () => {
 });
 
 describe('rule 5: floors', () => {
-  it('a sunset below qualityFloor is ineligible; a non-sunset below detectionFloor is ineligible', () => {
-    expect(isEligible(sun(1, 0.5), D)).toBe(false);
-    expect(isEligible(sun(1, 0.55), D)).toBe(true);
+  it('a sunset rated below the rating floor is ineligible; a non-sunset below detectionFloor is ineligible', () => {
+    expect(isEligible(sun(1, 0.5), D)).toBe(false); // rating 3.0
+    expect(isEligible(sun(1, 0.6), D)).toBe(true); // rating 3.4
+    expect(isEligible(sun(1, 0.0), { ...D, ratingFloor: 1 })).toBe(true); // the default: every sunset
     expect(isEligible(non(1, 0.29), D)).toBe(false);
     expect(isEligible(non(1, 0.3), D)).toBe(true);
   });

--- a/app/lib/solo/engine.ts
+++ b/app/lib/solo/engine.ts
@@ -1,5 +1,6 @@
 import { boundaryMs, slotFor } from './schedule';
 import type { BinEntry, Feed, ScreenState, SoloDials } from './types';
+import { qualityOf } from './scores';
 
 /**
  * The solo kiosk's ordering rules, spec §4, as a pure function. No clock, no
@@ -13,10 +14,10 @@ import type { BinEntry, Feed, ScreenState, SoloDials } from './types';
 /** Rule 3: a frame that arrived while its camera was already in the bin. */
 export const NEW_FRAME_BONUS = 0.1;
 
-/** Rule 5. */
+/** Rule 5. The rating floor is dialled on the 1–5 scale; quality is stored 0–1. */
 export function isEligible(e: BinEntry, d: SoloDials): boolean {
   return e.bin === 'sunset'
-    ? (e.quality ?? -1) >= d.qualityFloor
+    ? (e.quality ?? -1) >= qualityOf(d.ratingFloor)
     : e.detection >= d.detectionFloor;
 }
 

--- a/app/lib/solo/scores.test.ts
+++ b/app/lib/solo/scores.test.ts
@@ -1,0 +1,22 @@
+import { it, expect } from 'vitest';
+import { formatDetection, formatRating, qualityOf, ratingOf, scoreLine } from './scores';
+
+it('quality 0–1 is the 1–5 rating as 1 + 4q, clamped; qualityOf inverts it', () => {
+  expect(ratingOf(0)).toBe(1);
+  expect(ratingOf(0.75)).toBe(4);
+  expect(ratingOf(1)).toBe(5);
+  expect(ratingOf(1.3)).toBe(5); // a calibration multiplier can push quality past 1
+  expect(qualityOf(4)).toBe(0.75);
+  expect(qualityOf(1)).toBe(0);
+  expect(formatRating(0.91)).toBe('4.6');
+});
+
+it('detection is a probability and reads as a percent', () => {
+  expect(formatDetection(0.88)).toBe('88%');
+  expect(formatDetection(0.004)).toBe('0%');
+});
+
+it('one score line: rating and sunset probability for a sunset, the probability alone for a non-sunset', () => {
+  expect(scoreLine({ bin: 'sunset', quality: 0.91, detection: 0.88 })).toBe('rating 4.6 · sunset 88%');
+  expect(scoreLine({ bin: 'non_sunset', quality: null, detection: 0.12 })).toBe('sunset 12%');
+});

--- a/app/lib/solo/scores.ts
+++ b/app/lib/solo/scores.ts
@@ -1,0 +1,22 @@
+import type { BinKind } from './types';
+
+/**
+ * The two scores a bin entry carries, in the words the studio and the glass
+ * use for them.
+ *
+ * `quality` is the quality head's output in [0, 1]; the rubric it was trained
+ * on is the 1–5 rating (docs/ml/rating-rubric.md), stored as 1 + value·4
+ * (aiScoring.ts), so a quality of 0.75 is a rating of 4. `detection` is the
+ * binary head's probability that the frame is a sunset at all; it is not a
+ * rating, so it reads as a percent.
+ */
+export const ratingOf = (quality: number): number => Math.min(5, Math.max(1, 1 + 4 * quality));
+export const qualityOf = (rating: number): number => (rating - 1) / 4;
+export const formatRating = (quality: number): string => ratingOf(quality).toFixed(1);
+export const formatDetection = (detection: number): string => `${Math.round(detection * 100)}%`;
+
+/** One line for a frame's scores, the same wherever they are shown. Non-sunset rows carry no quality. */
+export function scoreLine(e: { bin: BinKind; quality: number | null; detection: number }): string {
+  const sunset = `sunset ${formatDetection(e.detection)}`;
+  return e.bin === 'sunset' ? `rating ${formatRating(e.quality ?? 0)} · ${sunset}` : sunset;
+}

--- a/app/lib/solo/settingsSchema.test.ts
+++ b/app/lib/solo/settingsSchema.test.ts
@@ -11,7 +11,7 @@ describe('SOLO_SETTINGS_SCHEMA', () => {
   it('defaults match the spec', () => {
     const d = dialsFrom(schemaDefaults(SOLO_SETTINGS_SCHEMA));
     expect(d).toEqual({
-      qualityFloor: 0.55, detectionFloor: 0.3, sunsetFloor: 6, mix: 2,
+      ratingFloor: 1, detectionFloor: 0.3, sunsetFloor: 6, mix: 2,
       rest: 4, promoteNew: true, zoneGrace: 2,
       dwellS: 20, offsetS: 10, fadeS: 0,
       showPlace: true, showScores: false, showRank: false, showTally: false,

--- a/app/lib/solo/settingsSchema.ts
+++ b/app/lib/solo/settingsSchema.ts
@@ -37,7 +37,7 @@ export const SOLO_SETTINGS_SCHEMA: SettingsSchema = [
   {
     key: 'showScores', kind: 'boolean', default: false,
     label: 'scores', section: 'glass',
-    description: 'Show q (quality 0–1) and d (detection probability 0–1) on glass.',
+    description: 'Show the rating (1–5) and the sunset probability on glass.',
   },
   {
     key: 'showRank', kind: 'boolean', default: false,
@@ -51,14 +51,14 @@ export const SOLO_SETTINGS_SCHEMA: SettingsSchema = [
   },
   // ---- bins ----
   {
-    key: 'qualityFloor', kind: 'number', min: 0, max: 1, step: 0.05, default: 0.55,
-    label: 'quality floor (sunsets)', section: 'bins',
-    description: 'A sunset-bin frame needs at least this quality to be eligible.',
+    key: 'ratingFloor', kind: 'number', min: 1, max: 5, step: 0.1, default: 1,
+    label: 'rating floor (sunsets)', section: 'bins',
+    description: 'A sunset-bin frame needs at least this rating (1–5) to be eligible. 1 shows every sunset: a poor sunset is still a sunset.',
   },
   {
     key: 'detectionFloor', kind: 'number', min: 0, max: 1, step: 0.05, default: 0.3,
-    label: 'detection floor (non-sunsets)', section: 'bins',
-    description: 'A non-sunset frame needs at least this detection probability to be eligible. Raise it to shrink that bin.',
+    label: 'sunset-probability floor (non-sunsets)', section: 'bins',
+    description: 'A non-sunset frame needs at least this probability of being a sunset (0–1) to be eligible. Raise it to shrink that bin.',
   },
   {
     key: 'sunsetFloor', kind: 'number', min: 0, max: 12, step: 1, default: 6,
@@ -96,7 +96,7 @@ export const SOLO_SETTINGS_SCHEMA: SettingsSchema = [
  */
 export function dialsFrom(values: SettingsValues): SoloDials {
   return {
-    qualityFloor: values.qualityFloor as number,
+    ratingFloor: values.ratingFloor as number,
     detectionFloor: values.detectionFloor as number,
     sunsetFloor: values.sunsetFloor as number,
     mix: values.mix as number,

--- a/app/lib/solo/types.ts
+++ b/app/lib/solo/types.ts
@@ -73,7 +73,8 @@ export interface CaptionDials {
  */
 export interface SoloDials extends CaptionDials {
   // bins group — change which frame comes next
-  qualityFloor: number;
+  /** 1–5, on the rubric's scale; 1 lets every sunset through. Compared to quality via scores.qualityOf. */
+  ratingFloor: number;
   detectionFloor: number;
   sunsetFloor: number;
   mix: number;

--- a/app/lib/solo2/settingsSchema.test.ts
+++ b/app/lib/solo2/settingsSchema.test.ts
@@ -24,7 +24,7 @@ describe('solo2 settings schema', () => {
     // Decided 2026-09-05: a camera change dips through black, the same camera dissolves.
     expect(d).toMatchObject({ transition: 'dip', fadeS: 1.5, sameCameraFadeS: 1.5 });
     // and still every solo dial
-    expect(d).toMatchObject({ dwellS: 20, offsetS: 10, qualityFloor: 0.55, mix: 2 });
+    expect(d).toMatchObject({ dwellS: 20, offsetS: 10, ratingFloor: 1, mix: 2 });
   });
   it('has no caption knobs of its own: the shared namespace carries them', () => {
     expect(SOLO2_SETTINGS_SCHEMA.some((k) => k.section === 'caption')).toBe(false);

--- a/app/lib/solo2/settingsSchema.ts
+++ b/app/lib/solo2/settingsSchema.ts
@@ -63,7 +63,7 @@ export const SOLO2_SETTINGS_SCHEMA: SettingsSchema = [
   solo('showRank'),
   solo('showTally'),
   // ---- bins ----
-  solo('qualityFloor'),
+  solo('ratingFloor'),
   solo('detectionFloor'),
   solo('sunsetFloor'),
   solo('mix'),

--- a/app/studio/solo/CaptionPreview.tsx
+++ b/app/studio/solo/CaptionPreview.tsx
@@ -10,8 +10,9 @@ const mono = 'ui-monospace, SFMono-Regular, Menlo, monospace';
 /**
  * The caption tab's main area: each screen's frame on glass right now, drawn
  * by the same component the glass uses, with the studio dials instead of the
- * live ones. What you see is what Deploy will send. Panels keep the shared
- * panel preset's aspect and fill the width they are given.
+ * live ones. What you see is what Deploy will send. The two screens sit side
+ * by side, one per column of the studio's main area, each keeping the shared
+ * panel preset's aspect at the width its column gives it.
  */
 export function CaptionPreview({ screens, dials, panel }: {
   screens: { feed: Feed; server: StateView | null; error?: string | null }[];
@@ -35,11 +36,11 @@ export function CaptionPreview({ screens, dials, panel }: {
   const h = Math.round(w * panel.height / panel.width);
 
   return (
-    <div style={{ gridColumn: '1 / -1', display: 'flex', flexDirection: 'column', gap: 14 }}>
+    <>
       {screens.map(({ feed, server, error }) => {
         const current = server?.current?.entry ?? null;
         return (
-          <section key={feed}>
+          <section key={feed} style={{ minWidth: 0 }}>
             <div style={{ fontFamily: mono, fontSize: 11, color: '#8b95a7', padding: '0 0 6px', display: 'flex', gap: 10 }}>
               <span style={{ color: '#e5e7eb' }}>{feed}</span>
               <span>{current ? `on glass now · frame ${current.snapshotId}` : error ?? 'nothing on glass'}</span>
@@ -58,10 +59,10 @@ export function CaptionPreview({ screens, dials, panel }: {
           </section>
         );
       })}
-      <p style={{ margin: 0, fontSize: 12, color: '#8b95a7', maxWidth: '64ch' }}>
+      <p style={{ gridColumn: '1 / -1', margin: 0, fontSize: 12, color: '#8b95a7', maxWidth: '64ch' }}>
         Drawn with the studio dials by the same code as the glass. Move a caption dial on the left and it changes here;
         Deploy sends it to the screens.
       </p>
-    </div>
+    </>
   );
 }

--- a/app/studio/solo/EntryRow.test.tsx
+++ b/app/studio/solo/EntryRow.test.tsx
@@ -11,8 +11,7 @@ const e = {
 it('shows tally first, scores, place, and the tags', () => {
   render(<EntryRow entry={e} feed="sunset" place="sunset" onClick={vi.fn()} />);
   expect(screen.getByText('shown ×2')).toHaveStyle({ fontWeight: 800 });
-  expect(screen.getByText(/q 0\.91/)).toBeInTheDocument();
-  expect(screen.getByText(/d 0\.88/)).toBeInTheDocument();
+  expect(screen.getByText(/rating 4\.6 · sunset 88%/)).toBeInTheDocument();
   expect(screen.getByText('NEW')).toBeInTheDocument();
   expect(screen.getByText(/Lisbon, Portugal/)).toBeInTheDocument();
 });
@@ -30,7 +29,8 @@ it('dims an ineligible frame and tags it FLOOR; a repeat keeps full strength and
 it('non-sunset rows show only detection, and a click reports the entry', () => {
   const onClick = vi.fn();
   render(<EntryRow entry={{ ...e, bin: 'non_sunset', quality: null }} feed="sunset" place="non_sunset" onClick={onClick} />);
-  expect(screen.queryByText(/q /)).toBeNull();
+  expect(screen.queryByText(/rating/)).toBeNull();
+  expect(screen.getByText(/sunset 88%/)).toBeInTheDocument();
   fireEvent.click(screen.getByRole('button'));
   expect(onClick).toHaveBeenCalledWith(expect.objectContaining({ snapshotId: 7 }));
 });

--- a/app/studio/solo/EntryRow.tsx
+++ b/app/studio/solo/EntryRow.tsx
@@ -3,6 +3,7 @@
 import type { EntryView } from '@/app/api/kiosk/solo/view';
 import type { Feed } from '@/app/lib/solo/types';
 import { formatTime } from '@/app/lib/solo/caption';
+import { scoreLine } from '@/app/lib/solo/scores';
 import type { Role } from '@/app/lib/solo2/types';
 
 const COLOR = { sunset: '#7ee2ac', non_sunset: '#c3cad6' } as const;
@@ -64,14 +65,12 @@ export function EntryRow({
   preluded?: boolean;
   onClick: (entry: EntryView) => void;
 }) {
-  const scores = e.bin === 'sunset'
-    ? `q ${(e.quality ?? 0).toFixed(2)} d ${e.detection.toFixed(2)}`
-    : `d ${e.detection.toFixed(2)}`;
+  const scores = scoreLine(e);
   const placeText = [[e.city, e.country].filter(Boolean).join(', '), clock(e)].filter(Boolean).join(' · ');
   const title =
     `${e.title} · ${placeText}. Frame ${e.snapshotId}, ${feed} feed` +
     (place === 'queue' ? ', in the queue. ' : '. ') +
-    (e.bin === 'sunset' ? 'Sunset bin, ordered by quality. ' : 'Non-sunset bin, ordered by detection. ') +
+    (e.bin === 'sunset' ? 'Sunset bin, ordered by rating. ' : 'Non-sunset bin, ordered by sunset probability. ') +
     (!e.eligible ? 'Below the floor dial; not eligible. ' : '') +
     (repeat ? 'Already appears earlier in the queue; this is a repeat showing. ' : '') +
     (preluded ? 'Already shown inside an earlier queued frame\'s prelude; this is its own turn. ' : '') +

--- a/app/studio/solo/FeedColumn.test.tsx
+++ b/app/studio/solo/FeedColumn.test.tsx
@@ -5,7 +5,7 @@ import { dialsFrom, SOLO_SETTINGS_SCHEMA } from '@/app/lib/solo/settingsSchema';
 import { schemaDefaults } from '@/app/lib/settings/schema';
 import { buildStateView, type ViewEntry } from '@/app/api/kiosk/solo/view';
 
-const D = dialsFrom(schemaDefaults(SOLO_SETTINGS_SCHEMA));
+const D = { ...dialsFrom(schemaDefaults(SOLO_SETTINGS_SCHEMA)), ratingFloor: 3.2 }; // quality 0.55: frame 4 (0.1) is below it
 const entry = (id: number, bin: 'sunset' | 'non_sunset', score: number, webcamId = 100 + id): ViewEntry => ({
   snapshotId: id, webcamId, bin, quality: bin === 'sunset' ? score : null, detection: bin === 'sunset' ? 0.9 : score,
   isNew: false, tally: 0, enteredAt: id, imageUrl: `u${id}`, title: `cam${id}`, city: '', region: '', country: '',
@@ -30,7 +30,7 @@ it('draws the on-glass frame at the top of the queue and keeps queued frames out
 
 it('says so when the studio dials would draw a different next frame than the glass', () => {
   const server = view();
-  const projected = view({ ...D, qualityFloor: 0.05, rest: 0, sunsetFloor: 0 });
+  const projected = view({ ...D, ratingFloor: 1, rest: 0, sunsetFloor: 0 });
   // With frame 4 admitted and shown frames sinking, the projection's first draw
   // differs from the server's only if the two first entries disagree; assert on
   // the message when they do, and on its absence when they do not, so the test

--- a/app/studio/solo/FeedColumn.tsx
+++ b/app/studio/solo/FeedColumn.tsx
@@ -6,6 +6,7 @@ import { nextBoundaryMs } from '@/app/lib/solo/schedule';
 import type { Feed, SoloDials } from '@/app/lib/solo/types';
 import type { SoloVersionSpec } from '@/app/lib/solo/versions';
 import { captionLines } from '@/app/lib/solo/caption';
+import { scoreLine } from '@/app/lib/solo/scores';
 import { preludePlan } from '@/app/lib/solo2/prelude';
 import type { Solo2Dials } from '@/app/lib/solo2/types';
 import { EntryRow, type Sequence } from './EntryRow';
@@ -87,10 +88,7 @@ export function FeedColumn({ feed, server, projected, liveDials, nowMs, version,
         {liveDials.showTally && <div>shown <b style={{ color: '#f5a344' }}>×{current.entry.tally}</b></div>}
         {liveDials.showRank && <div>{current.entry.bin === 'sunset' ? 'sunset' : 'non-sunset'} bin #{current.entry.rank}</div>}
         {liveDials.showScores && (
-          <div>
-            {current.entry.bin === 'sunset' ? `q ${(current.entry.quality ?? 0).toFixed(2)} · ` : ''}
-            d {current.entry.detection.toFixed(2)}
-          </div>
+          <div>{scoreLine(current.entry)}</div>
         )}
       </div>
       <div style={{
@@ -128,14 +126,14 @@ export function FeedColumn({ feed, server, projected, liveDials, nowMs, version,
       </div>
       <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr 1.15fr', gap: 6 }}>
         <Bin color="#7ee2ac" title={`Sunset bin · ${projected.bins.sunset.length} waiting · ${qSun} queued`}
-          hint="Frames the detection head calls a sunset, ordered by quality. Shown frames sink below unshown ones. Dimmed rows are below the quality floor.">
+          hint="Frames the detection head calls a sunset, ordered by rating (1–5). Shown frames sink below unshown ones. Dimmed rows are below the rating floor.">
           {projected.bins.sunset.map((e) => (
             <EntryRow key={e.snapshotId} entry={e} feed={feed} place="sunset" onClick={(x) => onSelect(x, feed)}
               sequence={seqFor(e, null)} rowS={rowS} preluded={preludedInQueue.has(e.snapshotId)} />
           ))}
         </Bin>
         <Bin color="#c3cad6" title={`Non-sunset bin · ${projected.bins.nonSunset.length} waiting · ${qNon} queued`}
-          hint="Frames the detection head does not call a sunset, ordered by detection probability so 'almost a sunset' is on top. Dimmed rows are below the detection floor.">
+          hint="Frames the detection head does not call a sunset, ordered by sunset probability so 'almost a sunset' is on top. Dimmed rows are below the sunset-probability floor.">
           {projected.bins.nonSunset.map((e) => (
             <EntryRow key={e.snapshotId} entry={e} feed={feed} place="non_sunset" onClick={(x) => onSelect(x, feed)}
               sequence={seqFor(e, null)} rowS={rowS} preluded={preludedInQueue.has(e.snapshotId)} />

--- a/app/studio/solo/RulesBox.test.tsx
+++ b/app/studio/solo/RulesBox.test.tsx
@@ -12,7 +12,8 @@ it('states the five rules with the dial values in force', () => {
   expect(screen.getByText(/rests/).textContent).toContain('2');
   expect(screen.getByText(/least shown first/)).toBeInTheDocument();
   expect(screen.getByText(/Never the same frame twice/)).toBeInTheDocument();
-  expect(screen.getByText(/Floors/).textContent).toContain('0.55');
+  expect(screen.getByText(/Floors/).textContent).toContain('1.0 (every sunset)');
+  expect(screen.getByText(/Floors/).textContent).toContain('30%');
   expect(screen.queryByText(/minus/)).toBeNull();
 });
 

--- a/app/studio/solo/RulesBox.tsx
+++ b/app/studio/solo/RulesBox.tsx
@@ -4,6 +4,7 @@ import type { ReactNode } from 'react';
 import type { SoloDials } from '@/app/lib/solo/types';
 import type { SoloVersionSpec } from '@/app/lib/solo/versions';
 import type { Solo2Dials } from '@/app/lib/solo2/types';
+import { formatDetection } from '@/app/lib/solo/scores';
 
 const box = {
   fontSize: 11.5, color: '#9aa3b2', border: '1px dashed #2a3242', borderRadius: 6,
@@ -23,7 +24,7 @@ export function RulesBox({ dials: d, version }: { dials: SoloDials; version?: So
       <div><B>2.</B> A shown frame rests <B>{d.rest}</B> {d.rest === 1 ? 'draw' : 'draws'}{d.rest === 0 ? ' (off)' : ''}.</div>
       <div><B>3.</B> In a bin: least shown first, then best score{d.promoteNew ? ', new frames +0.10' : ''}{rhythm ? <>;{rhythm}</> : null}.</div>
       <div><B>4.</B> Never the same frame twice in a row.</div>
-      <div><B>5.</B> Floors: sunsets q ≥ <B>{d.qualityFloor.toFixed(2)}</B>, non-sunsets d ≥ <B>{d.detectionFloor.toFixed(2)}</B>.</div>
+      <div><B>5.</B> Floors: sunsets rated ≥ <B>{d.ratingFloor.toFixed(1)}</B>{d.ratingFloor <= 1 ? ' (every sunset)' : ''}, non-sunsets sunset-probability ≥ <B>{formatDetection(d.detectionFloor)}</B>.</div>
     </div>
   );
 }

--- a/app/studio/solo/useSoloState.test.tsx
+++ b/app/studio/solo/useSoloState.test.tsx
@@ -4,7 +4,7 @@ import { useSoloState } from './useSoloState';
 import { dialsFrom, SOLO_SETTINGS_SCHEMA } from '@/app/lib/solo/settingsSchema';
 import { schemaDefaults } from '@/app/lib/settings/schema';
 
-const D = dialsFrom(schemaDefaults(SOLO_SETTINGS_SCHEMA));
+const D = { ...dialsFrom(schemaDefaults(SOLO_SETTINGS_SCHEMA)), ratingFloor: 3.2 }; // quality 0.55: frame 2 (0.5) is below it
 const entry = (id: number, q: number) => ({
   snapshotId: id, webcamId: 100 + id, bin: 'sunset', quality: q, detection: 0.9, isNew: false,
   tally: 0, enteredAt: id, imageUrl: `u${id}`, title: `t${id}`, city: '', region: '', country: '',
@@ -23,8 +23,8 @@ afterEach(() => {
 });
 
 describe('useSoloState', () => {
-  it('re-projects with the studio dials: a lower quality floor admits frame 2', async () => {
-    const dials = { ...D, qualityFloor: 0.4 };
+  it('re-projects with the studio dials: a lower rating floor admits frame 2', async () => {
+    const dials = { ...D, ratingFloor: 2.6 }; // quality 0.4
     const { result } = renderHook(() => useSoloState('sunset', dials));
     await waitFor(() => expect(result.current.projected).toBeDefined());
     expect(result.current.projected!.next.map((e) => e.snapshotId).slice(0, 2)).toEqual([1, 2]);

--- a/docs/superpowers/specs/2026-09-04-solo-kiosk-design.md
+++ b/docs/superpowers/specs/2026-09-04-solo-kiosk-design.md
@@ -105,7 +105,7 @@ force.
    `entered_at`, then snapshot id.
 4. **Never the same frame twice in a row on one screen.** If it is the only
    eligible frame, it repeats.
-5. **Floors.** Sunset bin: quality ≥ **quality floor** (0–1, default 0.55).
+5. **Floors.** Sunset bin: rating ≥ **rating floor** (1–5 on the rubric's scale, default 1: every sunset is eligible, because a poor sunset is still a sunset; the stored quality 0–1 is 1 + 4·q on that scale).
    Non-sunset bin: detection probability ≥ **detection floor** (0–1, default
    0.30). Frames below a floor stay in the table, render dimmed with a FLOOR
    tag, and are not eligible.


### PR DESCRIPTION
## Why

PR #139 merged (e5cfb3120) before its last two commits were pushed, so these two landed on the branch after the merge and are not in main. Same branch, same review context; nothing else changed.

## What changed

- **Scores on the rubric's scale.** New `app/lib/solo/scores.ts`: quality 0–1 shows as the 1–5 rating (`1 + 4q`, so 0.75 = 4.0); detection is the binary head's probability that the frame is a sunset at all, not a rating, so it reads as a percent. One `scoreLine` (`rating 4.6 · sunset 88%`, or `sunset 12%` for a non-sunset) serves the studio rows, the on-glass score overlay, the feed column and the rules box.
- **`ratingFloor` replaces `qualityFloor`.** Dialled 1–5, default **1**: every sunset-bin frame is eligible, because a poor sunset is still a sunset. Stored 0–1 quality is compared through `qualityOf(rating)`. No deployed row carried `qualityFloor`; a stale key is dropped on merge. The non-sunset floor keeps its 0–1 key, relabelled as a sunset-probability floor.
- **Caption preview side by side.** The two screens take one studio column each instead of stacking at full width.
- The solo spec's rule 5 restated.

## Effect on the deployed dials

The sunset bin's floor drops from quality 0.55 (rating 3.2) to rating 1 by default. Frames that were waiting below the old floor become eligible on deploy.

## Verification

- Full suite green on the branch (281 files, 2234 tests); tsc clean outside the pre-existing jest-dom typing noise; eslint clean.
- Not verified on the glass or signed-in studio. After merge: `bash scripts/pi/kiosk-doctor.sh --sync --reload`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015ovyDJa6YyLdzBQAUyqPuC
