### PR TITLE
feat(studio): the tape — a timeline of past, current and projected draws

### DIFF
--- a/app/api/cron/update-cameras/lib/binAdmission.test.ts
+++ b/app/api/cron/update-cameras/lib/binAdmission.test.ts
@@ -9,6 +9,7 @@ const markSeen = vi.fn();
 const markOutOfZone = vi.fn();
 const removeStale = vi.fn();
 const saveSweptZone = vi.fn();
+const pruneDraws = vi.fn();
 vi.mock('server-only', () => ({}));
 vi.mock('@/app/lib/solo/store', () => ({
   insertEntry: (...a: unknown[]) => insertEntry(...a),
@@ -19,6 +20,7 @@ vi.mock('@/app/lib/solo/store', () => ({
   markOutOfZone: (...a: unknown[]) => markOutOfZone(...a),
   removeStale: (...a: unknown[]) => removeStale(...a),
   saveSweptZone: (...a: unknown[]) => saveSweptZone(...a),
+  pruneDraws: (...a: unknown[]) => pruneDraws(...a),
 }));
 
 import { decideBin, enterBins, maintainBins, BIN_ADMIT_DETECTION_FLOOR } from './binAdmission';
@@ -88,6 +90,7 @@ describe('maintainBins', () => {
     expect(markOutOfZone).toHaveBeenCalledWith('sunset', [2]);
     expect(removeStale).toHaveBeenCalledWith('sunset', { grace: 2, maxAgeHours: 24 });
     expect(removeStale).toHaveBeenCalledWith('sunrise', { grace: 2, maxAgeHours: 24 });
+    expect(pruneDraws).toHaveBeenCalledWith(7); // the tape keeps a week
     expect(out).toEqual({ leftZone: 0, expired: 0 });
   });
   it('records the zone it aged entries against, so the state route shows the same band', async () => {

--- a/app/api/cron/update-cameras/lib/binAdmission.ts
+++ b/app/api/cron/update-cameras/lib/binAdmission.ts
@@ -7,6 +7,7 @@ import {
   markOutOfZone,
   markSeen,
   removeStale,
+  pruneDraws,
   saveSweptZone,
 } from '@/app/lib/solo/store';
 import { inFeedZone, type Zone } from '@/app/lib/solo/zone';
@@ -69,6 +70,9 @@ export async function enterBins(
   return out;
 }
 
+/** The tape keeps a week; the studio reads the last 24 draws. */
+const DRAW_LOG_DAYS = 7;
+
 /**
  * Removal is by zone, not by absence. Every active entry is checked against
  * where its camera's sun is right now; a poll that simply did not return the
@@ -100,5 +104,6 @@ export async function maintainBins(opts: {
     totals.leftZone += removed.leftZone;
     totals.expired += removed.expired;
   }
+  await pruneDraws(DRAW_LOG_DAYS);
   return totals;
 }

--- a/app/api/kiosk/solo/state/route.test.ts
+++ b/app/api/kiosk/solo/state/route.test.ts
@@ -9,6 +9,7 @@ const countAdmittedSince = vi.fn();
 const getLiveSettingsCached = vi.fn();
 const getProfileSettings = vi.fn();
 const getSweptZone = vi.fn();
+const listRecentDraws = vi.fn();
 vi.mock('server-only', () => ({}));
 // sweepGeometry's module pulls in the Neon client; the route only uses its pure half.
 vi.mock('@/app/lib/db', () => ({ sql: vi.fn() }));
@@ -19,6 +20,7 @@ vi.mock('@/app/lib/solo/store', () => ({
   getScreenState: (...a: unknown[]) => getScreenState(...a),
   countAdmittedSince: (...a: unknown[]) => countAdmittedSince(...a),
   getSweptZone: (...a: unknown[]) => getSweptZone(...a),
+  listRecentDraws: (...a: unknown[]) => listRecentDraws(...a),
 }));
 vi.mock('@/app/lib/settings/liveSettings', () => ({ getLiveSettingsCached: () => getLiveSettingsCached() }));
 vi.mock('@/app/lib/settings/store', () => ({ getProfileSettings: (p: string) => getProfileSettings(p) }));
@@ -34,6 +36,7 @@ beforeEach(() => {
   getScreenState.mockResolvedValue(null);
   countAdmittedSince.mockResolvedValue({ sunset: 0, nonSunset: 0 });
   getSweptZone.mockResolvedValue(null);
+  listRecentDraws.mockResolvedValue([]);
   getLiveSettingsCached.mockResolvedValue({
     namespaces: { shared: { activeVersion: 'solo', pictureHeight: 70 }, solo: { dwellS: 30, pictureHeight: 92 }, solo2: { dwellS: 9, valleys: 1 } }, revision: 1,
   });
@@ -45,6 +48,13 @@ describe('GET /api/kiosk/solo/state', () => {
     getSweptZone.mockResolvedValue({ minDeg: -39.75, maxDeg: 13.75 });
     const body = await (await get('?feed=sunrise')).json();
     expect(body.zone).toEqual({ minDeg: -39.75, maxDeg: 13.75 });
+  });
+  it('carries the last 24 draws as the tape', async () => {
+    const frame = { slot: 9, snapshotId: 4, shownAt: 1_000, imageUrl: 'u4', title: 't', city: '', country: '', bin: 'sunset' };
+    listRecentDraws.mockResolvedValue([frame]);
+    const body = await (await get('?feed=sunrise')).json();
+    expect(listRecentDraws).toHaveBeenCalledWith('sunrise', 24);
+    expect(body.tape).toEqual([frame]);
   });
   it('rejects a missing or unknown feed', async () => {
     expect((await get('')).status).toBe(400);

--- a/app/api/kiosk/solo/state/route.test.ts
+++ b/app/api/kiosk/solo/state/route.test.ts
@@ -50,11 +50,17 @@ describe('GET /api/kiosk/solo/state', () => {
     expect(body.zone).toEqual({ minDeg: -39.75, maxDeg: 13.75 });
   });
   it('carries the last 24 draws as the tape', async () => {
-    const frame = { slot: 9, snapshotId: 4, shownAt: 1_000, imageUrl: 'u4', title: 't', city: '', country: '', bin: 'sunset' };
+    const frame = {
+      feed: 'sunrise', slot: 9, shownAt: 1_000, snapshotId: 4, webcamId: 2, bin: 'sunset', quality: 0.8, detection: 0.9, isNew: false,
+      tally: 1, enteredAt: 0, firstShownAt: null, lastShownAt: 1_000, imageUrl: 'u4', title: 't', city: '', region: '', country: '',
+      lat: 1, lng: 2, capturedAt: 0, timezone: null, sunAltitudeDeg: null,
+    };
     listRecentDraws.mockResolvedValue([frame]);
     const body = await (await get('?feed=sunrise')).json();
     expect(listRecentDraws).toHaveBeenCalledWith('sunrise', 24);
-    expect(body.tape).toEqual([frame]);
+    expect(body.tape).toHaveLength(1);
+    expect(body.tape[0]).toMatchObject({ slot: 9, shownAt: 1_000, snapshotId: 4, title: 't', stage: { kind: 'inLine', position: null } });
+    expect(body.tape[0]).not.toHaveProperty('lat');
   });
   it('rejects a missing or unknown feed', async () => {
     expect((await get('')).status).toBe(400);

--- a/app/api/kiosk/solo/state/route.ts
+++ b/app/api/kiosk/solo/state/route.ts
@@ -6,11 +6,11 @@ import { mergeSettings } from '@/app/lib/settings/schema';
 import { SHARED_NAMESPACE } from '@/app/lib/settings/sharedSchema';
 import { withCaption } from '@/app/lib/solo/captionSchema';
 import { resolveSoloVersion } from '@/app/lib/solo/versions';
-import { countAdmittedSince, getScreenState, getSweptZone, listActiveEntries } from '@/app/lib/solo/store';
+import { countAdmittedSince, getScreenState, getSweptZone, listActiveEntries, listRecentDraws } from '@/app/lib/solo/store';
 import { isFlagEnabled, SWEEP_FORCE_DAY_RING } from '@/app/lib/runtimeFlags';
 import { sweepGeometry } from '@/app/api/cron/update-cameras/lib/sweepGeometry';
 import { TERMINATOR_DAY_SIDE_OFFSETS_DEG } from '@/app/lib/masterConfig';
-import { buildStateView, parseFeed, toViewEntry } from '../view';
+import { buildStateView, parseFeed, TAPE_PAST, toViewEntry } from '../view';
 
 export const dynamic = 'force-dynamic';
 export const runtime = 'nodejs';
@@ -42,12 +42,13 @@ export async function GET(request: NextRequest) {
   ));
 
   const nowMs = Date.now();
-  const [entries, screen, admitted, sweptZone, forcedDayRing] = await Promise.all([
+  const [entries, screen, admitted, sweptZone, forcedDayRing, tape] = await Promise.all([
     listActiveEntries(feed),
     getScreenState(feed),
     countAdmittedSince(feed, nowMs - LAST_PULL_WINDOW_MS),
     getSweptZone(),
     isFlagEnabled(SWEEP_FORCE_DAY_RING),
+    listRecentDraws(feed, TAPE_PAST),
   ]);
   // The zone the cron last aged entries against (binAdmission.maintainBins),
   // escalation rings included. Until the cron has recorded one, the
@@ -55,6 +56,6 @@ export async function GET(request: NextRequest) {
   const geometry = sweepGeometry(forcedDayRing ? TERMINATOR_DAY_SIDE_OFFSETS_DEG : []);
   const zone = sweptZone ?? { minDeg: geometry.coverageMinDeg, maxDeg: geometry.coverageMaxDeg };
   return NextResponse.json(buildStateView({
-    feed, dials, entries: entries.map(toViewEntry), screen, nowMs, admitted, zone, version,
+    feed, dials, entries: entries.map(toViewEntry), screen, nowMs, admitted, zone, version, tape,
   }));
 }

--- a/app/api/kiosk/solo/state/route.ts
+++ b/app/api/kiosk/solo/state/route.ts
@@ -10,7 +10,7 @@ import { countAdmittedSince, getScreenState, getSweptZone, listActiveEntries, li
 import { isFlagEnabled, SWEEP_FORCE_DAY_RING } from '@/app/lib/runtimeFlags';
 import { sweepGeometry } from '@/app/api/cron/update-cameras/lib/sweepGeometry';
 import { TERMINATOR_DAY_SIDE_OFFSETS_DEG } from '@/app/lib/masterConfig';
-import { buildStateView, parseFeed, TAPE_PAST, toViewEntry } from '../view';
+import { buildStateView, parseFeed, TAPE_PAST, toTapeInput, toViewEntry } from '../view';
 
 export const dynamic = 'force-dynamic';
 export const runtime = 'nodejs';
@@ -56,6 +56,6 @@ export async function GET(request: NextRequest) {
   const geometry = sweepGeometry(forcedDayRing ? TERMINATOR_DAY_SIDE_OFFSETS_DEG : []);
   const zone = sweptZone ?? { minDeg: geometry.coverageMinDeg, maxDeg: geometry.coverageMaxDeg };
   return NextResponse.json(buildStateView({
-    feed, dials, entries: entries.map(toViewEntry), screen, nowMs, admitted, zone, version, tape,
+    feed, dials, entries: entries.map(toViewEntry), screen, nowMs, admitted, zone, version, tape: tape.map(toTapeInput),
   }));
 }

--- a/app/api/kiosk/solo/view.test.ts
+++ b/app/api/kiosk/solo/view.test.ts
@@ -64,11 +64,14 @@ describe('buildStateView', () => {
   it('passes the draw log through as tape, oldest first, and defaults to empty', () => {
     const entries = [stored(1, 'sunset', 0.9)];
     const tape = [
-      { slot: 1, snapshotId: 5, shownAt: 20_000, imageUrl: 'u5', title: 'a', city: '', country: '', bin: 'sunset' as const },
-      { slot: 2, snapshotId: 6, shownAt: 40_000, imageUrl: 'u6', title: 'b', city: '', country: '', bin: null },
+      { ...stored(5, 'sunset', 0.7), slot: 1, shownAt: 20_000 },
+      { ...stored(6, 'sunset', 0.1), slot: 2, shownAt: 40_000 },
     ];
     const v = buildStateView({ feed: 'sunset', dials: D, entries, screen: null, nowMs: 0, admitted: { sunset: 0, nonSunset: 0 }, zone: ZONE, tape });
     expect(v.tape.map((f) => f.snapshotId)).toEqual([5, 6]);
+    // A tape frame is a full EntryView, so a click opens the detail card; one that left the bins has no live stage.
+    expect(v.tape[0]).toMatchObject({ slot: 1, shownAt: 20_000, eligible: true, stage: { kind: 'inLine', position: null } });
+    expect(v.tape[1].eligible).toBe(false);
     const bare = buildStateView({ feed: 'sunset', dials: D, entries, screen: null, nowMs: 0, admitted: { sunset: 0, nonSunset: 0 }, zone: ZONE });
     expect(bare.tape).toEqual([]);
   });

--- a/app/api/kiosk/solo/view.test.ts
+++ b/app/api/kiosk/solo/view.test.ts
@@ -61,6 +61,17 @@ describe('buildStateView', () => {
     expect(kinds[kinds.length - 1]).toBe('underFloor');
     expect(v.current?.entry.stage).toEqual({ kind: 'onGlass' });
   });
+  it('passes the draw log through as tape, oldest first, and defaults to empty', () => {
+    const entries = [stored(1, 'sunset', 0.9)];
+    const tape = [
+      { slot: 1, snapshotId: 5, shownAt: 20_000, imageUrl: 'u5', title: 'a', city: '', country: '', bin: 'sunset' as const },
+      { slot: 2, snapshotId: 6, shownAt: 40_000, imageUrl: 'u6', title: 'b', city: '', country: '', bin: null },
+    ];
+    const v = buildStateView({ feed: 'sunset', dials: D, entries, screen: null, nowMs: 0, admitted: { sunset: 0, nonSunset: 0 }, zone: ZONE, tape });
+    expect(v.tape.map((f) => f.snapshotId)).toEqual([5, 6]);
+    const bare = buildStateView({ feed: 'sunset', dials: D, entries, screen: null, nowMs: 0, admitted: { sunset: 0, nonSunset: 0 }, zone: ZONE });
+    expect(bare.tape).toEqual([]);
+  });
   it('current comes from the screen row and is excluded from next', () => {
     const entries = [stored(1, 'sunset', 0.9, 1), stored(2, 'sunset', 0.8)];
     const v = buildStateView({ feed: 'sunset', dials: D, entries,

--- a/app/api/kiosk/solo/view.ts
+++ b/app/api/kiosk/solo/view.ts
@@ -48,12 +48,22 @@ export function toViewEntry(e: StoredEntry): ViewEntry {
   };
 }
 
+export function toTapeInput(f: TapeFrame): ViewEntry & { slot: number; shownAt: number } {
+  return { ...toViewEntry(f), slot: f.slot, shownAt: f.shownAt };
+}
+
 export interface EntryView extends ViewEntry {
   eligible: boolean;
   /** 1-based position within its bin by score, queue membership ignored. The glass overlay prints it. */
   rank: number;
   /** Where the frame stands for this screen's next draw; the studio sections the bins by it. */
   stage: Stage;
+}
+
+/** A past draw on the tape: a full entry (so it opens the detail card) plus when it was drawn. */
+export interface TapeEntry extends EntryView {
+  slot: number;
+  shownAt: number;
 }
 
 export interface StateView {
@@ -70,7 +80,7 @@ export interface StateView {
   entries: ViewEntry[];
   zone: Zone;
   /** The last draws on this screen, oldest first (stages-and-tape spec §4). Empty until the log is migrated. */
-  tape: TapeFrame[];
+  tape: TapeEntry[];
 }
 
 const scoreOf = (e: ViewEntry) => (e.bin === 'sunset' ? e.quality ?? -1 : e.detection);
@@ -98,7 +108,7 @@ export function buildStateView(input: {
   /** Which engine projects the queue. Defaults to solo, so older callers are unchanged. */
   version?: SoloVersionSpec;
   /** Past draws for the tape; the state route supplies them, other callers may omit. */
-  tape?: TapeFrame[];
+  tape?: (ViewEntry & { slot: number; shownAt: number })[];
 }): StateView {
   const { feed, dials, entries, screen, nowMs } = input;
   const version = input.version ?? (SOLO_VERSIONS.solo as SoloVersionSpec);
@@ -145,6 +155,6 @@ export function buildStateView(input: {
     lastPull: { admitted: input.admitted },
     entries,
     zone: input.zone,
-    tape: input.tape ?? [],
+    tape: (input.tape ?? []).map((f) => ({ ...view(f), slot: f.slot, shownAt: f.shownAt })),
   };
 }

--- a/app/api/kiosk/solo/view.ts
+++ b/app/api/kiosk/solo/view.ts
@@ -2,7 +2,7 @@ import { isEligible } from '@/app/lib/solo/engine';
 import { SOLO_VERSIONS, type SoloVersionSpec } from '@/app/lib/solo/versions';
 import type { Role } from '@/app/lib/solo2/types';
 import { nextBoundaryMs, slotFor } from '@/app/lib/solo/schedule';
-import type { ScreenRow, StoredEntry } from '@/app/lib/solo/store';
+import type { ScreenRow, StoredEntry, TapeFrame } from '@/app/lib/solo/store';
 import type { BinEntry, Feed, SoloDials } from '@/app/lib/solo/types';
 import type { Zone } from '@/app/lib/solo/zone';
 import { assignStages, compareStaged, type Stage } from '@/app/lib/solo/stages';
@@ -14,6 +14,8 @@ import { assignStages, compareStaged, type Stage } from '@/app/lib/solo/stages';
  */
 
 export const NEXT_COUNT = 8;
+/** Past draws on the studio's tape. */
+export const TAPE_PAST = 24;
 
 const FEEDS: Feed[] = ['sunrise', 'sunset'];
 
@@ -67,6 +69,8 @@ export interface StateView {
   /** Every active entry, raw, so a client can re-project with other dials. */
   entries: ViewEntry[];
   zone: Zone;
+  /** The last draws on this screen, oldest first (stages-and-tape spec §4). Empty until the log is migrated. */
+  tape: TapeFrame[];
 }
 
 const scoreOf = (e: ViewEntry) => (e.bin === 'sunset' ? e.quality ?? -1 : e.detection);
@@ -93,6 +97,8 @@ export function buildStateView(input: {
   zone: Zone;
   /** Which engine projects the queue. Defaults to solo, so older callers are unchanged. */
   version?: SoloVersionSpec;
+  /** Past draws for the tape; the state route supplies them, other callers may omit. */
+  tape?: TapeFrame[];
 }): StateView {
   const { feed, dials, entries, screen, nowMs } = input;
   const version = input.version ?? (SOLO_VERSIONS.solo as SoloVersionSpec);
@@ -139,5 +145,6 @@ export function buildStateView(input: {
     lastPull: { admitted: input.admitted },
     entries,
     zone: input.zone,
+    tape: input.tape ?? [],
   };
 }

--- a/app/lib/solo/store.test.ts
+++ b/app/lib/solo/store.test.ts
@@ -132,20 +132,23 @@ describe('counts', () => {
 });
 
 describe('draw log (the tape)', () => {
-  it('listRecentDraws returns the last n draws oldest first, with numbers not strings', async () => {
+  it('listRecentDraws returns the last n draws oldest first as whole entries, with numbers not strings', async () => {
     // The query fetches newest first and the function reverses it.
-    sqlMock.mockResolvedValueOnce([
-      { slot: '101', snapshot_id: '8', shown_at: '2026-09-06T01:00:20Z', firebase_url: 'u8', title: 'B', city: 'Nuuk', country: 'Greenland', bin: 'sunset' },
-      { slot: '100', snapshot_id: '7', shown_at: '2026-09-06T01:00:00Z', firebase_url: 'u7', title: 'A', city: '', country: '', bin: null },
-    ]);
+    const row = (slot: string, id: string, shown: string) => ({
+      slot, shown_at: shown, snapshot_id: id, webcam_id: '3', bin: 'sunset', quality: '0.8', detection: '0.9', is_new: false,
+      tally: '2', entered_at: '2026-09-06T00:00:00Z', captured_at: '2026-09-06 00:30:00', first_shown_at: null, last_shown_at: shown,
+      firebase_url: `u${id}`, title: 'B', city: 'Nuuk', region: '', country: 'Greenland', lat: '64.17', lng: '-51.73',
+    });
+    sqlMock.mockResolvedValueOnce([row('101', '8', '2026-09-06T01:00:20Z'), row('100', '7', '2026-09-06T01:00:00Z')]);
     const out = await listRecentDraws('sunset', 24);
     expect(lastQuery()).toMatch(/from kiosk_draws d/);
+    expect(lastQuery()).toMatch(/join kiosk_bin_entries e/);
     expect(lastQuery()).toMatch(/order by d.slot desc/);
     expect(sqlMock.mock.calls.at(-1)!.slice(1)).toEqual(['sunset', 24]);
     expect(out.map((f) => f.snapshotId)).toEqual([7, 8]);
-    expect(out[1]).toEqual({ slot: 101, snapshotId: 8, shownAt: Date.parse('2026-09-06T01:00:20Z'),
-      imageUrl: 'u8', title: 'B', city: 'Nuuk', country: 'Greenland', bin: 'sunset' });
-    expect(out[0].bin).toBeNull();
+    expect(out[1]).toMatchObject({ slot: 101, snapshotId: 8, shownAt: Date.parse('2026-09-06T01:00:20Z'), feed: 'sunset',
+      imageUrl: 'u8', title: 'B', city: 'Nuuk', country: 'Greenland', bin: 'sunset', quality: 0.8, detection: 0.9, tally: 2, webcamId: 3 });
+    expect(out[0].capturedAt).toBe(Date.parse('2026-09-06T00:30:00Z'));
   });
   it('listRecentDraws is empty when the table is missing', async () => {
     sqlMock.mockRejectedValueOnce(new Error('relation "kiosk_draws" does not exist'));

--- a/app/lib/solo/store.test.ts
+++ b/app/lib/solo/store.test.ts
@@ -16,7 +16,7 @@ vi.mock('@/app/lib/db', async () => {
 import { sql } from '@/app/lib/db';
 import {
   listActiveEntries, insertEntry, removeStale, getScreenState, commitAdvance,
-  countAdmittedSince, getBinDigestSummary, saveSweptZone, getSweptZone,
+  countAdmittedSince, getBinDigestSummary, saveSweptZone, getSweptZone, logDraw, listRecentDraws, pruneDraws,
 } from './store';
 
 const sqlMock = (sql as unknown as SqlTag).__sqlMock;
@@ -100,13 +100,23 @@ describe('screen state', () => {
     expect(ok).toBe(false);
     expect(sqlMock).toHaveBeenCalledTimes(1);
   });
-  it('commitAdvance bumps the tally after a successful state write', async () => {
-    sqlMock.mockResolvedValueOnce([{ feed: 'sunset' }]).mockResolvedValueOnce([]);
+  it('commitAdvance bumps the tally after a successful state write, then logs the draw', async () => {
+    sqlMock.mockResolvedValueOnce([{ feed: 'sunset' }]).mockResolvedValueOnce([]).mockResolvedValueOnce([]);
     const ok = await commitAdvance('sunset', 42, { snapshotId: 7, webcamId: 3, bin: 'sunset', quality: 0.9, detection: 0.8, isNew: true, tally: 0, enteredAt: 0 }, 1);
     expect(ok).toBe(true);
-    expect(sqlMock).toHaveBeenCalledTimes(2);
-    expect(lastQuery()).toMatch(/tally = tally \+ 1/);
-    expect(lastQuery()).toMatch(/is_new = false/);
+    expect(sqlMock).toHaveBeenCalledTimes(3);
+    const tally = (sqlMock.mock.calls[1][0] as TemplateStringsArray).join('?');
+    expect(tally).toMatch(/tally = tally \+ 1/);
+    expect(tally).toMatch(/is_new = false/);
+    expect(lastQuery()).toMatch(/insert into kiosk_draws/);
+    expect(lastQuery()).toMatch(/on conflict \(feed, slot\) do nothing/);
+    expect(sqlMock.mock.calls.at(-1)!.slice(1)).toEqual(['sunset', 42, 7]);
+  });
+  it('a failed draw log does not fail the advance', async () => {
+    sqlMock.mockResolvedValueOnce([{ feed: 'sunset' }]).mockResolvedValueOnce([])
+      .mockRejectedValueOnce(new Error('relation "kiosk_draws" does not exist'));
+    const ok = await commitAdvance('sunset', 42, { snapshotId: 7, webcamId: 3, bin: 'sunset', quality: 0.9, detection: 0.8, isNew: true, tally: 0, enteredAt: 0 }, 1);
+    expect(ok).toBe(true);
   });
 });
 
@@ -118,5 +128,39 @@ describe('counts', () => {
   it('getBinDigestSummary swallows its own failure', async () => {
     sqlMock.mockRejectedValueOnce(new Error('relation does not exist'));
     expect(await getBinDigestSummary()).toBeNull();
+  });
+});
+
+describe('draw log (the tape)', () => {
+  it('listRecentDraws returns the last n draws oldest first, with numbers not strings', async () => {
+    // The query fetches newest first and the function reverses it.
+    sqlMock.mockResolvedValueOnce([
+      { slot: '101', snapshot_id: '8', shown_at: '2026-09-06T01:00:20Z', firebase_url: 'u8', title: 'B', city: 'Nuuk', country: 'Greenland', bin: 'sunset' },
+      { slot: '100', snapshot_id: '7', shown_at: '2026-09-06T01:00:00Z', firebase_url: 'u7', title: 'A', city: '', country: '', bin: null },
+    ]);
+    const out = await listRecentDraws('sunset', 24);
+    expect(lastQuery()).toMatch(/from kiosk_draws d/);
+    expect(lastQuery()).toMatch(/order by d.slot desc/);
+    expect(sqlMock.mock.calls.at(-1)!.slice(1)).toEqual(['sunset', 24]);
+    expect(out.map((f) => f.snapshotId)).toEqual([7, 8]);
+    expect(out[1]).toEqual({ slot: 101, snapshotId: 8, shownAt: Date.parse('2026-09-06T01:00:20Z'),
+      imageUrl: 'u8', title: 'B', city: 'Nuuk', country: 'Greenland', bin: 'sunset' });
+    expect(out[0].bin).toBeNull();
+  });
+  it('listRecentDraws is empty when the table is missing', async () => {
+    sqlMock.mockRejectedValueOnce(new Error('relation "kiosk_draws" does not exist'));
+    expect(await listRecentDraws('sunrise', 24)).toEqual([]);
+  });
+  it('pruneDraws deletes by age and swallows its own failure', async () => {
+    sqlMock.mockResolvedValueOnce([]);
+    await pruneDraws(7);
+    expect(lastQuery()).toMatch(/delete from kiosk_draws/);
+    expect(sqlMock.mock.calls.at(-1)!.slice(1)).toEqual([7]);
+    sqlMock.mockRejectedValueOnce(new Error('nope'));
+    await expect(pruneDraws(7)).resolves.toBeUndefined();
+  });
+  it('logDraw swallows its own failure', async () => {
+    sqlMock.mockRejectedValueOnce(new Error('nope'));
+    await expect(logDraw('sunset', 1, 2)).resolves.toBeUndefined();
   });
 });

--- a/app/lib/solo/store.ts
+++ b/app/lib/solo/store.ts
@@ -297,18 +297,16 @@ export async function commitAdvance(
   return true;
 }
 
-/** One past draw on the studio's tape (stages-and-tape spec §4). */
-export interface TapeFrame {
+/**
+ * One past draw on the studio's tape (stages-and-tape spec §4): the whole
+ * entry, so a click opens the same detail and rating card as a queue row,
+ * plus when it was drawn. Bin rows are only ever marked removed, never
+ * deleted, so the join holds after a camera leaves the zone.
+ */
+export interface TapeFrame extends StoredEntry {
   slot: number;
-  snapshotId: number;
   /** ms since epoch. */
   shownAt: number;
-  imageUrl: string;
-  title: string;
-  city: string;
-  country: string;
-  /** Null once the bin row is gone; the tape then draws a neutral outline. */
-  bin: BinKind | null;
 }
 
 /**
@@ -331,22 +329,19 @@ export async function logDraw(feed: Feed, slot: number, snapshotId: number): Pro
 export async function listRecentDraws(feed: Feed, n: number): Promise<TapeFrame[]> {
   try {
     const rows = (await sql`
-      select d.slot, d.snapshot_id, d.shown_at, s.firebase_url, w.title, w.city, w.country, e.bin
+      select d.slot, d.shown_at,
+             e.snapshot_id, e.webcam_id, e.bin, e.quality, e.detection, e.is_new, e.tally,
+             e.entered_at, e.first_shown_at, e.last_shown_at,
+             s.firebase_url, s.captured_at::text as captured_at, w.title, w.city, w.region, w.country, w.lat, w.lng
       from kiosk_draws d
+      join kiosk_bin_entries e on e.feed = d.feed and e.snapshot_id = d.snapshot_id
       join webcam_snapshots s on s.id = d.snapshot_id
-      join webcams w on w.id = s.webcam_id
-      left join kiosk_bin_entries e on e.feed = d.feed and e.snapshot_id = d.snapshot_id
+      join webcams w on w.id = e.webcam_id
       where d.feed = ${feed}
       order by d.slot desc
       limit ${n}
-    `) as unknown as {
-      slot: string | number; snapshot_id: string | number; shown_at: string; firebase_url: string;
-      title: string | null; city: string | null; country: string | null; bin: BinKind | null;
-    }[];
-    return rows.reverse().map((r) => ({
-      slot: num(r.slot), snapshotId: num(r.snapshot_id), shownAt: Date.parse(r.shown_at),
-      imageUrl: r.firebase_url, title: r.title ?? '', city: r.city ?? '', country: r.country ?? '', bin: r.bin ?? null,
-    }));
+    `) as unknown as (EntryRow & { slot: string | number; shown_at: string })[];
+    return rows.reverse().map((r) => ({ ...toEntry(feed, r), slot: num(r.slot), shownAt: Date.parse(r.shown_at) }));
   } catch (error) {
     console.warn('[solo/store] draw log read failed:', error);
     return [];

--- a/app/lib/solo/store.ts
+++ b/app/lib/solo/store.ts
@@ -293,7 +293,75 @@ export async function commitAdvance(
         last_shown_at = now()
     where feed = ${feed} and snapshot_id = ${entry.snapshotId}
   `;
+  await logDraw(feed, slot, entry.snapshotId);
   return true;
+}
+
+/** One past draw on the studio's tape (stages-and-tape spec §4). */
+export interface TapeFrame {
+  slot: number;
+  snapshotId: number;
+  /** ms since epoch. */
+  shownAt: number;
+  imageUrl: string;
+  title: string;
+  city: string;
+  country: string;
+  /** Null once the bin row is gone; the tape then draws a neutral outline. */
+  bin: BinKind | null;
+}
+
+/**
+ * Record a draw for the tape. Best-effort: an unmigrated table must not stop
+ * the glass advancing. Idempotent on (feed, slot), like the state write.
+ */
+export async function logDraw(feed: Feed, slot: number, snapshotId: number): Promise<void> {
+  try {
+    await sql`
+      insert into kiosk_draws (feed, slot, snapshot_id, shown_at)
+      values (${feed}, ${slot}, ${snapshotId}, now())
+      on conflict (feed, slot) do nothing
+    `;
+  } catch (error) {
+    console.warn('[solo/store] draw log failed:', error);
+  }
+}
+
+/** The last `n` draws for a screen, oldest first. Empty when the table is missing. */
+export async function listRecentDraws(feed: Feed, n: number): Promise<TapeFrame[]> {
+  try {
+    const rows = (await sql`
+      select d.slot, d.snapshot_id, d.shown_at, s.firebase_url, w.title, w.city, w.country, e.bin
+      from kiosk_draws d
+      join webcam_snapshots s on s.id = d.snapshot_id
+      join webcams w on w.id = s.webcam_id
+      left join kiosk_bin_entries e on e.feed = d.feed and e.snapshot_id = d.snapshot_id
+      where d.feed = ${feed}
+      order by d.slot desc
+      limit ${n}
+    `) as unknown as {
+      slot: string | number; snapshot_id: string | number; shown_at: string; firebase_url: string;
+      title: string | null; city: string | null; country: string | null; bin: BinKind | null;
+    }[];
+    return rows.reverse().map((r) => ({
+      slot: num(r.slot), snapshotId: num(r.snapshot_id), shownAt: Date.parse(r.shown_at),
+      imageUrl: r.firebase_url, title: r.title ?? '', city: r.city ?? '', country: r.country ?? '', bin: r.bin ?? null,
+    }));
+  } catch (error) {
+    console.warn('[solo/store] draw log read failed:', error);
+    return [];
+  }
+}
+
+/** Drop draws older than `olderThanDays`. Best-effort; the cron calls it every tick. */
+export async function pruneDraws(olderThanDays: number): Promise<void> {
+  try {
+    await sql`
+      delete from kiosk_draws where shown_at < now() - make_interval(days => ${olderThanDays})
+    `;
+  } catch (error) {
+    console.warn('[solo/store] draw log prune failed:', error);
+  }
 }
 
 export async function countAdmittedSince(

--- a/app/studio/solo/FeedColumn.test.tsx
+++ b/app/studio/solo/FeedColumn.test.tsx
@@ -1,5 +1,5 @@
 import { it, expect, vi } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import { FeedColumn } from './FeedColumn';
 import { dialsFrom, SOLO_SETTINGS_SCHEMA } from '@/app/lib/solo/settingsSchema';
 import { schemaDefaults } from '@/app/lib/settings/schema';
@@ -38,6 +38,23 @@ it('each bin is three labelled stages with counts, even when a stage is empty', 
   expect(screen.getByText('UNDER FLOOR · 0')).toBeInTheDocument();
   expect(screen.getByText('rating 1.4 < 3.2')).toBeInTheDocument();
   expect(screen.getByText(/^on glass · shown ×/)).toBeInTheDocument();
+});
+
+it('the tape sits under the heading and above the bins with the server past and the projected next, and the button folds it away', () => {
+  const v = view();
+  const past = { ...v.bins.sunset[0], snapshotId: 2, imageUrl: 'u2', title: 'cam2', slot: 1, shownAt: 0 };
+  render(<FeedColumn feed="sunset" server={{ ...v, tape: [past] }} projected={v} liveDials={D} studioDials={D} nowMs={5_000} onSelect={vi.fn()} />);
+  const tape = screen.getByTestId('tape');
+  expect(screen.getByTestId('tape-past-2-1')).toBeInTheDocument();
+  expect(screen.getByTestId('tape-current')).toBeInTheDocument();
+  expect(screen.getByTestId('tape-next-0')).toBeInTheDocument();
+  // The tape precedes the bins in document order.
+  const binHeading = screen.getByText(/Sunset bin ·/);
+  expect(tape.compareDocumentPosition(binHeading) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+  fireEvent.click(screen.getByRole('button', { name: /tape/ }));
+  expect(screen.queryByTestId('tape')).toBeNull();
+  fireEvent.click(screen.getByRole('button', { name: /tape/ }));
+  expect(screen.getByTestId('tape')).toBeInTheDocument();
 });
 
 it('says so when the studio dials would draw a different next frame than the glass', () => {

--- a/app/studio/solo/FeedColumn.tsx
+++ b/app/studio/solo/FeedColumn.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import type { ReactNode } from 'react';
+import { useEffect, useState, type ReactNode } from 'react';
 import type { EntryView, StateView } from '@/app/api/kiosk/solo/view';
 import { nextBoundaryMs } from '@/app/lib/solo/schedule';
 import type { Feed, SoloDials } from '@/app/lib/solo/types';
@@ -10,6 +10,7 @@ import type { Solo2Dials } from '@/app/lib/solo2/types';
 import type { Stage } from '@/app/lib/solo/stages';
 import { EntryRow, type Sequence } from './EntryRow';
 import { reasonLine } from './reason';
+import { Tape } from './Tape';
 
 const mono = 'ui-monospace, SFMono-Regular, Menlo, monospace';
 const LABEL: Record<Feed, string> = { sunrise: 'Sunrise · left screen', sunset: 'Sunset · right screen' };
@@ -63,9 +64,26 @@ const byStage = (rows: EntryView[]) => ({
   underFloor: rows.filter((e) => e.stage.kind === 'underFloor'),
 });
 
+const TAPE_OPEN_KEY = 'studio.tape.open';
+
+/** The tape's open/closed state, remembered per browser so a closed tape stays closed across reloads. */
+function useTapeOpen(): [boolean, () => void] {
+  const [open, setOpen] = useState(true);
+  useEffect(() => {
+    try {
+      if (localStorage.getItem(TAPE_OPEN_KEY) === '0') setOpen(false);
+    } catch { /* storage unavailable: stay open */ }
+  }, []);
+  const toggle = () => setOpen((o) => {
+    try { localStorage.setItem(TAPE_OPEN_KEY, o ? '0' : '1'); } catch { /* ignore */ }
+    return !o;
+  });
+  return [open, toggle];
+}
+
 /**
- * One feed's two bins, each as three stages (in line, resting, under floor),
- * and its queue as the STUDIO dials would order them. Every frame appears in
+ * One feed's tape, its two bins, each as three stages (in line, resting,
+ * under floor), and its queue as the STUDIO dials would order them. Every frame appears in
  * exactly one of the three columns; the on-glass frame heads the queue. The
  * screen itself is drawn above, by GlassPreview, so nothing here repeats the
  * picture.
@@ -110,16 +128,30 @@ export function FeedColumn({ feed, server, projected, liveDials, nowMs, version,
     return { earlier: frames, stepS: plan.preludeStepS, holdS: plan.dwellS - frames.length * plan.preludeStepS };
   };
   const queueSeqs = queue.map((e, i) => seqFor(e, i > 0 ? queue[i - 1] : null));
+  const [tapeOpen, toggleTape] = useTapeOpen();
   const preludedInQueue = new Set(queueSeqs.flatMap((s) => s?.earlier.map((f) => f.snapshotId) ?? []));
 
   return (
     <div style={{ display: 'flex', flexDirection: 'column', gap: 8, minWidth: 0 }}>
       <h3 style={{ margin: 0, fontSize: 13, color: '#9aa3b2', display: 'flex', justifyContent: 'space-between' }}>
         <span>{LABEL[feed]}</span>
-        <span title="Time until this screen changes, on the live dials' clock">
-          next frame in <b style={{ color: '#f5a344', fontFamily: mono }}>{leftS} s</b>
+        <span style={{ display: 'flex', gap: 10, alignItems: 'baseline' }}>
+          <button type="button" onClick={toggleTape} aria-expanded={tapeOpen}
+            title={tapeOpen ? 'Hide the tape' : 'Show the tape: past draws, on glass, projected next, width is time'}
+            style={{ background: 'none', border: '1px solid #2a3242', borderRadius: 4, color: '#9aa3b2', fontFamily: mono, fontSize: 10, padding: '1px 6px', cursor: 'pointer' }}>
+            tape {tapeOpen ? '▾' : '▸'}
+          </button>
+          <span title="Time until this screen changes, on the live dials' clock">
+            next frame in <b style={{ color: '#f5a344', fontFamily: mono }}>{leftS} s</b>
+          </span>
         </span>
       </h3>
+      {tapeOpen && (
+        <Tape past={server.tape} current={current?.entry ?? null} currentSince={current?.shownSince ?? null} next={projected.next}
+          nextSequences={queueSeqs.slice(current ? 1 : 0)}
+          pastDials={{ dwellS: liveDials.dwellS, fadeS: liveDials.fadeS }} nextDials={{ dwellS: projected.dials.dwellS, fadeS: projected.dials.fadeS }}
+          onSelect={(e) => onSelect(e, feed)} />
+      )}
       <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr 1.15fr', gap: 6 }}>
         <Bin color="#7ee2ac" title={`Sunset bin · ${projected.bins.sunset.length} waiting · ${qSun} queued`}
           hint="Frames the detection head calls a sunset. Three stages: in line (draw order), resting, under the rating floor.">

--- a/app/studio/solo/SoloStudioClient.tsx
+++ b/app/studio/solo/SoloStudioClient.tsx
@@ -11,6 +11,7 @@ import { FeedColumn } from './FeedColumn';
 import { SoloStatusStrip } from './SoloStatusStrip';
 import { useSoloState } from './useSoloState';
 import { toWebcam } from './toWebcam';
+import { formatTime } from '@/app/lib/solo/caption';
 import { SOLO_VERSIONS, type SoloVersionSpec } from '@/app/lib/solo/versions';
 import { mergeSettings } from '@/app/lib/settings/schema';
 import { withCaption } from '@/app/lib/solo/captionSchema';
@@ -112,6 +113,12 @@ export function SoloStudioClient({ version = SOLO_VERSIONS.solo as SoloVersionSp
             }}>close</button>
             <div style={{ fontFamily: mono, fontSize: 12, color: '#9aa3b2', marginBottom: 8 }}>
               frame {selected.entry.snapshotId} · {selected.entry.bin === 'sunset' ? 'sunset' : 'non-sunset'} bin · shown ×{selected.entry.tally}
+              {formatTime('12h', selected.entry.capturedAt, selected.entry.timezone, null) && (
+                <> · captured {formatTime('12h', selected.entry.capturedAt, selected.entry.timezone, null)} there</>
+              )}
+              {'shownAt' in selected.entry && typeof selected.entry.shownAt === 'number' && (
+                <> · drawn at {new Date(selected.entry.shownAt).toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' })}</>
+              )}
             </div>
             <FrameLabelCard webcam={toWebcam(selected.entry, selected.feed)} allowCapture={false} />
           </div>

--- a/app/studio/solo/Tape.test.tsx
+++ b/app/studio/solo/Tape.test.tsx
@@ -1,21 +1,24 @@
 import { it, expect, vi } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
-import { Tape } from './Tape';
-import type { EntryView } from '@/app/api/kiosk/solo/view';
+import { Tape, TAPE_PX_PER_S } from './Tape';
+import type { EntryView, TapeEntry } from '@/app/api/kiosk/solo/view';
 
 const entry = (id: number, bin: 'sunset' | 'non_sunset' = 'sunset'): EntryView => ({
   snapshotId: id, webcamId: 100 + id, bin, quality: bin === 'sunset' ? 0.8 : null, detection: 0.9, isNew: false, tally: 1,
   enteredAt: 0, imageUrl: `u${id}`, title: `cam${id}`, city: 'Nuuk', region: '', country: 'Greenland', capturedAt: 0,
   timezone: null, sunAltitudeDeg: null, eligible: true, rank: 1, stage: { kind: 'queued', position: 1 },
 });
-const past = [
-  { slot: 10, snapshotId: 1, shownAt: 1_000, imageUrl: 'u1', title: 'cam1', city: 'Nuuk', country: 'Greenland', bin: 'sunset' as const },
-  { slot: 11, snapshotId: 2, shownAt: 2_000, imageUrl: 'u2', title: 'cam2', city: '', country: '', bin: 'non_sunset' as const },
-  { slot: 12, snapshotId: 1, shownAt: 3_000, imageUrl: 'u1', title: 'cam1', city: 'Nuuk', country: 'Greenland', bin: 'sunset' as const },
-];
+const drawn = (id: number, slot: number, shownAt: number, bin: 'sunset' | 'non_sunset' = 'sunset'): TapeEntry =>
+  ({ ...entry(id, bin), slot, shownAt, stage: { kind: 'inLine', position: null } });
+
+const D = { dwellS: 20, fadeS: 0 };
+// Three draws 20 s apart; the current frame took over 20 s after the last.
+const past = [drawn(1, 10, 0), drawn(2, 11, 20_000, 'non_sunset'), drawn(1, 12, 40_000)];
+const since = 60_000;
 
 it('lays out past, current, seam, and projected in order, outlined by bin', () => {
-  render(<Tape past={past} current={entry(3)} next={[entry(4, 'non_sunset'), entry(1)]} onSelect={vi.fn()} />);
+  render(<Tape past={past} current={entry(3)} currentSince={since} next={[entry(4, 'non_sunset'), entry(1)]}
+    pastDials={D} nextDials={D} onSelect={vi.fn()} />);
   const strip = screen.getByTestId('tape');
   const ids = [...strip.querySelectorAll('[data-testid^="tape-"]')].map((n) => n.getAttribute('data-testid'));
   expect(ids).toEqual(['tape-past-1-10', 'tape-past-2-11', 'tape-past-1-12', 'tape-current', 'tape-seam', 'tape-next-0', 'tape-next-1']);
@@ -25,28 +28,68 @@ it('lays out past, current, seam, and projected in order, outlined by bin', () =
   expect(screen.getByTestId('tape-next-0')).toHaveStyle({ borderLeftStyle: 'dashed' });
 });
 
+it('width is time: a dwell is dwellS × px/s; a frame held on glass is wider and says so; the projection is one dwell each', () => {
+  const held = [drawn(1, 10, 0), drawn(2, 11, 20_000), drawn(3, 12, 40_000)];
+  // Frame 3 stayed 60 s (three dwells) before the current frame took over.
+  render(<Tape past={held} current={entry(9)} currentSince={100_000} next={[entry(4)]} pastDials={D} nextDials={{ dwellS: 30, fadeS: 0 }} onSelect={vi.fn()} />);
+  expect(screen.getByTestId('tape-past-1-10')).toHaveStyle({ width: `${20 * TAPE_PX_PER_S}px` });
+  expect(screen.getByTestId('tape-past-3-12')).toHaveStyle({ width: `${60 * TAPE_PX_PER_S}px` });
+  expect(screen.getByTestId('tape-held')).toBeInTheDocument();
+  expect(screen.getByTestId('tape-past-3-12').getAttribute('title')).toMatch(/on glass 60 s · held/);
+  expect(screen.getByTestId('tape-past-1-10').getAttribute('title')).toMatch(/on glass 20 s$/);
+  expect(screen.getByTestId('tape-next-0')).toHaveStyle({ width: `${30 * TAPE_PX_PER_S}px` });
+});
+
+it('a crossfade is an X as wide as the fade dial, straddling every cut; fade 0 draws none', () => {
+  const { unmount } = render(<Tape past={past} current={entry(3)} currentSince={since} next={[entry(4), entry(5)]}
+    pastDials={{ dwellS: 20, fadeS: 2 }} nextDials={{ dwellS: 20, fadeS: 4 }} onSelect={vi.fn()} />);
+  // past→past ×2, past→current, current→next, next→next
+  expect(screen.getAllByTestId(/^tape-fade-/)).toHaveLength(5);
+  expect(screen.getByTestId('tape-fade-0')).toHaveStyle({ width: `${2 * TAPE_PX_PER_S}px` });
+  expect(screen.getByTestId('tape-fade-3')).toHaveStyle({ width: `${4 * TAPE_PX_PER_S}px` });
+  expect(screen.getByTestId('tape-fade-3').getAttribute('title')).toMatch(/crossfade 4 s/);
+  unmount();
+  render(<Tape past={past} current={entry(3)} currentSince={since} next={[entry(4)]} pastDials={D} nextDials={D} onSelect={vi.fn()} />);
+  expect(screen.queryAllByTestId(/^tape-fade-/)).toHaveLength(0);
+});
+
 it('a frame that already appears earlier on the strip gets the red top edge; the first appearance does not', () => {
-  render(<Tape past={past} current={entry(3)} next={[entry(1)]} onSelect={vi.fn()} />);
+  render(<Tape past={past} current={entry(3)} currentSince={since} next={[entry(1)]} pastDials={D} nextDials={D} onSelect={vi.fn()} />);
   expect(screen.getByTestId('tape-past-1-10')).not.toHaveStyle({ borderTopColor: '#8b2e2e' });
   expect(screen.getByTestId('tape-past-1-12')).toHaveStyle({ borderTopColor: '#8b2e2e' });
   expect(screen.getByTestId('tape-next-0')).toHaveStyle({ borderTopColor: '#8b2e2e' });
   expect(screen.getByTestId('tape-current')).not.toHaveStyle({ borderTopColor: '#8b2e2e' });
 });
 
-it('hover text names the frame; clicking a projected or current thumb reports the entry', () => {
+it('hover text names the frame and its time; clicking any thumb, past included, reports the entry', () => {
   const onSelect = vi.fn();
-  render(<Tape past={past} current={entry(3)} next={[entry(4)]} onSelect={onSelect} />);
+  render(<Tape past={past} current={entry(3)} currentSince={since} next={[entry(4)]} pastDials={D} nextDials={D} onSelect={onSelect} />);
   expect(screen.getByTestId('tape-past-1-10').getAttribute('title')).toMatch(/cam1 · Nuuk, Greenland · draw at/);
   expect(screen.getByTestId('tape-next-0').getAttribute('title')).toMatch(/^draw 1 · cam4/);
+  fireEvent.click(screen.getByTestId('tape-past-2-11'));
+  expect(onSelect).toHaveBeenCalledWith(expect.objectContaining({ snapshotId: 2, slot: 11 }));
   fireEvent.click(screen.getByTestId('tape-next-0'));
   expect(onSelect).toHaveBeenCalledWith(expect.objectContaining({ snapshotId: 4 }));
   fireEvent.click(screen.getByTestId('tape-current'));
   expect(onSelect).toHaveBeenCalledWith(expect.objectContaining({ snapshotId: 3 }));
 });
 
-it('with no past and nothing on glass it still renders the seam and the projection', () => {
-  render(<Tape past={[]} current={null} next={[entry(4)]} onSelect={vi.fn()} />);
+it('a projected dwell with a prelude shows the earlier frames as narrow sub-blocks before the chosen one, inside one dwell', () => {
+  const earlier = [entry(7), entry(8)];
+  render(<Tape past={[]} current={entry(3)} next={[entry(4)]} nextSequences={[{ earlier, stepS: 1.5, holdS: 17 }]}
+    pastDials={D} nextDials={D} onSelect={vi.fn()} />);
+  const group = screen.getByTestId('tape-next-0-group');
+  const ids = [...group.querySelectorAll('[data-testid^="tape-next-0"]')].map((n) => n.getAttribute('data-testid'));
+  expect(ids).toEqual(['tape-next-0-pre-7', 'tape-next-0-pre-8', 'tape-next-0']);
+  expect(screen.getByTestId('tape-next-0-pre-7')).toHaveStyle({ width: '6px' }); // 1.5 s × 3 px = 4.5, floored to the legible minimum
+  expect(screen.getByTestId('tape-next-0')).toHaveStyle({ width: `${20 * TAPE_PX_PER_S - 12}px` });
+  expect(screen.getByTestId('tape-next-0').getAttribute('title')).toMatch(/after 2 earlier frames of this camera, 1.5 s each/);
+});
+
+it('with no past and nothing on glass it renders a blank, the seam, and the projection', () => {
+  render(<Tape past={[]} current={null} next={[entry(4)]} pastDials={D} nextDials={D} onSelect={vi.fn()} />);
   expect(screen.queryByTestId('tape-current')).toBeNull();
+  expect(screen.getByTestId('tape-blank')).toBeInTheDocument();
   expect(screen.getByTestId('tape-seam')).toBeInTheDocument();
   expect(screen.getByTestId('tape-next-0')).toBeInTheDocument();
   expect(screen.getByText(/no draws logged yet/)).toBeInTheDocument();

--- a/app/studio/solo/Tape.test.tsx
+++ b/app/studio/solo/Tape.test.tsx
@@ -1,0 +1,53 @@
+import { it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { Tape } from './Tape';
+import type { EntryView } from '@/app/api/kiosk/solo/view';
+
+const entry = (id: number, bin: 'sunset' | 'non_sunset' = 'sunset'): EntryView => ({
+  snapshotId: id, webcamId: 100 + id, bin, quality: bin === 'sunset' ? 0.8 : null, detection: 0.9, isNew: false, tally: 1,
+  enteredAt: 0, imageUrl: `u${id}`, title: `cam${id}`, city: 'Nuuk', region: '', country: 'Greenland', capturedAt: 0,
+  timezone: null, sunAltitudeDeg: null, eligible: true, rank: 1, stage: { kind: 'queued', position: 1 },
+});
+const past = [
+  { slot: 10, snapshotId: 1, shownAt: 1_000, imageUrl: 'u1', title: 'cam1', city: 'Nuuk', country: 'Greenland', bin: 'sunset' as const },
+  { slot: 11, snapshotId: 2, shownAt: 2_000, imageUrl: 'u2', title: 'cam2', city: '', country: '', bin: 'non_sunset' as const },
+  { slot: 12, snapshotId: 1, shownAt: 3_000, imageUrl: 'u1', title: 'cam1', city: 'Nuuk', country: 'Greenland', bin: 'sunset' as const },
+];
+
+it('lays out past, current, seam, and projected in order, outlined by bin', () => {
+  render(<Tape past={past} current={entry(3)} next={[entry(4, 'non_sunset'), entry(1)]} onSelect={vi.fn()} />);
+  const strip = screen.getByTestId('tape');
+  const ids = [...strip.querySelectorAll('[data-testid^="tape-"]')].map((n) => n.getAttribute('data-testid'));
+  expect(ids).toEqual(['tape-past-1-10', 'tape-past-2-11', 'tape-past-1-12', 'tape-current', 'tape-seam', 'tape-next-0', 'tape-next-1']);
+  expect(screen.getByTestId('tape-past-1-10')).toHaveStyle({ borderLeftColor: '#7ee2ac' });
+  expect(screen.getByTestId('tape-past-2-11')).toHaveStyle({ borderLeftColor: '#c3cad6' });
+  expect(screen.getByTestId('tape-current')).toHaveStyle({ boxShadow: '0 0 0 2px #f5a344' });
+  expect(screen.getByTestId('tape-next-0')).toHaveStyle({ borderLeftStyle: 'dashed' });
+});
+
+it('a frame that already appears earlier on the strip gets the red top edge; the first appearance does not', () => {
+  render(<Tape past={past} current={entry(3)} next={[entry(1)]} onSelect={vi.fn()} />);
+  expect(screen.getByTestId('tape-past-1-10')).not.toHaveStyle({ borderTopColor: '#8b2e2e' });
+  expect(screen.getByTestId('tape-past-1-12')).toHaveStyle({ borderTopColor: '#8b2e2e' });
+  expect(screen.getByTestId('tape-next-0')).toHaveStyle({ borderTopColor: '#8b2e2e' });
+  expect(screen.getByTestId('tape-current')).not.toHaveStyle({ borderTopColor: '#8b2e2e' });
+});
+
+it('hover text names the frame; clicking a projected or current thumb reports the entry', () => {
+  const onSelect = vi.fn();
+  render(<Tape past={past} current={entry(3)} next={[entry(4)]} onSelect={onSelect} />);
+  expect(screen.getByTestId('tape-past-1-10').getAttribute('title')).toMatch(/cam1 · Nuuk, Greenland · draw at/);
+  expect(screen.getByTestId('tape-next-0').getAttribute('title')).toMatch(/^draw 1 · cam4/);
+  fireEvent.click(screen.getByTestId('tape-next-0'));
+  expect(onSelect).toHaveBeenCalledWith(expect.objectContaining({ snapshotId: 4 }));
+  fireEvent.click(screen.getByTestId('tape-current'));
+  expect(onSelect).toHaveBeenCalledWith(expect.objectContaining({ snapshotId: 3 }));
+});
+
+it('with no past and nothing on glass it still renders the seam and the projection', () => {
+  render(<Tape past={[]} current={null} next={[entry(4)]} onSelect={vi.fn()} />);
+  expect(screen.queryByTestId('tape-current')).toBeNull();
+  expect(screen.getByTestId('tape-seam')).toBeInTheDocument();
+  expect(screen.getByTestId('tape-next-0')).toBeInTheDocument();
+  expect(screen.getByText(/no draws logged yet/)).toBeInTheDocument();
+});

--- a/app/studio/solo/Tape.tsx
+++ b/app/studio/solo/Tape.tsx
@@ -1,49 +1,89 @@
 'use client';
 
-import { useEffect, useRef } from 'react';
-import type { EntryView } from '@/app/api/kiosk/solo/view';
-import type { TapeFrame } from '@/app/lib/solo/store';
+import { useEffect, useRef, type ReactNode } from 'react';
+import type { EntryView, TapeEntry } from '@/app/api/kiosk/solo/view';
 import type { BinKind } from '@/app/lib/solo/types';
+import type { Sequence } from './EntryRow';
 
 const COLOR: Record<BinKind, string> = { sunset: '#7ee2ac', non_sunset: '#c3cad6' };
-const NEUTRAL = '#2a3242';
 const REPEAT = '#8b2e2e';
 const RING = '0 0 0 2px #f5a344';
 const mono = 'ui-monospace, SFMono-Regular, Menlo, monospace';
-export const THUMB_W = 40;
 export const THUMB_H = 22;
+/** Width is time on the tape: this many pixels per second of glass. */
+export const TAPE_PX_PER_S = 3;
+/** A block never draws narrower than this, whatever its time says. */
+const MIN_BLOCK_PX = 14;
+/** A past frame that stayed on glass longer than this many dwells was held (nothing else eligible). */
+const HELD_AFTER = 1.5;
+/** …and its block is capped here so one long hold does not push everything off screen. */
+const MAX_DWELLS = 3;
+
+export interface TapeDials {
+  dwellS: number;
+  fadeS: number;
+}
 
 const clock = (ms: number) => new Date(ms).toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' });
 const place = (f: { city: string; country: string }) => [f.city, f.country].filter(Boolean).join(', ');
+const secs = (s: number) => `${Number.isInteger(s) ? s : s.toFixed(1)} s`;
 
-function Thumb({ testId, src, color, dashed = false, ring = false, repeat = false, title, onClick }: {
-  testId: string; src: string; color: string; dashed?: boolean; ring?: boolean; repeat?: boolean; title: string;
-  onClick?: () => void;
+function Thumb({ testId, src, color, width, dashed = false, ring = false, repeat = false, title, onClick, children }: {
+  testId: string; src: string; color: string; width: number; dashed?: boolean; ring?: boolean; repeat?: boolean;
+  title: string; onClick?: () => void; children?: ReactNode;
 }) {
   return (
     <button type="button" data-testid={testId} title={title} onClick={onClick} disabled={!onClick} style={{
-      flex: 'none', width: THUMB_W, height: THUMB_H, padding: 0, background: '#000', cursor: onClick ? 'pointer' : 'default',
+      flex: 'none', width, height: THUMB_H, padding: 0, background: '#000', cursor: onClick ? 'pointer' : 'default',
       borderWidth: 1.5, borderStyle: dashed ? 'dashed' : 'solid', borderColor: color, borderTopColor: repeat ? REPEAT : color,
       borderTopWidth: repeat ? 3 : 1.5, borderRadius: 3, boxShadow: ring ? RING : undefined, boxSizing: 'border-box',
+      position: 'relative', overflow: 'hidden',
     }}>
       {/* eslint-disable-next-line @next/next/no-img-element */}
       <img src={src} alt="" style={{ width: '100%', height: '100%', objectFit: 'cover', display: 'block' }} />
+      {children}
     </button>
+  );
+}
+
+/** The Final Cut "X": the seconds during which both pictures are on glass. */
+function Fade({ testId, seconds }: { testId: string; seconds: number }) {
+  const width = Math.max(4, seconds * TAPE_PX_PER_S);
+  return (
+    <div data-testid={testId} title={`crossfade ${secs(seconds)}: both pictures on glass`} style={{
+      flex: 'none', width, height: THUMB_H, marginLeft: -width / 2, marginRight: -width / 2, position: 'relative', zIndex: 1,
+      background: 'linear-gradient(135deg, rgba(245,163,68,0) 0%, rgba(245,163,68,0.55) 50%, rgba(245,163,68,0) 100%)',
+      borderLeft: '1px solid rgba(245,163,68,0.8)', borderRight: '1px solid rgba(245,163,68,0.8)', boxSizing: 'border-box',
+    }} />
   );
 }
 
 /**
  * The tape (stages-and-tape spec §4): what this screen drew, is drawing, and
- * will draw, in one strip. Past thumbs are fact from the draw log; the frame
- * on glass wears the orange ring; a seam separates fact from the projection,
- * whose thumbs are dashed. A frame already seen earlier on the strip carries
- * a red top edge, the REPEAT tag's colour. Scrolls sideways; on mount and
- * whenever the past grows, the seam is brought to about two thirds across.
+ * will draw, in one strip where width is time. Past blocks are fact from the
+ * draw log, each as wide as the frame stayed on glass (a hold, when nothing
+ * else was eligible, reads as a wide block); the frame on glass wears the
+ * orange ring; a seam separates fact from the projection, whose blocks are
+ * dashed and one dwell wide. A crossfade is an orange X straddling the cut,
+ * as wide as the fade dial. A solo2 dwell with a prelude shows its earlier
+ * frames as narrow sub-blocks before the chosen one. A frame already seen
+ * earlier on the strip carries a red top edge, the REPEAT tag's colour. When
+ * nothing is on glass the seam is preceded by a black blank. Scrolls
+ * sideways; on mount and whenever the past grows, the seam is brought to
+ * about two thirds across.
  */
-export function Tape({ past, current, next, onSelect }: {
-  past: TapeFrame[];
+export function Tape({ past, current, currentSince, next, nextSequences, pastDials, nextDials, onSelect }: {
+  past: TapeEntry[];
   current: EntryView | null;
+  /** When the current frame went on glass, ms; sizes the last past block. */
+  currentSince?: number | null;
   next: EntryView[];
+  /** solo2: parallel to `next`, the prelude each dwell plays first. */
+  nextSequences?: (Sequence | undefined)[];
+  /** The live dials: what the past and the on-glass frame were drawn with. */
+  pastDials: TapeDials;
+  /** The studio dials: what the projection is drawn with. */
+  nextDials: TapeDials;
   onSelect: (entry: EntryView) => void;
 }) {
   const strip = useRef<HTMLDivElement>(null);
@@ -61,29 +101,85 @@ export function Tape({ past, current, next, onSelect }: {
     seen.add(id);
     return r;
   };
+  const dwellPx = (d: TapeDials) => Math.max(MIN_BLOCK_PX, d.dwellS * TAPE_PX_PER_S);
+
+  const blocks: ReactNode[] = [];
+  let fades = 0;
+  const fade = (seconds: number) => {
+    if (seconds > 0) blocks.push(<Fade key={`fade-${fades}`} testId={`tape-fade-${fades}`} seconds={seconds} />);
+    fades += 1;
+  };
+
+  past.forEach((f, i) => {
+    const endMs = i + 1 < past.length ? past[i + 1].shownAt : currentSince ?? f.shownAt + pastDials.dwellS * 1000;
+    const onGlassS = Math.max(0, (endMs - f.shownAt) / 1000);
+    const dwells = pastDials.dwellS > 0 ? onGlassS / pastDials.dwellS : 1;
+    const held = dwells > HELD_AFTER;
+    const width = Math.max(MIN_BLOCK_PX, Math.min(dwells, MAX_DWELLS) * pastDials.dwellS * TAPE_PX_PER_S);
+    blocks.push(
+      <Thumb key={`${f.snapshotId}-${f.slot}`} testId={`tape-past-${f.snapshotId}-${f.slot}`} src={f.imageUrl} width={width}
+        color={COLOR[f.bin]} repeat={repeatOf(f.snapshotId)} onClick={() => onSelect(f)}
+        title={`${f.title}${place(f) ? ` · ${place(f)}` : ''} · draw at ${clock(f.shownAt)} · on glass ${secs(Math.round(onGlassS))}`
+          + (held ? ' · held: nothing else was eligible' : '')}>
+        {held && <span data-testid="tape-held" style={{ position: 'absolute', right: 2, bottom: 0, fontFamily: mono, fontSize: 8, color: '#f5a344' }}>held</span>}
+      </Thumb>,
+    );
+    fade(pastDials.fadeS);
+  });
+
+  if (current) {
+    blocks.push(
+      <Thumb key="current" testId="tape-current" src={current.imageUrl} width={dwellPx(pastDials)} color={COLOR[current.bin]} ring
+        repeat={repeatOf(current.snapshotId)} onClick={() => onSelect(current)}
+        title={`on glass${currentSince ? ` since ${clock(currentSince)}` : ''} · ${current.title}${place(current) ? ` · ${place(current)}` : ''}`} />,
+    );
+  } else {
+    blocks.push(
+      <div key="blank" data-testid="tape-blank" title="Nothing on glass: the screen is black until a frame is eligible" style={{
+        flex: 'none', width: dwellPx(pastDials), height: THUMB_H, background: '#000', border: '1.5px solid #2a3242', borderRadius: 3,
+        boxSizing: 'border-box', fontFamily: mono, fontSize: 8, color: '#4b5568', display: 'grid', placeItems: 'center',
+      }}>blank</div>,
+    );
+  }
+  blocks.push(
+    <div key="seam" ref={seam} data-testid="tape-seam" title="Left: what happened. Right: what the studio dials project."
+      style={{ flex: 'none', width: 2, height: THUMB_H + 6, background: '#f5a344', opacity: 0.6, margin: '0 2px' }} />,
+  );
+
+  next.forEach((e, i) => {
+    fade(nextDials.fadeS);
+    const seq = nextSequences?.[i];
+    const stepPx = seq ? Math.max(6, seq.stepS * TAPE_PX_PER_S) : 0;
+    const total = dwellPx(nextDials);
+    const mainWidth = Math.max(MIN_BLOCK_PX, total - (seq?.earlier.length ?? 0) * stepPx);
+    const title = `draw ${i + 1} · ${e.title}${place(e) ? ` · ${place(e)}` : ''}`
+      + (seq && seq.earlier.length > 0 ? ` · after ${seq.earlier.length} earlier frame${seq.earlier.length === 1 ? '' : 's'} of this camera, ${secs(seq.stepS)} each` : '');
+    if (seq && seq.earlier.length > 0) {
+      blocks.push(
+        <div key={`next-${i}`} data-testid={`tape-next-${i}-group`} style={{ flex: 'none', display: 'flex', gap: 1 }}>
+          {seq.earlier.map((f) => (
+            <Thumb key={f.snapshotId} testId={`tape-next-${i}-pre-${f.snapshotId}`} src={f.imageUrl} width={stepPx} color="#2a3242" dashed
+              title={`prelude · ${f.title} · ${secs(seq.stepS)}`} />
+          ))}
+          <Thumb testId={`tape-next-${i}`} src={e.imageUrl} width={mainWidth} color={COLOR[e.bin]} dashed
+            repeat={repeatOf(e.snapshotId)} title={title} onClick={() => onSelect(e)} />
+        </div>,
+      );
+    } else {
+      blocks.push(
+        <Thumb key={`next-${i}`} testId={`tape-next-${i}`} src={e.imageUrl} width={total} color={COLOR[e.bin]} dashed
+          repeat={repeatOf(e.snapshotId)} title={title} onClick={() => onSelect(e)} />,
+      );
+    }
+  });
 
   return (
-    <div ref={strip} data-testid="tape" title="The tape: past draws, the frame on glass, then the projected next draws"
-      style={{ display: 'flex', gap: 3, alignItems: 'center', overflowX: 'auto', padding: '4px 2px', minHeight: THUMB_H + 12 }}>
+    <div ref={strip} data-testid="tape" title="The tape: width is time. Past draws, the frame on glass, then the projected next draws."
+      style={{ display: 'flex', alignItems: 'center', overflowX: 'auto', padding: '4px 2px', minHeight: THUMB_H + 12 }}>
       {past.length === 0 && (
         <span style={{ fontFamily: mono, fontSize: 9.5, color: '#4b5568', whiteSpace: 'nowrap', paddingRight: 6 }}>no draws logged yet</span>
       )}
-      {past.map((f) => (
-        <Thumb key={`${f.snapshotId}-${f.slot}`} testId={`tape-past-${f.snapshotId}-${f.slot}`} src={f.imageUrl}
-          color={f.bin ? COLOR[f.bin] : NEUTRAL} repeat={repeatOf(f.snapshotId)}
-          title={`${f.title}${place(f) ? ` · ${place(f)}` : ''} · draw at ${clock(f.shownAt)}`} />
-      ))}
-      {current && (
-        <Thumb testId="tape-current" src={current.imageUrl} color={COLOR[current.bin]} ring repeat={repeatOf(current.snapshotId)}
-          title={`on glass · ${current.title}${place(current) ? ` · ${place(current)}` : ''}`} onClick={() => onSelect(current)} />
-      )}
-      <div ref={seam} data-testid="tape-seam" title="Left: what happened. Right: what the studio dials project."
-        style={{ flex: 'none', width: 2, height: THUMB_H + 6, background: '#f5a344', opacity: 0.6, margin: '0 2px' }} />
-      {next.map((e, i) => (
-        <Thumb key={`${e.snapshotId}-${i}`} testId={`tape-next-${i}`} src={e.imageUrl} color={COLOR[e.bin]} dashed
-          repeat={repeatOf(e.snapshotId)} title={`draw ${i + 1} · ${e.title}${place(e) ? ` · ${place(e)}` : ''}`}
-          onClick={() => onSelect(e)} />
-      ))}
+      {blocks}
     </div>
   );
 }

--- a/app/studio/solo/Tape.tsx
+++ b/app/studio/solo/Tape.tsx
@@ -1,0 +1,89 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+import type { EntryView } from '@/app/api/kiosk/solo/view';
+import type { TapeFrame } from '@/app/lib/solo/store';
+import type { BinKind } from '@/app/lib/solo/types';
+
+const COLOR: Record<BinKind, string> = { sunset: '#7ee2ac', non_sunset: '#c3cad6' };
+const NEUTRAL = '#2a3242';
+const REPEAT = '#8b2e2e';
+const RING = '0 0 0 2px #f5a344';
+const mono = 'ui-monospace, SFMono-Regular, Menlo, monospace';
+export const THUMB_W = 40;
+export const THUMB_H = 22;
+
+const clock = (ms: number) => new Date(ms).toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' });
+const place = (f: { city: string; country: string }) => [f.city, f.country].filter(Boolean).join(', ');
+
+function Thumb({ testId, src, color, dashed = false, ring = false, repeat = false, title, onClick }: {
+  testId: string; src: string; color: string; dashed?: boolean; ring?: boolean; repeat?: boolean; title: string;
+  onClick?: () => void;
+}) {
+  return (
+    <button type="button" data-testid={testId} title={title} onClick={onClick} disabled={!onClick} style={{
+      flex: 'none', width: THUMB_W, height: THUMB_H, padding: 0, background: '#000', cursor: onClick ? 'pointer' : 'default',
+      borderWidth: 1.5, borderStyle: dashed ? 'dashed' : 'solid', borderColor: color, borderTopColor: repeat ? REPEAT : color,
+      borderTopWidth: repeat ? 3 : 1.5, borderRadius: 3, boxShadow: ring ? RING : undefined, boxSizing: 'border-box',
+    }}>
+      {/* eslint-disable-next-line @next/next/no-img-element */}
+      <img src={src} alt="" style={{ width: '100%', height: '100%', objectFit: 'cover', display: 'block' }} />
+    </button>
+  );
+}
+
+/**
+ * The tape (stages-and-tape spec §4): what this screen drew, is drawing, and
+ * will draw, in one strip. Past thumbs are fact from the draw log; the frame
+ * on glass wears the orange ring; a seam separates fact from the projection,
+ * whose thumbs are dashed. A frame already seen earlier on the strip carries
+ * a red top edge, the REPEAT tag's colour. Scrolls sideways; on mount and
+ * whenever the past grows, the seam is brought to about two thirds across.
+ */
+export function Tape({ past, current, next, onSelect }: {
+  past: TapeFrame[];
+  current: EntryView | null;
+  next: EntryView[];
+  onSelect: (entry: EntryView) => void;
+}) {
+  const strip = useRef<HTMLDivElement>(null);
+  const seam = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    const s = strip.current;
+    const m = seam.current;
+    if (!s || !m) return;
+    s.scrollLeft = Math.max(0, m.offsetLeft - s.clientWidth * (2 / 3));
+  }, [past.length, current?.snapshotId]);
+
+  const seen = new Set<number>();
+  const repeatOf = (id: number) => {
+    const r = seen.has(id);
+    seen.add(id);
+    return r;
+  };
+
+  return (
+    <div ref={strip} data-testid="tape" title="The tape: past draws, the frame on glass, then the projected next draws"
+      style={{ display: 'flex', gap: 3, alignItems: 'center', overflowX: 'auto', padding: '4px 2px', minHeight: THUMB_H + 12 }}>
+      {past.length === 0 && (
+        <span style={{ fontFamily: mono, fontSize: 9.5, color: '#4b5568', whiteSpace: 'nowrap', paddingRight: 6 }}>no draws logged yet</span>
+      )}
+      {past.map((f) => (
+        <Thumb key={`${f.snapshotId}-${f.slot}`} testId={`tape-past-${f.snapshotId}-${f.slot}`} src={f.imageUrl}
+          color={f.bin ? COLOR[f.bin] : NEUTRAL} repeat={repeatOf(f.snapshotId)}
+          title={`${f.title}${place(f) ? ` · ${place(f)}` : ''} · draw at ${clock(f.shownAt)}`} />
+      ))}
+      {current && (
+        <Thumb testId="tape-current" src={current.imageUrl} color={COLOR[current.bin]} ring repeat={repeatOf(current.snapshotId)}
+          title={`on glass · ${current.title}${place(current) ? ` · ${place(current)}` : ''}`} onClick={() => onSelect(current)} />
+      )}
+      <div ref={seam} data-testid="tape-seam" title="Left: what happened. Right: what the studio dials project."
+        style={{ flex: 'none', width: 2, height: THUMB_H + 6, background: '#f5a344', opacity: 0.6, margin: '0 2px' }} />
+      {next.map((e, i) => (
+        <Thumb key={`${e.snapshotId}-${i}`} testId={`tape-next-${i}`} src={e.imageUrl} color={COLOR[e.bin]} dashed
+          repeat={repeatOf(e.snapshotId)} title={`draw ${i + 1} · ${e.title}${place(e) ? ` · ${place(e)}` : ''}`}
+          onClick={() => onSelect(e)} />
+      ))}
+    </div>
+  );
+}

--- a/app/studio/solo/useSoloState.ts
+++ b/app/studio/solo/useSoloState.ts
@@ -31,7 +31,7 @@ export function useSoloState(feed: Feed, studioDials: SoloDials, version: SoloVe
       : null;
     return buildStateView({
       feed, dials: studioDials, entries: data.entries, screen, nowMs: Date.now(),
-      admitted: data.lastPull.admitted, zone: data.zone, version,
+      admitted: data.lastPull.admitted, zone: data.zone, version, tape: data.tape,
     });
   }, [data, feed, studioDials, version]);
   return { server: data, projected, error: error ? String(error) : undefined };

--- a/database/migrations/20260906_kiosk_draws.sql
+++ b/database/migrations/20260906_kiosk_draws.sql
@@ -1,0 +1,22 @@
+-- Solo kiosk: one row per draw per screen, the record behind the studio's
+-- tape (stages-and-tape spec §4). Written by store.commitAdvance right after
+-- the screen-state upsert succeeds, best-effort; read by GET
+-- /api/kiosk/solo/state for the last 24 draws; pruned by
+-- binAdmission.maintainBins after 7 days. About 8.6k rows a day per screen
+-- at a 20 s dwell.
+--
+-- Forward-only, idempotent. The writer and the reader both degrade to
+-- nothing when the table is missing, so the glass never depends on it, but
+-- APPLY BEFORE MERGING the code: a swallowed insert loses the tape silently.
+--   node scripts/apply-migration.mjs database/migrations/20260906_kiosk_draws.sql
+--   node scripts/apply-migration.mjs database/migrations/20260906_kiosk_draws.sql --apply
+
+CREATE TABLE IF NOT EXISTS kiosk_draws (
+  feed         TEXT        NOT NULL CHECK (feed IN ('sunrise', 'sunset')),
+  slot         BIGINT      NOT NULL,
+  snapshot_id  BIGINT      NOT NULL,
+  shown_at     TIMESTAMPTZ NOT NULL DEFAULT now(),
+  PRIMARY KEY (feed, slot)
+);
+
+CREATE INDEX IF NOT EXISTS kiosk_draws_shown_idx ON kiosk_draws (shown_at);

--- a/docs/superpowers/plans/2026-09-06-solo-tape-pr-b.md
+++ b/docs/superpowers/plans/2026-09-06-solo-tape-pr-b.md
@@ -1,0 +1,711 @@
+# Solo tape, PR B: the draw log and the filmstrip — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Each studio screen gets a horizontal filmstrip of the last 24 draws, the frame on glass, and the projected next 8, fed by a new per-draw log table.
+
+**Architecture:** `commitAdvance` logs one row per draw into `kiosk_draws` (best-effort, so a missing table never stops the glass). The state route reads the last 24 rows joined to snapshots and webcams, and `buildStateView` passes them through as `tape`. A `Tape` component renders past thumbs, an orange-ringed current thumb, a seam, and dashed projected thumbs, at the top of `FeedColumn`. The cron's `maintainBins` prunes rows older than 7 days.
+
+**Tech Stack:** Next.js app router, Neon HTTP driver via `app/lib/db`, Vitest + Testing Library. The store's SQL is mocked in tests through the `__sqlMock` tag already used in `store.test.ts`.
+
+**Spec:** `docs/superpowers/specs/2026-09-05-solo-stages-and-tape-design.md` §4.
+
+## Global Constraints
+
+- Worktree `~/GitHub/the-sunset-webcam-map.worktrees/feat-solo-tape`, branch `feat/solo-tape`. Verify the branch in the same command as every commit; stage explicit paths.
+- **The migration must be applied to production before this code merges** (CLAUDE.md). The log insert is best-effort, so nothing breaks before then, but the tape stays empty.
+- Every store call added here swallows its own failure with `console.warn('[solo/store] …')`, like `saveSweptZone`, and the readers return `[]`.
+- Colours in use: sunset `#7ee2ac`, non-sunset `#c3cad6`, orange ring `#f5a344`, red repeat `#8b2e2e`, panel `#0b0e14`, line `#2a3242`, text `#9aa3b2`. No new ones.
+- Tape thumbnails are 40×22 px. Past count is 24 (`TAPE_PAST`); projected count is `NEXT_COUNT` (8).
+- Commit trailer on every commit:
+  ```
+  Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>
+  Claude-Session: https://claude.ai/code/session_01Tsi2mkYSmb48KkQc97w39U
+  ```
+
+---
+
+## File map
+
+| File | Change |
+|---|---|
+| `database/migrations/20260906_kiosk_draws.sql` (new) | the log table |
+| `app/lib/solo/store.ts` + test | `TapeFrame`, `logDraw` (called by `commitAdvance`), `listRecentDraws`, `pruneDraws` |
+| `app/api/cron/update-cameras/lib/binAdmission.ts` + test | `maintainBins` calls `pruneDraws` |
+| `app/api/kiosk/solo/view.ts` + test | `StateView.tape`, optional `tape` input, `TAPE_PAST` |
+| `app/api/kiosk/solo/state/route.ts` | fetches `listRecentDraws(feed, TAPE_PAST)` |
+| `app/studio/solo/useSoloState.ts` | passes `data.tape` into the re-projection |
+| `app/studio/solo/Tape.tsx` (new) + test | the filmstrip |
+| `app/studio/solo/FeedColumn.tsx` + test | mounts `Tape` above the bins |
+
+---
+
+### Task 1: Migration and the store's three draw functions
+
+**Files:**
+- Create: `database/migrations/20260906_kiosk_draws.sql`
+- Modify: `app/lib/solo/store.ts` (after `commitAdvance`)
+- Test: `app/lib/solo/store.test.ts`
+
+**Interfaces:**
+- Produces:
+  ```ts
+  export interface TapeFrame {
+    slot: number; snapshotId: number; shownAt: number; // ms
+    imageUrl: string; title: string; city: string; country: string;
+    bin: BinKind | null; // null when the bin row is gone
+  }
+  export async function logDraw(feed: Feed, slot: number, snapshotId: number): Promise<void>;
+  export async function listRecentDraws(feed: Feed, n: number): Promise<TapeFrame[]>; // oldest first
+  export async function pruneDraws(olderThanDays: number): Promise<void>;
+  ```
+  `commitAdvance` calls `logDraw` after the tally update; its signature and return are unchanged.
+
+- [ ] **Step 1: Write the migration**
+
+```sql
+-- Solo kiosk: one row per draw per screen, the record behind the studio's
+-- tape (stages-and-tape spec §4). Written by store.commitAdvance right after
+-- the screen-state upsert succeeds, best-effort; read by GET
+-- /api/kiosk/solo/state for the last 24 draws; pruned by
+-- binAdmission.maintainBins after 7 days. About 8.6k rows a day per screen
+-- at a 20 s dwell.
+--
+-- Forward-only, idempotent. The writer and the reader both degrade to
+-- nothing when the table is missing, so the glass never depends on it, but
+-- APPLY BEFORE MERGING the code: a swallowed insert loses the tape silently.
+--   node scripts/apply-migration.mjs database/migrations/20260906_kiosk_draws.sql
+--   node scripts/apply-migration.mjs database/migrations/20260906_kiosk_draws.sql --apply
+
+CREATE TABLE IF NOT EXISTS kiosk_draws (
+  feed         TEXT        NOT NULL CHECK (feed IN ('sunrise', 'sunset')),
+  slot         BIGINT      NOT NULL,
+  snapshot_id  BIGINT      NOT NULL,
+  shown_at     TIMESTAMPTZ NOT NULL DEFAULT now(),
+  PRIMARY KEY (feed, slot)
+);
+
+CREATE INDEX IF NOT EXISTS kiosk_draws_shown_idx ON kiosk_draws (shown_at);
+```
+
+- [ ] **Step 2: Write the store tests**
+
+Add to the import list in `app/lib/solo/store.test.ts`: `logDraw, listRecentDraws, pruneDraws`. Then, in the `describe('screen state', …)` block (the one holding the `commitAdvance` tests), change the second `commitAdvance` test and add a third:
+
+```ts
+  it('commitAdvance bumps the tally after a successful state write, then logs the draw', async () => {
+    sqlMock.mockResolvedValueOnce([{ feed: 'sunset' }]).mockResolvedValueOnce([]).mockResolvedValueOnce([]);
+    const ok = await commitAdvance('sunset', 42, { snapshotId: 7, webcamId: 3, bin: 'sunset', quality: 0.9, detection: 0.8, isNew: true, tally: 0, enteredAt: 0 }, 1);
+    expect(ok).toBe(true);
+    expect(sqlMock).toHaveBeenCalledTimes(3);
+    const tally = (sqlMock.mock.calls[1][0] as TemplateStringsArray).join('?');
+    expect(tally).toMatch(/tally = tally \+ 1/);
+    expect(lastQuery()).toMatch(/insert into kiosk_draws/);
+    expect(lastQuery()).toMatch(/on conflict \(feed, slot\) do nothing/);
+    expect(sqlMock.mock.calls.at(-1)!.slice(1)).toEqual(['sunset', 42, 7]);
+  });
+  it('a failed draw log does not fail the advance', async () => {
+    sqlMock.mockResolvedValueOnce([{ feed: 'sunset' }]).mockResolvedValueOnce([])
+      .mockRejectedValueOnce(new Error('relation "kiosk_draws" does not exist'));
+    const ok = await commitAdvance('sunset', 42, { snapshotId: 7, webcamId: 3, bin: 'sunset', quality: 0.9, detection: 0.8, isNew: true, tally: 0, enteredAt: 0 }, 1);
+    expect(ok).toBe(true);
+  });
+```
+
+Add a new describe block at the end of the file:
+
+```ts
+describe('draw log (the tape)', () => {
+  it('listRecentDraws returns the last n draws oldest first, with numbers not strings', async () => {
+    // The query fetches newest first and the function reverses it.
+    sqlMock.mockResolvedValueOnce([
+      { slot: '101', snapshot_id: '8', shown_at: '2026-09-06T01:00:20Z', firebase_url: 'u8', title: 'B', city: 'Nuuk', country: 'Greenland', bin: 'sunset' },
+      { slot: '100', snapshot_id: '7', shown_at: '2026-09-06T01:00:00Z', firebase_url: 'u7', title: 'A', city: '', country: '', bin: null },
+    ]);
+    const out = await listRecentDraws('sunset', 24);
+    expect(lastQuery()).toMatch(/from kiosk_draws d/);
+    expect(lastQuery()).toMatch(/order by d.slot desc/);
+    expect(sqlMock.mock.calls.at(-1)!.slice(1)).toEqual(['sunset', 24]);
+    expect(out.map((f) => f.snapshotId)).toEqual([7, 8]);
+    expect(out[1]).toEqual({ slot: 101, snapshotId: 8, shownAt: Date.parse('2026-09-06T01:00:20Z'),
+      imageUrl: 'u8', title: 'B', city: 'Nuuk', country: 'Greenland', bin: 'sunset' });
+    expect(out[0].bin).toBeNull();
+  });
+  it('listRecentDraws is empty when the table is missing', async () => {
+    sqlMock.mockRejectedValueOnce(new Error('relation "kiosk_draws" does not exist'));
+    expect(await listRecentDraws('sunrise', 24)).toEqual([]);
+  });
+  it('pruneDraws deletes by age and swallows its own failure', async () => {
+    sqlMock.mockResolvedValueOnce([]);
+    await pruneDraws(7);
+    expect(lastQuery()).toMatch(/delete from kiosk_draws/);
+    expect(sqlMock.mock.calls.at(-1)!.slice(1)).toEqual([7]);
+    sqlMock.mockRejectedValueOnce(new Error('nope'));
+    await expect(pruneDraws(7)).resolves.toBeUndefined();
+  });
+  it('logDraw swallows its own failure', async () => {
+    sqlMock.mockRejectedValueOnce(new Error('nope'));
+    await expect(logDraw('sunset', 1, 2)).resolves.toBeUndefined();
+  });
+});
+```
+
+- [ ] **Step 3: Run to see them fail**
+
+Run: `npx vitest run app/lib/solo/store.test.ts`
+Expected: FAIL: `logDraw` etc. not exported; the commitAdvance call count is 2.
+
+- [ ] **Step 4: Implement in `store.ts`**
+
+In `commitAdvance`, after the tally `update` statement and before `return true;`, add:
+
+```ts
+  await logDraw(feed, slot, entry.snapshotId);
+```
+
+After `commitAdvance`, add:
+
+```ts
+/** One past draw on the studio's tape (stages-and-tape spec §4). */
+export interface TapeFrame {
+  slot: number;
+  snapshotId: number;
+  /** ms since epoch. */
+  shownAt: number;
+  imageUrl: string;
+  title: string;
+  city: string;
+  country: string;
+  /** Null once the bin row is gone; the tape then draws a neutral outline. */
+  bin: BinKind | null;
+}
+
+/**
+ * Record a draw for the tape. Best-effort: an unmigrated table must not stop
+ * the glass advancing. Idempotent on (feed, slot), like the state write.
+ */
+export async function logDraw(feed: Feed, slot: number, snapshotId: number): Promise<void> {
+  try {
+    await sql`
+      insert into kiosk_draws (feed, slot, snapshot_id, shown_at)
+      values (${feed}, ${slot}, ${snapshotId}, now())
+      on conflict (feed, slot) do nothing
+    `;
+  } catch (error) {
+    console.warn('[solo/store] draw log failed:', error);
+  }
+}
+
+/** The last `n` draws for a screen, oldest first. Empty when the table is missing. */
+export async function listRecentDraws(feed: Feed, n: number): Promise<TapeFrame[]> {
+  try {
+    const rows = (await sql`
+      select d.slot, d.snapshot_id, d.shown_at, s.firebase_url, w.title, w.city, w.country, e.bin
+      from kiosk_draws d
+      join webcam_snapshots s on s.id = d.snapshot_id
+      join webcams w on w.id = s.webcam_id
+      left join kiosk_bin_entries e on e.feed = d.feed and e.snapshot_id = d.snapshot_id
+      where d.feed = ${feed}
+      order by d.slot desc
+      limit ${n}
+    `) as unknown as {
+      slot: string | number; snapshot_id: string | number; shown_at: string; firebase_url: string;
+      title: string | null; city: string | null; country: string | null; bin: BinKind | null;
+    }[];
+    return rows.reverse().map((r) => ({
+      slot: num(r.slot), snapshotId: num(r.snapshot_id), shownAt: Date.parse(r.shown_at),
+      imageUrl: r.firebase_url, title: r.title ?? '', city: r.city ?? '', country: r.country ?? '', bin: r.bin ?? null,
+    }));
+  } catch (error) {
+    console.warn('[solo/store] draw log read failed:', error);
+    return [];
+  }
+}
+
+/** Drop draws older than `olderThanDays`. Best-effort; the cron calls it every tick. */
+export async function pruneDraws(olderThanDays: number): Promise<void> {
+  try {
+    await sql`
+      delete from kiosk_draws where shown_at < now() - make_interval(days => ${olderThanDays})
+    `;
+  } catch (error) {
+    console.warn('[solo/store] draw log prune failed:', error);
+  }
+}
+```
+
+- [ ] **Step 5: Run the store tests**
+
+Run: `npx vitest run app/lib/solo/store.test.ts`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd ~/GitHub/the-sunset-webcam-map.worktrees/feat-solo-tape && \
+  [ "$(git rev-parse --abbrev-ref HEAD)" = "feat/solo-tape" ] && \
+  git add database/migrations/20260906_kiosk_draws.sql app/lib/solo/store.ts app/lib/solo/store.test.ts && \
+  git commit -m "feat(solo): kiosk_draws log — one row per draw, read back for the tape, pruned at 7 days
+
+Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01Tsi2mkYSmb48KkQc97w39U"
+```
+
+---
+
+### Task 2: The cron prunes the log
+
+**Files:**
+- Modify: `app/api/cron/update-cameras/lib/binAdmission.ts` (`maintainBins`, imports)
+- Test: `app/api/cron/update-cameras/lib/binAdmission.test.ts`
+
+- [ ] **Step 1: Find how the test mocks the store**
+
+Run: `grep -n "vi.mock('@/app/lib/solo/store'\|removeStale\|saveSweptZone" app/api/cron/update-cameras/lib/binAdmission.test.ts | head`
+The store is mocked with `vi.mock('@/app/lib/solo/store', …)` returning `vi.fn()`s. Add `pruneDraws: vi.fn().mockResolvedValue(undefined)` to that factory the same way `saveSweptZone` is provided, and add one test inside the `maintainBins` describe:
+
+```ts
+  it('prunes the draw log after ageing the bins', async () => {
+    await maintainBins({ now: new Date(), zone: { minDeg: -24, maxDeg: -2 }, grace: 2 });
+    expect(pruneDraws).toHaveBeenCalledWith(7);
+  });
+```
+
+(import `pruneDraws` from `@/app/lib/solo/store` next to the other mocked names the file already imports; if the file builds its fixtures differently, match the existing `maintainBins` test's arguments verbatim.)
+
+- [ ] **Step 2: Run to see it fail**
+
+Run: `npx vitest run app/api/cron/update-cameras/lib/binAdmission.test.ts`
+Expected: FAIL: `pruneDraws` not called.
+
+- [ ] **Step 3: Implement**
+
+In `binAdmission.ts`, add `pruneDraws` to the import from `@/app/lib/solo/store`, add near the top:
+
+```ts
+/** The tape keeps a week; the studio reads the last 24 draws. */
+const DRAW_LOG_DAYS = 7;
+```
+
+and in `maintainBins`, after the `for (const feed of FEEDS)` loop and before `return totals;`:
+
+```ts
+  await pruneDraws(DRAW_LOG_DAYS);
+```
+
+- [ ] **Step 4: Run**
+
+Run: `npx vitest run app/api/cron/update-cameras/lib/binAdmission.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd ~/GitHub/the-sunset-webcam-map.worktrees/feat-solo-tape && \
+  [ "$(git rev-parse --abbrev-ref HEAD)" = "feat/solo-tape" ] && \
+  git add app/api/cron/update-cameras/lib/binAdmission.ts app/api/cron/update-cameras/lib/binAdmission.test.ts && \
+  git commit -m "feat(cron): maintainBins prunes the draw log after a week
+
+Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01Tsi2mkYSmb48KkQc97w39U"
+```
+
+---
+
+### Task 3: The view and the state route carry the tape
+
+**Files:**
+- Modify: `app/api/kiosk/solo/view.ts` (`StateView`, `buildStateView` input and return; export `TAPE_PAST`)
+- Modify: `app/api/kiosk/solo/state/route.ts` (fetch and pass)
+- Modify: `app/studio/solo/useSoloState.ts` (pass `data.tape`)
+- Test: `app/api/kiosk/solo/view.test.ts`
+
+**Interfaces:**
+- Consumes: `TapeFrame`, `listRecentDraws` from Task 1.
+- Produces: `StateView.tape: TapeFrame[]` (oldest first, at most `TAPE_PAST`), `export const TAPE_PAST = 24`, `buildStateView` input field `tape?: TapeFrame[]` (default `[]`).
+
+- [ ] **Step 1: Add the view test**
+
+In `app/api/kiosk/solo/view.test.ts`, inside `describe('buildStateView', …)`:
+
+```ts
+  it('passes the draw log through as tape, oldest first, and defaults to empty', () => {
+    const entries = [stored(1, 'sunset', 0.9)];
+    const tape = [
+      { slot: 1, snapshotId: 5, shownAt: 20_000, imageUrl: 'u5', title: 'a', city: '', country: '', bin: 'sunset' as const },
+      { slot: 2, snapshotId: 6, shownAt: 40_000, imageUrl: 'u6', title: 'b', city: '', country: '', bin: null },
+    ];
+    const v = buildStateView({ feed: 'sunset', dials: D, entries, screen: null, nowMs: 0, admitted: { sunset: 0, nonSunset: 0 }, zone: ZONE, tape });
+    expect(v.tape.map((f) => f.snapshotId)).toEqual([5, 6]);
+    const bare = buildStateView({ feed: 'sunset', dials: D, entries, screen: null, nowMs: 0, admitted: { sunset: 0, nonSunset: 0 }, zone: ZONE });
+    expect(bare.tape).toEqual([]);
+  });
+```
+
+- [ ] **Step 2: Run to see it fail**
+
+Run: `npx vitest run app/api/kiosk/solo/view.test.ts`
+Expected: FAIL: `tape` undefined.
+
+- [ ] **Step 3: Change `view.ts`**
+
+Import the type: `import type { ScreenRow, StoredEntry, TapeFrame } from '@/app/lib/solo/store';` (extend the existing type import). Below `NEXT_COUNT`:
+
+```ts
+/** Past draws on the studio's tape. */
+export const TAPE_PAST = 24;
+```
+
+In `StateView`, after `zone: Zone;`:
+
+```ts
+  /** The last draws on this screen, oldest first (stages-and-tape spec §4). Empty until the log is migrated. */
+  tape: TapeFrame[];
+```
+
+In `buildStateView`'s input type, after `version?: SoloVersionSpec;`:
+
+```ts
+  /** Past draws for the tape; the state route supplies them, other callers may omit. */
+  tape?: TapeFrame[];
+```
+
+In the return object, after `zone: input.zone,`:
+
+```ts
+    tape: input.tape ?? [],
+```
+
+- [ ] **Step 4: The state route fetches it; the studio hook forwards it**
+
+In `app/api/kiosk/solo/state/route.ts`, add `listRecentDraws` to the store import and `TAPE_PAST` to the `../view` import. Extend the `Promise.all` to:
+
+```ts
+  const [entries, screen, admitted, sweptZone, forcedDayRing, tape] = await Promise.all([
+    listActiveEntries(feed),
+    getScreenState(feed),
+    countAdmittedSince(feed, nowMs - LAST_PULL_WINDOW_MS),
+    getSweptZone(),
+    isFlagEnabled(SWEEP_FORCE_DAY_RING),
+    listRecentDraws(feed, TAPE_PAST),
+  ]);
+```
+
+and add `tape,` to the `buildStateView({ … })` call.
+
+In `app/studio/solo/useSoloState.ts`, add `tape: data.tape,` to the `buildStateView({ … })` call so the projected view keeps the server's past.
+
+- [ ] **Step 5: Run the view and studio tests, then type-check**
+
+Run: `npx vitest run app/api/kiosk/solo app/studio/solo && npx tsc --noEmit -p . 2>&1 | grep -i "tape" | head`
+Expected: PASS; no `tape` type errors. (`FeedColumn.test.tsx` builds views without `tape`, which is allowed.)
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd ~/GitHub/the-sunset-webcam-map.worktrees/feat-solo-tape && \
+  [ "$(git rev-parse --abbrev-ref HEAD)" = "feat/solo-tape" ] && \
+  git add app/api/kiosk/solo/view.ts app/api/kiosk/solo/view.test.ts app/api/kiosk/solo/state/route.ts app/studio/solo/useSoloState.ts && \
+  git commit -m "feat(solo): the state view carries the last 24 draws as the tape
+
+Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01Tsi2mkYSmb48KkQc97w39U"
+```
+
+---
+
+### Task 4: The Tape component
+
+**Files:**
+- Create: `app/studio/solo/Tape.tsx`
+- Test: `app/studio/solo/Tape.test.tsx`
+
+**Interfaces:**
+- Consumes: `TapeFrame` (Task 1), `EntryView` (view).
+- Produces:
+  ```tsx
+  export function Tape(props: {
+    past: TapeFrame[];            // oldest first
+    current: EntryView | null;    // on glass
+    next: EntryView[];            // projected, first draw first
+    onSelect: (entry: EntryView) => void;
+  }): JSX.Element
+  ```
+  Test ids: `tape`, `tape-past-<snapshotId>-<slot>`, `tape-current`, `tape-seam`, `tape-next-<i>`.
+
+- [ ] **Step 1: Write the test**
+
+```tsx
+import { it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { Tape } from './Tape';
+import type { EntryView } from '@/app/api/kiosk/solo/view';
+
+const entry = (id: number, bin: 'sunset' | 'non_sunset' = 'sunset'): EntryView => ({
+  snapshotId: id, webcamId: 100 + id, bin, quality: bin === 'sunset' ? 0.8 : null, detection: 0.9, isNew: false, tally: 1,
+  enteredAt: 0, imageUrl: `u${id}`, title: `cam${id}`, city: 'Nuuk', region: '', country: 'Greenland', capturedAt: 0,
+  timezone: null, sunAltitudeDeg: null, eligible: true, rank: 1, stage: { kind: 'queued', position: 1 },
+});
+const past = [
+  { slot: 10, snapshotId: 1, shownAt: 1_000, imageUrl: 'u1', title: 'cam1', city: 'Nuuk', country: 'Greenland', bin: 'sunset' as const },
+  { slot: 11, snapshotId: 2, shownAt: 2_000, imageUrl: 'u2', title: 'cam2', city: '', country: '', bin: 'non_sunset' as const },
+  { slot: 12, snapshotId: 1, shownAt: 3_000, imageUrl: 'u1', title: 'cam1', city: 'Nuuk', country: 'Greenland', bin: 'sunset' as const },
+];
+
+it('lays out past, current, seam, and projected in order, outlined by bin', () => {
+  render(<Tape past={past} current={entry(3)} next={[entry(4, 'non_sunset'), entry(1)]} onSelect={vi.fn()} />);
+  const strip = screen.getByTestId('tape');
+  const ids = [...strip.querySelectorAll('[data-testid^="tape-"]')].map((n) => n.getAttribute('data-testid'));
+  expect(ids).toEqual(['tape-past-1-10', 'tape-past-2-11', 'tape-past-1-12', 'tape-current', 'tape-seam', 'tape-next-0', 'tape-next-1']);
+  expect(screen.getByTestId('tape-past-1-10')).toHaveStyle({ borderColor: '#7ee2ac' });
+  expect(screen.getByTestId('tape-past-2-11')).toHaveStyle({ borderColor: '#c3cad6' });
+  expect(screen.getByTestId('tape-current')).toHaveStyle({ boxShadow: '0 0 0 2px #f5a344' });
+  expect(screen.getByTestId('tape-next-0')).toHaveStyle({ borderStyle: 'dashed' });
+});
+
+it('a frame that already appears earlier on the strip gets the red top edge; the first appearance does not', () => {
+  render(<Tape past={past} current={entry(3)} next={[entry(1)]} onSelect={vi.fn()} />);
+  expect(screen.getByTestId('tape-past-1-10')).not.toHaveStyle({ borderTopColor: '#8b2e2e' });
+  expect(screen.getByTestId('tape-past-1-12')).toHaveStyle({ borderTopColor: '#8b2e2e' });
+  expect(screen.getByTestId('tape-next-0')).toHaveStyle({ borderTopColor: '#8b2e2e' });
+  expect(screen.getByTestId('tape-current')).not.toHaveStyle({ borderTopColor: '#8b2e2e' });
+});
+
+it('hover text names the frame; clicking a projected or current thumb reports the entry', () => {
+  const onSelect = vi.fn();
+  render(<Tape past={past} current={entry(3)} next={[entry(4)]} onSelect={onSelect} />);
+  expect(screen.getByTestId('tape-past-1-10').getAttribute('title')).toMatch(/cam1 · Nuuk, Greenland · draw at/);
+  expect(screen.getByTestId('tape-next-0').getAttribute('title')).toMatch(/^draw 1 · cam4/);
+  fireEvent.click(screen.getByTestId('tape-next-0'));
+  expect(onSelect).toHaveBeenCalledWith(expect.objectContaining({ snapshotId: 4 }));
+  fireEvent.click(screen.getByTestId('tape-current'));
+  expect(onSelect).toHaveBeenCalledWith(expect.objectContaining({ snapshotId: 3 }));
+});
+
+it('with no past and nothing on glass it still renders the seam and the projection', () => {
+  render(<Tape past={[]} current={null} next={[entry(4)]} onSelect={vi.fn()} />);
+  expect(screen.queryByTestId('tape-current')).toBeNull();
+  expect(screen.getByTestId('tape-seam')).toBeInTheDocument();
+  expect(screen.getByTestId('tape-next-0')).toBeInTheDocument();
+  expect(screen.getByText(/no draws logged yet/)).toBeInTheDocument();
+});
+```
+
+- [ ] **Step 2: Run to see the module missing**
+
+Run: `npx vitest run app/studio/solo/Tape.test.tsx`
+Expected: FAIL: cannot resolve `./Tape`.
+
+- [ ] **Step 3: Write `Tape.tsx`**
+
+```tsx
+'use client';
+
+import { useEffect, useRef } from 'react';
+import type { EntryView } from '@/app/api/kiosk/solo/view';
+import type { TapeFrame } from '@/app/lib/solo/store';
+import type { BinKind } from '@/app/lib/solo/types';
+
+const COLOR: Record<BinKind, string> = { sunset: '#7ee2ac', non_sunset: '#c3cad6' };
+const NEUTRAL = '#2a3242';
+const REPEAT = '#8b2e2e';
+const RING = '0 0 0 2px #f5a344';
+const mono = 'ui-monospace, SFMono-Regular, Menlo, monospace';
+export const THUMB_W = 40;
+export const THUMB_H = 22;
+
+const clock = (ms: number) => new Date(ms).toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' });
+const place = (f: { city: string; country: string }) => [f.city, f.country].filter(Boolean).join(', ');
+
+function Thumb({ testId, src, color, dashed = false, ring = false, repeat = false, title, onClick }: {
+  testId: string; src: string; color: string; dashed?: boolean; ring?: boolean; repeat?: boolean; title: string;
+  onClick?: () => void;
+}) {
+  return (
+    <button type="button" data-testid={testId} title={title} onClick={onClick} disabled={!onClick} style={{
+      flex: 'none', width: THUMB_W, height: THUMB_H, padding: 0, background: '#000', cursor: onClick ? 'pointer' : 'default',
+      borderWidth: 1.5, borderStyle: dashed ? 'dashed' : 'solid', borderColor: color, borderTopColor: repeat ? REPEAT : color,
+      borderTopWidth: repeat ? 3 : 1.5, borderRadius: 3, boxShadow: ring ? RING : undefined, boxSizing: 'border-box',
+    }}>
+      {/* eslint-disable-next-line @next/next/no-img-element */}
+      <img src={src} alt="" style={{ width: '100%', height: '100%', objectFit: 'cover', display: 'block' }} />
+    </button>
+  );
+}
+
+/**
+ * The tape (stages-and-tape spec §4): what this screen drew, is drawing, and
+ * will draw, in one strip. Past thumbs are fact from the draw log; the frame
+ * on glass wears the orange ring; a seam separates fact from the projection,
+ * whose thumbs are dashed. A frame already seen earlier on the strip carries
+ * a red top edge, the REPEAT tag's colour. Scrolls sideways; on mount and
+ * whenever the past grows, the seam is brought to about two thirds across.
+ */
+export function Tape({ past, current, next, onSelect }: {
+  past: TapeFrame[];
+  current: EntryView | null;
+  next: EntryView[];
+  onSelect: (entry: EntryView) => void;
+}) {
+  const strip = useRef<HTMLDivElement>(null);
+  const seam = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    const s = strip.current;
+    const m = seam.current;
+    if (!s || !m) return;
+    s.scrollLeft = Math.max(0, m.offsetLeft - s.clientWidth * (2 / 3));
+  }, [past.length, current?.snapshotId]);
+
+  const seen = new Set<number>();
+  const repeatOf = (id: number) => {
+    const r = seen.has(id);
+    seen.add(id);
+    return r;
+  };
+
+  return (
+    <div ref={strip} data-testid="tape" title="The tape: past draws, the frame on glass, then the projected next draws"
+      style={{ display: 'flex', gap: 3, alignItems: 'center', overflowX: 'auto', padding: '4px 2px', minHeight: THUMB_H + 12 }}>
+      {past.length === 0 && (
+        <span style={{ fontFamily: mono, fontSize: 9.5, color: '#4b5568', whiteSpace: 'nowrap', paddingRight: 6 }}>no draws logged yet</span>
+      )}
+      {past.map((f) => (
+        <Thumb key={`${f.snapshotId}-${f.slot}`} testId={`tape-past-${f.snapshotId}-${f.slot}`} src={f.imageUrl}
+          color={f.bin ? COLOR[f.bin] : NEUTRAL} repeat={repeatOf(f.snapshotId)}
+          title={`${f.title}${place(f) ? ` · ${place(f)}` : ''} · draw at ${clock(f.shownAt)}`} />
+      ))}
+      {current && (
+        <Thumb testId="tape-current" src={current.imageUrl} color={COLOR[current.bin]} ring repeat={repeatOf(current.snapshotId)}
+          title={`on glass · ${current.title}${place(current) ? ` · ${place(current)}` : ''}`} onClick={() => onSelect(current)} />
+      )}
+      <div ref={seam} data-testid="tape-seam" title="Left: what happened. Right: what the studio dials project."
+        style={{ flex: 'none', width: 2, height: THUMB_H + 6, background: '#f5a344', opacity: 0.6, margin: '0 2px' }} />
+      {next.map((e, i) => (
+        <Thumb key={`${e.snapshotId}-${i}`} testId={`tape-next-${i}`} src={e.imageUrl} color={COLOR[e.bin]} dashed
+          repeat={repeatOf(e.snapshotId)} title={`draw ${i + 1} · ${e.title}${place(e) ? ` · ${place(e)}` : ''}`}
+          onClick={() => onSelect(e)} />
+      ))}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 4: Run the Tape tests**
+
+Run: `npx vitest run app/studio/solo/Tape.test.tsx`
+Expected: PASS. If `toHaveStyle({ borderColor })` fails on jsdom shorthand expansion, assert `borderLeftColor` instead in both the test and this step's note.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd ~/GitHub/the-sunset-webcam-map.worktrees/feat-solo-tape && \
+  [ "$(git rev-parse --abbrev-ref HEAD)" = "feat/solo-tape" ] && \
+  git add app/studio/solo/Tape.tsx app/studio/solo/Tape.test.tsx && \
+  git commit -m "feat(studio): the tape — past draws, on glass, seam, projected next
+
+Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01Tsi2mkYSmb48KkQc97w39U"
+```
+
+---
+
+### Task 5: Mount the tape above the bins
+
+**Files:**
+- Modify: `app/studio/solo/FeedColumn.tsx`
+- Test: `app/studio/solo/FeedColumn.test.tsx`
+
+- [ ] **Step 1: Add the test**
+
+```tsx
+it('the tape sits under the screen heading and above the bins, with the server past and the projected next', () => {
+  const v = view();
+  const withTape = { ...v, tape: [{ slot: 1, snapshotId: 2, shownAt: 0, imageUrl: 'u2', title: 'cam2', city: '', country: '', bin: 'sunset' as const }] };
+  render(<FeedColumn feed="sunset" server={withTape} projected={v} liveDials={D} studioDials={D} nowMs={5_000} onSelect={vi.fn()} />);
+  const tape = screen.getByTestId('tape');
+  expect(tape).toBeInTheDocument();
+  expect(screen.getByTestId('tape-past-2-1')).toBeInTheDocument();
+  expect(screen.getByTestId('tape-current')).toBeInTheDocument();
+  expect(screen.getByTestId('tape-next-0')).toBeInTheDocument();
+  // The tape precedes the bins in document order.
+  const binHeading = screen.getByText(/Sunset bin ·/);
+  expect(tape.compareDocumentPosition(binHeading) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+});
+```
+
+- [ ] **Step 2: Run to see it fail**
+
+Run: `npx vitest run app/studio/solo/FeedColumn.test.tsx`
+Expected: FAIL: no `tape` test id.
+
+- [ ] **Step 3: Mount it**
+
+In `FeedColumn.tsx`, import `{ Tape } from './Tape'`, and between the `<h3 …>` heading and the bins grid insert:
+
+```tsx
+      <Tape past={server.tape} current={current?.entry ?? null} next={projected.next} onSelect={(e) => onSelect(e, feed)} />
+```
+
+Update the component doc comment's first sentence to "One feed's tape, its two bins, each as three stages …".
+
+- [ ] **Step 4: Run the studio tests**
+
+Run: `npx vitest run app/studio/solo`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd ~/GitHub/the-sunset-webcam-map.worktrees/feat-solo-tape && \
+  [ "$(git rev-parse --abbrev-ref HEAD)" = "feat/solo-tape" ] && \
+  git add app/studio/solo/FeedColumn.tsx app/studio/solo/FeedColumn.test.tsx && \
+  git commit -m "feat(studio): the tape sits above each screen's bins
+
+Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01Tsi2mkYSmb48KkQc97w39U"
+```
+
+---
+
+### Task 6: Whole-suite check, static render, push, PR, migration handoff
+
+- [ ] **Step 1: Lint, type-check, full tests**
+
+```bash
+npm run lint && npm run test
+```
+and `npx tsc --noEmit -p . 2>&1 | grep -i "tape\|draw" | head` must print nothing.
+
+- [ ] **Step 2: Static render for the PR**
+
+Reuse the PR A approach: a throwaway vitest file in `app/studio/solo/` that builds a view from the scratchpad's `sunset.json` entries plus a synthetic `tape` of ~24 frames drawn from those entries (repeat a few ids so the red edge shows), renders `FeedColumn` with `renderToStaticMarkup`, writes `studio-tape.html` to the scratchpad; screenshot with `agent-browser --session tape`. Delete the throwaway file before committing.
+
+- [ ] **Step 3: Push, PR**
+
+```bash
+cd ~/GitHub/the-sunset-webcam-map.worktrees/feat-solo-tape && \
+  [ "$(git rev-parse --abbrev-ref HEAD)" = "feat/solo-tape" ] && git push -u origin feat/solo-tape
+```
+
+`gh pr create` titled `feat(studio): the tape — a filmstrip of past, current and projected draws`. The body states what the tape is, the migration and that it must be applied first, that the log insert is best-effort, that the kiosk does not read the tape (no kiosk reload needed), and the one-studio note (the tape ports as one component). End with the session trailer.
+
+- [ ] **Step 4: Hand Jesse the migration**
+
+Tell Jesse to run, from the main checkout, dry then apply:
+
+```
+node scripts/apply-migration.mjs database/migrations/20260906_kiosk_draws.sql --from feat/solo-tape
+```
+```
+node scripts/apply-migration.mjs database/migrations/20260906_kiosk_draws.sql --from feat/solo-tape --apply
+```
+
+Then merge. Rows begin at the next advance; the tape fills over the following eight minutes.
+
+---
+
+## Self-review
+
+- **Spec §4.1** storage: Task 1 (table, best-effort insert in `commitAdvance`, prune in `maintainBins` via Task 2). **§4.2** read path: Task 1 (`listRecentDraws`, joins, left join for bin), Task 3 (`StateView.tape`, `TAPE_PAST`). **§4.3** render: Task 4 (thumbs, outlines, ring, dashed, red edge, hover, click, seam scroll), Task 5 (position under the screen, above the bins). **§5** sequencing: Task 6. Kiosk unaffected: the advance route never passes `tape`, and no kiosk component reads it.
+- **Placeholders:** none.
+- **Type consistency:** `TapeFrame` fields match between store, view test, Tape test, and FeedColumn test. `listRecentDraws(feed, n)` matches the route call. `pruneDraws(7)` matches the cron test.

--- a/docs/superpowers/specs/2026-09-05-solo-stages-and-tape-design.md
+++ b/docs/superpowers/specs/2026-09-05-solo-stages-and-tape-design.md
@@ -165,15 +165,34 @@ bin, shownAt }`. The state route passes `n = 24`.
 
 ### 4.3 Render
 
-`Tape.tsx` in `app/studio/solo/`. Thumbnails 40×22, outlined in bin colour.
-Past frames sit left of a vertical seam, at full strength; the on-glass
-frame carries the orange ring used elsewhere; projected frames sit right of
-the seam with a dashed outline. A frame that already appears earlier on the
-strip gets a thin red top edge, matching the REPEAT tag. Hover gives title,
-place and time for past frames, and draw number for projected ones. The
-strip scrolls horizontally; on load it scrolls so the seam sits at about
-two thirds of the width. Clicking a thumbnail opens the same detail as a
-row. Projected frames use the studio dials, like the queue column.
+`Tape.tsx` in `app/studio/solo/`, mounted at the top of `FeedColumn` under
+the screen heading, with a `tape ▾/▸` button in the heading that folds it
+away (remembered per browser in localStorage). **Width is time**, 3 px per
+second of glass, the way a Final Cut timeline reads:
+
+- Past blocks are fact from the draw log, each as wide as the frame stayed
+  on glass (from the next draw's time, or the current frame's `shownSince`).
+  A frame held past 1.5 dwells because nothing else was eligible reads as a
+  wide block with a small `held` mark; blocks cap at 3 dwells.
+- The frame on glass wears the orange ring; when nothing is on glass a
+  black `blank` block stands in its place.
+- A vertical seam separates fact from projection. Projected blocks are
+  dashed, one dwell wide at the studio dials, in the queue's order.
+- A crossfade is an orange X straddling the cut, as wide as the fade dial
+  (live dials on the left of the seam, studio dials on the right). Fade 0
+  draws nothing.
+- A solo2 dwell with a prelude shows the earlier frames as narrow
+  sub-blocks (one prelude step each) before the chosen frame, inside one
+  dwell. Past preludes are not logged and are not drawn.
+- A frame already seen earlier on the strip carries a thin red top edge,
+  the REPEAT tag's colour.
+- Hover names the frame, its place, the draw time and the time on glass;
+  clicking any block, past included, opens the same detail and rating card
+  as a row. The card names the capture time there and, for a past draw,
+  when it was drawn. To make that possible a tape row is the whole entry,
+  not just an image.
+- On mount and whenever the past grows, the strip scrolls so the seam sits
+  about two thirds across.
 
 The kiosk does not read the tape.
 
@@ -183,7 +202,7 @@ Two PRs, both branched from `main` after #140, #141 and #142 merge, since
 all three touch `engine.ts`, `FeedColumn.tsx` and `EntryRow.tsx`:
 
 - **PR A** — rule 3 (section 2) and staged bins (section 3). No migration.
-- **PR B** — the tape (section 4). Migration applied before merge.
+- **PR B** — the tape (section 4), PR #TBD. Migration `20260906_kiosk_draws.sql` applied before merge.
 
 After each merge: `bash scripts/pi/kiosk-doctor.sh --sync --reload` for
 PR A (the glass runs the engine); PR B is studio-only.


### PR DESCRIPTION
## What the tape is

A timeline under each studio screen, above the bins: the last 24 draws, the frame on glass, a seam, then the projected next 8. **Width is time** (3 px per second), so it reads like a Final Cut track:

- Past blocks are fact from a new draw log, each as wide as the frame stayed on glass. A frame held because nothing else was eligible is a wide block marked `held`.
- The on-glass block wears the orange ring; nothing on glass shows a black `blank`.
- Projected blocks are dashed, one dwell wide at the studio dials.
- A crossfade is an orange X straddling each cut, as wide as the fade dial (live dials left of the seam, studio dials right). Fade 0 draws none.
- A solo2 dwell with a prelude shows its earlier frames as narrow sub-blocks before the chosen one.
- A frame already seen earlier on the strip gets a thin red top edge (the REPEAT colour).
- Hover names the frame, place, draw time and time on glass. Clicking any block, past included, opens the same detail and rating card as a row; the card now says when the frame was captured there and, for a past draw, when it was drawn.
- A `tape ▾/▸` button in the screen heading folds it away, remembered per browser.

Spec: `docs/superpowers/specs/2026-09-05-solo-stages-and-tape-design.md` §4. Plan: `docs/superpowers/plans/2026-09-06-solo-tape-pr-b.md`.

## Storage

New table `kiosk_draws (feed, slot, snapshot_id, shown_at)`, one row per draw per screen (~8.6k/day/screen at 20 s), written by `commitAdvance` after the screen-state upsert, pruned after 7 days by `maintainBins`. The insert, the read and the prune each swallow their own failure, so the glass never depends on the table, but the tape stays empty until it exists.

## ⚠️ Apply the migration BEFORE merging

From the main checkout, dry run then apply:

```
node scripts/apply-migration.mjs database/migrations/20260906_kiosk_draws.sql --from feat/solo-tape
```
```
node scripts/apply-migration.mjs database/migrations/20260906_kiosk_draws.sql --from feat/solo-tape --apply
```

Rows begin at the next advance after the deploy; the tape fills over the following eight minutes. No kiosk reload is needed: the kiosk does not read the tape.

## One-studio note

The tape is one component (`Tape.tsx`) plus `StateView.tape`; the one-studio page mounts it under each screen in the solo version panel.

## Verification

- `npm run test`: 284 files, 2267 tests pass.
- `npm run lint`: only pre-existing warnings in unrelated files.
- Rendered statically from live sunset entries with a synthetic 24-draw log (the page is owner-gated); screenshots in the session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tsi2mkYSmb48KkQc97w39U
