### PR TITLE
feat(studio): saved takes (phase B, stacked on #146)

### DIFF
--- a/app/api/kiosk/deploys/[id]/route.ts
+++ b/app/api/kiosk/deploys/[id]/route.ts
@@ -2,11 +2,10 @@ import { NextRequest, NextResponse } from 'next/server';
 import { requireOwner } from '@/app/lib/owner';
 import { relabelDeploy } from '@/app/lib/settings/deploys';
 import { parseDeployId } from '../parseId';
+import { parseLabel } from '../labels';
 
 export const dynamic = 'force-dynamic';
 export const runtime = 'nodejs';
-
-const LABEL_MAX = 60;
 
 /** Rename a deploy. `{ label: null }` clears it. */
 export async function PATCH(
@@ -25,18 +24,11 @@ export async function PATCH(
   } catch {
     return NextResponse.json({ error: 'invalid JSON' }, { status: 400 });
   }
-  const raw = body?.label;
-  if (raw !== null && typeof raw !== 'string') {
-    return NextResponse.json({ error: 'label must be a string or null' }, { status: 400 });
+  const parsed = parseLabel(body?.label);
+  if ('error' in parsed) {
+    return NextResponse.json({ error: parsed.error }, { status: 400 });
   }
-  if (typeof raw === 'string' && raw.length > LABEL_MAX) {
-    return NextResponse.json(
-      { error: `label must be at most ${LABEL_MAX} characters` },
-      { status: 400 },
-    );
-  }
-  const label = typeof raw === 'string' && raw.trim() ? raw.trim() : null;
-  const found = await relabelDeploy(id, label);
+  const found = await relabelDeploy(id, parsed.label);
   if (!found) return NextResponse.json({ error: 'no such deploy' }, { status: 404 });
   return NextResponse.json({ ok: true });
 }

--- a/app/api/kiosk/deploys/labels.ts
+++ b/app/api/kiosk/deploys/labels.ts
@@ -1,0 +1,20 @@
+/**
+ * Shared label parsing for the deploys/takes routes: a positive-integer
+ * length cap, non-string rejection, and empty-to-null folding. Route files
+ * may only export handler fields, so this lives beside them. Callers decide
+ * how to treat a missing key before calling in (the [id] route requires an
+ * explicit `label` field; POST /deploys normalizes a missing key to `null`
+ * so the take can be saved without one).
+ */
+export const LABEL_MAX = 60;
+
+export function parseLabel(raw: unknown): { label: string | null } | { error: string } {
+  if (raw !== null && typeof raw !== 'string') {
+    return { error: 'label must be a string or null' };
+  }
+  if (typeof raw === 'string' && raw.length > LABEL_MAX) {
+    return { error: `label must be at most ${LABEL_MAX} characters` };
+  }
+  const label = typeof raw === 'string' && raw.trim() ? raw.trim() : null;
+  return { label };
+}

--- a/app/api/kiosk/deploys/route.test.ts
+++ b/app/api/kiosk/deploys/route.test.ts
@@ -1,13 +1,28 @@
 // @vitest-environment node
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { NextResponse } from 'next/server';
+import { NextRequest, NextResponse } from 'next/server';
 
 const requireOwnerMock = vi.fn();
 vi.mock('@/app/lib/owner', () => ({ requireOwner: () => requireOwnerMock() }));
 const listDeploysMock = vi.fn();
-vi.mock('@/app/lib/settings/deploys', () => ({ listDeploys: () => listDeploysMock() }));
+const saveTakeMock = vi.fn();
+vi.mock('@/app/lib/settings/deploys', () => ({
+  listDeploys: () => listDeploysMock(),
+  saveTake: (studio: unknown, label: unknown) => saveTakeMock(studio, label),
+}));
+const getProfileSettingsMock = vi.fn();
+vi.mock('@/app/lib/settings/store', () => ({
+  getProfileSettings: (profile: string) => getProfileSettingsMock(profile),
+}));
 
-import { GET } from './route';
+import { GET, POST } from './route';
+
+const req = (body: unknown) =>
+  new NextRequest('http://test/api/kiosk/deploys', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  });
 
 describe('GET /api/kiosk/deploys', () => {
   beforeEach(() => {
@@ -25,5 +40,45 @@ describe('GET /api/kiosk/deploys', () => {
     expect(await (await GET()).json()).toEqual({
       deploys: [{ id: 1, label: null, namespaces: {}, deployedAt: 'T' }],
     });
+  });
+});
+
+describe('POST /api/kiosk/deploys', () => {
+  beforeEach(() => {
+    requireOwnerMock.mockReset();
+    saveTakeMock.mockReset();
+    getProfileSettingsMock.mockReset();
+    requireOwnerMock.mockResolvedValue(null);
+    getProfileSettingsMock.mockResolvedValue({ namespaces: {}, revision: 1 });
+  });
+  it('rejects non-owners', async () => {
+    requireOwnerMock.mockResolvedValueOnce(NextResponse.json({ error: 'Forbidden' }, { status: 403 }));
+    expect((await POST(req({ label: 'x' }))).status).toBe(403);
+    expect(saveTakeMock).not.toHaveBeenCalled();
+  });
+  it('saves a take with no deployedAt', async () => {
+    saveTakeMock.mockResolvedValueOnce({
+      id: 1,
+      label: 'x',
+      namespaces: {},
+      deployedAt: null,
+      createdAt: 'T',
+    });
+    const res = await POST(req({ label: 'x' }));
+    expect(res.status).toBe(201);
+    const body = await res.json();
+    expect(body.take.deployedAt).toBeNull();
+    expect(saveTakeMock).toHaveBeenCalledWith({ namespaces: {}, revision: 1 }, 'x');
+  });
+  it('400 on a label over 60 chars', async () => {
+    const res = await POST(req({ label: 'x'.repeat(61) }));
+    expect(res.status).toBe(400);
+    expect(saveTakeMock).not.toHaveBeenCalled();
+  });
+  it('503 when saveTake fails', async () => {
+    saveTakeMock.mockResolvedValueOnce(null);
+    const res = await POST(req({ label: 'x' }));
+    expect(res.status).toBe(503);
+    expect(await res.json()).toEqual({ error: 'take not recorded' });
   });
 });

--- a/app/api/kiosk/deploys/route.test.ts
+++ b/app/api/kiosk/deploys/route.test.ts
@@ -23,6 +23,12 @@ const req = (body: unknown) =>
     headers: { 'content-type': 'application/json' },
     body: JSON.stringify(body),
   });
+const rawReq = (raw: string) =>
+  new NextRequest('http://test/api/kiosk/deploys', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: raw,
+  });
 
 describe('GET /api/kiosk/deploys', () => {
   beforeEach(() => {
@@ -80,5 +86,47 @@ describe('POST /api/kiosk/deploys', () => {
     const res = await POST(req({ label: 'x' }));
     expect(res.status).toBe(503);
     expect(await res.json()).toEqual({ error: 'take not recorded' });
+  });
+  it('a missing label key saves a take with a null label', async () => {
+    saveTakeMock.mockResolvedValueOnce({
+      id: 1,
+      label: null,
+      namespaces: {},
+      deployedAt: null,
+      createdAt: 'T',
+    });
+    const res = await POST(req({}));
+    expect(res.status).toBe(201);
+    expect(saveTakeMock).toHaveBeenCalledWith({ namespaces: {}, revision: 1 }, null);
+  });
+  it('an explicit null label saves a take with a null label', async () => {
+    saveTakeMock.mockResolvedValueOnce({
+      id: 1,
+      label: null,
+      namespaces: {},
+      deployedAt: null,
+      createdAt: 'T',
+    });
+    const res = await POST(req({ label: null }));
+    expect(res.status).toBe(201);
+    expect(saveTakeMock).toHaveBeenCalledWith({ namespaces: {}, revision: 1 }, null);
+  });
+  it('400 on invalid JSON', async () => {
+    const res = await POST(rawReq('not json'));
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: 'invalid JSON' });
+    expect(saveTakeMock).not.toHaveBeenCalled();
+  });
+  it('a label of exactly 60 chars is accepted', async () => {
+    saveTakeMock.mockResolvedValueOnce({
+      id: 1,
+      label: 'x'.repeat(60),
+      namespaces: {},
+      deployedAt: null,
+      createdAt: 'T',
+    });
+    const res = await POST(req({ label: 'x'.repeat(60) }));
+    expect(res.status).toBe(201);
+    expect(saveTakeMock).toHaveBeenCalledWith({ namespaces: {}, revision: 1 }, 'x'.repeat(60));
   });
 });

--- a/app/api/kiosk/deploys/route.ts
+++ b/app/api/kiosk/deploys/route.ts
@@ -1,6 +1,8 @@
-import { NextResponse } from 'next/server';
+import { NextRequest, NextResponse } from 'next/server';
 import { requireOwner } from '@/app/lib/owner';
-import { listDeploys } from '@/app/lib/settings/deploys';
+import { listDeploys, saveTake } from '@/app/lib/settings/deploys';
+import { getProfileSettings } from '@/app/lib/settings/store';
+import { parseLabel } from './labels';
 
 export const dynamic = 'force-dynamic';
 export const runtime = 'nodejs';
@@ -10,4 +12,25 @@ export async function GET() {
   const denied = await requireOwner();
   if (denied) return denied;
   return NextResponse.json({ deploys: await listDeploys() });
+}
+
+/** Save the current studio profile as a take (spec §4.2). Never reaches the glass. */
+export async function POST(request: NextRequest) {
+  const denied = await requireOwner();
+  if (denied) return denied;
+  let body: { label?: unknown };
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: 'invalid JSON' }, { status: 400 });
+  }
+  const raw = body?.label === undefined ? null : body.label;
+  const parsed = parseLabel(raw);
+  if ('error' in parsed) {
+    return NextResponse.json({ error: parsed.error }, { status: 400 });
+  }
+  const studio = await getProfileSettings('studio');
+  const take = await saveTake(studio, parsed.label);
+  if (!take) return NextResponse.json({ error: 'take not recorded' }, { status: 503 });
+  return NextResponse.json({ take }, { status: 201 });
 }

--- a/app/lib/settings/deploys.test.ts
+++ b/app/lib/settings/deploys.test.ts
@@ -27,7 +27,7 @@ vi.mock('@/app/components/mosaic/registry', () => ({
   },
 }));
 
-import { recordDeploy, listDeploys, loadDeployIntoStudio, relabelDeploy } from './deploys';
+import { recordDeploy, listDeploys, loadDeployIntoStudio, relabelDeploy, saveTake } from './deploys';
 import { sql } from '@/app/lib/db';
 
 const sqlMock = (sql as unknown as SqlTag).__sqlMock;
@@ -50,11 +50,15 @@ beforeEach(() => {
 describe('recordDeploy', () => {
   it('inserts the whole profile and returns the row', async () => {
     sqlMock.mockResolvedValueOnce([
-      { id: 7, label: null, namespaces: { v1: { floorPx: 140 } }, deployed_at: '2026-09-05T18:30:00.000Z' },
+      {
+        id: 7, label: null, namespaces: { v1: { floorPx: 140 } },
+        deployed_at: '2026-09-05T18:30:00.000Z', created_at: '2026-09-05T18:30:00.000Z',
+      },
     ]);
     const row = await recordDeploy({ namespaces: { v1: { floorPx: 140 } }, revision: 3 }, null);
     expect(row).toEqual({
-      id: 7, label: null, namespaces: { v1: { floorPx: 140 } }, deployedAt: '2026-09-05T18:30:00.000Z',
+      id: 7, label: null, namespaces: { v1: { floorPx: 140 } },
+      deployedAt: '2026-09-05T18:30:00.000Z', createdAt: '2026-09-05T18:30:00.000Z',
     });
     expect(text(sqlMock.mock.calls[0])).toContain('INSERT INTO kiosk_deploys');
     expect(sqlMock.mock.calls[0][2]).toBe(JSON.stringify({ v1: { floorPx: 140 } }));
@@ -65,15 +69,38 @@ describe('recordDeploy', () => {
   });
 });
 
+describe('saveTake', () => {
+  it('inserts with deployed_at NULL and returns a row with deployedAt null', async () => {
+    sqlMock.mockResolvedValueOnce([
+      {
+        id: 9, label: 'draft', namespaces: { v1: { floorPx: 140 } },
+        deployed_at: null, created_at: '2026-09-06T10:00:00.000Z',
+      },
+    ]);
+    const row = await saveTake({ namespaces: { v1: { floorPx: 140 } }, revision: 2 }, 'draft');
+    expect(row).toEqual({
+      id: 9, label: 'draft', namespaces: { v1: { floorPx: 140 } },
+      deployedAt: null, createdAt: '2026-09-06T10:00:00.000Z',
+    });
+    expect(text(sqlMock.mock.calls[0])).toContain('INSERT INTO kiosk_deploys');
+    expect(sqlMock.mock.calls[0][1]).toBe('draft');
+    expect(sqlMock.mock.calls[0][2]).toBe(JSON.stringify({ v1: { floorPx: 140 } }));
+  });
+  it('returns null instead of throwing when the insert fails', async () => {
+    sqlMock.mockRejectedValueOnce(new Error('relation "kiosk_deploys" does not exist'));
+    expect(await saveTake({ namespaces: {}, revision: 1 })).toBeNull();
+  });
+});
+
 describe('listDeploys', () => {
   it('maps rows newest first and defaults the limit to 50', async () => {
     sqlMock.mockResolvedValueOnce([
-      { id: 2, label: 'b', namespaces: {}, deployed_at: '2026-09-05T18:30:00.000Z' },
-      { id: 1, label: null, namespaces: {}, deployed_at: '2026-09-05T17:00:00.000Z' },
+      { id: 2, label: 'b', namespaces: {}, deployed_at: '2026-09-05T18:30:00.000Z', created_at: '2026-09-05T18:30:00.000Z' },
+      { id: 1, label: null, namespaces: {}, deployed_at: '2026-09-05T17:00:00.000Z', created_at: '2026-09-05T17:00:00.000Z' },
     ]);
     const rows = await listDeploys();
     expect(rows.map((r) => r.id)).toEqual([2, 1]);
-    expect(text(sqlMock.mock.calls[0])).toContain('ORDER BY id DESC');
+    expect(text(sqlMock.mock.calls[0])).toContain('ORDER BY created_at DESC, id DESC');
     expect(sqlMock.mock.calls[0][1]).toBe(50);
   });
   it('returns [] when the read fails', async () => {

--- a/app/lib/settings/deploys.test.ts
+++ b/app/lib/settings/deploys.test.ts
@@ -60,7 +60,11 @@ describe('recordDeploy', () => {
       id: 7, label: null, namespaces: { v1: { floorPx: 140 } },
       deployedAt: '2026-09-05T18:30:00.000Z', createdAt: '2026-09-05T18:30:00.000Z',
     });
-    expect(text(sqlMock.mock.calls[0])).toContain('INSERT INTO kiosk_deploys');
+    const queryText = text(sqlMock.mock.calls[0]);
+    // Column list only, not the whole query: RETURNING always mentions deployed_at,
+    // so this proves the INSERT itself never sets it (the column defaults to now()).
+    expect(queryText).toMatch(/INSERT INTO kiosk_deploys \(label, namespaces\)/);
+    expect(queryText).not.toMatch(/INSERT INTO kiosk_deploys \(label, namespaces, deployed_at\)/);
     expect(sqlMock.mock.calls[0][2]).toBe(JSON.stringify({ v1: { floorPx: 140 } }));
   });
   it('returns null instead of throwing when the table is missing', async () => {
@@ -82,7 +86,11 @@ describe('saveTake', () => {
       id: 9, label: 'draft', namespaces: { v1: { floorPx: 140 } },
       deployedAt: null, createdAt: '2026-09-06T10:00:00.000Z',
     });
-    expect(text(sqlMock.mock.calls[0])).toContain('INSERT INTO kiosk_deploys');
+    const queryText = text(sqlMock.mock.calls[0]);
+    // Proves saveTake's INSERT actually names deployed_at and sets it to NULL,
+    // not just that it inserts into kiosk_deploys (recordDeploy does too).
+    expect(queryText).toMatch(/INSERT INTO kiosk_deploys \(label, namespaces, deployed_at\)/);
+    expect(queryText).toMatch(/VALUES \([^)]*::jsonb, NULL\)/);
     expect(sqlMock.mock.calls[0][1]).toBe('draft');
     expect(sqlMock.mock.calls[0][2]).toBe(JSON.stringify({ v1: { floorPx: 140 } }));
   });

--- a/app/lib/settings/deploys.ts
+++ b/app/lib/settings/deploys.ts
@@ -15,7 +15,8 @@ export interface DeployRow {
   id: number;
   label: string | null;
   namespaces: Record<string, SettingsValues>;
-  deployedAt: string;
+  deployedAt: string | null;
+  createdAt: string;
 }
 
 export type DroppedDeployKey = DroppedKey & { namespace: string };
@@ -24,7 +25,8 @@ interface Row {
   id: number;
   label: string | null;
   namespaces: Record<string, SettingsValues>;
-  deployed_at: string | Date;
+  deployed_at: string | Date | null;
+  created_at: string | Date;
 }
 
 function toRow(r: Row): DeployRow {
@@ -32,7 +34,8 @@ function toRow(r: Row): DeployRow {
     id: Number(r.id),
     label: r.label,
     namespaces: r.namespaces,
-    deployedAt: new Date(r.deployed_at).toISOString(),
+    deployedAt: r.deployed_at ? new Date(r.deployed_at).toISOString() : null,
+    createdAt: new Date(r.created_at).toISOString(),
   };
 }
 
@@ -49,7 +52,7 @@ export async function recordDeploy(
     const rows = (await sql`
       INSERT INTO kiosk_deploys (label, namespaces)
       VALUES (${label ?? null}, ${JSON.stringify(live.namespaces)}::jsonb)
-      RETURNING id, label, namespaces, deployed_at
+      RETURNING id, label, namespaces, deployed_at, created_at
     `) as unknown as Row[];
     return toRow(rows[0]);
   } catch (error) {
@@ -58,10 +61,33 @@ export async function recordDeploy(
   }
 }
 
+/**
+ * Save the studio profile as a take: a kiosk_deploys row with `deployed_at`
+ * left NULL, so it lists and loads exactly like a Deploy but never claims to
+ * have reached the glass. Never throws, mirroring recordDeploy.
+ */
+export async function saveTake(
+  studio: ProfileSettings,
+  label?: string | null,
+): Promise<DeployRow | null> {
+  try {
+    const rows = (await sql`
+      INSERT INTO kiosk_deploys (label, namespaces, deployed_at)
+      VALUES (${label ?? null}, ${JSON.stringify(studio.namespaces)}::jsonb, NULL)
+      RETURNING id, label, namespaces, deployed_at, created_at
+    `) as unknown as Row[];
+    return toRow(rows[0]);
+  } catch (error) {
+    console.warn('[deploys] saveTake failed:', error);
+    return null;
+  }
+}
+
 export async function listDeploys(limit = 50): Promise<DeployRow[]> {
   try {
     const rows = (await sql`
-      SELECT id, label, namespaces, deployed_at FROM kiosk_deploys ORDER BY id DESC LIMIT ${limit}
+      SELECT id, label, namespaces, deployed_at, created_at FROM kiosk_deploys
+      ORDER BY created_at DESC, id DESC LIMIT ${limit}
     `) as unknown as Row[];
     return rows.map(toRow);
   } catch (error) {

--- a/app/studio/DeployHistory.test.tsx
+++ b/app/studio/DeployHistory.test.tsx
@@ -14,8 +14,8 @@ vi.mock('@/app/components/mosaic/registry', () => ({
 import { DeployHistory } from './DeployHistory';
 
 const deploys: DeployRow[] = [
-  { id: 2, label: 'opening night', namespaces: { v1: { floorPx: 140 } }, deployedAt: '2026-09-05T18:30:00.000Z' },
-  { id: 1, label: null, namespaces: {}, deployedAt: '2026-09-05T17:00:00.000Z' },
+  { id: 2, label: 'opening night', namespaces: { v1: { floorPx: 140 } }, deployedAt: '2026-09-05T18:30:00.000Z', createdAt: '2026-09-05T18:30:00.000Z' },
+  { id: 1, label: null, namespaces: {}, deployedAt: '2026-09-05T17:00:00.000Z', createdAt: '2026-09-05T17:00:00.000Z' },
 ];
 
 function api(over: Partial<StudioSettingsApi> = {}): StudioSettingsApi {

--- a/app/studio/DeployHistory.test.tsx
+++ b/app/studio/DeployHistory.test.tsx
@@ -80,7 +80,7 @@ describe('DeployHistory', () => {
   it('clicking a row loads it into the studio and reports a partial fit', async () => {
     const loadDeploy = vi.fn(async () => [{ namespace: 'v1', key: 'ghost', reason: 'unknown' as const }]);
     list({ loadDeploy, deploys: [{ ...deploys[0], namespaces: { v1: { floorPx: 140, ghost: 1 } } }] });
-    await act(async () => { fireEvent.click(screen.getByRole('button', { name: /load deploy #2/i })); });
+    await act(async () => { fireEvent.click(screen.getByRole('button', { name: /load take #2/i })); });
     expect(loadDeploy).toHaveBeenCalledWith(2);
     expect(screen.getByText('loaded, 1 of 2 keys fit the current schema')).toBeInTheDocument();
   });
@@ -88,19 +88,19 @@ describe('DeployHistory', () => {
   it('a 404 on load reads as gone', async () => {
     const loadDeploy = vi.fn(async () => { throw new Error('load deploy failed: 404'); });
     list({ loadDeploy });
-    await act(async () => { fireEvent.click(screen.getByRole('button', { name: /load deploy #1/i })); });
+    await act(async () => { fireEvent.click(screen.getByRole('button', { name: /load take #1/i })); });
     expect(screen.getByText('gone')).toBeInTheDocument();
   });
 
   it('the label is edited inline: Enter saves, Escape cancels', async () => {
     const relabelDeploy = vi.fn(async () => {});
     list({ relabelDeploy });
-    fireEvent.click(screen.getByRole('button', { name: /label deploy #1/i }));
+    fireEvent.click(screen.getByRole('button', { name: /label take #1/i }));
     const input = screen.getByRole('textbox');
     fireEvent.change(input, { target: { value: 'before the show' } });
     await act(async () => { fireEvent.keyDown(input, { key: 'Enter' }); });
     expect(relabelDeploy).toHaveBeenCalledWith(1, 'before the show');
-    fireEvent.click(screen.getByRole('button', { name: /label deploy #2/i }));
+    fireEvent.click(screen.getByRole('button', { name: /label take #2/i }));
     fireEvent.keyDown(screen.getByRole('textbox'), { key: 'Escape' });
     expect(screen.queryByRole('textbox')).toBeNull();
     expect(relabelDeploy).toHaveBeenCalledTimes(1);
@@ -183,5 +183,18 @@ describe('DeployHistory — saving a take', () => {
     await act(async () => { fireEvent.keyDown(screen.getByLabelText('label for the new take'), { key: 'Enter' }); });
     expect(screen.getByText('take not recorded')).toBeInTheDocument();
     expect(onSavingChange).toHaveBeenCalledWith(false);
+  });
+
+  it('ignores a repeated Enter while a save is in flight, so auto-repeat cannot post twice', async () => {
+    let resolveSave: (row: DeployRow) => void = () => {};
+    const saveTake = vi.fn(() => new Promise<DeployRow>((resolve) => { resolveSave = resolve; }));
+    const { onSavingChange } = list({ saveTake }, true);
+    const input = screen.getByLabelText('label for the new take');
+    fireEvent.keyDown(input, { key: 'Enter' });
+    fireEvent.keyDown(input, { key: 'Enter' });
+    await act(async () => { resolveSave(deploys[0]); });
+    expect(saveTake).toHaveBeenCalledTimes(1);
+    expect(onSavingChange).toHaveBeenCalledWith(false);
+    expect(onSavingChange).toHaveBeenCalledTimes(1);
   });
 });

--- a/app/studio/DeployHistory.test.tsx
+++ b/app/studio/DeployHistory.test.tsx
@@ -26,7 +26,7 @@ function api(over: Partial<StudioSettingsApi> = {}): StudioSettingsApi {
     lastPollAt: null, liveRevision: 1,
     effective: () => ({}), setKnob: vi.fn(), resetSection: vi.fn(), applyNamespace: () => [],
     diffByNamespace: {}, diffCount: 1,
-    deploy: async () => {}, revert: async () => {}, deployedAtMs: null, droppedKeys: [],
+    deploy: async () => {}, revert: async () => {}, saveTake: async () => null, deployedAtMs: null, droppedKeys: [],
     deploys, loadDeploy: vi.fn(async () => []), relabelDeploy: vi.fn(async () => {}), lastDeployRecorded: null,
     ...over,
   };

--- a/app/studio/DeployHistory.test.tsx
+++ b/app/studio/DeployHistory.test.tsx
@@ -1,5 +1,5 @@
-import { describe, it, expect, vi } from 'vitest';
-import { render, screen, fireEvent, act } from '@testing-library/react';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, fireEvent, act, within } from '@testing-library/react';
 import type { StudioSettingsApi } from './useStudioSettings';
 import type { DeployRow } from '@/app/lib/settings/deploys';
 
@@ -26,29 +26,60 @@ function api(over: Partial<StudioSettingsApi> = {}): StudioSettingsApi {
     lastPollAt: null, liveRevision: 1,
     effective: () => ({}), setKnob: vi.fn(), resetSection: vi.fn(), applyNamespace: () => [],
     diffByNamespace: {}, diffCount: 1,
-    deploy: async () => {}, revert: async () => {}, saveTake: async () => null, deployedAtMs: null, droppedKeys: [],
+    deploy: async () => {}, revert: async () => {}, saveTake: vi.fn(async () => null), deployedAtMs: null, droppedKeys: [],
     deploys, loadDeploy: vi.fn(async () => []), relabelDeploy: vi.fn(async () => {}), lastDeployRecorded: null,
     ...over,
   };
 }
 
+/** The list is a controlled surface now: `saving` opens the label field. */
+function list(over: Partial<StudioSettingsApi> = {}, saving = false, onSavingChange = vi.fn()) {
+  return { onSavingChange, ...render(<DeployHistory api={api(over)} saving={saving} onSavingChange={onSavingChange} />) };
+}
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
 describe('DeployHistory', () => {
-  it('lists deploys newest first with number, label, summary, and the glass/studio badges', () => {
-    render(<DeployHistory api={api()} />);
+  it('lists takes newest first with number, label, summary, and the live/in studio badges', () => {
+    list();
+    expect(screen.getByText('takes')).toBeInTheDocument();
     const rows = screen.getAllByRole('listitem');
     expect(rows[0]).toHaveTextContent('#2');
     expect(rows[0]).toHaveTextContent('opening night');
     expect(rows[0]).toHaveTextContent('floorPx 140');
-    expect(rows[0]).toHaveTextContent('studio');
+    expect(within(rows[0]).getByText('in studio')).toBeInTheDocument();
     expect(rows[1]).toHaveTextContent('#1');
     expect(rows[1]).toHaveTextContent('first recorded');
-    expect(rows[1]).toHaveTextContent('glass');
-    expect(rows[0]).not.toHaveTextContent('glass');
+    expect(within(rows[1]).getByText('live')).toBeInTheDocument();
+    expect(within(rows[0]).queryByText('live')).toBeNull();
+  });
+
+  it('badges each of the four states, and live replaces deployed on the row the glass is running', () => {
+    const badgeRows: DeployRow[] = [
+      // saved, and different from everything
+      { id: 4, label: null, namespaces: { v1: { floorPx: 200 } }, deployedAt: null, createdAt: '2026-09-05T19:00:00.000Z' },
+      // saved and equal to the studio profile
+      { id: 3, label: null, namespaces: { v1: { floorPx: 140 } }, deployedAt: null, createdAt: '2026-09-05T18:45:00.000Z' },
+      // deployed, but not what the glass is running
+      { id: 2, label: null, namespaces: { v1: { floorPx: 180 } }, deployedAt: '2026-09-05T18:30:00.000Z', createdAt: '2026-09-05T18:30:00.000Z' },
+      // deployed and equal to the live profile
+      { id: 1, label: null, namespaces: {}, deployedAt: '2026-09-05T17:00:00.000Z', createdAt: '2026-09-05T17:00:00.000Z' },
+    ];
+    list({ deploys: badgeRows });
+    const rows = screen.getAllByRole('listitem');
+    const badges = (i: number) => ['live', 'deployed', 'saved', 'in studio']
+      .filter((name) => within(rows[i]).queryByText(name) !== null);
+    expect(badges(0)).toEqual(['saved']);
+    expect(badges(1)).toEqual(['saved', 'in studio']);
+    expect(badges(2)).toEqual(['deployed']);
+    expect(badges(3)).toEqual(['live']);
   });
 
   it('clicking a row loads it into the studio and reports a partial fit', async () => {
     const loadDeploy = vi.fn(async () => [{ namespace: 'v1', key: 'ghost', reason: 'unknown' as const }]);
-    render(<DeployHistory api={api({ loadDeploy, deploys: [{ ...deploys[0], namespaces: { v1: { floorPx: 140, ghost: 1 } } }] })} />);
+    list({ loadDeploy, deploys: [{ ...deploys[0], namespaces: { v1: { floorPx: 140, ghost: 1 } } }] });
     await act(async () => { fireEvent.click(screen.getByRole('button', { name: /load deploy #2/i })); });
     expect(loadDeploy).toHaveBeenCalledWith(2);
     expect(screen.getByText('loaded, 1 of 2 keys fit the current schema')).toBeInTheDocument();
@@ -56,14 +87,14 @@ describe('DeployHistory', () => {
 
   it('a 404 on load reads as gone', async () => {
     const loadDeploy = vi.fn(async () => { throw new Error('load deploy failed: 404'); });
-    render(<DeployHistory api={api({ loadDeploy })} />);
+    list({ loadDeploy });
     await act(async () => { fireEvent.click(screen.getByRole('button', { name: /load deploy #1/i })); });
     expect(screen.getByText('gone')).toBeInTheDocument();
   });
 
   it('the label is edited inline: Enter saves, Escape cancels', async () => {
     const relabelDeploy = vi.fn(async () => {});
-    render(<DeployHistory api={api({ relabelDeploy })} />);
+    list({ relabelDeploy });
     fireEvent.click(screen.getByRole('button', { name: /label deploy #1/i }));
     const input = screen.getByRole('textbox');
     fireEvent.change(input, { target: { value: 'before the show' } });
@@ -76,13 +107,81 @@ describe('DeployHistory', () => {
   });
 
   it('says when the last deploy was not recorded', () => {
-    render(<DeployHistory api={api({ lastDeployRecorded: false })} />);
+    list({ lastDeployRecorded: false });
     expect(screen.getByText(/history not recorded/)).toBeInTheDocument();
   });
 
-  it('renders nothing but the heading when there are no deploys', () => {
-    render(<DeployHistory api={api({ deploys: [] })} />);
-    expect(screen.getByText('deploys')).toBeInTheDocument();
+  it('renders nothing but the heading when there are no takes', () => {
+    list({ deploys: [] });
+    expect(screen.getByText('takes')).toBeInTheDocument();
     expect(screen.queryAllByRole('listitem')).toHaveLength(0);
+  });
+});
+
+describe('DeployHistory — saving a take', () => {
+  it('shows no label field until the header asks for one', () => {
+    list();
+    expect(screen.queryByLabelText('label for the new take')).toBeNull();
+  });
+
+  it('autofocuses the label field and saves the trimmed label on Enter', async () => {
+    const saveTake = vi.fn(async () => deploys[0]);
+    const { onSavingChange } = list({ saveTake, studio: { namespaces: {}, revision: 1 } }, true);
+    const input = screen.getByLabelText('label for the new take');
+    expect(input).toHaveFocus();
+    expect(input).toHaveAttribute('maxLength', '60');
+    fireEvent.change(input, { target: { value: '  dusk over the sound  ' } });
+    await act(async () => { fireEvent.keyDown(input, { key: 'Enter' }); });
+    expect(saveTake).toHaveBeenCalledWith('dusk over the sound');
+    expect(onSavingChange).toHaveBeenCalledWith(false);
+  });
+
+  it('saves an unlabelled take when the field is left blank', async () => {
+    const saveTake = vi.fn(async () => deploys[0]);
+    list({ saveTake, studio: { namespaces: {}, revision: 1 } }, true);
+    await act(async () => { fireEvent.keyDown(screen.getByLabelText('label for the new take'), { key: 'Enter' }); });
+    expect(saveTake).toHaveBeenCalledWith(null);
+  });
+
+  it('Escape closes the field without saving', () => {
+    const saveTake = vi.fn(async () => deploys[0]);
+    const { onSavingChange } = list({ saveTake }, true);
+    fireEvent.keyDown(screen.getByLabelText('label for the new take'), { key: 'Escape' });
+    expect(saveTake).not.toHaveBeenCalled();
+    expect(onSavingChange).toHaveBeenCalledWith(false);
+  });
+
+  it('still saves when the dials already equal the newest take, and says so for a few seconds', async () => {
+    vi.useFakeTimers();
+    // The default api(): studio equals #2's namespaces, so this is the duplicate.
+    const saveTake = vi.fn(async () => ({ ...deploys[0], id: 3, deployedAt: null }));
+    list({ saveTake }, true);
+    await act(async () => { fireEvent.keyDown(screen.getByLabelText('label for the new take'), { key: 'Enter' }); });
+    expect(saveTake).toHaveBeenCalledTimes(1);
+    expect(screen.getByText('same as #2')).toBeInTheDocument();
+    await act(async () => { vi.advanceTimersByTime(4000); });
+    expect(screen.queryByText('same as #2')).toBeNull();
+  });
+
+  it('says nothing about duplicates when the dials differ from the newest take', async () => {
+    const saveTake = vi.fn(async () => ({ ...deploys[0], id: 3, deployedAt: null }));
+    list({ saveTake, studio: { namespaces: { v1: { floorPx: 999 } }, revision: 1 } }, true);
+    await act(async () => { fireEvent.keyDown(screen.getByLabelText('label for the new take'), { key: 'Enter' }); });
+    expect(screen.queryByText(/same as/)).toBeNull();
+  });
+
+  it('reports a take the server did not record', async () => {
+    const saveTake = vi.fn(async () => null);
+    list({ saveTake }, true);
+    await act(async () => { fireEvent.keyDown(screen.getByLabelText('label for the new take'), { key: 'Enter' }); });
+    expect(screen.getByText('take not recorded')).toBeInTheDocument();
+  });
+
+  it('reports a save that threw', async () => {
+    const saveTake = vi.fn(async () => { throw new Error('save take failed: 503'); });
+    const { onSavingChange } = list({ saveTake }, true);
+    await act(async () => { fireEvent.keyDown(screen.getByLabelText('label for the new take'), { key: 'Enter' }); });
+    expect(screen.getByText('take not recorded')).toBeInTheDocument();
+    expect(onSavingChange).toHaveBeenCalledWith(false);
   });
 });

--- a/app/studio/DeployHistory.tsx
+++ b/app/studio/DeployHistory.tsx
@@ -91,7 +91,7 @@ export function DeployHistory({ api }: { api: StudioSettingsApi }) {
                   }}
                 >
                   <b style={{ color: '#f5a344' }}>#{row.id}</b>
-                  <span style={{ color: '#6b7280', marginLeft: 6 }}>{when(row.deployedAt)}</span>
+                  <span style={{ color: '#6b7280', marginLeft: 6 }}>{when(row.deployedAt ?? row.createdAt)}</span>
                   <span style={{ display: 'block', color: '#9aa3b2', whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>
                     {summarize(row, deploys[i + 1])}
                   </span>

--- a/app/studio/DeployHistory.tsx
+++ b/app/studio/DeployHistory.tsx
@@ -1,12 +1,15 @@
 'use client';
 
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import type { StudioSettingsApi } from './useStudioSettings';
 import type { DeployRow } from '@/app/lib/settings/deploys';
 import { profileEquals, summarize } from './deploySummary';
 
 const mono = 'ui-monospace, SFMono-Regular, Menlo, monospace';
 const LABEL_MAX = 60;
+
+/** How long the duplicate/failure line under the new take stays up. */
+const SAVE_NOTE_MS = 4000;
 
 function when(iso: string): string {
   const d = new Date(iso);
@@ -28,14 +31,41 @@ function Badge({ children, color }: { children: string; color: string }) {
 }
 
 /**
- * Every recorded Deploy, newest first, under the Deploy button (spec §2.5).
- * Click a row to put that deploy into the studio; Deploy then sends it to
- * the glass. Nothing here touches live.
+ * Every recorded take, newest first, in the rail (spec §4.3). A take is a
+ * numbered snapshot of the whole studio profile: some were deployed to the
+ * glass, some were only saved. Click a row to put it into the studio; Deploy
+ * then sends it to the glass. Nothing here touches live.
+ *
+ * The badges say which of the four states a row is in:
+ * `live` (deployed and equal to what the glass is running) replaces
+ * `deployed`; `saved` is a row that was never deployed; `in studio` rides
+ * along on whichever row the dials currently match.
+ *
+ * `saving` is owned by the page, because the button that raises it is in the
+ * header and the field it opens is here.
  */
-export function DeployHistory({ api }: { api: StudioSettingsApi }) {
-  const { deploys, studio, live, loadDeploy, relabelDeploy, lastDeployRecorded } = api;
+export function DeployHistory({ api, saving, onSavingChange }: {
+  api: StudioSettingsApi;
+  saving: boolean;
+  onSavingChange: (value: boolean) => void;
+}) {
+  const { deploys, studio, live, loadDeploy, relabelDeploy, saveTake, lastDeployRecorded } = api;
   const [editing, setEditing] = useState<{ id: number; draft: string } | null>(null);
   const [note, setNote] = useState<{ id: number; text: string } | null>(null);
+  const [draft, setDraft] = useState('');
+  const [saveNote, setSaveNote] = useState<string | null>(null);
+  const saveNoteTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => () => {
+    if (saveNoteTimer.current !== null) clearTimeout(saveNoteTimer.current);
+  }, []);
+
+  /** A line at the top of the list that clears itself. */
+  const flash = (text: string) => {
+    if (saveNoteTimer.current !== null) clearTimeout(saveNoteTimer.current);
+    setSaveNote(text);
+    saveNoteTimer.current = setTimeout(() => setSaveNote(null), SAVE_NOTE_MS);
+  };
 
   const load = async (row: DeployRow) => {
     setNote(null);
@@ -61,20 +91,67 @@ export function DeployHistory({ api }: { api: StudioSettingsApi }) {
     }
   };
 
+  /**
+   * Saving dials that already equal the newest take is allowed — a label is a
+   * reason to save — but the duplicate is named so it is visible.
+   */
+  const save = async () => {
+    const label = draft.trim().slice(0, LABEL_MAX) || null;
+    const newest = deploys[0];
+    const duplicateOf = newest && profileEquals(newest.namespaces, studio?.namespaces) ? newest.id : null;
+    setDraft('');
+    setSaveNote(null);
+    try {
+      const row = await saveTake(label);
+      onSavingChange(false);
+      if (!row) flash('take not recorded');
+      else if (duplicateOf !== null) flash(`same as #${duplicateOf}`);
+    } catch {
+      onSavingChange(false);
+      flash('take not recorded');
+    }
+  };
+
+  const cancelSave = () => {
+    setDraft('');
+    onSavingChange(false);
+  };
+
   return (
     <section style={{ marginTop: 10, fontFamily: mono, fontSize: 11 }}>
       <h4
         style={{ margin: '0 0 4px', fontSize: 10, letterSpacing: '.06em', textTransform: 'uppercase', color: '#8b95a7', cursor: 'help' }}
-        title="Every Deploy, newest first. Click one to load it into the studio; Deploy then sends it to the glass."
+        title="Every take, newest first: saved and deployed snapshots of the dials. Click one to load it into the studio; Deploy then sends it to the glass."
       >
-        deploys
+        takes
       </h4>
       {lastDeployRecorded === false && (
         <div style={{ color: '#e5484d', marginBottom: 4 }}>history not recorded (table missing?)</div>
       )}
+      {saving && (
+        <input
+          autoFocus
+          value={draft}
+          maxLength={LABEL_MAX}
+          placeholder="label this take…"
+          aria-label="label for the new take"
+          onChange={(e) => setDraft(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter') void save();
+            if (e.key === 'Escape') cancelSave();
+          }}
+          style={{
+            width: '100%', marginBottom: 4, background: '#0b0e14', color: '#e5e7eb', border: '1px solid #2a3242',
+            borderRadius: 4, fontFamily: mono, fontSize: 11, padding: '2px 4px',
+          }}
+        />
+      )}
+      {/* Sits where the new row lands once the list refetches. */}
+      {saveNote !== null && <div style={{ color: '#f5a344', marginBottom: 4 }}>{saveNote}</div>}
       <ul style={{ listStyle: 'none', margin: 0, padding: 0, maxHeight: 260, overflowY: 'auto' }}>
         {deploys.map((row, i) => {
-          const onGlass = profileEquals(row.namespaces, live?.namespaces);
+          const isSaved = row.deployedAt === null;
+          const isLive = !isSaved && profileEquals(row.namespaces, live?.namespaces);
           const inStudio = profileEquals(row.namespaces, studio?.namespaces);
           const isEditing = editing?.id === row.id;
           return (
@@ -97,8 +174,11 @@ export function DeployHistory({ api }: { api: StudioSettingsApi }) {
                   </span>
                 </button>
                 <span style={{ whiteSpace: 'nowrap' }}>
-                  {onGlass && <Badge color="#7ee2ac">glass</Badge>}
-                  {inStudio && <Badge color="#f5a344">studio</Badge>}
+                  {isLive && <Badge color="#7ee2ac">live</Badge>}
+                  {isSaved
+                    ? <Badge color="#c4a7f7">saved</Badge>
+                    : !isLive && <Badge color="#8b95a7">deployed</Badge>}
+                  {inStudio && <Badge color="#f5a344">in studio</Badge>}
                 </span>
               </div>
               {isEditing ? (

--- a/app/studio/DeployHistory.tsx
+++ b/app/studio/DeployHistory.tsx
@@ -55,6 +55,8 @@ export function DeployHistory({ api, saving, onSavingChange }: {
   const [draft, setDraft] = useState('');
   const [saveNote, setSaveNote] = useState<string | null>(null);
   const saveNoteTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const inFlight = useRef(false);
+  const [busy, setBusy] = useState(false);
 
   useEffect(() => () => {
     if (saveNoteTimer.current !== null) clearTimeout(saveNoteTimer.current);
@@ -96,6 +98,9 @@ export function DeployHistory({ api, saving, onSavingChange }: {
    * reason to save — but the duplicate is named so it is visible.
    */
   const save = async () => {
+    if (inFlight.current) return;
+    inFlight.current = true;
+    setBusy(true);
     const label = draft.trim().slice(0, LABEL_MAX) || null;
     const newest = deploys[0];
     const duplicateOf = newest && profileEquals(newest.namespaces, studio?.namespaces) ? newest.id : null;
@@ -109,6 +114,9 @@ export function DeployHistory({ api, saving, onSavingChange }: {
     } catch {
       onSavingChange(false);
       flash('take not recorded');
+    } finally {
+      inFlight.current = false;
+      setBusy(false);
     }
   };
 
@@ -133,6 +141,7 @@ export function DeployHistory({ api, saving, onSavingChange }: {
           autoFocus
           value={draft}
           maxLength={LABEL_MAX}
+          disabled={busy}
           placeholder="label this take…"
           aria-label="label for the new take"
           onChange={(e) => setDraft(e.target.value)}
@@ -160,7 +169,7 @@ export function DeployHistory({ api, saving, onSavingChange }: {
                 <button
                   type="button"
                   onClick={() => void load(row)}
-                  aria-label={`load deploy #${row.id} into the studio`}
+                  aria-label={`load take #${row.id} into the studio`}
                   title="Load into the studio (undeployed studio edits are discarded)"
                   style={{
                     background: 'transparent', border: 0, padding: 0, color: '#e5e7eb', fontFamily: mono,
@@ -186,7 +195,7 @@ export function DeployHistory({ api, saving, onSavingChange }: {
                   autoFocus
                   value={editing.draft}
                   maxLength={LABEL_MAX}
-                  aria-label={`label for deploy #${row.id}`}
+                  aria-label={`label for take #${row.id}`}
                   onChange={(e) => setEditing({ id: row.id, draft: e.target.value })}
                   onKeyDown={(e) => {
                     if (e.key === 'Enter') void saveLabel();
@@ -201,7 +210,7 @@ export function DeployHistory({ api, saving, onSavingChange }: {
                 <button
                   type="button"
                   onClick={() => setEditing({ id: row.id, draft: row.label ?? '' })}
-                  aria-label={`label deploy #${row.id}`}
+                  aria-label={`label take #${row.id}`}
                   title="Click to rename"
                   style={{
                     background: 'transparent', border: 0, padding: 0, color: row.label ? '#c3cad6' : '#4b5568',

--- a/app/studio/Header.test.tsx
+++ b/app/studio/Header.test.tsx
@@ -15,7 +15,7 @@ function api(over: Partial<StudioSettingsApi> = {}): StudioSettingsApi {
     effective: () => mergeSettings(SHARED_SCHEMA, { activeVersion: 'solo2', panelPreset: 'dell-l' }),
     setKnob: vi.fn(), resetSection: vi.fn(), applyNamespace: () => [],
     diffByNamespace: { shared: ['activeVersion'] }, diffCount: 3,
-    deploy: async () => {}, revert: vi.fn(async () => {}), deployedAtMs: null, droppedKeys: [],
+    deploy: async () => {}, revert: vi.fn(async () => {}), saveTake: async () => null, deployedAtMs: null, droppedKeys: [],
     deploys: [], loadDeploy: async () => [], relabelDeploy: async () => {}, lastDeployRecorded: null,
     ...over,
   };

--- a/app/studio/Rail.test.tsx
+++ b/app/studio/Rail.test.tsx
@@ -18,7 +18,7 @@ function api(over: Partial<StudioSettingsApi> = {}): StudioSettingsApi {
       : mergeSettings(MOSAIC_SETTINGS_SCHEMAS[ns], {}),
     setKnob: vi.fn(), resetSection: vi.fn(), applyNamespace: () => [],
     diffByNamespace: {}, diffCount: 0,
-    deploy: async () => {}, revert: async () => {}, deployedAtMs: null, droppedKeys: [],
+    deploy: async () => {}, revert: async () => {}, saveTake: async () => null, deployedAtMs: null, droppedKeys: [],
     deploys: [], loadDeploy: async () => [], relabelDeploy: async () => {}, lastDeployRecorded: null,
     ...over,
   };

--- a/app/studio/StudioClient.test.tsx
+++ b/app/studio/StudioClient.test.tsx
@@ -53,7 +53,7 @@ function api(): StudioSettingsApi {
       : mergeSettings(MOSAIC_SETTINGS_SCHEMAS[ns], {}),
     setKnob: vi.fn(), resetSection: vi.fn(), applyNamespace: () => [],
     diffByNamespace: {}, diffCount: 0,
-    deploy: async () => {}, revert: async () => {}, deployedAtMs: null, droppedKeys: [],
+    deploy: async () => {}, revert: async () => {}, saveTake: async () => null, deployedAtMs: null, droppedKeys: [],
     deploys: [], loadDeploy: async () => [], relabelDeploy: async () => {}, lastDeployRecorded: null,
   };
 }

--- a/app/studio/StudioClient.test.tsx
+++ b/app/studio/StudioClient.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { render, screen, within } from '@testing-library/react';
+import { render, screen, within, fireEvent } from '@testing-library/react';
 import { StudioClient } from './StudioClient';
 import { SHARED_SCHEMA } from '@/app/lib/settings/sharedSchema';
 import { mergeSettings } from '@/app/lib/settings/schema';
@@ -127,7 +127,7 @@ describe('StudioClient — one page, the version select decides what it is', () 
     const { container } = render(<StudioClient />);
     expect(screen.getByLabelText('version')).toHaveValue(version);
     expect(screen.getByTestId('nav-slot')).toBeInTheDocument();
-    expect(aside(container).getByText('deploys')).toBeInTheDocument();
+    expect(aside(container).getByText('takes')).toBeInTheDocument();
   });
 
   it('waits for the studio profile instead of flashing the default version', () => {
@@ -167,5 +167,17 @@ describe('StudioClient — the page keeps no clock of its own', () => {
     } finally {
       setIntervalSpy.mockRestore();
     }
+  });
+});
+
+describe('StudioClient — save take', () => {
+  it('the header button opens the label field down in the takes list', () => {
+    // The button is in the header and the field is in the rail, so the page
+    // owns the flag between them.
+    activeVersion = 'v4';
+    const { container } = render(<StudioClient />);
+    expect(aside(container).queryByLabelText('label for the new take')).toBeNull();
+    fireEvent.click(screen.getByTestId('save-take'));
+    expect(aside(container).getByLabelText('label for the new take')).toBeInTheDocument();
   });
 });

--- a/app/studio/StudioClient.tsx
+++ b/app/studio/StudioClient.tsx
@@ -102,6 +102,7 @@ export function StudioClient() {
               type="button"
               data-testid="save-take"
               onClick={() => setSaving(true)}
+              disabled={gated}
               title="Save these dials as a take without sending them to the glass"
               style={{
                 flex: 'none',

--- a/app/studio/StudioClient.tsx
+++ b/app/studio/StudioClient.tsx
@@ -21,6 +21,8 @@ import { surfaceFor } from './surfaces';
 import { useStudioSettings } from './useStudioSettings';
 import { useSceneWebcams, type SceneSource } from './useSceneWebcams';
 
+const mono = 'ui-monospace, SFMono-Regular, Menlo, monospace';
+
 /**
  * The one `/studio` (one-studio spec §2). There is no second studio page and
  * no per-version chrome: the header's version select names a surface, and the
@@ -47,6 +49,9 @@ export function StudioClient() {
   const panel = PANEL_PRESETS[String(shared.panelPreset)] ?? PANEL_PRESETS[DEFAULT_PANEL_PRESET];
   const [tab, setTab] = useState<RailTab>('play');
   const [sceneSource, setSceneSource] = useState<SceneSource>({ kind: 'live' });
+  // The save-take button is in the header; the field it opens is down in the
+  // takes list, so the page owns the flag between them.
+  const [saving, setSaving] = useState(false);
 
   // Before the first poll answers, `effective()` is the schema defaults, which
   // name v1 — not necessarily the version the operator is on. Rendering that
@@ -90,7 +95,30 @@ export function StudioClient() {
       height: '100vh', background: '#0b0e14', color: '#e5e7eb', overflow: 'hidden',
     }}>
       <div style={{ gridColumn: '1 / -1' }}>
-        <Header api={api} />
+        <Header
+          api={api}
+          extra={(
+            <button
+              type="button"
+              data-testid="save-take"
+              onClick={() => setSaving(true)}
+              title="Save these dials as a take without sending them to the glass"
+              style={{
+                flex: 'none',
+                background: 'transparent',
+                border: '1px solid #2a3242',
+                borderRadius: 6,
+                padding: '2px 8px',
+                fontFamily: mono,
+                fontSize: 11,
+                color: '#8b95a7',
+                cursor: 'pointer',
+              }}
+            >
+              save take
+            </button>
+          )}
+        />
       </div>
 
       {gated ? (
@@ -105,7 +133,7 @@ export function StudioClient() {
             display: 'flex', flexDirection: 'column', overflowY: 'auto',
           }}>
             <Rail api={api} surface={surface} tab={tab} onTab={setTab} runFrames={runFrames}>
-              <DeployHistory api={api} />
+              <DeployHistory api={api} saving={saving} onSavingChange={setSaving} />
             </Rail>
           </aside>
 

--- a/app/studio/deploySummary.test.ts
+++ b/app/studio/deploySummary.test.ts
@@ -16,7 +16,7 @@ vi.mock('@/app/components/mosaic/registry', () => ({
 import { summarize, profileEquals, formatValue } from './deploySummary';
 
 const row = (id: number, namespaces: Record<string, Record<string, number | boolean | string>>) =>
-  ({ id, label: null, namespaces, deployedAt: 'T' });
+  ({ id, label: null, namespaces, deployedAt: 'T', createdAt: 'T' });
 
 describe('formatValue', () => {
   it('integers plain, fractions to two places, booleans on/off, strings as-is', () => {

--- a/app/studio/useStudioSettings.test.tsx
+++ b/app/studio/useStudioSettings.test.tsx
@@ -3,6 +3,7 @@ import { renderHook, act } from '@testing-library/react';
 import { SWRConfig } from 'swr';
 import type { ReactNode } from 'react';
 import { useStudioSettings } from './useStudioSettings';
+import type { DeployRow } from '@/app/lib/settings/deploys';
 
 // v1's floorPx default is 100 (COMPOSITION_TILE_FLOOR_PX) — see
 // app/components/mosaic/v1/config.ts.
@@ -655,5 +656,89 @@ describe('useStudioSettings.applyNamespace — restoring a saved dial set', () =
     const call = fetchMock.mock.calls.find(([u]) => u === '/api/kiosk/deploys/7');
     expect((call?.[1] as RequestInit).method).toBe('PATCH');
     expect(JSON.parse(String((call?.[1] as RequestInit).body))).toEqual({ label: 'opening night' });
+  });
+
+  it('saveTake flushes a pending debounced PATCH, then POSTs to /api/kiosk/deploys and refetches the list', async () => {
+    const getResponse = settingsResponse({}, {});
+    const take = { id: 9, label: 'take one', namespaces: { v1: { floorPx: 200 } }, deployedAt: null, createdAt: 'T' };
+    fetchMock = vi.fn(async (url: string, init?: RequestInit) => {
+      if (!init || (!init.method && url === '/api/kiosk/settings')) {
+        return { ok: true, json: async () => getResponse };
+      }
+      if (url === '/api/kiosk/deploys' && (!init.method || init.method === 'GET')) {
+        return { ok: true, json: async () => ({ deploys: [] }) };
+      }
+      if (init.method === 'PATCH' && url === '/api/kiosk/settings') {
+        return { ok: true, json: async () => ({ revision: 2 }) };
+      }
+      if (init.method === 'POST' && url === '/api/kiosk/deploys') {
+        return { ok: true, json: async () => ({ take }) };
+      }
+      return { ok: true, json: async () => ({}) };
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { result } = renderHook(() => useStudioSettings(), { wrapper });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+
+    act(() => {
+      result.current.setKnob('v1', 'floorPx', 200);
+    });
+
+    // Call saveTake immediately — no timer advance — so the debounce window
+    // has not fired yet and the edit is still only in the optimistic overlay.
+    let saved: DeployRow | null = null;
+    await act(async () => {
+      saved = await result.current.saveTake('take one');
+    });
+
+    expect(saved).toEqual(take);
+
+    const relevantCalls = fetchMock.mock.calls.filter(
+      (c) =>
+        c[1]?.method === 'PATCH' ||
+        (c[1]?.method === 'POST' && c[0] === '/api/kiosk/deploys')
+    );
+    expect(relevantCalls.length).toBe(2);
+    expect(relevantCalls[0][1]?.method).toBe('PATCH');
+    expect(relevantCalls[1][0]).toBe('/api/kiosk/deploys');
+    expect(relevantCalls[1][1]?.method).toBe('POST');
+    const postBody = JSON.parse(relevantCalls[1][1].body as string);
+    expect(postBody).toEqual({ label: 'take one' });
+
+    // The deploys list is refetched after saving a take.
+    const deploysGetCalls = fetchMock.mock.calls.filter(
+      (c) => c[0] === '/api/kiosk/deploys' && (!c[1] || !c[1].method)
+    );
+    expect(deploysGetCalls.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('saveTake throws when the deploys route responds non-ok', async () => {
+    fetchMock = vi.fn(async (url: string, init?: RequestInit) => {
+      if (!init || (!init.method && url === '/api/kiosk/settings')) {
+        return { ok: true, json: async () => settingsResponse({}, {}) };
+      }
+      if (url === '/api/kiosk/deploys' && (!init.method || init.method === 'GET')) {
+        return { ok: true, json: async () => ({ deploys: [] }) };
+      }
+      if (init.method === 'POST' && url === '/api/kiosk/deploys') {
+        return { ok: false, status: 500, json: async () => ({ error: 'boom' }) };
+      }
+      return { ok: true, json: async () => ({}) };
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { result } = renderHook(() => useStudioSettings(), { wrapper });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+
+    await expect(
+      act(async () => {
+        await result.current.saveTake();
+      })
+    ).rejects.toThrow();
   });
 });

--- a/app/studio/useStudioSettings.ts
+++ b/app/studio/useStudioSettings.ts
@@ -48,6 +48,8 @@ export interface StudioSettingsApi {
   diffCount: number; // total across namespaces — the badge number
   deploy: (label?: string) => Promise<void>;
   revert: () => Promise<void>;
+  /** Save the current studio profile as a take (spec §4.2) — never reaches the glass. */
+  saveTake: (label?: string | null) => Promise<DeployRow | null>;
   /** Recorded deploys, newest first. [] until the first fetch lands. */
   deploys: DeployRow[];
   /** Put a recorded deploy into the studio profile (the glass is untouched). Returns the keys the current schema could not take. */
@@ -295,6 +297,24 @@ export function useStudioSettings(): StudioSettingsApi {
     [flushPending, mutate, mutateDeploys]
   );
 
+  const saveTake = useCallback(
+    async (label?: string | null): Promise<DeployRow | null> => {
+      await flushPending();
+      const res = await fetch(DEPLOYS_URL, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ label: label ?? null }),
+      });
+      if (!res.ok) {
+        throw new Error(`save take failed: ${res.status}`);
+      }
+      const json = (await res.json()) as { take: DeployRow };
+      void mutateDeploys();
+      return json.take;
+    },
+    [flushPending, mutateDeploys]
+  );
+
   const revert = useCallback(async () => {
     cancelPending();
     const res = await fetch('/api/kiosk/settings/revert', { method: 'POST' });
@@ -360,6 +380,7 @@ export function useStudioSettings(): StudioSettingsApi {
     diffCount,
     deploy,
     revert,
+    saveTake,
     deploys: deploysData?.deploys ?? [],
     loadDeploy,
     relabelDeploy,

--- a/database/migrations/20260906_kiosk_takes.sql
+++ b/database/migrations/20260906_kiosk_takes.sql
@@ -1,0 +1,20 @@
+-- kiosk_takes: lets a kiosk_deploys row be a saved take that was never
+-- deployed (spec: docs/superpowers/specs/2026-09-05-one-studio-design.md §4).
+-- `deployed_at` stops meaning "when this row was created" and starts meaning
+-- "when this row was pushed to the glass, if ever" — a take saved via
+-- saveTake() leaves it NULL. `created_at` is the new source of truth for
+-- row ordering and display time, backfilled from the existing deployed_at
+-- so history keeps its original timestamps.
+-- Loading a row back still sanitizes each namespace through its current
+-- schema (see 20260905_kiosk_deploys.sql); this migration touches only the
+-- two timestamp columns.
+--
+-- Forward-only, idempotent. Apply via:
+--   node scripts/apply-migration.mjs database/migrations/20260906_kiosk_takes.sql
+--   node scripts/apply-migration.mjs database/migrations/20260906_kiosk_takes.sql --apply
+
+ALTER TABLE kiosk_deploys ADD COLUMN IF NOT EXISTS created_at TIMESTAMPTZ NOT NULL DEFAULT now();
+
+UPDATE kiosk_deploys SET created_at = deployed_at WHERE created_at > deployed_at;
+
+ALTER TABLE kiosk_deploys ALTER COLUMN deployed_at DROP NOT NULL;


### PR DESCRIPTION
## Saved takes (phase B of 3, stacked on #146)

**Apply before merge (production, ledger rule):**

```
node scripts/apply-migration.mjs database/migrations/20260906_kiosk_takes.sql --apply
npm run migrate:status
```

The migration adds `created_at` and makes `deployed_at` nullable on `kiosk_deploys`. Until it is applied, `recordDeploy` fails on the missing column, so a Deploy made in the window reaches the glass but writes no history row, and the takes list renders empty. Nothing existing is touched. The three statements each run as their own request and are all idempotent, so a partial failure is fixed by running the file again.

Known consequences, on purpose: deploys and saved takes share the list's 50-row window; a deployed row's one-line summary is now the delta against the previous row, which may be a saved take.

### What this adds
A dial setup can be **saved as a take** without being deployed. Spec §4 of `docs/superpowers/specs/2026-09-05-one-studio-design.md`.

- `save take` button in the header, left of Deploy. It opens a label field at the top of the takes list; Enter saves, Escape cancels.
- The list under the dials is now **Takes**: deploys and saved takes in one numbered sequence, newest first, with badges `live` (matches the glass), `deployed`, `saved`, `in studio` (matches the rail). Load any row to preview it; Deploy sends it.
- Deploying a loaded saved take records a new deployed row. The saved row stays saved, so every deployed row is something that was on the glass.
- Saving when the studio equals the newest row still saves (a label is a reason) and shows `same as #n` briefly.
- `POST /api/kiosk/deploys` (owner-gated) saves the studio profile; `useStudioSettings.saveTake` flushes pending edits first so the take holds what you see.

### Verification
Test, lint and build counts are in the last commit message. Every task was reviewed; the branch had a whole-branch review.

**Not done:** a signed-in look; the migration apply.

### Signed-in smoke
1. Move a dial, press `save take`, type a label, Enter → a `saved` row appears at the top with `in studio`.
2. Move another dial, load the saved row → the rail snaps back, the row shows `in studio` again.
3. Deploy → a new `deployed` + `live` row appears; the saved row keeps its `saved` badge.
4. Rename a row → the label sticks after reload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PWRkdgYyZLfgjkBhJza1NM
