### PR TITLE
feat(studio): solo preview plays the projected queue (phase C, stacked on #147)

### DIFF
--- a/app/studio/StudioClient.tsx
+++ b/app/studio/StudioClient.tsx
@@ -151,8 +151,8 @@ export function StudioClient() {
               <>
                 <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 12, minHeight: 0 }}>
                   <GlassPreview dials={studioDials!} panel={panel} version={solo!} screens={[
-                    { feed: 'sunrise', server: sunrise.server ?? null, error: sunrise.error },
-                    { feed: 'sunset', server: sunset.server ?? null, error: sunset.error },
+                    { feed: 'sunrise', server: sunrise.server ?? null, projected: sunrise.projected ?? null, error: sunrise.error },
+                    { feed: 'sunset', server: sunset.server ?? null, projected: sunset.projected ?? null, error: sunset.error },
                   ]} />
                 </div>
                 <SoloPanel version={solo!} liveDials={liveDials!} sunrise={sunrise} sunset={sunset} />

--- a/app/studio/solo/GlassPreview.test.tsx
+++ b/app/studio/solo/GlassPreview.test.tsx
@@ -131,3 +131,31 @@ it('restarts at the on-glass frame when the server advances', async () => {
   rerender(<GlassPreview screens={[{ feed: 'sunset', server: advanced, projected }]} dials={dials} panel={panel} />);
   expect(screen.getByText('on glass now · frame 21')).toBeInTheDocument();
 });
+
+it('restarts the run\'s stage clock when the server advances a different camera while still at index 0 (keyed on the dwell start, not the index)', async () => {
+  const { SOLO_VERSIONS } = await import('@/app/lib/solo/versions');
+  const { SOLO2_SETTINGS_SCHEMA, dialsFrom2 } = await import('@/app/lib/solo2/settingsSchema');
+  vi.useFakeTimers();
+  const d2 = { ...dialsFrom2(schemaDefaults(SOLO2_SETTINGS_SCHEMA)), dwellS: 6, sameCameraFadeS: 1 }; // 2 frames → 3 s each
+  const panel = { width: 1920, height: 1080 };
+  const camAOlder = at(5, 1, entry.capturedAt - 20 * 60_000);
+  const s2a = { current: { entry, shownSince: 0, slot: 1 }, entries: [camAOlder, entry] } as unknown as StateView;
+  const { rerender } = render(<GlassPreview version={SOLO_VERSIONS.solo2} screens={[{ feed: 'sunset', server: s2a, projected: null }]}
+    dials={d2} panel={panel} />);
+  expect(screen.getByTestId('top')).toHaveAttribute('src', 'u5'); // run's first frame at mount
+
+  await act(async () => { vi.advanceTimersByTime(4_000); }); // past the 3 s step, still inside the 6 s dwell (index 0 unchanged)
+  expect(screen.getByTestId('top')).toHaveAttribute('src', 'u7'); // stage advanced within the same dwell
+
+  // The server advances to a different camera while the preview is still
+  // sitting at index 0: the dwell restarts (index 0 → 0, unchanged) with a
+  // new startMs. If the stage clock were still keyed on the index, it would
+  // not restart and would show a frame computed from the stale clock instead
+  // of the new run's first frame.
+  const camB = at(21, 4, entry.capturedAt);
+  const camBOlder = at(20, 4, entry.capturedAt - 10 * 60_000);
+  const s2b = { current: { entry: camB, shownSince: 0, slot: 2 }, entries: [camBOlder, camB] } as unknown as StateView;
+  rerender(<GlassPreview version={SOLO_VERSIONS.solo2} screens={[{ feed: 'sunset', server: s2b, projected: null }]}
+    dials={d2} panel={panel} />);
+  expect(screen.getByTestId('top')).toHaveAttribute('src', 'u20'); // camera B's run, first frame — the stage restarted
+});

--- a/app/studio/solo/GlassPreview.test.tsx
+++ b/app/studio/solo/GlassPreview.test.tsx
@@ -28,7 +28,7 @@ beforeAll(() => {
 });
 
 it('draws each screen\'s current frame at the panel\'s true pixels with the studio dials, and says when a screen has nothing', () => {
-  render(<GlassPreview screens={[{ feed: 'sunrise', server }, { feed: 'sunset', server: null }]}
+  render(<GlassPreview screens={[{ feed: 'sunrise', server, projected: null }, { feed: 'sunset', server: null, projected: null }]}
     dials={{ ...D, titleClean: 'spot' }} panel={{ width: 1920, height: 1080 }} />);
   expect(screen.getByTestId('caption-title')).toHaveTextContent('Northern Lights webcam');
   expect(screen.getByTestId('caption-place')).toHaveTextContent('Porjus, Norrbotten County, Sweden');
@@ -43,7 +43,7 @@ it('draws each screen\'s current frame at the panel\'s true pixels with the stud
 });
 
 it('names the screen before the title on each preview', () => {
-  render(<GlassPreview screens={[{ feed: 'sunrise', server }, { feed: 'sunset', server }]} dials={D} panel={{ width: 1920, height: 1080 }} />);
+  render(<GlassPreview screens={[{ feed: 'sunrise', server, projected: null }, { feed: 'sunset', server, projected: null }]} dials={D} panel={{ width: 1920, height: 1080 }} />);
   const titles = screen.getAllByTestId('caption-title').map((t) => t.textContent);
   expect(titles[0]).toMatch(/^Sunrise: /);
   expect(titles[1]).toMatch(/^Sunset: /);
@@ -60,7 +60,7 @@ it('solo2 plays the on-glass camera\'s run on the studio dials, looping on a loc
   const older = (id: number, capturedAt: number) => ({ ...entry, snapshotId: id, imageUrl: `u${id}`, capturedAt });
   const entries = [older(5, entry.capturedAt - 20 * 60_000), older(6, entry.capturedAt - 10 * 60_000), entry];
   const s2 = { ...server, entries } as unknown as StateView;
-  render(<GlassPreview version={SOLO_VERSIONS.solo2} screens={[{ feed: 'sunset', server: s2 }]} dials={d2} panel={{ width: 1920, height: 1080 }} />);
+  render(<GlassPreview version={SOLO_VERSIONS.solo2} screens={[{ feed: 'sunset', server: s2, projected: null }]} dials={d2} panel={{ width: 1920, height: 1080 }} />);
   expect(screen.getByTestId('top')).toHaveAttribute('src', 'u5');
   expect(screen.getByTestId('seq-1')).toHaveStyle({ opacity: '0', transition: 'opacity 1s linear' });
   await act(async () => { vi.advanceTimersByTime(2_100); });
@@ -69,4 +69,65 @@ it('solo2 plays the on-glass camera\'s run on the studio dials, looping on a loc
   expect(screen.getByTestId('top')).toHaveAttribute('src', 'u7');
   await act(async () => { vi.advanceTimersByTime(2_000); });
   expect(screen.getByTestId('top')).toHaveAttribute('src', 'u5'); // round again
+});
+
+// The queue the preview walks: the on-glass frame, then the STUDIO projection.
+const at = (id: number, webcamId: number, capturedAt = entry.capturedAt) => ({
+  ...entry, snapshotId: id, webcamId, imageUrl: `u${id}`, capturedAt,
+});
+
+it('walks the projected queue on the studio dwell, crossfading from the frame it replaces', async () => {
+  vi.useFakeTimers();
+  const projected = { next: [at(8, 2), at(9, 3)] } as unknown as StateView;
+  const { container } = render(<GlassPreview screens={[{ feed: 'sunset', server, projected }]}
+    dials={{ ...D, dwellS: 4, fadeS: 2 }} panel={{ width: 1920, height: 1080 }} />);
+  expect(screen.getByText('on glass now · frame 7')).toBeInTheDocument();
+
+  await act(async () => { vi.advanceTimersByTime(4_100); });
+  expect(screen.getByText(/^preview · frame 8 · next in \d+ s$/)).toBeInTheDocument();
+  // The frame it replaced sits underneath, and the top layer carries the studio's fade dial.
+  const imgs = [...container.querySelectorAll('img')];
+  expect(imgs.map((i) => i.getAttribute('src'))).toEqual(['u7', 'u8']);
+  expect(imgs[1]).toHaveStyle({ transition: 'opacity 2s ease' });
+
+  await act(async () => { vi.advanceTimersByTime(4_000); });
+  expect(screen.getByText(/^preview · frame 9/)).toBeInTheDocument();
+  await act(async () => { vi.advanceTimersByTime(4_000); });
+  expect(screen.getByText('on glass now · frame 7')).toBeInTheDocument(); // wraps to the glass frame
+});
+
+it('solo2 plays the queued dwell\'s own camera run once the preview advances', async () => {
+  const { SOLO_VERSIONS } = await import('@/app/lib/solo/versions');
+  const { SOLO2_SETTINGS_SCHEMA, dialsFrom2 } = await import('@/app/lib/solo2/settingsSchema');
+  vi.useFakeTimers();
+  const d2 = { ...dialsFrom2(schemaDefaults(SOLO2_SETTINGS_SCHEMA)), dwellS: 6, sameCameraFadeS: 1 };
+  const cam2a = at(11, 2, entry.capturedAt - 30 * 60_000);
+  const cam2b = at(12, 2, entry.capturedAt - 20 * 60_000);
+  const s2 = { ...server, entries: [entry, cam2a, cam2b] } as unknown as StateView;
+  const projected = { next: [cam2b] } as unknown as StateView;
+  render(<GlassPreview version={SOLO_VERSIONS.solo2} screens={[{ feed: 'sunset', server: s2, projected }]}
+    dials={d2} panel={{ width: 1920, height: 1080 }} />);
+  // The on-glass frame is camera 1's only frame: a run of one.
+  expect(screen.queryByTestId('seq-1')).toBeNull();
+
+  await act(async () => { vi.advanceTimersByTime(6_100); });
+  expect(screen.getByText(/^preview · frame 12/)).toBeInTheDocument();
+  // Camera 2's run: 11 then 12, and the stage clock restarted with the step.
+  expect(screen.getByTestId('seq-1')).toBeInTheDocument();
+  expect(screen.queryByTestId('seq-2')).toBeNull();
+  expect(screen.getByTestId('top')).toHaveAttribute('src', 'u11');
+});
+
+it('restarts at the on-glass frame when the server advances', async () => {
+  vi.useFakeTimers();
+  const projected = { next: [at(8, 2)] } as unknown as StateView;
+  const dials = { ...D, dwellS: 4 };
+  const panel = { width: 1920, height: 1080 };
+  const { rerender } = render(<GlassPreview screens={[{ feed: 'sunset', server, projected }]} dials={dials} panel={panel} />);
+  await act(async () => { vi.advanceTimersByTime(4_100); });
+  expect(screen.getByText(/^preview · frame 8/)).toBeInTheDocument();
+
+  const advanced = { current: { entry: at(21, 4), shownSince: 0, slot: 2 } } as unknown as StateView;
+  rerender(<GlassPreview screens={[{ feed: 'sunset', server: advanced, projected }]} dials={dials} panel={panel} />);
+  expect(screen.getByText('on glass now · frame 21')).toBeInTheDocument();
 });

--- a/app/studio/solo/GlassPreview.tsx
+++ b/app/studio/solo/GlassPreview.tsx
@@ -63,7 +63,11 @@ function PlayingScreen({ feed, server, projected, error, dials, panel, version }
   const d2 = dials as Solo2Dials;
   const run = solo2 && dwell.entry ? runOf(dwell.entry, server?.entries ?? [], d2.cameraRun) : [];
   const plan = fitPlan({ dwellS: dials.dwellS, leadS: d2.leadS ?? 0 }, Math.max(1, run.length));
-  const stage = useLoopingStage(plan, dwell.index);
+  // Keyed on the dwell start, not the index: the start changes on every step
+  // AND every restart (a server advance while sitting at index 0 still gets
+  // a fresh start), but never on a bare tick, so this is the one value that
+  // means "the dwell actually changed."
+  const stage = useLoopingStage(plan, dwell.startMs);
 
   const remainingS = Math.max(0, Math.ceil((dwell.startMs + dials.dwellS * 1000 - now) / 1000));
   const status = dwell.entry

--- a/app/studio/solo/GlassPreview.tsx
+++ b/app/studio/solo/GlassPreview.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { SoloFrame } from '@/app/components/solo/SoloFrame';
 import { Solo2Frame } from '@/app/components/solo2/Solo2Frame';
 import { StudioPanelFrame } from '../StudioPanelFrame';
@@ -11,42 +11,108 @@ import type { Solo2Dials } from '@/app/lib/solo2/types';
 import { fitPlan } from '@/app/lib/solo2/plan';
 import { runOf } from '@/app/lib/solo2/run';
 import { useLoopingStage } from './useLoopingStage';
+import { useSoloPreview } from './useSoloPreview';
 
 const mono = 'ui-monospace, SFMono-Regular, Menlo, monospace';
 const SIDE: Record<Feed, string> = { sunrise: 'left screen', sunset: 'right screen' };
 
+/** One screen's inputs: what the glass holds, and the queue re-projected on the studio dials. */
+export interface PreviewScreen {
+  feed: Feed;
+  server: StateView | null;
+  /** `useSoloState`'s re-projection: what these dials would draw next. */
+  projected: StateView | null;
+  error?: string | null;
+}
+
 /**
- * solo2's screen, playing (camera-run spec §5.1): the on-glass camera's run
- * on the STUDIO dials, over and over on a local clock, so the dissolves and
- * the camera-change transition are visible here and dialled from this
- * page. `previous` is derived in the same render as the new frame, as the
- * kiosk does.
+ * A wall clock for the countdown only. The dwell itself is `useSoloPreview`'s
+ * business; this just re-renders often enough for `next in N s` to fall.
  */
-function PlayingScreen({ current, entries, dials, feed, panel }: {
-  current: EntryView; entries: StateView['entries']; dials: Solo2Dials; feed: Feed; panel: { width: number; height: number };
+function useNow(tickMs = 250): number {
+  const [now, setNow] = useState(() => Date.now());
+  useEffect(() => {
+    const t = setInterval(() => setNow(Date.now()), Math.max(1, tickMs));
+    return () => clearInterval(t);
+  }, [tickMs]);
+  return now;
+}
+
+/**
+ * One screen, playing (spec §5): the on-glass frame and then the projected
+ * queue, each for the studio's dwell, on a local clock, so a dial move is
+ * visible in motion instead of on one held frame. The header keeps the live
+ * truth in sight — `on glass now` only while the preview is on the frame the
+ * glass is actually showing.
+ *
+ * Both versions play here. solo crossfades on `fadeS`; solo2 additionally
+ * plays each dwell's camera run, its stage clock restarted by the preview's
+ * index so the run and the dwell step together. `previous` comes from the
+ * same state update as the new frame, as the kiosk does.
+ */
+function PlayingScreen({ feed, server, projected, error, dials, panel, version }: PreviewScreen & {
+  dials: SoloDials; panel: { width: number; height: number }; version: SoloVersionSpec;
 }) {
-  const [track, setTrack] = useState<{ entry: EntryView; previous: EntryView | null }>({ entry: current, previous: null });
-  if (current.snapshotId !== track.entry.snapshotId) setTrack({ entry: current, previous: track.entry });
-  const run = runOf(current, entries, dials.cameraRun);
-  const plan = fitPlan(dials, run.length);
-  const stage = useLoopingStage(plan, current.snapshotId);
+  const current = server?.current?.entry ?? null;
+  const order: EntryView[] = current ? [current, ...(projected?.next ?? [])] : [];
+  const dwell = useSoloPreview(order, dials.dwellS);
+  const now = useNow();
+
+  // Hooks run on both versions; only solo2 reads the stage.
+  const solo2 = version.name === 'solo2';
+  const d2 = dials as Solo2Dials;
+  const run = solo2 && dwell.entry ? runOf(dwell.entry, server?.entries ?? [], d2.cameraRun) : [];
+  const plan = fitPlan({ dwellS: dials.dwellS, leadS: d2.leadS ?? 0 }, Math.max(1, run.length));
+  const stage = useLoopingStage(plan, dwell.index);
+
+  const remainingS = Math.max(0, Math.ceil((dwell.startMs + dials.dwellS * 1000 - now) / 1000));
+  const status = dwell.entry
+    ? (dwell.index === 0
+      ? `on glass now · frame ${dwell.entry.snapshotId}`
+      : `preview · frame ${dwell.entry.snapshotId} · next in ${remainingS} s`)
+    : error ?? 'nothing on glass';
+
   return (
-    <Solo2Frame entry={current} run={run} previous={track.previous} stage={stage} plan={plan} dials={dials}
-      width={panel.width} height={panel.height} feed={feed} />
+    <section style={{ display: 'flex', flexDirection: 'column', minWidth: 0, minHeight: 0 }}>
+      <div style={{ fontFamily: mono, fontSize: 11, color: '#8b95a7', padding: '0 0 6px', display: 'flex', gap: 10 }}>
+        <span style={{ color: '#e5e7eb' }}>{feed} · {SIDE[feed]}</span>
+        <span>{status}</span>
+        <span style={{ marginLeft: 'auto' }}>{panel.width} × {panel.height}</span>
+      </div>
+      <div data-testid={`preview-${feed}`} style={{ flex: 1, minHeight: 0, background: '#000', border: '1px solid #1d2432' }}>
+        {dwell.entry ? (
+          <StudioPanelFrame panel={panel}>
+            {solo2 ? (
+              <Solo2Frame entry={dwell.entry} run={run} previous={dwell.previous} stage={stage} plan={plan} dials={d2}
+                width={panel.width} height={panel.height} feed={feed} />
+            ) : (
+              // No key: SoloFrame's fade is a mount animation on an <img> keyed
+              // by the snapshot id, so a new entry replays it on its own.
+              <SoloFrame entry={dwell.entry} previous={dwell.previous} fadeS={dials.fadeS} dials={dials}
+                width={panel.width} height={panel.height} feed={feed} />
+            )}
+          </StudioPanelFrame>
+        ) : (
+          <div style={{ height: '100%', display: 'grid', placeItems: 'center', color: '#4b5568', fontFamily: mono, fontSize: 12 }}>
+            no frame to preview
+          </div>
+        )}
+      </div>
+    </section>
   );
 }
 
 /**
- * The two screens as the glass draws them right now, by the same component
- * the glass uses, with the studio dials instead of the live ones: what Deploy
- * will send. Each screen composes at the shared panel preset's true pixels
- * and StudioPanelFrame scales it to the box it is given, so the caption is
- * sized exactly as on glass and both screens fit above the fold. Always on
- * screen in the solo studio, whichever rail page is up, so a picture dial
- * shows its effect without a tab switch. solo2's screens play (§5.1).
+ * The two screens as the glass draws them, by the same component the glass
+ * uses, with the studio dials instead of the live ones: what Deploy will
+ * send. Each screen composes at the shared panel preset's true pixels and
+ * StudioPanelFrame scales it to the box it is given, so the caption is sized
+ * exactly as on glass and both screens fit above the fold. Always on screen
+ * in the solo studio, whichever rail page is up, so a picture dial shows its
+ * effect without a tab switch. Both versions play the projected queue (§5).
  */
 export function GlassPreview({ screens, dials, panel, version = SOLO_VERSIONS.solo as SoloVersionSpec }: {
-  screens: { feed: Feed; server: StateView | null; error?: string | null }[];
+  screens: PreviewScreen[];
   dials: SoloDials;
   /** The glass geometry: the frame composes at this size. */
   panel: { width: number; height: number };
@@ -54,33 +120,9 @@ export function GlassPreview({ screens, dials, panel, version = SOLO_VERSIONS.so
 }) {
   return (
     <>
-      {screens.map(({ feed, server, error }) => {
-        const current = server?.current?.entry ?? null;
-        return (
-          <section key={feed} style={{ display: 'flex', flexDirection: 'column', minWidth: 0, minHeight: 0 }}>
-            <div style={{ fontFamily: mono, fontSize: 11, color: '#8b95a7', padding: '0 0 6px', display: 'flex', gap: 10 }}>
-              <span style={{ color: '#e5e7eb' }}>{feed} · {SIDE[feed]}</span>
-              <span>{current ? `on glass now · frame ${current.snapshotId}` : error ?? 'nothing on glass'}</span>
-              <span style={{ marginLeft: 'auto' }}>{panel.width} × {panel.height}</span>
-            </div>
-            <div data-testid={`preview-${feed}`} style={{ flex: 1, minHeight: 0, background: '#000', border: '1px solid #1d2432' }}>
-              {current ? (
-                <StudioPanelFrame panel={panel}>
-                  {version.name === 'solo2' ? (
-                    <PlayingScreen current={current} entries={server?.entries ?? []} dials={dials as Solo2Dials} feed={feed} panel={panel} />
-                  ) : (
-                    <SoloFrame entry={current} previous={null} fadeS={0} dials={dials} width={panel.width} height={panel.height} feed={feed} />
-                  )}
-                </StudioPanelFrame>
-              ) : (
-                <div style={{ height: '100%', display: 'grid', placeItems: 'center', color: '#4b5568', fontFamily: mono, fontSize: 12 }}>
-                  no frame to preview
-                </div>
-              )}
-            </div>
-          </section>
-        );
-      })}
+      {screens.map((screen) => (
+        <PlayingScreen key={screen.feed} {...screen} dials={dials} panel={panel} version={version} />
+      ))}
     </>
   );
 }

--- a/app/studio/solo/useSoloPreview.test.ts
+++ b/app/studio/solo/useSoloPreview.test.ts
@@ -146,6 +146,21 @@ describe('useSoloPreview', () => {
     expect(result.current.previous?.snapshotId).toBe(3);
   });
 
+  it('catches up in one jump after a long pause, instead of stepping through every dwell', () => {
+    const order = [entry(1), entry(2), entry(3), entry(4)];
+    const { result } = renderHook(() => useSoloPreview(order, DWELL));
+    act(() => {
+      // A backgrounded tab suspends the interval entirely rather than firing
+      // it late; the wall clock jumps and only the NEXT tick sees the gap.
+      vi.setSystemTime(new Date(T0 + 3.5 * DWELL * 1000));
+      vi.advanceTimersByTime(250);
+    });
+    expect(result.current.index).toBe(3);
+    expect(result.current.startMs).toBe(T0 + 3 * DWELL * 1000);
+    expect(result.current.previous?.snapshotId).toBe(order[0].snapshotId);
+    expect(result.current.entry?.snapshotId).toBe(order[3].snapshotId);
+  });
+
   it('takes a new dwell on the next tick without restarting the frame that is showing', () => {
     const order = [entry(1), entry(2), entry(3)];
     const { result, rerender } = renderHook(

--- a/app/studio/solo/useSoloPreview.test.ts
+++ b/app/studio/solo/useSoloPreview.test.ts
@@ -1,0 +1,163 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act, render, cleanup } from '@testing-library/react';
+import { createElement } from 'react';
+import type { EntryView } from '@/app/api/kiosk/solo/view';
+import { useSoloPreview, type PreviewDwell } from './useSoloPreview';
+
+const entry = (id: number): EntryView => ({
+  snapshotId: id, webcamId: 100 + id, bin: 'sunset', quality: 0.8, detection: 0.9, isNew: false, tally: 1,
+  enteredAt: 0, imageUrl: `u${id}`, title: `cam${id}`, city: 'Nuuk', region: '', country: 'Greenland',
+  capturedAt: 0, timezone: null, sunAltitudeDeg: null, eligible: true, rank: 1,
+  stage: { kind: 'queued', position: 1 },
+});
+
+const T0 = 100_000;
+const DWELL = 8;
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.setSystemTime(new Date(T0));
+});
+afterEach(() => {
+  cleanup();
+  vi.useRealTimers();
+});
+
+describe('useSoloPreview', () => {
+  it('starts on the first frame of the order with no previous and the clock at mount', () => {
+    const order = [entry(1), entry(2), entry(3)];
+    const { result } = renderHook(() => useSoloPreview(order, DWELL));
+    expect(result.current.entry?.snapshotId).toBe(1);
+    expect(result.current.previous).toBeNull();
+    expect(result.current.index).toBe(0);
+    expect(result.current.startMs).toBe(T0);
+  });
+
+  it('advances a dwell later: entry, previous and startMs all move together', () => {
+    const order = [entry(1), entry(2), entry(3)];
+    const { result } = renderHook(() => useSoloPreview(order, DWELL));
+    act(() => { vi.advanceTimersByTime(DWELL * 1000); });
+    expect(result.current.entry?.snapshotId).toBe(2);
+    expect(result.current.previous?.snapshotId).toBe(1);
+    expect(result.current.index).toBe(1);
+    expect(result.current.startMs).toBe(T0 + DWELL * 1000);
+  });
+
+  it('holds the frame until the dwell is up', () => {
+    const order = [entry(1), entry(2)];
+    const { result } = renderHook(() => useSoloPreview(order, DWELL));
+    act(() => { vi.advanceTimersByTime(DWELL * 1000 - 500); });
+    expect(result.current.entry?.snapshotId).toBe(1);
+    expect(result.current.previous).toBeNull();
+    expect(result.current.startMs).toBe(T0);
+  });
+
+  it('never renders a new entry beside a stale previous (Appendix A concerns 1 and 2)', () => {
+    const order = [entry(1), entry(2), entry(3)];
+    const seen: Array<{ entry: number | null; previous: number | null; startMs: number }> = [];
+    function Probe() {
+      const dwell: PreviewDwell = useSoloPreview(order, DWELL);
+      seen.push({
+        entry: dwell.entry?.snapshotId ?? null,
+        previous: dwell.previous?.snapshotId ?? null,
+        startMs: dwell.startMs,
+      });
+      return null;
+    }
+    render(createElement(Probe));
+    act(() => { vi.advanceTimersByTime(DWELL * 1000); });
+    act(() => { vi.advanceTimersByTime(DWELL * 1000); });
+
+    // Every recorded render is a coherent pair: entry N is only ever shown
+    // beside entry N-1, and the dwell start matches the frame it belongs to.
+    const pairs = seen.map((s) => `${s.previous}->${s.entry}@${s.startMs}`);
+    expect(pairs.every((p) => (
+      p === `null->1@${T0}`
+      || p === `1->2@${T0 + DWELL * 1000}`
+      || p === `2->3@${T0 + 2 * DWELL * 1000}`
+    ))).toBe(true);
+    // and all three dwells were actually reached, in order.
+    expect([...new Set(pairs)]).toEqual([
+      `null->1@${T0}`,
+      `1->2@${T0 + DWELL * 1000}`,
+      `2->3@${T0 + 2 * DWELL * 1000}`,
+    ]);
+  });
+
+  it('wraps at the end of the order', () => {
+    const order = [entry(1), entry(2), entry(3)];
+    const { result } = renderHook(() => useSoloPreview(order, DWELL));
+    act(() => { vi.advanceTimersByTime(order.length * DWELL * 1000); });
+    expect(result.current.entry?.snapshotId).toBe(1);
+    expect(result.current.previous?.snapshotId).toBe(3);
+    expect(result.current.index).toBe(0);
+  });
+
+  it('restarts at index 0 when the server advanced (order[0] changed), keeping the showing frame as previous', () => {
+    const first = [entry(1), entry(2), entry(3)];
+    const second = [entry(2), entry(3), entry(4)];
+    const { result, rerender } = renderHook(
+      (p: { order: EntryView[] }) => useSoloPreview(p.order, DWELL),
+      { initialProps: { order: first } },
+    );
+    act(() => { vi.advanceTimersByTime(DWELL * 1000); }); // showing 2, previous 1
+    expect(result.current.entry?.snapshotId).toBe(2);
+    act(() => { vi.setSystemTime(new Date(T0 + DWELL * 1000 + 1_500)); });
+    rerender({ order: second });
+    expect(result.current.index).toBe(0);
+    expect(result.current.entry?.snapshotId).toBe(2);
+    expect(result.current.previous?.snapshotId).toBe(2);
+    expect(result.current.startMs).toBe(T0 + DWELL * 1000 + 1_500);
+  });
+
+  it('an empty order gives an empty dwell, and filling it starts the clock', () => {
+    const { result, rerender } = renderHook(
+      (p: { order: EntryView[] }) => useSoloPreview(p.order, DWELL),
+      { initialProps: { order: [] as EntryView[] } },
+    );
+    expect(result.current.entry).toBeNull();
+    expect(result.current.previous).toBeNull();
+    expect(result.current.index).toBe(0);
+    act(() => { vi.advanceTimersByTime(DWELL * 1000 * 2); });
+    expect(result.current.entry).toBeNull();
+    expect(result.current.index).toBe(0);
+
+    act(() => { vi.setSystemTime(new Date(T0 + 20_000)); });
+    rerender({ order: [entry(5), entry(6)] });
+    expect(result.current.entry?.snapshotId).toBe(5);
+    expect(result.current.index).toBe(0);
+    expect(result.current.startMs).toBe(T0 + 20_000);
+  });
+
+  it('clamps to the first frame on the next tick when the order shrinks under the index', () => {
+    const long = [entry(1), entry(2), entry(3)];
+    const short = [entry(1), entry(2)];
+    const { result, rerender } = renderHook(
+      (p: { order: EntryView[] }) => useSoloPreview(p.order, DWELL),
+      { initialProps: { order: long } },
+    );
+    act(() => { vi.advanceTimersByTime(2 * DWELL * 1000); }); // index 2
+    expect(result.current.index).toBe(2);
+    rerender({ order: short }); // head is unchanged, so no restart
+    expect(result.current.index).toBe(2);
+    act(() => { vi.advanceTimersByTime(250); });
+    expect(result.current.index).toBe(0);
+    expect(result.current.entry?.snapshotId).toBe(1);
+    expect(result.current.previous?.snapshotId).toBe(3);
+  });
+
+  it('takes a new dwell on the next tick without restarting the frame that is showing', () => {
+    const order = [entry(1), entry(2), entry(3)];
+    const { result, rerender } = renderHook(
+      (p: { dwellS: number }) => useSoloPreview(order, p.dwellS),
+      { initialProps: { dwellS: DWELL } },
+    );
+    act(() => { vi.advanceTimersByTime(4_000); });
+    rerender({ dwellS: 5 }); // 4 s in, the new dwell is 5 s: 1 s left, no restart
+    expect(result.current.entry?.snapshotId).toBe(1);
+    expect(result.current.startMs).toBe(T0);
+    act(() => { vi.advanceTimersByTime(1_000); });
+    expect(result.current.entry?.snapshotId).toBe(2);
+    expect(result.current.startMs).toBe(T0 + 5_000);
+  });
+});

--- a/app/studio/solo/useSoloPreview.ts
+++ b/app/studio/solo/useSoloPreview.ts
@@ -1,0 +1,68 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+import type { EntryView } from '@/app/api/kiosk/solo/view';
+
+/**
+ * What the preview is showing: the frame, the one it replaced, when this
+ * dwell began, and where it sits in `order`. All four move in ONE state
+ * update, so no render ever pairs a new frame with the old `previous`
+ * (Appendix A concern 2) and a tick that does not advance never disturbs
+ * the frame that is showing (concern 1).
+ */
+export interface PreviewDwell {
+  entry: EntryView | null;
+  previous: EntryView | null;
+  startMs: number;
+  index: number;
+}
+
+const empty = (startMs: number): PreviewDwell => ({ entry: null, previous: null, startMs, index: 0 });
+
+/**
+ * A local clock through `order` (the on-glass frame first, then the projected
+ * queue) at `dwellS` per frame, wrapping at the end. It calls nothing: the
+ * studio preview plays on the studio's dials while the glass keeps its own
+ * clock. When `order[0]` changes — the server advanced — the clock restarts
+ * at index 0 with the frame that was showing as `previous`.
+ */
+export function useSoloPreview(order: EntryView[], dwellS: number, tickMs = 250): PreviewDwell {
+  const [dwell, setDwell] = useState<PreviewDwell>(() => (
+    order.length === 0 ? empty(Date.now()) : { entry: order[0], previous: null, startMs: Date.now(), index: 0 }
+  ));
+
+  // The head we started this walk from. Derived during render, like the
+  // glass's Dwell, so the restart and its previous frame commit together.
+  const head = order[0]?.snapshotId ?? null;
+  const [walkedFrom, setWalkedFrom] = useState<number | null>(head);
+  if (head !== walkedFrom) {
+    setWalkedFrom(head);
+    setDwell(order.length === 0
+      ? empty(Date.now())
+      : { entry: order[0], previous: dwell.entry, startMs: Date.now(), index: 0 });
+  }
+
+  // The interval reads the latest order without being torn down and rebuilt
+  // on every parent render (a studio dial in motion would starve the tick).
+  const latest = useRef(order);
+  useEffect(() => { latest.current = order; });
+
+  useEffect(() => {
+    const period = Math.max(1, dwellS * 1000);
+    const tick = () => setDwell((prev) => {
+      const now = latest.current;
+      if (now.length === 0) return prev;
+      // The order shrank under us: take its first frame rather than nothing.
+      if (prev.index >= now.length) {
+        return { entry: now[0], previous: prev.entry, startMs: Date.now(), index: 0 };
+      }
+      if (Date.now() - prev.startMs < period) return prev;
+      const next = (prev.index + 1) % now.length;
+      return { entry: now[next], previous: prev.entry, startMs: prev.startMs + period, index: next };
+    });
+    const t = setInterval(tick, Math.max(1, tickMs));
+    return () => clearInterval(t);
+  }, [dwellS, tickMs]);
+
+  return dwell;
+}

--- a/app/studio/solo/useSoloPreview.ts
+++ b/app/studio/solo/useSoloPreview.ts
@@ -49,17 +49,30 @@ export function useSoloPreview(order: EntryView[], dwellS: number, tickMs = 250)
 
   useEffect(() => {
     const period = Math.max(1, dwellS * 1000);
-    const tick = () => setDwell((prev) => {
-      const now = latest.current;
-      if (now.length === 0) return prev;
-      // The order shrank under us: take its first frame rather than nothing.
-      if (prev.index >= now.length) {
-        return { entry: now[0], previous: prev.entry, startMs: Date.now(), index: 0 };
-      }
-      if (Date.now() - prev.startMs < period) return prev;
-      const next = (prev.index + 1) % now.length;
-      return { entry: now[next], previous: prev.entry, startMs: prev.startMs + period, index: next };
-    });
+    const tick = () => {
+      // Captured once per real tick, outside the updater: a functional
+      // setState update can be queued and evaluated later rather than at
+      // call time, and a fresh `Date.now()` read from inside the updater
+      // would then see whatever time the eventual evaluation happens to
+      // land on instead of when this tick actually fired.
+      const nowMs = Date.now();
+      setDwell((prev) => {
+        const now = latest.current;
+        if (now.length === 0) return prev;
+        // The order shrank under us: take its first frame rather than nothing.
+        if (prev.index >= now.length) {
+          return { entry: now[0], previous: prev.entry, startMs: nowMs, index: 0 };
+        }
+        // Jump straight to where the clock should be rather than walking one
+        // step per tick: after a long pause (backgrounded tab, sleep) a
+        // one-step-per-tick catch-up would replay every intermediate fade
+        // and restart the stage clock at each step — a flicker storm.
+        const steps = Math.floor((nowMs - prev.startMs) / period);
+        if (steps < 1) return prev;
+        const next = (prev.index + steps) % now.length;
+        return { entry: now[next], previous: prev.entry, startMs: prev.startMs + steps * period, index: next };
+      });
+    };
     const t = setInterval(tick, Math.max(1, tickMs));
     return () => clearInterval(t);
   }, [dwellS, tickMs]);

--- a/docs/superpowers/specs/2026-09-05-one-studio-design.md
+++ b/docs/superpowers/specs/2026-09-05-one-studio-design.md
@@ -1,8 +1,7 @@
 # One studio — design
 
 **Date:** 2026-09-05
-**Status:** phase A built on feat/one-studio (PR to follow); phases B and C
-follow as stacked PRs.
+**Status:** phases A, B, C built (PRs #146, #147, phase C PR to follow)
 **Branch:** `docs/one-studio` (this document only).
 **Builds on:** `2026-08-30-kiosk-studio-control-and-mosaic-v2-design.md`
 (studio/live profiles, Deploy), `2026-09-04-solo-kiosk-design.md` §6.4 (the
@@ -269,10 +268,14 @@ one page with one preview makes its absence obvious.
   solo2, `SoloFrame` for solo, `resolveMosaic(v)` for the mosaic versions.
   `Solo2Frame` today is reachable only from `Solo2Kiosk`; it takes the same
   props shape and needs no change.
-- For solo versions the preview **plays**: a `useSoloPreview(feed, order,
-  dials)` hook advances a local clock through the projected queue on the
-  studio dials, with the version's `roleAt` for lead/prelude/transition
-  phases. No server advance is called. The glass keeps its own clock; the
+- For solo versions the preview **plays**: a `useSoloPreview(order, dwellS,
+  tickMs = 250)` hook advances a local clock through the projected queue on
+  the studio dials, returning `{ entry, previous, startMs, index }`. No
+  server advance is called. Roles arrive baked into `projected.next` rather
+  than from the version's `roleAt`; the lead and camera-run phases are
+  played by `useLoopingStage` + `Solo2Frame`, keyed on the dwell start
+  (`dwell.startMs`) so a server advance while the preview sits at index 0
+  also restarts the run's stage clock. The glass keeps its own clock; the
   status line's poll age is the only live truth on the page.
 - The mosaic preview is unchanged: `resolveMosaic(v)` on the live or scene
   pool with studio dials, which already previews the studio profile.
@@ -314,7 +317,7 @@ New:
   `StudioClient` behind the surface lookup.
 - `app/studio/pollAge.ts` — `formatPollAge`, the header status line's "last
   heard from the kiosk" readout.
-- `app/studio/useSoloPreview.ts` — §5.
+- `app/studio/solo/useSoloPreview.ts` — §5.
 - `database/migrations/2026MMDD_kiosk_takes.sql` — §4.1.
 
 Changed: `StudioClient.tsx` (becomes the grid + the surface lookup),


### PR DESCRIPTION
## The solo preview plays the projected queue (phase C of 3, stacked on phase B)

Spec §5 and Appendix A of `docs/superpowers/specs/2026-09-05-one-studio-design.md`.

### What this changes
- `useSoloPreview(order, dwellS)`: a local clock that walks the on-glass frame and then the projected queue at the studio dwell, wrapping at the end, and restarts when the server advances. `entry`, `previous` and `startMs` change in **one** state update, so there is never a render with a new frame and a stale previous one (the two bugs Appendix A found in follow mode; PR #145 fixed them on the glass, this keeps the preview honest the same way).
- Both solo versions play in the studio: `solo` with its fade on the studio dials, `solo2` with its camera run, lead and transitions through the existing `useLoopingStage`, restarted per preview step.
- After a backgrounded tab, the preview jumps to where the clock should be instead of fast-forwarding one step per tick. The solo2 stage clock is keyed on the dwell start, so a server advance while the preview sits on the on-glass frame restarts the camera run at its first frame.
- The screen's header line says `on glass now · frame N` on the first step and `preview · frame N · next in <s> s` afterwards, so the live truth stays visible.
- No change to what the glass draws: nothing under `app/components/`, `app/lib/` or `app/kiosk/` changed.

### Verification
Counts in the last commit message. Hook tests run on fake timers and assert the one-update contract directly.

**Not done:** a signed-in look at the dissolves on real panels.

### Signed-in smoke
1. Pick `solo2`: each screen plays through its queue; a camera change dips, a same-camera step dissolves, the lead pushes in at the end.
2. Pick `solo`: the screens crossfade at the studio `fade (s)` as they step.
3. Move `dwell (s)`: the step rate follows within one step.
4. Wait for a real advance on the glass (the countdown in the bins column): the preview restarts on the new frame.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PWRkdgYyZLfgjkBhJza1NM
