### PR TITLE
feat(solo2): the prelude counts as shown — one grouped pass per camera; studio group numbered 1/3, 2/3, 3/3

### DIFF
--- a/app/api/kiosk/solo/advance/route.test.ts
+++ b/app/api/kiosk/solo/advance/route.test.ts
@@ -68,7 +68,7 @@ describe('POST /api/kiosk/solo/advance', () => {
     expect(body.advanced).toBe(true);
     expect(body.current.entry.snapshotId).toBe(1);
     expect(body.current.entry.tally).toBe(1);
-    expect(commitAdvance).toHaveBeenCalledWith('sunrise', 50_000_000, expect.objectContaining({ snapshotId: 1 }), 1);
+    expect(commitAdvance).toHaveBeenCalledWith('sunrise', 50_000_000, expect.objectContaining({ snapshotId: 1 }), 1, []);
   });
   it('version=solo2 with valleys 1 draws the valley on an odd slot', async () => {
     getLiveSettingsCached.mockResolvedValue({ namespaces: { solo2: { valleys: 1 } }, revision: 1 });
@@ -94,5 +94,24 @@ describe('POST /api/kiosk/solo/advance', () => {
     const res = await post({ feed: 'sunrise', slot: 50_000_000 });
     expect((await res.json()).advanced).toBe(false);
     expect(commitAdvance).not.toHaveBeenCalled();
+  });
+});
+
+describe('solo2 prelude', () => {
+  it('marks the prelude frames shown with the pick, and the returned queue treats them as shown', async () => {
+    getLiveSettingsCached.mockResolvedValue({ namespaces: { solo2: { prelude: true } }, revision: 1 });
+    const cam = (id: number, q: number, at: number) => ({ ...entry(id, q), webcamId: 7, capturedAt: at });
+    listActiveEntries.mockResolvedValue([cam(1, 0.6, 100), cam(2, 0.7, 200), cam(3, 0.9, 300), { ...entry(4, 0.8), capturedAt: 250 }]);
+    const body = await (await post({ feed: 'sunrise', slot: 50_000_000, version: 'solo2' })).json();
+    expect(body.advanced).toBe(true);
+    expect(commitAdvance).toHaveBeenCalledWith('sunrise', 50_000_000, expect.objectContaining({ snapshotId: 3 }), 1, [1, 2]);
+    expect(body.current.entry.snapshotId).toBe(3);
+    expect(body.next[0].snapshotId).toBe(4);
+    expect(body.entries.filter((e: { tally: number }) => e.tally === 1).map((e: { snapshotId: number }) => e.snapshotId).sort()).toEqual([1, 2, 3]);
+  });
+  it('solo shows nothing with the pick', async () => {
+    const body = await (await post({ feed: 'sunrise', slot: 50_000_000 })).json();
+    expect(body.advanced).toBe(true);
+    expect(commitAdvance).toHaveBeenCalledWith('sunrise', 50_000_000, expect.objectContaining({ snapshotId: 1 }), 1, []);
   });
 });

--- a/app/api/kiosk/solo/advance/route.ts
+++ b/app/api/kiosk/solo/advance/route.ts
@@ -57,11 +57,18 @@ export async function POST(request: Request) {
     const pick = version.next(entries, dials, state, slot, feed);
     if (pick) {
       const after = afterShowing(pick, state);
-      advanced = await commitAdvance(feed, slot, pick, after.sunsetStreak);
+      // What the dwell shows besides the pick (solo2's prelude) is shown too:
+      // it counts and rests with the pick, so the queue moves on to another camera.
+      const previous = entries.find((e) => e.snapshotId === state.lastSnapshotId) ?? null;
+      const alsoShown = version.shownWith(pick, entries, dials, previous);
+      advanced = await commitAdvance(feed, slot, pick, after.sunsetStreak, alsoShown.map((e) => e.snapshotId));
       if (advanced) {
-        const stored = entries.find((e) => e.snapshotId === pick.snapshotId)!;
-        stored.tally += 1;
-        stored.isNew = false;
+        for (const shown of [pick, ...alsoShown]) {
+          const stored = entries.find((e) => e.snapshotId === shown.snapshotId)!;
+          stored.tally += 1;
+          stored.isNew = false;
+          stored.lastShownAt = nowMs;
+        }
         screen = { feed, currentSnapshotId: pick.snapshotId, shownSince: nowMs, slot, sunsetStreak: after.sunsetStreak };
       }
     }

--- a/app/lib/solo/store.test.ts
+++ b/app/lib/solo/store.test.ts
@@ -107,6 +107,14 @@ describe('screen state', () => {
     expect(sqlMock).toHaveBeenCalledTimes(2);
     expect(lastQuery()).toMatch(/tally = tally \+ 1/);
     expect(lastQuery()).toMatch(/is_new = false/);
+    expect(sqlMock.mock.calls.at(-1)![1]).toEqual('sunset');
+    expect(sqlMock.mock.calls.at(-1)![2]).toEqual([7]);
+  });
+  it('commitAdvance marks the frames shown with the pick (a prelude) in the same statement, the pick once', async () => {
+    sqlMock.mockResolvedValueOnce([{ feed: 'sunset' }]).mockResolvedValueOnce([]);
+    await commitAdvance('sunset', 42, { snapshotId: 7, webcamId: 3, bin: 'sunset', quality: 0.9, detection: 0.8, isNew: true, tally: 0, enteredAt: 0 }, 1, [5, 6, 7]);
+    expect(lastQuery()).toMatch(/snapshot_id = any\(\?\)/);
+    expect(sqlMock.mock.calls.at(-1)![2]).toEqual([7, 5, 6]);
   });
 });
 

--- a/app/lib/solo/store.ts
+++ b/app/lib/solo/store.ts
@@ -264,13 +264,16 @@ export async function getScreenState(feed: Feed): Promise<ScreenRow | null> {
  * Put `entry` on glass for `slot`. The state write is conditional on the slot
  * being new, which is what makes POST /advance idempotent: a second call for
  * the same slot writes nothing and returns false, and the tally is bumped
- * only after the state write succeeded.
+ * only after the state write succeeded. `alsoShownIds` are the frames the
+ * dwell plays with the pick (solo2's prelude); they are marked shown in the
+ * same statement, so a camera's group counts once and rests together.
  */
 export async function commitAdvance(
   feed: Feed,
   slot: number,
   entry: BinEntry,
   sunsetStreak: number,
+  alsoShownIds: number[] = [],
 ): Promise<boolean> {
   const rows = (await sql`
     insert into kiosk_screen_state (feed, current_snapshot_id, shown_since, slot, sunset_streak, updated_at)
@@ -285,13 +288,14 @@ export async function commitAdvance(
     returning feed
   `) as unknown as { feed: Feed }[];
   if (rows.length === 0) return false;
+  const ids = [entry.snapshotId, ...alsoShownIds.filter((id) => id !== entry.snapshotId)];
   await sql`
     update kiosk_bin_entries
     set tally = tally + 1,
         is_new = false,
         first_shown_at = coalesce(first_shown_at, now()),
         last_shown_at = now()
-    where feed = ${feed} and snapshot_id = ${entry.snapshotId}
+    where feed = ${feed} and snapshot_id = any(${ids})
   `;
   return true;
 }

--- a/app/lib/solo/types.ts
+++ b/app/lib/solo/types.ts
@@ -21,6 +21,12 @@ export interface BinEntry {
   enteredAt: number;
   /** When this frame was last on glass, ms since epoch. Undefined or null = never (rule 2). */
   lastShownAt?: number | null;
+  /**
+   * When the picture was taken, ms since epoch. The store always has it; a
+   * fixture may omit it, and a frame without it never forms or joins a
+   * prelude (solo2 spec §4.4).
+   */
+  capturedAt?: number;
 }
 
 // ---- caption dials (see lib/solo/caption.ts) ----

--- a/app/lib/solo/versions.test.ts
+++ b/app/lib/solo/versions.test.ts
@@ -28,6 +28,7 @@ describe('descriptors', () => {
     expect(v.project(entries, d, S0, 3, 17, 'sunset')).toEqual(project(entries, d, S0, 3));
     expect(v.roleAt(1, 'sunset', d)).toBe('peak');
     expect(v.namespace).toBe('solo');
+    expect(v.shownWith(entries[0], entries, d, null)).toEqual([]);
   });
   it('solo2 reads its own namespace and follows the beat', () => {
     const v = SOLO_VERSIONS.solo2;
@@ -35,5 +36,14 @@ describe('descriptors', () => {
     expect(v.namespace).toBe('solo2');
     expect(v.roleAt(1, 'sunrise', d)).toBe('valley');
     expect(v.project(entries, d, S0, 3, 0, 'sunrise').map((e) => e.snapshotId)).toEqual([1, 3, 2]);
+  });
+  it('solo2 shows a prelude with the pick when the dial is on: the same camera\'s earlier frames', () => {
+    const v = SOLO_VERSIONS.solo2;
+    const d = { ...v.dialsFrom(schemaDefaults(v.schema)), prelude: true };
+    const cam = (id: number, q: number, at: number) => ({ ...sun(id, q), webcamId: 7, capturedAt: at });
+    const es = [cam(1, 0.6, 100), cam(2, 0.7, 200), cam(3, 0.9, 300), { ...sun(4, 0.8), capturedAt: 250 }];
+    expect(v.shownWith(es[2], es, d, null).map((e) => e.snapshotId)).toEqual([1, 2]);
+    expect(v.shownWith(es[2], es, { ...d, prelude: false }, null)).toEqual([]);
+    expect(v.shownWith(es[3], es, d, null)).toEqual([]);
   });
 });

--- a/app/lib/solo/versions.ts
+++ b/app/lib/solo/versions.ts
@@ -2,7 +2,7 @@ import type { SettingsSchema, SettingsValues } from '@/app/lib/settings/schema';
 import { next, project } from './engine';
 import { SOLO_NAMESPACE, SOLO_SETTINGS_SCHEMA, dialsFrom } from './settingsSchema';
 import type { BinEntry, Feed, ScreenState, SoloDials } from './types';
-import { next2, project2, roleAt } from '@/app/lib/solo2/engine';
+import { next2, project2, roleAt, shownWith2 } from '@/app/lib/solo2/engine';
 import { SOLO2_NAMESPACE, SOLO2_SETTINGS_SCHEMA, dialsFrom2 } from '@/app/lib/solo2/settingsSchema';
 import type { Role, Solo2Dials } from '@/app/lib/solo2/types';
 
@@ -23,6 +23,12 @@ export interface SoloVersionSpec<D extends SoloDials = SoloDials> {
   project(entries: BinEntry[], d: D, state: ScreenState, n: number, firstSlot: number, feed: Feed): BinEntry[];
   /** What a draw at `slot` is inside the bar; solo is all peaks. */
   roleAt(slot: number, feed: Feed, d: D): Role;
+  /**
+   * The frames a dwell of `pick` also puts on glass, which the advance route
+   * marks shown with it. solo shows one frame per dwell; solo2 plays a
+   * prelude (its spec §4.4).
+   */
+  shownWith(pick: BinEntry, entries: BinEntry[], d: D, previous: BinEntry | null): BinEntry[];
 }
 
 export type SoloVersionName = 'solo' | 'solo2';
@@ -35,6 +41,7 @@ const solo: SoloVersionSpec<SoloDials> = {
   next,
   project,
   roleAt: () => 'peak',
+  shownWith: () => [],
 };
 
 const solo2: SoloVersionSpec<Solo2Dials> = {
@@ -45,6 +52,7 @@ const solo2: SoloVersionSpec<Solo2Dials> = {
   next: next2,
   project: project2,
   roleAt,
+  shownWith: shownWith2,
 };
 
 export const SOLO_VERSIONS = { solo, solo2 } as const;

--- a/app/lib/solo2/engine.test.ts
+++ b/app/lib/solo2/engine.test.ts
@@ -3,7 +3,7 @@ import { schemaDefaults } from '@/app/lib/settings/schema';
 import { project } from '@/app/lib/solo/engine';
 import type { BinEntry, ScreenState } from '@/app/lib/solo/types';
 import { boundaryMs } from '@/app/lib/solo/schedule';
-import { beatOf, next2, project2, roleAt } from './engine';
+import { beatOf, next2, project2, roleAt, shownWith2 } from './engine';
 import { SOLO2_SETTINGS_SCHEMA, dialsFrom2 } from './settingsSchema';
 import type { Solo2Dials } from './types';
 
@@ -112,5 +112,29 @@ describe('rhythm', () => {
     expect(next2(entries, d, S0, 1, 'sunrise')?.snapshotId).toBe(2);
     // slot 2 is a peak: frame 2 is on glass, 1 and 3 still rest → rest waived → best is 1.
     expect(next2(entries, d, { lastSnapshotId: 2, sunsetStreak: 1 }, 2, 'sunrise')?.snapshotId).toBe(1);
+  });
+});
+
+describe('the prelude counts as shown (spec §4.4)', () => {
+  const cam = (id: number, q: number, at: number) => sun(id, q, { webcamId: 7, capturedAt: at });
+  const es = () => [cam(1, 0.6, 100), cam(2, 0.7, 200), cam(3, 0.9, 300), sun(4, 0.8, { capturedAt: 250 }), sun(5, 0.5, { capturedAt: 260 })];
+  const on = { ...D, prelude: true, preludeFrames: 3 };
+  it('with the prelude on, a camera plays once as a group and the queue moves on to other cameras', () => {
+    expect(labels(project2(es(), on, S0, 3, 0, 'sunrise'))).toEqual(['S3', 'S4', 'S5']);
+  });
+  it('with the prelude off, each of the camera\'s frames takes a turn of its own', () => {
+    expect(labels(project2(es(), D, S0, 3, 0, 'sunrise'))).toEqual(['S3', 'S4', 'S2']);
+  });
+  it('shownWith2 is the prelude the glass draws, continuing from a same-camera previous frame', () => {
+    const e = es();
+    expect(shownWith2(e[2], e, on, null).map((x) => x.snapshotId)).toEqual([1, 2]);
+    expect(shownWith2(e[2], e, on, e[0]).map((x) => x.snapshotId)).toEqual([2]);
+    expect(shownWith2(e[2], e, on, e[1])).toEqual([]);
+    expect(shownWith2(e[2], e, D, null)).toEqual([]);
+  });
+  it('project2 still leaves its inputs alone', () => {
+    const e = es();
+    project2(e, on, S0, 3, 0, 'sunrise');
+    expect(e.map((x) => x.tally)).toEqual([0, 0, 0, 0, 0]);
   });
 });

--- a/app/lib/solo2/engine.ts
+++ b/app/lib/solo2/engine.ts
@@ -1,6 +1,7 @@
 import { afterShowing, choosePool, rankScore } from '@/app/lib/solo/engine';
 import { boundaryMs } from '@/app/lib/solo/schedule';
 import type { BinEntry, Feed, ScreenState } from '@/app/lib/solo/types';
+import { preludePlan } from './prelude';
 import type { Role, Solo2Dials } from './types';
 
 /**
@@ -38,6 +39,18 @@ function compareValley(d: Solo2Dials) {
     a.snapshotId - b.snapshotId;
 }
 
+/**
+ * The frames a dwell of `pick` also puts on glass: its prelude (spec §4.4),
+ * continuing from `previous` when that is the same camera. They count as
+ * shown, tally and rest alike, so a camera plays once as one group and the
+ * queue moves on instead of bringing each of its frames back for a turn of
+ * its own. The glass draws exactly these (Solo2Kiosk calls preludePlan with
+ * the same inputs), so what is marked shown is what was seen.
+ */
+export function shownWith2(pick: BinEntry, entries: BinEntry[], d: Solo2Dials, previous: BinEntry | null): BinEntry[] {
+  return preludePlan(pick, entries, d, previous).frames;
+}
+
 /** The next frame for one screen drawing at `slot`, or null when nothing is eligible. */
 export function next2(
   entries: BinEntry[], d: Solo2Dials, state: ScreenState, slot: number, feed: Feed,
@@ -52,7 +65,8 @@ export function next2(
 
 /**
  * `n` draws forward from `state`, the first at `firstSlot`, each applied to
- * a private copy of the entries. Inputs are never mutated.
+ * a private copy of the entries. Each draw marks the pick AND its prelude
+ * shown, as the advance route does. Inputs are never mutated.
  */
 export function project2(
   entries: BinEntry[], d: Solo2Dials, state: ScreenState, n: number, firstSlot: number, feed: Feed,
@@ -64,9 +78,13 @@ export function project2(
     const pick = next2(working, d, s, firstSlot + i, feed);
     if (!pick) break;
     out.push({ ...pick });
-    pick.tally += 1;
-    pick.isNew = false;
-    pick.lastShownAt = boundaryMs(firstSlot + i, feed, d.dwellS, d.offsetS);
+    const previous = working.find((e) => e.snapshotId === s.lastSnapshotId) ?? null;
+    const shownAt = boundaryMs(firstSlot + i, feed, d.dwellS, d.offsetS);
+    for (const f of [pick, ...shownWith2(pick, working, d, previous)]) {
+      f.tally += 1;
+      f.isNew = false;
+      f.lastShownAt = shownAt;
+    }
     s = afterShowing(pick, s);
   }
   return out;

--- a/app/lib/solo2/prelude.test.ts
+++ b/app/lib/solo2/prelude.test.ts
@@ -16,6 +16,11 @@ describe('preludeFor', () => {
     expect(preludeFor(f(3, 9, 250), pool, 3)).toEqual([]);
     expect(preludeFor(f(6, 7, 500), pool, 0)).toEqual([]);
   });
+  it('a frame without a capture time neither has a prelude nor joins one', () => {
+    const bare = { snapshotId: 8, webcamId: 7 };
+    expect(preludeFor(bare, [...pool, bare], 3)).toEqual([]);
+    expect(preludeFor(f(6, 7, 500), [...pool, bare], 10).map((e) => e.snapshotId)).toEqual([1, 2, 4, 5]);
+  });
 });
 
 describe('preludeFor after a moment', () => {

--- a/app/lib/solo2/prelude.ts
+++ b/app/lib/solo2/prelude.ts
@@ -1,6 +1,6 @@
 import { fitPlan, type DwellPlan, type PlanDials } from './plan';
 
-export interface PreludeEntry { webcamId: number; snapshotId: number; capturedAt: number }
+export interface PreludeEntry { webcamId: number; snapshotId: number; capturedAt?: number }
 
 /**
  * The prelude of a frame: the same camera's earlier captures, oldest first,
@@ -8,13 +8,15 @@ export interface PreludeEntry { webcamId: number; snapshotId: number; capturedAt
  * already returned: no query. Frames below a floor are fine here; they are
  * earlier pictures of the same scene. `afterMs` keeps only captures after
  * that moment, so a prelude can continue from the frame already on glass
- * instead of rewinding past it.
+ * instead of rewinding past it. A frame without a capture time (an engine
+ * fixture) neither has a prelude nor joins one.
  */
 export function preludeFor<T extends PreludeEntry>(entry: T, entries: T[], max: number, afterMs = -Infinity): T[] {
-  if (max <= 0) return [];
+  const at = entry.capturedAt;
+  if (max <= 0 || at === undefined || !Number.isFinite(at)) return [];
   return entries
-    .filter((e) => e.webcamId === entry.webcamId && e.snapshotId !== entry.snapshotId
-      && e.capturedAt < entry.capturedAt && e.capturedAt > afterMs)
+    .filter((e): e is T & { capturedAt: number } => e.webcamId === entry.webcamId && e.snapshotId !== entry.snapshotId
+      && e.capturedAt !== undefined && Number.isFinite(e.capturedAt) && e.capturedAt < at && e.capturedAt > afterMs)
     .sort((a, b) => a.capturedAt - b.capturedAt || a.snapshotId - b.snapshotId)
     .slice(-Math.floor(max));
 }
@@ -29,7 +31,7 @@ export function preludeFor<T extends PreludeEntry>(entry: T, entries: T[], max: 
 export function preludePlan<T extends PreludeEntry>(
   entry: T, entries: T[], dials: PlanDials & { preludeFrames: number }, previous?: PreludeEntry | null,
 ): { frames: T[]; plan: DwellPlan } {
-  const after = previous && previous.webcamId === entry.webcamId ? previous.capturedAt : -Infinity;
+  const after = previous && previous.webcamId === entry.webcamId && previous.capturedAt !== undefined ? previous.capturedAt : -Infinity;
   const wanted = dials.prelude ? preludeFor(entry, entries, dials.preludeFrames, after) : [];
   const plan = fitPlan(dials, wanted.length);
   return { frames: plan.preludeFrames > 0 ? wanted.slice(-plan.preludeFrames) : [], plan };

--- a/app/studio/solo/EntryRow.test.tsx
+++ b/app/studio/solo/EntryRow.test.tsx
@@ -51,10 +51,11 @@ it('a sequence stacks the earlier frames above the chosen one, each with its loc
   // earlier frames first, the chosen frame last; each is its own button
   const buttons = screen.getAllByRole('button');
   expect(buttons).toHaveLength(3);
-  expect(buttons[0]).toHaveTextContent('6:58 pm');
-  expect(buttons[1]).toHaveTextContent('7:14 pm');
+  expect(buttons[0]).toHaveTextContent('1/3 · 6:58 pm');
+  expect(buttons[1]).toHaveTextContent('2/3 · 7:14 pm');
   expect(buttons[2]).toHaveTextContent('Pier');
   expect(buttons[2]).toHaveTextContent('7:42 pm');
+  expect(buttons[2]).toHaveTextContent('3/3');
   // every frame carries a light border inside the group
   for (const b of buttons) expect(b).toHaveStyle({ border: '1px solid #2a3242' });
   fireEvent.click(buttons[0]);

--- a/app/studio/solo/EntryRow.tsx
+++ b/app/studio/solo/EntryRow.tsx
@@ -39,22 +39,22 @@ const clock = (e: EntryView) => formatTime('12h', e.capturedAt, e.timezone, null
  * One frame, wherever it sits: a bin or the queue. The outline is always the
  * colour of the bin the frame belongs to, so the queue reads at a glance.
  * With a `sequence` the row becomes a group: the earlier frames stacked
- * above the chosen one in capture order, each its own light box with its
- * local time, all inside one bin-coloured border, so a dwell that plays
- * several pictures reads as one box. With `rowS` the row is as tall as the
+ * above the chosen one in capture order, each its own light box numbered
+ * 1/3, 2/3 with its local time, the chosen frame last as 3/3, all inside one
+ * bin-coloured border, so a dwell that plays several pictures reads as one
+ * box. With `rowS` the row is as tall as the
  * time it gets on glass. Dimming means the frame will not be shown (it is
  * below a floor); a repeat IS shown again, so it keeps full strength and a
  * red tag says so.
  */
 export function EntryRow({
-  entry: e, feed, place, onGlass = false, repeat = false, cameraIndex, role, sequence, rowS, preluded = false, onClick,
+  entry: e, feed, place, onGlass = false, repeat = false, role, sequence, rowS, preluded = false, onClick,
 }: {
   entry: EntryView;
   feed: Feed;
   place: 'sunset' | 'non_sunset' | 'queue';
   onGlass?: boolean;
   repeat?: boolean;
-  cameraIndex?: { n: number; m: number };
   /** solo2: what this queued draw is inside its bar. */
   role?: Role;
   /** solo2: the prelude this dwell plays first. */
@@ -77,6 +77,7 @@ export function EntryRow({
     (sequence ? `Plays ${sequence.earlier.length} earlier frame${sequence.earlier.length === 1 ? '' : 's'} of this camera first, ${sequence.stepS} s each. ` : '') +
     `Shown ${e.tally} time${e.tally === 1 ? '' : 's'} today.`;
   const grouped = !!sequence && sequence.earlier.length > 0;
+  const steps = grouped ? sequence.earlier.length + 1 : 0;
   const ring = onGlass ? '0 0 0 2px #f5a344' : undefined;
 
   const main = (
@@ -99,9 +100,7 @@ export function EntryRow({
           {e.isNew && <Tag bg="#f5a344" fg="#1a1000" title="Newer frame from a camera already in the bin">NEW</Tag>}
           {!e.eligible && <Tag bg="#3a4356" fg="#e5e7eb" title="Below the floor dial">FLOOR</Tag>}
           {repeat && <Tag bg="#8b2e2e" fg="#ffe1e1" title="Already earlier in this queue; the rest dial let it come round again">REPEAT</Tag>}
-          {cameraIndex && (
-            <Tag bg="#7ea6e2" fg="#061224" title="Same camera as another queue entry">{`CAM ${cameraIndex.n}/${cameraIndex.m}`}</Tag>
-          )}
+          {grouped && <Tag bg="#7ea6e2" fg="#061224" title={`The last of ${steps} frames this dwell plays; the ones above it are its prelude`}>{`${steps}/${steps}`}</Tag>}
           {preluded && (
             <Tag bg="#5b4b8a" fg="#efe9ff" title="An earlier queued frame already shows this picture inside its prelude; this is its own turn">PRELUDE</Tag>
           )}
@@ -122,11 +121,11 @@ export function EntryRow({
       border: `2px solid ${COLOR[e.bin]}`, borderRadius: 6, padding: 3, marginBottom: 4,
       background: '#0b0e14', boxShadow: ring, display: 'flex', flexDirection: 'column', gap: 3,
     }}>
-      {sequence.earlier.map((f) => {
+      {sequence.earlier.map((f, i) => {
         const t = clock(f) ?? `${Math.max(1, Math.round((e.capturedAt - f.capturedAt) / 60_000))} min earlier`;
         return (
           <button key={f.snapshotId} type="button" onClick={() => onClick(f)}
-            title={`${f.title} · ${t}. Frame ${f.snapshotId}, shown for ${sequence.stepS} s as part of this dwell's prelude, without a caption.`}
+            title={`${f.title} · ${t}. Frame ${f.snapshotId}, step ${i + 1} of ${steps}: shown for ${sequence.stepS} s as part of this dwell's prelude, without a caption.`}
             style={{
               display: 'flex', gap: 5, alignItems: 'center', width: '100%', boxSizing: 'border-box', height: stepPx,
               textAlign: 'left', border: `1px solid ${LIGHT}`, borderRadius: 4, padding: '0 3px',
@@ -134,7 +133,9 @@ export function EntryRow({
             }}>
             {/* eslint-disable-next-line @next/next/no-img-element */}
             <img src={f.imageUrl} alt="" style={{ height: '100%', aspectRatio: '16/9', objectFit: 'cover', borderRadius: 2, display: 'block' }} />
-            <span style={{ whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>{t}</span>
+            <span style={{ whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>
+              <b style={{ color: '#7ea6e2' }}>{i + 1}/{steps}</b> · {t}
+            </span>
           </button>
         );
       })}

--- a/app/studio/solo/FeedColumn.test.tsx
+++ b/app/studio/solo/FeedColumn.test.tsx
@@ -25,7 +25,6 @@ it('draws the on-glass frame at the top of the queue and keeps queued frames out
   expect(screen.getByText(/next frame in/).textContent).toContain('5 s');
   expect(screen.getByText(/Sunset bin · 1 waiting/)).toBeInTheDocument(); // frame 4 (below floor) waits
   expect(screen.getAllByText('cam1').length).toBeGreaterThan(0);
-  expect(screen.getAllByText(/CAM 1\/\d+/).length).toBeGreaterThan(0); // frames 1 and 2 share webcam 101, so the queue indexes them
 });
 
 it('says so when the studio dials would draw a different next frame than the glass', () => {
@@ -65,7 +64,7 @@ it('solo2 with valleys tags queued draws PEAK and VALLEY and captions the local 
   expect(screen.getByText('BCS, Mexico · 7:42 pm there')).toBeInTheDocument();
 });
 
-it('solo2 with the prelude on groups a camera\'s earlier frames under the queued draw and flags their own later turns', async () => {
+it('solo2 with the prelude on groups a camera\'s earlier frames under the queued draw, numbered, and they rest instead of coming back', async () => {
   const { SOLO_VERSIONS } = await import('@/app/lib/solo/versions');
   const { SOLO2_SETTINGS_SCHEMA, dialsFrom2 } = await import('@/app/lib/solo2/settingsSchema');
   const d2 = { ...dialsFrom2(schemaDefaults(SOLO2_SETTINGS_SCHEMA)), prelude: true, preludeFrames: 3, rest: 0 };
@@ -79,10 +78,11 @@ it('solo2 with the prelude on groups a camera\'s earlier frames under the queued
     screen: { feed: 'sunrise', currentSnapshotId: 3, shownSince: 0, slot: 0, sunsetStreak: 1 },
     nowMs: 0, admitted: { sunset: 0, nonSunset: 0 }, zone: { minDeg: -24, maxDeg: -2 }, version: SOLO_VERSIONS.solo2 });
   render(<FeedColumn feed="sunrise" server={v} projected={v} liveDials={d2} studioDials={d2} nowMs={0} version={SOLO_VERSIONS.solo2} onSelect={vi.fn()} />);
-  // The on-glass row is a group whose earlier frames read 6:58 pm then 7:14 pm.
-  const groups = screen.getAllByRole('group');
-  expect(groups.length).toBeGreaterThan(0);
-  expect(groups[0]).toHaveTextContent(/6:58 pm.*7:14 pm.*cam3/s);
-  // Frames 1 and 2 still get their own turn somewhere later, flagged.
-  expect(screen.getAllByText('PRELUDE').length).toBeGreaterThan(0);
+  // The on-glass row is a group whose steps read 1/3 · 6:58 pm, 2/3 · 7:14 pm, then cam3 tagged 3/3.
+  // (The bins draw frame 2 as a group of its own too, so pick the queue's by its chosen frame.)
+  const group = screen.getAllByRole('group').find((g) => /cam3/.test(g.textContent ?? ''));
+  expect(group).toHaveTextContent(/1\/3 · 6:58 pm.*2\/3 · 7:14 pm.*3\/3.*cam3/s);
+  // Frames 1 and 2 were shown inside the group, so the projection counts them shown: camera 9 comes next, not them.
+  expect(v.next[0].snapshotId).toBe(4);
+  expect(screen.queryByText(/CAM /)).toBeNull();
 });

--- a/app/studio/solo/FeedColumn.tsx
+++ b/app/studio/solo/FeedColumn.tsx
@@ -45,9 +45,6 @@ export function FeedColumn({ feed, server, projected, liveDials, nowMs, version,
   const current = server.current;
   const queue: EntryView[] = [...(current ? [current.entry] : []), ...projected.next];
   const seen = new Set<number>();
-  const camCount = new Map<number, number>();
-  for (const e of queue) camCount.set(e.webcamId, (camCount.get(e.webcamId) ?? 0) + 1);
-  const camSeen = new Map<number, number>();
   const differs =
     !!server.next[0] && !!projected.next[0] && server.next[0].snapshotId !== projected.next[0].snapshotId;
   const qSun = queue.filter((e) => e.bin === 'sunset').length;
@@ -149,14 +146,11 @@ export function FeedColumn({ feed, server, projected, liveDials, nowMs, version,
           {queue.map((e, i) => {
             const repeat = seen.has(e.snapshotId);
             seen.add(e.snapshotId);
-            const m = camCount.get(e.webcamId) ?? 1;
-            const n = (camSeen.get(e.webcamId) ?? 0) + 1;
-            camSeen.set(e.webcamId, n);
             // Flagged when a dwell above this one already played the frame inside its prelude.
             const preluded = queueSeqs.slice(0, i).some((s) => s?.earlier.some((f) => f.snapshotId === e.snapshotId));
             return (
               <EntryRow key={`${e.snapshotId}-${i}`} entry={e} feed={feed} place="queue" onGlass={i === 0 && !!current}
-                repeat={repeat} cameraIndex={m > 1 ? { n, m } : undefined} role={roleOf(i)} onClick={(x) => onSelect(x, feed)}
+                repeat={repeat} role={roleOf(i)} onClick={(x) => onSelect(x, feed)}
                 sequence={queueSeqs[i]} rowS={rowS} preluded={preluded} />
             );
           })}

--- a/docs/superpowers/specs/2026-09-04-solo2-rhythm-design.md
+++ b/docs/superpowers/specs/2026-09-04-solo2-rhythm-design.md
@@ -215,6 +215,19 @@ cron never archived (detection below 0.20) were never pictures we hold.
 The glass preloads the prelude of the projected next frame along with the
 frame itself.
 
+**The prelude counts as shown** (added 2026-09-05). Every frame a dwell
+plays is a frame the viewer saw, so the advance route marks the prelude
+frames shown with the pick: tally +1, `last_shown_at`, in one statement
+(`commitAdvance(..., alsoShownIds)`). The descriptor's `shownWith(pick,
+entries, dials, previous)` says what those frames are (`solo` none, `solo2`
+its `preludePlan`), and `project2` marks them the same way inside the
+projection, so the studio's queue and the glass agree. The effect is the
+grouping Jesse asked for: a camera plays once, oldest frame to newest, and
+the queue moves on to another camera instead of bringing each of that
+camera's frames back for a turn of its own. Its frames come round again
+only when the rest has lapsed and they are the least shown, and then the
+newest of them plays with whatever earlier frames the budget keeps.
+
 ### 4.5 Caption and the time
 
 **place + country** stays. A new **time** dial (enum, default `12h`) sets
@@ -313,18 +326,21 @@ Additions:
 - **a dwell is one box** (added 2026-09-05): with the prelude dial on, a
   frame that will play earlier frames of its camera first becomes a group:
   the earlier frames stacked above the chosen one in capture order, each a
-  light-bordered strip (thumbnail + local time, e.g. `6:58 pm`, `7:14 pm`)
-  as tall as a prelude step, then the chosen frame with its usual
-  annotations and the time on its place line, all inside one thick
+  light-bordered strip (thumbnail, step number and local time, e.g.
+  `1/3 · 6:58 pm`, `2/3 · 7:14 pm`) as tall as a prelude step, then the
+  chosen frame tagged `3/3` with its usual annotations and the time on its
+  place line, all inside one thick
   bin-coloured border (green sunset, grey non-sunset). Queue rows continue
   from their predecessor as the glass does; bin rows show the full prelude
   a draw would get. Every frame in the group is clickable and opens its own
   detail;
 - **PRELUDE** tag (added 2026-09-05): a frame that an earlier queued dwell
   already shows inside its prelude carries the tag when it comes back for
-  its own turn, in the queue or in a bin. This makes the parked same-camera
-  dedup question visible without deciding it: the tag is how often a
-  viewer sees a picture twice;
+  its own turn, in the queue or in a bin. Since the prelude counts as shown
+  (§4.4) this is rare within the eight-deep queue; when it appears it means
+  the rest lapsed and the camera came round again. The earlier `CAM n/m`
+  tag on scattered same-camera entries was dropped the same day: with the
+  group box, same-camera frames are grouped, not indexed;
 - the panel preview's caption uses `captionLines`, so it shows the time;
 - the rules box states rule 3 with valleys and screens substituted;
 - each studio links to the other.


### PR DESCRIPTION
## Why

Jesse wants one grouped pass per camera: a quick dip to black between cameras, then a dissolve forward through the same camera's frames, oldest to newest. solo2's prelude already draws that, but two things kept it from reading as a group:

1. Frames shown inside a prelude still got a turn of their own later, so the same camera kept coming back, scattered through the queue (the `CAM 1/2`, `2/2` tags he did not understand were exactly those scattered turns).
2. The studio's group box did not say which step was which.

Stacked on #140 (base branch `fix/solo-caption-parity`); GitHub retargets to `main` when #140 merges.

## What changed

- **The prelude counts as shown.** The version descriptor gains `shownWith(pick, entries, dials, previous)`: the frames a dwell also puts on glass. `solo` returns none; `solo2` returns its `preludePlan`, the same function the glass draws with. The advance route passes them to `commitAdvance(..., alsoShownIds)`, which bumps tally and `last_shown_at` for pick and prelude in one statement. `project2` marks them the same way inside the projection, so the studio queue and the glass agree. `BinEntry` carries `capturedAt` (optional; an engine fixture without it never forms or joins a prelude).
- **Effect on the glass (solo2, prelude on):** a camera plays once as a group and rests; the next dwell goes to another camera. Its frames come round again only when the rest has lapsed and they are the least shown, and then the newest plays with whatever earlier frames the dwell budget keeps.
- **Studio group box numbered.** Prelude strips read `1/3 · 6:58 pm`, `2/3 · 7:14 pm`; the chosen frame is tagged `3/3`. The `CAM n/m` tag is removed: with the group box, same-camera frames are grouped, not indexed. The `PRELUDE` tag stays but is now rare within the queue.
- solo2 spec §4.4 and §5.4 updated.

## What it does not change

- The prelude toggle is the existing `prelude` checkbox on /studio/solo2 (Glass section), default off. The fade dials are already there: `camera change` (cut / crossfade / dip), `fade (s)` for the camera change, `same-camera fade (s)` for the dissolve between prelude frames, `prelude step (s)`, `prelude frames`.
- The prelude still fits inside one dwell (up to `prelude frames` earlier frames at `prelude step` each, keeping a 3 s hold), not the camera's whole day.
- The glass runs `solo`; to see any of this, set active version to `solo2` on /studio and Deploy, then turn `prelude` on at /studio/solo2 and Deploy.

## Verification

- `npx vitest run`: 281 files, 2243 tests pass. New tests: `project2` with the prelude on plays `S3, S4, S5` where off plays `S3, S4, S2`; `shownWith2` continues from a same-camera previous frame; `commitAdvance` marks `[pick, ...prelude]` via `any(...)`; the advance route for solo2 passes `[1, 2]` and the returned view treats them shown; a frame without `capturedAt` is excluded; the group's step labels.
- `npx tsc --noEmit` clean outside the repo's pre-existing jest-dom typing noise; eslint clean.
- Not verified on the glass. After merge: `bash scripts/pi/kiosk-doctor.sh --sync --reload`, then watch /studio/solo2 with prelude on: the queue should show one numbered group per camera and move on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015ovyDJa6YyLdzBQAUyqPuC
