### PR TITLE
feat(solo): stamped draw log + replay CLI (what we showed, under which dials, out of what)

### DIFF
--- a/app/api/cron/update-cameras/lib/binAdmission.test.ts
+++ b/app/api/cron/update-cameras/lib/binAdmission.test.ts
@@ -90,7 +90,7 @@ describe('maintainBins', () => {
     expect(markOutOfZone).toHaveBeenCalledWith('sunset', [2]);
     expect(removeStale).toHaveBeenCalledWith('sunset', { grace: 2, maxAgeHours: 24 });
     expect(removeStale).toHaveBeenCalledWith('sunrise', { grace: 2, maxAgeHours: 24 });
-    expect(pruneDraws).toHaveBeenCalledWith(7); // the tape keeps a week
+    expect(pruneDraws).toHaveBeenCalledWith(30); // the tape keeps a month (replay spec §2)
     expect(out).toEqual({ leftZone: 0, expired: 0 });
   });
   it('records the zone it aged entries against, so the state route shows the same band', async () => {

--- a/app/api/cron/update-cameras/lib/binAdmission.ts
+++ b/app/api/cron/update-cameras/lib/binAdmission.ts
@@ -71,7 +71,7 @@ export async function enterBins(
 }
 
 /** The tape keeps a week; the studio reads the last 24 draws. */
-const DRAW_LOG_DAYS = 7;
+const DRAW_LOG_DAYS = 30;
 
 /**
  * Removal is by zone, not by absence. Every active entry is checked against

--- a/app/api/cron/update-cameras/lib/binAdmission.ts
+++ b/app/api/cron/update-cameras/lib/binAdmission.ts
@@ -70,7 +70,13 @@ export async function enterBins(
   return out;
 }
 
-/** The tape keeps a week; the studio reads the last 24 draws. */
+/**
+ * The draw log keeps a month: the studio's tape reads only the last 24
+ * draws, but the replay (replay spec §2) reads windows, and 30 days covers
+ * the run through the show. Measured 2026-09-06: about 4.8 k rows a day
+ * across both screens, so a month is roughly 145 k rows and under 30 MB
+ * with indexes. Steady state, so the per-tick prune volume is unchanged.
+ */
 const DRAW_LOG_DAYS = 30;
 
 /**

--- a/app/api/kiosk/solo/advance/route.test.ts
+++ b/app/api/kiosk/solo/advance/route.test.ts
@@ -69,7 +69,7 @@ describe('POST /api/kiosk/solo/advance', () => {
     expect(body.current.entry.snapshotId).toBe(1);
     expect(body.current.entry.tally).toBe(1);
     expect(commitAdvance).toHaveBeenCalledWith('sunrise', 50_000_000, expect.objectContaining({ snapshotId: 1 }), 1,
-      [expect.objectContaining({ snapshotId: 1 })]);
+      [expect.objectContaining({ snapshotId: 1 })], 'solo');
   });
   it('version=solo2 marks every frame of the camera run shown, and the pick is the newest', async () => {
     // Camera 101 has frames 1 (older) and 3 (newer); camera 102 has frame 2.
@@ -80,7 +80,7 @@ describe('POST /api/kiosk/solo/advance', () => {
     const body = await res.json();
     expect(body.current.entry.snapshotId).toBe(3);
     expect(commitAdvance).toHaveBeenLastCalledWith('sunrise', 50_000_000, expect.objectContaining({ snapshotId: 3 }), 1,
-      [expect.objectContaining({ snapshotId: 1 }), expect.objectContaining({ snapshotId: 3 })]);
+      [expect.objectContaining({ snapshotId: 1 }), expect.objectContaining({ snapshotId: 3 })], 'solo2');
     const tallies = Object.fromEntries(body.entries.map((e: { snapshotId: number; tally: number }) => [e.snapshotId, e.tally]));
     expect(tallies).toEqual({ 1: 1, 2: 0, 3: 1 });
   });

--- a/app/api/kiosk/solo/advance/route.ts
+++ b/app/api/kiosk/solo/advance/route.ts
@@ -58,7 +58,7 @@ export async function POST(request: Request) {
     if (pick) {
       const after = afterShowing(pick, state);
       const shown = version.shown(entries, pick, dials);
-      advanced = await commitAdvance(feed, slot, pick, after.sunsetStreak, shown);
+      advanced = await commitAdvance(feed, slot, pick, after.sunsetStreak, shown, version.name);
       if (advanced) {
         for (const f of shown) {
           const stored = entries.find((e) => e.snapshotId === f.snapshotId)!;

--- a/app/lib/solo/replay.test.ts
+++ b/app/lib/solo/replay.test.ts
@@ -66,6 +66,20 @@ describe('seedFromDraws and initialState', () => {
     expect(seedFromDraws(rows, [])[1].isNew).toBe(true);
     expect(seedFromDraws(rows, [])[0].isNew).toBe(false);
   });
+  it('a row shown before the log began is seeded from its own record, exactly when that record predates the window', () => {
+    const start = 10_000;
+    const exact = sun(1, 0.9, { tally: 5, firstShownAt: 1_000, lastShownAt: 8_000 });
+    const bound = sun(2, 0.9, { tally: 5, firstShownAt: 1_000, lastShownAt: 12_000 }); // shown again inside the window: only the first showing is known to predate it
+    const fresh = sun(3, 0.9, { tally: 0, firstShownAt: null, lastShownAt: null });
+    const logged = sun(4, 0.9, { tally: 5, firstShownAt: 1_000, lastShownAt: 9_000 });
+    const out = seedFromDraws([exact, bound, fresh, logged], [{ slot: 1, shownAt: 9_500, snapshotId: 4 }], start);
+    expect(out[0]).toMatchObject({ tally: 5, lastShownAt: 8_000, isNew: false });
+    expect(out[1]).toMatchObject({ tally: 5, lastShownAt: 1_000, isNew: false });
+    expect(out[2]).toMatchObject({ tally: 0, lastShownAt: null });
+    expect(out[3]).toMatchObject({ tally: 1, lastShownAt: 9_500 }); // the log wins over the row
+    // Without a window start the rows are not consulted: everything unlogged is unshown.
+    expect(seedFromDraws([exact], [])[0]).toMatchObject({ tally: 0, lastShownAt: null });
+  });
   it('the screen remembers the last frame and the trailing sunset run', () => {
     const rows = [sun(1, 0.9), non(2, 0.5)];
     const draws: DrawLike[] = [
@@ -160,7 +174,10 @@ describe('actualStrip, summarize, compare', () => {
   });
   it('compare counts shared slots that drew the same frame, and refuses another grid', () => {
     const other = { ...actual, frames: actual.frames.map((f) => (f.slot === 11 ? { ...f, snapshotId: 1 } : f)) };
-    expect(compare(actual, other)).toEqual({ slots: 4, same: 3 });
+    expect(compare(actual, other)).toEqual({ slots: 4, same: 3, inOrder: 3 });
     expect(compare(actual, { ...other, grid: { dwellS: 10, offsetS: 10 } })).toBeNull();
+    // The glass missed slot 11: every later draw sits one slot early. Slot-for-slot says 1; the order says 3 of 4 survive.
+    const shifted = { ...actual, frames: [actual.frames[0], { ...actual.frames[2], slot: 11 }, { ...actual.frames[3], slot: 12 }] };
+    expect(compare(actual, shifted)).toEqual({ slots: 3, same: 1, inOrder: 3 });
   });
 });

--- a/app/lib/solo/replay.test.ts
+++ b/app/lib/solo/replay.test.ts
@@ -1,0 +1,166 @@
+import { describe, it, expect } from 'vitest';
+import {
+  poolAt, isNewAtEntry, seedFromDraws, initialState, replay, actualStrip, summarize, compare,
+  type ReplayEntry, type DrawLike,
+} from './replay';
+import { boundaryMs } from './schedule';
+import { SOLO_VERSIONS } from './versions';
+import { dialsFrom, SOLO_SETTINGS_SCHEMA } from './settingsSchema';
+import { dialsFrom2, SOLO2_SETTINGS_SCHEMA } from '@/app/lib/solo2/settingsSchema';
+import { schemaDefaults } from '@/app/lib/settings/schema';
+import type { Feed, SoloDials } from './types';
+
+const FEED: Feed = 'sunrise';
+const D: SoloDials = { ...dialsFrom(schemaDefaults(SOLO_SETTINGS_SCHEMA)), dwellS: 20, offsetS: 10 };
+const T0 = 1_000_000_000_000; // a slot boundary for dwell 20 on the sunrise grid
+const at = (slot: number, d: SoloDials = D) => boundaryMs(slot, FEED, d.dwellS, d.offsetS);
+const SLOT0 = T0 / 20_000;
+
+function sun(id: number, q: number, extra: Partial<ReplayEntry> = {}): ReplayEntry {
+  return { snapshotId: id, webcamId: 1000 + id, bin: 'sunset', quality: q, detection: 0.9,
+    isNew: false, tally: 0, enteredAt: T0 - 3_600_000 + id, lastShownAt: null, removedAt: null, title: `cam${id}`, ...extra };
+}
+function non(id: number, det: number, extra: Partial<ReplayEntry> = {}): ReplayEntry {
+  return { snapshotId: id, webcamId: 2000 + id, bin: 'non_sunset', quality: null, detection: det,
+    isNew: false, tally: 0, enteredAt: T0 - 3_600_000 + id, lastShownAt: null, removedAt: null, ...extra };
+}
+/** Turn `project`'s picks into draw-log rows on the solo grid. */
+const drawsOf = (picks: { snapshotId: number; bin: 'sunset' | 'non_sunset' }[], firstSlot: number): DrawLike[] =>
+  picks.map((p, i) => ({ slot: firstSlot + i, shownAt: at(firstSlot + i), snapshotId: p.snapshotId, bin: p.bin }));
+const ids = (s: { frames: { snapshotId: number | null }[] }) => s.frames.map((f) => f.snapshotId);
+
+describe('poolAt', () => {
+  it('includes a row entered at t and excludes one removed at t', () => {
+    const a = sun(1, 0.9, { enteredAt: 500, removedAt: null });
+    const b = sun(2, 0.9, { enteredAt: 100, removedAt: 500 });
+    const c = sun(3, 0.9, { enteredAt: 600, removedAt: null });
+    expect(poolAt([a, b, c], 500).map((e) => e.snapshotId)).toEqual([1]);
+    expect(poolAt([a, b, c], 499).map((e) => e.snapshotId)).toEqual([2]);
+  });
+});
+
+describe('isNewAtEntry', () => {
+  it('is true only when an older frame of the same camera was in the bin at arrival', () => {
+    const older = sun(1, 0.9, { webcamId: 7, enteredAt: 100, removedAt: null });
+    const newer = sun(2, 0.9, { webcamId: 7, enteredAt: 200 });
+    const gone = sun(3, 0.9, { webcamId: 8, enteredAt: 100, removedAt: 150 });
+    const late = sun(4, 0.9, { webcamId: 8, enteredAt: 200 });
+    expect(isNewAtEntry(newer, [older, newer])).toBe(true);
+    expect(isNewAtEntry(older, [older, newer])).toBe(false);
+    expect(isNewAtEntry(late, [gone, late])).toBe(false);
+  });
+});
+
+describe('seedFromDraws and initialState', () => {
+  it('rebuilds tally, last shown and isNew from the draws, not the rows', () => {
+    const rows = [sun(1, 0.9, { tally: 99, lastShownAt: 5, webcamId: 7, enteredAt: 100 }), sun(2, 0.8, { webcamId: 7, enteredAt: 200 })];
+    const draws: DrawLike[] = [
+      { slot: 1, shownAt: 1000, snapshotId: 1 },
+      { slot: 2, shownAt: 2000, snapshotId: 2, shownSnapshotIds: [1, 2] },
+    ];
+    const seeded = seedFromDraws(rows, draws);
+    expect(seeded[0]).toMatchObject({ tally: 2, lastShownAt: 2000, isNew: false });
+    expect(seeded[1]).toMatchObject({ tally: 1, lastShownAt: 2000, isNew: false });
+    expect(rows[0].tally).toBe(99); // input untouched
+    // Never drawn and arrived beside an older frame of its camera: still new.
+    expect(seedFromDraws(rows, [])[1].isNew).toBe(true);
+    expect(seedFromDraws(rows, [])[0].isNew).toBe(false);
+  });
+  it('the screen remembers the last frame and the trailing sunset run', () => {
+    const rows = [sun(1, 0.9), non(2, 0.5)];
+    const draws: DrawLike[] = [
+      { slot: 1, shownAt: 1, snapshotId: 2 }, // bin looked up from the rows
+      { slot: 2, shownAt: 2, snapshotId: 1, bin: 'sunset' },
+      { slot: 3, shownAt: 3, snapshotId: 1, bin: 'sunset' },
+    ];
+    expect(initialState(draws, rows)).toEqual({ lastSnapshotId: 1, sunsetStreak: 2 });
+    expect(initialState([], rows)).toEqual({ lastSnapshotId: null, sunsetStreak: 0 });
+  });
+});
+
+describe('replay', () => {
+  const entries = [sun(1, 0.97), sun(2, 0.6), sun(3, 0.4), ...[1, 2, 3, 4, 5, 6, 7, 8].map((i) => non(100 + i, 0.6 - i * 0.02))];
+  const solo = SOLO_VERSIONS.solo;
+
+  it('parity: reproduces project() slot for slot from an empty history', () => {
+    const picks = solo.project(entries, D, { lastSnapshotId: null, sunsetStreak: 0 }, 12, SLOT0, FEED);
+    const strip = replay({ feed: FEED, version: solo, dials: D, entries, priorDraws: [], fromMs: at(SLOT0), toMs: at(SLOT0 + 11) });
+    expect(ids(strip)).toEqual(picks.map((p) => p.snapshotId));
+    expect(strip.frames.map((f) => f.slot)).toEqual(picks.map((_, i) => SLOT0 + i));
+    expect(strip.grid).toEqual({ dwellS: 20, offsetS: 10 });
+  });
+
+  it('parity: seeded from the first five draws, reproduces draws six to twelve', () => {
+    const picks = solo.project(entries, D, { lastSnapshotId: null, sunsetStreak: 0 }, 12, SLOT0, FEED);
+    const prior = drawsOf(picks.slice(0, 5), SLOT0);
+    const strip = replay({ feed: FEED, version: solo, dials: D, entries, priorDraws: prior, fromMs: at(SLOT0 + 5), toMs: at(SLOT0 + 11) });
+    expect(ids(strip)).toEqual(picks.slice(5).map((p) => p.snapshotId));
+  });
+
+  it('a frame is only drawn while it is in the bin', () => {
+    const rows = [sun(1, 0.97, { removedAt: at(SLOT0 + 2) }), sun(2, 0.6), sun(3, 0.4, { enteredAt: at(SLOT0 + 3) })];
+    const strip = replay({ feed: FEED, version: solo, dials: { ...D, rest: 0 }, entries: rows, priorDraws: [], fromMs: at(SLOT0), toMs: at(SLOT0 + 4) });
+    // Slot 0: best (1). Slot 1: not 1 (on glass), so 2. Slot 2: 1 has left, 3 has not arrived, 2 is on glass and the only one: it repeats.
+    // Slot 3: 3 arrives, never shown, wins. Slot 4: 2 (longest since shown).
+    expect(ids(strip)).toEqual([1, 2, 2, 3, 2]);
+    expect(strip.frames.map((f) => f.repeat)).toEqual([false, false, true, false, true]);
+  });
+
+  it('a higher rating floor changes the picks; a blank when nothing is eligible', () => {
+    const rows = [sun(1, 0.3), sun(2, 0.2)];
+    const low = replay({ feed: FEED, version: solo, dials: D, entries: rows, priorDraws: [], fromMs: at(SLOT0), toMs: at(SLOT0 + 1) });
+    expect(ids(low)).toEqual([1, 2]);
+    const high = replay({ feed: FEED, version: solo, dials: { ...D, ratingFloor: 3 }, entries: rows, priorDraws: [], fromMs: at(SLOT0), toMs: at(SLOT0 + 1) });
+    expect(ids(high)).toEqual([null, null]);
+    expect(summarize(high)).toMatchObject({ draws: 0, blanks: 2 });
+  });
+
+  it('a different dwell puts frames on the new grid', () => {
+    const d = { ...D, dwellS: 10 };
+    const strip = replay({ feed: FEED, version: solo, dials: d, entries, priorDraws: [], fromMs: at(SLOT0), toMs: at(SLOT0 + 1) - 1 });
+    expect(strip.frames).toHaveLength(2); // 20 s of glass at a 10 s dwell
+    expect(strip.frames.map((f) => f.shownAt)).toEqual([at(SLOT0), at(SLOT0) + 10_000]);
+    expect(strip.grid.dwellS).toBe(10);
+  });
+
+  it('solo2 marks every frame of the camera run shown, and the strip carries them', () => {
+    const d2 = { ...dialsFrom2(schemaDefaults(SOLO2_SETTINGS_SCHEMA)), dwellS: 20, offsetS: 10, cameraRun: true };
+    const rows = [
+      sun(1, 0.9, { webcamId: 7, capturedAt: 100 }), sun(3, 0.7, { webcamId: 7, capturedAt: 300 }),
+      sun(2, 0.8, { webcamId: 8, capturedAt: 150 }),
+    ];
+    const strip = replay({ feed: FEED, version: SOLO_VERSIONS.solo2, dials: d2, entries: rows, priorDraws: [], fromMs: at(SLOT0), toMs: at(SLOT0 + 1) });
+    expect(strip.frames[0]).toMatchObject({ snapshotId: 3, shownSnapshotIds: [1, 3] });
+    expect(strip.frames[1].snapshotId).toBe(2);
+  });
+});
+
+describe('actualStrip, summarize, compare', () => {
+  const rows = [sun(1, 0.95), sun(2, 0.05), non(103, 0.5)];
+  const draws = [
+    { ...rows[0], slot: 10, shownAt: at(10) },
+    { ...rows[1], slot: 11, shownAt: at(11) },
+    { ...rows[0], slot: 12, shownAt: at(12) },
+    { ...rows[2], slot: 13, shownAt: at(13) },
+  ];
+  const grid = { dwellS: 20, offsetS: 10 };
+  const actual = actualStrip(FEED, draws, grid, at(10), at(13));
+
+  it('the fact strip flags repeats and keeps the grid', () => {
+    expect(actual.version).toBe('actual');
+    expect(actual.frames.map((f) => f.repeat)).toEqual([false, false, true, false]);
+    expect(actual.frames[0].shownSnapshotIds).toEqual([1]);
+  });
+  it('summarize counts what the strip showed', () => {
+    const s = summarize(actual);
+    expect(s).toMatchObject({ draws: 4, blanks: 0, distinctFrames: 3, distinctCameras: 3, repeats: 1, nonSunsetShare: 0.25, minQuality: 0.05 });
+    expect(s.meanQuality).toBeCloseTo((0.95 + 0.05 + 0.95) / 3);
+    expect(s.qualityHistogram).toEqual([1, 0, 0, 0, 0, 0, 0, 0, 0, 2]);
+    expect(s.perCamera[0]).toEqual({ webcamId: 1001, title: 'cam1', draws: 2 });
+  });
+  it('compare counts shared slots that drew the same frame, and refuses another grid', () => {
+    const other = { ...actual, frames: actual.frames.map((f) => (f.slot === 11 ? { ...f, snapshotId: 1 } : f)) };
+    expect(compare(actual, other)).toEqual({ slots: 4, same: 3 });
+    expect(compare(actual, { ...other, grid: { dwellS: 10, offsetS: 10 } })).toBeNull();
+  });
+});

--- a/app/lib/solo/replay.ts
+++ b/app/lib/solo/replay.ts
@@ -12,13 +12,19 @@ import type { SoloVersionSpec } from './versions';
  * trusting the rows, which hold today's values.
  */
 
-/** A bin row as the replay needs it. `StoredEntry & { removedAt }` satisfies this. */
-export interface ReplayEntry extends BinEntry {
-  /** When the row left the bin, ms since epoch; null while it is still in. */
-  removedAt: number | null;
+/** An entry plus what a strip block shows of it. `StoredEntry` satisfies this. */
+export interface FrameFacts extends BinEntry {
   capturedAt?: number;
   title?: string;
   imageUrl?: string;
+}
+
+/** A bin row as the replay needs it. `StoredEntry & { removedAt }` satisfies this. */
+export interface ReplayEntry extends FrameFacts {
+  /** When the row left the bin, ms since epoch; null while it is still in. */
+  removedAt: number | null;
+  /** The row's own record of its first showing, for draws older than the log. */
+  firstShownAt?: number | null;
 }
 
 /** One logged draw, as much of it as the replay reads. `DrawRecord` satisfies this. */
@@ -80,11 +86,16 @@ export function isNewAtEntry(entry: ReplayEntry, entries: ReplayEntry[]): boolea
 }
 
 /**
- * Rebuild the shown state as it stood after `priorDraws`: tally, last
- * shown and isNew come from the draws, not from the rows. Returns copies;
- * the inputs are never mutated.
+ * Rebuild the shown state as it stood at `windowStart`, after `priorDraws`:
+ * tally, last shown and isNew come from the draws, not from the rows.
+ * A row the log never saw drawn but whose own `firstShownAt` is before the
+ * window was shown before the log began (the log is younger than the bins,
+ * or was pruned); it is seeded from the row's record, which is exact when
+ * its `lastShownAt` is also before the window and a lower bound otherwise.
+ * Bins expire at 24 h, so a 24 h lookback of draws makes the fallback moot
+ * once the log is a day old. Returns copies; the inputs are never mutated.
  */
-export function seedFromDraws<T extends ReplayEntry>(entries: T[], priorDraws: DrawLike[]): T[] {
+export function seedFromDraws<T extends ReplayEntry>(entries: T[], priorDraws: DrawLike[], windowStart = -Infinity): T[] {
   const shownAt = new Map<number, number>();
   const tally = new Map<number, number>();
   for (const d of priorDraws) {
@@ -94,13 +105,16 @@ export function seedFromDraws<T extends ReplayEntry>(entries: T[], priorDraws: D
     }
   }
   return entries.map((e) => {
-    const t = tally.get(e.snapshotId) ?? 0;
-    return {
-      ...e,
-      tally: t,
-      lastShownAt: shownAt.get(e.snapshotId) ?? null,
-      isNew: t === 0 && isNewAtEntry(e, entries),
-    };
+    const logged = shownAt.get(e.snapshotId);
+    if (logged != null) {
+      return { ...e, tally: tally.get(e.snapshotId) ?? 0, lastShownAt: logged, isNew: false };
+    }
+    const first = e.firstShownAt ?? null;
+    if (first != null && first < windowStart) {
+      const last = e.lastShownAt != null && e.lastShownAt < windowStart ? e.lastShownAt : first;
+      return { ...e, tally: Math.max(1, e.tally), lastShownAt: last, isNew: false };
+    }
+    return { ...e, tally: 0, lastShownAt: null, isNew: isNewAtEntry(e, entries) };
   });
 }
 
@@ -118,7 +132,7 @@ const blank = (slot: number, shownAt: number): StripFrame => ({
   title: '', imageUrl: '', capturedAt: null, shownSnapshotIds: [], repeat: false,
 });
 
-function frameOf(e: ReplayEntry, slot: number, shownAt: number, shownIds: number[], repeat: boolean): StripFrame {
+function frameOf(e: FrameFacts, slot: number, shownAt: number, shownIds: number[], repeat: boolean): StripFrame {
   return {
     slot, shownAt, snapshotId: e.snapshotId, webcamId: e.webcamId, bin: e.bin,
     quality: e.quality, detection: e.detection, title: e.title ?? '', imageUrl: e.imageUrl ?? '',
@@ -147,7 +161,7 @@ export interface ReplayOptions<D extends SoloDials> {
 export function replay<D extends SoloDials>(o: ReplayOptions<D>): Strip {
   const { feed, version, dials } = o;
   const grid = { dwellS: dials.dwellS, offsetS: dials.offsetS };
-  const working = seedFromDraws(o.entries, o.priorDraws);
+  const working = seedFromDraws(o.entries, o.priorDraws, o.fromMs);
   let state = initialState(o.priorDraws, o.entries);
   const seen = new Set<number>();
   const frames: StripFrame[] = [];
@@ -177,7 +191,7 @@ export function replay<D extends SoloDials>(o: ReplayOptions<D>): Strip {
 
 /** The fact strip, from the draw log, on the grid the glass was running. */
 export function actualStrip(
-  feed: Feed, draws: (DrawLike & ReplayEntry)[], grid: Grid, fromMs: number, toMs: number,
+  feed: Feed, draws: (DrawLike & FrameFacts)[], grid: Grid, fromMs: number, toMs: number,
 ): Strip {
   const seen = new Set<number>();
   const frames = draws.map((d) => {
@@ -232,12 +246,27 @@ export function summarize(strip: Strip): StripSummary {
   };
 }
 
+/** Length of the longest common subsequence of two id sequences: how much of the order survives. */
+function lcs(a: (number | null)[], b: (number | null)[]): number {
+  let prev = new Array<number>(b.length + 1).fill(0);
+  for (let i = 1; i <= a.length; i++) {
+    const cur = new Array<number>(b.length + 1).fill(0);
+    for (let j = 1; j <= b.length; j++) {
+      cur[j] = a[i - 1] === b[j - 1] ? prev[j - 1] + 1 : Math.max(prev[j], cur[j - 1]);
+    }
+    prev = cur;
+  }
+  return prev[b.length];
+}
+
 /**
- * Slot-for-slot agreement between two strips on the same grid: how many
- * slots both have, and how many of those drew the same frame. Null when the
- * grids differ, since their slots do not line up.
+ * Agreement between two strips on the same grid: `same` is slot-for-slot
+ * (a missed slot on the glass shifts everything after it, so this reads
+ * low even when the order is right); `inOrder` is the longest run of draws
+ * both strips make in the same order, which survives that shift. Null when
+ * the grids differ, since their slots do not line up.
  */
-export function compare(a: Strip, b: Strip): { slots: number; same: number } | null {
+export function compare(a: Strip, b: Strip): { slots: number; same: number; inOrder: number } | null {
   if (a.grid.dwellS !== b.grid.dwellS || a.grid.offsetS !== b.grid.offsetS) return null;
   const byB = new Map(b.frames.map((f) => [f.slot, f.snapshotId]));
   let slots = 0;
@@ -247,5 +276,5 @@ export function compare(a: Strip, b: Strip): { slots: number; same: number } | n
     slots++;
     if (byB.get(f.slot) === f.snapshotId) same++;
   }
-  return { slots, same };
+  return { slots, same, inOrder: lcs(a.frames.map((f) => f.snapshotId), b.frames.map((f) => f.snapshotId)) };
 }

--- a/app/lib/solo/replay.ts
+++ b/app/lib/solo/replay.ts
@@ -1,0 +1,251 @@
+import { afterShowing } from './engine';
+import { boundaryMs, slotFor } from './schedule';
+import type { BinEntry, BinKind, Feed, ScreenState, SoloDials } from './types';
+import type { SoloVersionSpec } from './versions';
+
+/**
+ * The replay (spec docs/superpowers/specs/2026-09-06-solo-replay-design.md
+ * §4): re-run a version's engine over the pool the glass actually had,
+ * under any dials, and shape the result like the studio's tape. Pure: no
+ * I/O, no clock. The store supplies bin rows with `removedAt` and the draw
+ * log; this module rebuilds the shown state from the draws rather than
+ * trusting the rows, which hold today's values.
+ */
+
+/** A bin row as the replay needs it. `StoredEntry & { removedAt }` satisfies this. */
+export interface ReplayEntry extends BinEntry {
+  /** When the row left the bin, ms since epoch; null while it is still in. */
+  removedAt: number | null;
+  capturedAt?: number;
+  title?: string;
+  imageUrl?: string;
+}
+
+/** One logged draw, as much of it as the replay reads. `DrawRecord` satisfies this. */
+export interface DrawLike {
+  slot: number;
+  shownAt: number;
+  snapshotId: number;
+  /** Every frame the dwell played; defaults to the drawn frame alone. */
+  shownSnapshotIds?: number[];
+  bin?: BinKind | null;
+}
+
+/** A block on a strip: a draw, actual or replayed. `snapshotId` null is a blank (nothing eligible). */
+export interface StripFrame {
+  slot: number;
+  shownAt: number;
+  snapshotId: number | null;
+  webcamId: number | null;
+  bin: BinKind | null;
+  quality: number | null;
+  detection: number | null;
+  title: string;
+  imageUrl: string;
+  capturedAt: number | null;
+  shownSnapshotIds: number[];
+  /** Seen earlier on this strip. */
+  repeat: boolean;
+}
+
+/** The slot grid a strip was drawn on; strips compare only on the same grid. */
+export interface Grid {
+  dwellS: number;
+  offsetS: number;
+}
+
+export interface Strip {
+  feed: Feed;
+  /** The engine that drew, or 'actual' for the fact strip. */
+  version: string;
+  grid: Grid;
+  fromMs: number;
+  toMs: number;
+  frames: StripFrame[];
+}
+
+/** Entries in the bin at `tMs`: entered on or before, not yet removed. */
+export function poolAt<T extends ReplayEntry>(entries: T[], tMs: number): T[] {
+  return entries.filter((e) => e.enteredAt <= tMs && (e.removedAt == null || e.removedAt > tMs));
+}
+
+/**
+ * The admission rule for `isNew`: another frame of the same camera was in
+ * the bin when this one arrived (binAdmission.ts `activeByFeed`).
+ */
+export function isNewAtEntry(entry: ReplayEntry, entries: ReplayEntry[]): boolean {
+  return entries.some((o) =>
+    o !== entry && o.snapshotId !== entry.snapshotId && o.webcamId === entry.webcamId &&
+    o.enteredAt < entry.enteredAt && (o.removedAt == null || o.removedAt > entry.enteredAt));
+}
+
+/**
+ * Rebuild the shown state as it stood after `priorDraws`: tally, last
+ * shown and isNew come from the draws, not from the rows. Returns copies;
+ * the inputs are never mutated.
+ */
+export function seedFromDraws<T extends ReplayEntry>(entries: T[], priorDraws: DrawLike[]): T[] {
+  const shownAt = new Map<number, number>();
+  const tally = new Map<number, number>();
+  for (const d of priorDraws) {
+    for (const id of d.shownSnapshotIds?.length ? d.shownSnapshotIds : [d.snapshotId]) {
+      shownAt.set(id, Math.max(shownAt.get(id) ?? -Infinity, d.shownAt));
+      tally.set(id, (tally.get(id) ?? 0) + 1);
+    }
+  }
+  return entries.map((e) => {
+    const t = tally.get(e.snapshotId) ?? 0;
+    return {
+      ...e,
+      tally: t,
+      lastShownAt: shownAt.get(e.snapshotId) ?? null,
+      isNew: t === 0 && isNewAtEntry(e, entries),
+    };
+  });
+}
+
+/** The screen's memory after `priorDraws`: the last frame, and how many sunsets ran up to it. */
+export function initialState(priorDraws: DrawLike[], entries: ReplayEntry[]): ScreenState {
+  const binOf = (d: DrawLike): BinKind | null =>
+    d.bin ?? entries.find((e) => e.snapshotId === d.snapshotId)?.bin ?? null;
+  let streak = 0;
+  for (let i = priorDraws.length - 1; i >= 0 && binOf(priorDraws[i]) === 'sunset'; i--) streak++;
+  return { lastSnapshotId: priorDraws.at(-1)?.snapshotId ?? null, sunsetStreak: streak };
+}
+
+const blank = (slot: number, shownAt: number): StripFrame => ({
+  slot, shownAt, snapshotId: null, webcamId: null, bin: null, quality: null, detection: null,
+  title: '', imageUrl: '', capturedAt: null, shownSnapshotIds: [], repeat: false,
+});
+
+function frameOf(e: ReplayEntry, slot: number, shownAt: number, shownIds: number[], repeat: boolean): StripFrame {
+  return {
+    slot, shownAt, snapshotId: e.snapshotId, webcamId: e.webcamId, bin: e.bin,
+    quality: e.quality, detection: e.detection, title: e.title ?? '', imageUrl: e.imageUrl ?? '',
+    capturedAt: e.capturedAt ?? null, shownSnapshotIds: shownIds, repeat,
+  };
+}
+
+export interface ReplayOptions<D extends SoloDials> {
+  feed: Feed;
+  version: SoloVersionSpec<D>;
+  dials: D;
+  /** Every bin row that overlapped the window (store.listEntriesOverlapping). */
+  entries: ReplayEntry[];
+  /** Draws before `fromMs`, oldest first, so rest and recency start true. */
+  priorDraws: DrawLike[];
+  fromMs: number;
+  toMs: number;
+}
+
+/**
+ * Re-run the engine from `fromMs` to `toMs` on the replay dials' grid. Each
+ * slot sees the pool as it was at that slot's boundary and the shown state
+ * the replay itself has built, so this is what the glass would have shown
+ * had these dials been live, given the same arrivals and departures.
+ */
+export function replay<D extends SoloDials>(o: ReplayOptions<D>): Strip {
+  const { feed, version, dials } = o;
+  const grid = { dwellS: dials.dwellS, offsetS: dials.offsetS };
+  const working = seedFromDraws(o.entries, o.priorDraws);
+  let state = initialState(o.priorDraws, o.entries);
+  const seen = new Set<number>();
+  const frames: StripFrame[] = [];
+  const first = slotFor(o.fromMs, feed, grid.dwellS, grid.offsetS);
+  const last = slotFor(o.toMs, feed, grid.dwellS, grid.offsetS);
+  for (let slot = first; slot <= last; slot++) {
+    const at = boundaryMs(slot, feed, grid.dwellS, grid.offsetS);
+    const pool = poolAt(working, at);
+    const pick = version.next(pool, dials, state, slot, feed);
+    if (!pick) {
+      frames.push(blank(slot, at));
+      continue;
+    }
+    const shown = version.shown(pool, pick, dials);
+    for (const f of shown) {
+      f.tally += 1;
+      f.isNew = false;
+      f.lastShownAt = at;
+    }
+    const chosen = working.find((e) => e.snapshotId === pick.snapshotId)!;
+    frames.push(frameOf(chosen, slot, at, shown.map((f) => f.snapshotId), seen.has(pick.snapshotId)));
+    seen.add(pick.snapshotId);
+    state = afterShowing(pick, state);
+  }
+  return { feed, version: version.name, grid, fromMs: o.fromMs, toMs: o.toMs, frames };
+}
+
+/** The fact strip, from the draw log, on the grid the glass was running. */
+export function actualStrip(
+  feed: Feed, draws: (DrawLike & ReplayEntry)[], grid: Grid, fromMs: number, toMs: number,
+): Strip {
+  const seen = new Set<number>();
+  const frames = draws.map((d) => {
+    const f = frameOf(d, d.slot, d.shownAt, d.shownSnapshotIds?.length ? d.shownSnapshotIds : [d.snapshotId], seen.has(d.snapshotId));
+    seen.add(d.snapshotId);
+    return f;
+  });
+  return { feed, version: 'actual', grid, fromMs, toMs, frames };
+}
+
+export interface StripSummary {
+  draws: number;
+  blanks: number;
+  distinctFrames: number;
+  distinctCameras: number;
+  repeats: number;
+  /** Non-sunset draws over all draws, 0–1. */
+  nonSunsetShare: number;
+  /** Over sunset-bin draws; null when there were none. */
+  meanQuality: number | null;
+  minQuality: number | null;
+  /** Sunset-bin draws by quality decile, [0,0.1) … [0.9,1]. */
+  qualityHistogram: number[];
+  /** Draws per camera, most first, top 8. */
+  perCamera: { webcamId: number; title: string; draws: number }[];
+}
+
+export function summarize(strip: Strip): StripSummary {
+  const drawn = strip.frames.filter((f) => f.snapshotId != null);
+  const sunsets = drawn.filter((f) => f.bin === 'sunset' && f.quality != null);
+  const hist = new Array<number>(10).fill(0);
+  for (const f of sunsets) hist[Math.min(9, Math.max(0, Math.floor((f.quality as number) * 10)))] += 1;
+  const perCam = new Map<number, { webcamId: number; title: string; draws: number }>();
+  for (const f of drawn) {
+    const id = f.webcamId as number;
+    const row = perCam.get(id) ?? { webcamId: id, title: f.title, draws: 0 };
+    row.draws += 1;
+    perCam.set(id, row);
+  }
+  const qs = sunsets.map((f) => f.quality as number);
+  return {
+    draws: drawn.length,
+    blanks: strip.frames.length - drawn.length,
+    distinctFrames: new Set(drawn.map((f) => f.snapshotId)).size,
+    distinctCameras: perCam.size,
+    repeats: drawn.filter((f) => f.repeat).length,
+    nonSunsetShare: drawn.length ? drawn.filter((f) => f.bin === 'non_sunset').length / drawn.length : 0,
+    meanQuality: qs.length ? qs.reduce((a, b) => a + b, 0) / qs.length : null,
+    minQuality: qs.length ? Math.min(...qs) : null,
+    qualityHistogram: hist,
+    perCamera: [...perCam.values()].sort((a, b) => b.draws - a.draws || a.webcamId - b.webcamId).slice(0, 8),
+  };
+}
+
+/**
+ * Slot-for-slot agreement between two strips on the same grid: how many
+ * slots both have, and how many of those drew the same frame. Null when the
+ * grids differ, since their slots do not line up.
+ */
+export function compare(a: Strip, b: Strip): { slots: number; same: number } | null {
+  if (a.grid.dwellS !== b.grid.dwellS || a.grid.offsetS !== b.grid.offsetS) return null;
+  const byB = new Map(b.frames.map((f) => [f.slot, f.snapshotId]));
+  let slots = 0;
+  let same = 0;
+  for (const f of a.frames) {
+    if (!byB.has(f.slot)) continue;
+    slots++;
+    if (byB.get(f.slot) === f.snapshotId) same++;
+  }
+  return { slots, same };
+}

--- a/app/lib/solo/store.test.ts
+++ b/app/lib/solo/store.test.ts
@@ -17,6 +17,7 @@ import { sql } from '@/app/lib/db';
 import {
   listActiveEntries, insertEntry, removeStale, getScreenState, commitAdvance,
   countAdmittedSince, getBinDigestSummary, saveSweptZone, getSweptZone, logDraw, listRecentDraws, pruneDraws,
+  listDrawsBetween, listEntriesOverlapping,
 } from './store';
 
 const sqlMock = (sql as unknown as SqlTag).__sqlMock;
@@ -110,7 +111,9 @@ describe('screen state', () => {
     expect(tally).toMatch(/is_new = false/);
     expect(lastQuery()).toMatch(/insert into kiosk_draws/);
     expect(lastQuery()).toMatch(/on conflict \(feed, slot\) do nothing/);
-    expect(sqlMock.mock.calls.at(-1)!.slice(1)).toEqual(['sunset', 42, 7]);
+    // The stamp (replay spec §2): version, the newest deploy, the entry as the engine saw it, the frames played.
+    expect(lastQuery()).toMatch(/\(select max\(id\) from kiosk_deploys\)/);
+    expect(sqlMock.mock.calls.at(-1)!.slice(1)).toEqual(['sunset', 42, 7, 'solo', 'sunset', 0.9, 0.8, [7]]);
   });
   it('a failed draw log does not fail the advance', async () => {
     sqlMock.mockResolvedValueOnce([{ feed: 'sunset' }]).mockResolvedValueOnce([])
@@ -123,9 +126,10 @@ describe('screen state', () => {
   it('commitAdvance marks every frame of the run shown in one statement', async () => {
     sqlMock.mockResolvedValueOnce([{ feed: 'sunset' }]).mockResolvedValueOnce([]).mockResolvedValueOnce([]);
     const e = (id: number) => ({ snapshotId: id, webcamId: 3, bin: 'sunset' as const, quality: 0.9, detection: 0.8, isNew: true, tally: 0, enteredAt: 0 });
-    await commitAdvance('sunset', 42, e(9), 1, [e(7), e(8), e(9)]);
+    await commitAdvance('sunset', 42, e(9), 1, [e(7), e(8), e(9)], 'solo2');
     expect(sqlMock.mock.calls[1].slice(1)).toEqual(['sunset', [7, 8, 9]]);
-    expect(sqlMock.mock.calls.at(-1)!.slice(1)).toEqual(['sunset', 42, 9]); // the draw log names the drawn frame
+    // The draw log names the drawn frame and stamps every frame the dwell played.
+    expect(sqlMock.mock.calls.at(-1)!.slice(1)).toEqual(['sunset', 42, 9, 'solo2', 'sunset', 0.9, 0.8, [7, 8, 9]]);
   });
 });
 
@@ -173,6 +177,52 @@ describe('draw log (the tape)', () => {
   });
   it('logDraw swallows its own failure', async () => {
     sqlMock.mockRejectedValueOnce(new Error('nope'));
-    await expect(logDraw('sunset', 1, 2)).resolves.toBeUndefined();
+    const e = { snapshotId: 2, webcamId: 3, bin: 'sunset' as const, quality: 0.9, detection: 0.8, isNew: true, tally: 0, enteredAt: 0 };
+    await expect(logDraw('sunset', 1, e, 'solo', [e])).resolves.toBeUndefined();
+  });
+});
+
+describe('replay reads (replay spec §3)', () => {
+  const row = (slot: string, id: string, shown: string, stamp: Record<string, unknown> = {}) => ({
+    slot, shown_at: shown, snapshot_id: id, webcam_id: '3', bin: 'sunset', quality: '0.8', detection: '0.9', is_new: false,
+    tally: '2', entered_at: '2026-09-06T00:00:00Z', captured_at: '2026-09-06 00:30:00', first_shown_at: null, last_shown_at: shown,
+    firebase_url: `u${id}`, title: 'B', city: 'Nuuk', region: '', country: 'Greenland', lat: '64.17', lng: '-51.73',
+    version: null, deploy_id: null, shown_snapshot_ids: null, ...stamp,
+  });
+  it('listDrawsBetween returns the window oldest first with the stamp, numbers not strings', async () => {
+    sqlMock.mockResolvedValueOnce([
+      row('100', '7', '2026-09-06T01:00:00Z'),
+      row('101', '8', '2026-09-06T01:00:20Z', { version: 'solo2', deploy_id: '4', shown_snapshot_ids: ['6', '8'] }),
+    ]);
+    const from = Date.parse('2026-09-06T00:00:00Z');
+    const to = Date.parse('2026-09-06T02:00:00Z');
+    const out = await listDrawsBetween('sunset', from, to);
+    expect(lastQuery()).toMatch(/from kiosk_draws d/);
+    expect(lastQuery()).toMatch(/left join kiosk_bin_entries e/);
+    expect(lastQuery()).toMatch(/coalesce\(d.bin, e.bin\)/);
+    expect(lastQuery()).toMatch(/order by d.slot asc/);
+    expect(sqlMock.mock.calls.at(-1)!.slice(1)).toEqual(['sunset', new Date(from).toISOString(), new Date(to).toISOString()]);
+    expect(out.map((f) => f.snapshotId)).toEqual([7, 8]);
+    // An unstamped row: the frames played default to the drawn frame alone.
+    expect(out[0]).toMatchObject({ slot: 100, version: null, deployId: null, shownSnapshotIds: [7], bin: 'sunset', quality: 0.8 });
+    expect(out[1]).toMatchObject({ slot: 101, version: 'solo2', deployId: 4, shownSnapshotIds: [6, 8], shownAt: Date.parse('2026-09-06T01:00:20Z') });
+  });
+  it('listDrawsBetween is empty when the table is missing', async () => {
+    sqlMock.mockRejectedValueOnce(new Error('relation "kiosk_draws" does not exist'));
+    expect(await listDrawsBetween('sunset', 0, 1)).toEqual([]);
+  });
+  it('listEntriesOverlapping bounds both ends and carries removedAt', async () => {
+    sqlMock.mockResolvedValueOnce([
+      { ...row('0', '7', '2026-09-06T01:00:00Z'), removed_at: null },
+      { ...row('0', '8', '2026-09-06T01:00:20Z'), removed_at: '2026-09-06T01:30:00Z' },
+    ]);
+    const from = Date.parse('2026-09-06T00:00:00Z');
+    const to = Date.parse('2026-09-06T02:00:00Z');
+    const out = await listEntriesOverlapping('sunset', from, to);
+    expect(lastQuery()).toMatch(/e.entered_at <= /);
+    expect(lastQuery()).toMatch(/e.removed_at is null or e.removed_at >= /);
+    expect(sqlMock.mock.calls.at(-1)!.slice(1)).toEqual(['sunset', new Date(to).toISOString(), new Date(from).toISOString()]);
+    expect(out[0]).toMatchObject({ snapshotId: 7, removedAt: null, quality: 0.8, webcamId: 3 });
+    expect(out[1].removedAt).toBe(Date.parse('2026-09-06T01:30:00Z'));
   });
 });

--- a/app/lib/solo/store.ts
+++ b/app/lib/solo/store.ts
@@ -2,6 +2,7 @@ import 'server-only';
 import tzLookup from 'tz-lookup';
 import { sql } from '@/app/lib/db';
 import type { BinEntry, BinKind, Feed } from './types';
+import type { SoloVersionName } from './versions';
 import { sunAltitudeDeg } from './zone';
 
 /**
@@ -276,6 +277,7 @@ export async function commitAdvance(
   entry: BinEntry,
   sunsetStreak: number,
   shown: BinEntry[] = [entry],
+  version: SoloVersionName = 'solo',
 ): Promise<boolean> {
   const rows = (await sql`
     insert into kiosk_screen_state (feed, current_snapshot_id, shown_since, slot, sunset_streak, updated_at)
@@ -298,7 +300,7 @@ export async function commitAdvance(
         last_shown_at = now()
     where feed = ${feed} and snapshot_id = any(${shown.map((e) => e.snapshotId)}::bigint[])
   `;
-  await logDraw(feed, slot, entry.snapshotId);
+  await logDraw(feed, slot, entry, version, shown);
   return true;
 }
 
@@ -315,14 +317,21 @@ export interface TapeFrame extends StoredEntry {
 }
 
 /**
- * Record a draw for the tape. Best-effort: an unmigrated table must not stop
- * the glass advancing. Idempotent on (feed, slot), like the state write.
+ * Record a draw for the tape, stamped with what drew it (replay spec §2):
+ * the version, the newest deploy (the live profile only changes on Deploy,
+ * so that is the profile in force), the entry as the engine saw it, and
+ * every frame the dwell played. Best-effort: an unmigrated table or column
+ * must not stop the glass advancing. Idempotent on (feed, slot), like the
+ * state write.
  */
-export async function logDraw(feed: Feed, slot: number, snapshotId: number): Promise<void> {
+export async function logDraw(
+  feed: Feed, slot: number, entry: BinEntry, version: SoloVersionName, shown: BinEntry[],
+): Promise<void> {
   try {
     await sql`
-      insert into kiosk_draws (feed, slot, snapshot_id, shown_at)
-      values (${feed}, ${slot}, ${snapshotId}, now())
+      insert into kiosk_draws (feed, slot, snapshot_id, shown_at, version, deploy_id, bin, quality, detection, shown_snapshot_ids)
+      select ${feed}, ${slot}, ${entry.snapshotId}, now(), ${version}, (select max(id) from kiosk_deploys),
+             ${entry.bin}, ${entry.quality}, ${entry.detection}, ${shown.map((e) => e.snapshotId)}::bigint[]
       on conflict (feed, slot) do nothing
     `;
   } catch (error) {
@@ -351,6 +360,82 @@ export async function listRecentDraws(feed: Feed, n: number): Promise<TapeFrame[
     console.warn('[solo/store] draw log read failed:', error);
     return [];
   }
+}
+
+/** A logged draw with its stamp, for the replay (spec §3). Unstamped rows read as "unknown". */
+export interface DrawRecord extends TapeFrame {
+  version: SoloVersionName | null;
+  deployId: number | null;
+  /** Every frame the dwell played; the drawn frame alone when the row predates the stamp. */
+  shownSnapshotIds: number[];
+}
+
+/** A bin row as the replay needs it: the entry plus when it left the bin, if it has. */
+export interface ReplayEntry extends StoredEntry {
+  /** ms since epoch; null while the row is still in the bin. */
+  removedAt: number | null;
+}
+
+type DrawRow = EntryRow & {
+  slot: string | number; shown_at: string; version: string | null; deploy_id: string | number | null;
+  shown_snapshot_ids: (string | number)[] | null;
+};
+
+/**
+ * The draws on one screen between two moments, oldest first. Bin and scores
+ * come from the stamp when present, else from the bin-entry join; the
+ * webcam comes from the snapshot so a draw older than the bin history still
+ * resolves. Empty when the table is missing.
+ */
+export async function listDrawsBetween(feed: Feed, fromMs: number, toMs: number): Promise<DrawRecord[]> {
+  try {
+    const rows = (await sql`
+      select d.slot, d.shown_at, d.snapshot_id, d.version, d.deploy_id, d.shown_snapshot_ids,
+             coalesce(e.webcam_id, s.webcam_id) as webcam_id,
+             coalesce(d.bin, e.bin) as bin, coalesce(d.quality, e.quality) as quality, coalesce(d.detection, e.detection) as detection,
+             coalesce(e.is_new, false) as is_new, coalesce(e.tally, 0) as tally,
+             coalesce(e.entered_at, d.shown_at) as entered_at, e.first_shown_at, e.last_shown_at,
+             s.firebase_url, s.captured_at::text as captured_at, w.title, w.city, w.region, w.country, w.lat, w.lng
+      from kiosk_draws d
+      left join kiosk_bin_entries e on e.feed = d.feed and e.snapshot_id = d.snapshot_id
+      join webcam_snapshots s on s.id = d.snapshot_id
+      join webcams w on w.id = coalesce(e.webcam_id, s.webcam_id)
+      where d.feed = ${feed} and d.shown_at >= ${new Date(fromMs).toISOString()} and d.shown_at <= ${new Date(toMs).toISOString()}
+      order by d.slot asc
+    `) as unknown as DrawRow[];
+    return rows.map((r) => ({
+      ...toEntry(feed, r),
+      slot: num(r.slot),
+      shownAt: Date.parse(r.shown_at),
+      version: r.version === 'solo' || r.version === 'solo2' ? r.version : null,
+      deployId: r.deploy_id == null ? null : num(r.deploy_id),
+      shownSnapshotIds: r.shown_snapshot_ids?.length ? r.shown_snapshot_ids.map(num) : [num(r.snapshot_id)],
+    }));
+  } catch (error) {
+    console.warn('[solo/store] draw window read failed:', error);
+    return [];
+  }
+}
+
+/**
+ * Every bin row that was in the bin at any moment between `fromMs` and
+ * `toMs`, removed or not. Scores are the admission-time values the row
+ * holds, which is what the engine saw. Shown state on the row is today's
+ * and is rebuilt by the replay from the draw log.
+ */
+export async function listEntriesOverlapping(feed: Feed, fromMs: number, toMs: number): Promise<ReplayEntry[]> {
+  const rows = (await sql`
+    select e.snapshot_id, e.webcam_id, e.bin, e.quality, e.detection, e.is_new, e.tally,
+           e.entered_at, e.first_shown_at, e.last_shown_at, e.removed_at,
+           s.firebase_url, s.captured_at::text as captured_at, w.title, w.city, w.region, w.country, w.lat, w.lng
+    from kiosk_bin_entries e
+    join webcam_snapshots s on s.id = e.snapshot_id
+    join webcams w on w.id = e.webcam_id
+    where e.feed = ${feed} and e.entered_at <= ${new Date(toMs).toISOString()}
+      and (e.removed_at is null or e.removed_at >= ${new Date(fromMs).toISOString()})
+    order by e.entered_at asc
+  `) as unknown as (EntryRow & { removed_at: string | null })[];
+  return rows.map((r) => ({ ...toEntry(feed, r), removedAt: ms(r.removed_at) }));
 }
 
 /** Drop draws older than `olderThanDays`. Best-effort; the cron calls it every tick. */

--- a/database/migrations/20260906_kiosk_draws.sql
+++ b/database/migrations/20260906_kiosk_draws.sql
@@ -1,9 +1,13 @@
 -- Solo kiosk: one row per draw per screen, the record behind the studio's
 -- tape (stages-and-tape spec §4). Written by store.commitAdvance right after
 -- the screen-state upsert succeeds, best-effort; read by GET
--- /api/kiosk/solo/state for the last 24 draws; pruned by
--- binAdmission.maintainBins after 7 days. About 8.6k rows a day per screen
--- at a 20 s dwell.
+-- /api/kiosk/solo/state for the last 24 draws, and in windows by the replay
+-- (2026-09-06-solo-replay-design.md); pruned by binAdmission.maintainBins
+-- after 30 days. A 20 s dwell allows at most 4.3k rows a day per screen, and
+-- measured on 2026-09-06 about 2.4k land, since a slot the glass never
+-- advanced through logs nothing. Both screens over 30 days is roughly 145k
+-- rows, under 30 MB with indexes. (Until 2026-09-06 this read "8.6k rows a
+-- day per screen", which was the two-screen total mislabelled.)
 --
 -- Forward-only, idempotent. The writer and the reader both degrade to
 -- nothing when the table is missing, so the glass never depends on it, but

--- a/database/migrations/20260906_kiosk_draws_stamp.sql
+++ b/database/migrations/20260906_kiosk_draws_stamp.sql
@@ -1,0 +1,25 @@
+-- Solo replay: stamp each draw with what drew it (spec
+-- docs/superpowers/specs/2026-09-06-solo-replay-design.md §2), so a draw
+-- row explains itself after the bin row is gone and the deploy has moved on.
+--
+--   version            'solo' | 'solo2', the engine that drew
+--   deploy_id          newest kiosk_deploys.id at the draw: the dials in force
+--   bin / quality / detection   the entry as the engine saw it
+--   shown_snapshot_ids every frame the dwell played (solo2 camera run), the
+--                      chosen one included; [snapshot_id] for solo
+--
+-- Rows from before this migration keep nulls; readers fall back to the
+-- kiosk_bin_entries join for bin and scores.
+--
+-- Forward-only, idempotent. APPLY BEFORE MERGING the code: logDraw writes
+-- these columns in one insert and swallows its own error, so a missing
+-- column loses the tape silently.
+--   node scripts/apply-migration.mjs database/migrations/20260906_kiosk_draws_stamp.sql
+--   node scripts/apply-migration.mjs database/migrations/20260906_kiosk_draws_stamp.sql --apply
+
+ALTER TABLE kiosk_draws ADD COLUMN IF NOT EXISTS version            TEXT;
+ALTER TABLE kiosk_draws ADD COLUMN IF NOT EXISTS deploy_id          INTEGER;
+ALTER TABLE kiosk_draws ADD COLUMN IF NOT EXISTS bin                TEXT;
+ALTER TABLE kiosk_draws ADD COLUMN IF NOT EXISTS quality            REAL;
+ALTER TABLE kiosk_draws ADD COLUMN IF NOT EXISTS detection          REAL;
+ALTER TABLE kiosk_draws ADD COLUMN IF NOT EXISTS shown_snapshot_ids BIGINT[];

--- a/docs/superpowers/specs/2026-09-06-solo-replay-design.md
+++ b/docs/superpowers/specs/2026-09-06-solo-replay-design.md
@@ -1,6 +1,6 @@
 # Solo replay — stamped draws and a counterfactual strip
 
-Date: 2026-09-06. Status: approved in conversation, building. Follows the
+Date: 2026-09-06. Status: built (PR feat/solo-replay); the studio strip (§8) is not. Follows the
 stages-and-tape design (`2026-09-05-solo-stages-and-tape-design.md` §4) and
 the deploy history (`2026-09-05-studio-deploy-history-and-solo-preview-design.md`).
 
@@ -12,7 +12,7 @@ under other dials?":
 
 | Record | Table | State on 2026-09-06 |
 |---|---|---|
-| What we showed | `kiosk_draws` | Live since 23:51 PT tonight; one row per screen per slot; pruned at 7 days |
+| What we showed | `kiosk_draws` | Live since 23:51 PT on 09-05; one row per screen per slot; pruned at 7 days, now 30 |
 | Dials in force | `kiosk_deploys` | Every Deploy since 09-05, all namespaces |
 | What we had access to | `kiosk_bin_entries` | `entered_at` / `removed_at` on every row; removed rows are never deleted, so the pool at any past moment rebuilds from the table |
 
@@ -87,11 +87,18 @@ Two store reads, both in `app/lib/solo/store.ts`:
 or `> t`). The shown state (`tally`, `lastShownAt`, `isNew`) is not read
 from the row, because the row holds today's values; it is rebuilt:
 
-- `seedFromDraws(entries, priorDraws)`: for each prior draw, every id in
-  `shownSnapshotIds` (or the snapshot alone) gets `tally + 1`,
-  `lastShownAt = shownAt`, `isNew = false`. Prior draws are the draws
-  before the window; the CLI fetches one hour of them so rest and recency
-  start true.
+- `seedFromDraws(entries, priorDraws, windowStart)`: for each prior draw,
+  every id in `shownSnapshotIds` (or the snapshot alone) gets `tally + 1`,
+  `lastShownAt = shownAt`, `isNew = false`. Bins expire at 24 h, so every
+  draw of a frame still in the pool is within a day: the CLI fetches 24 h
+  of prior draws and the seed is exact from the log.
+- A row the log never saw drawn but whose own `firstShownAt` is before the
+  window was shown before the log began (the log is younger than the bins,
+  or was pruned). It is seeded from the row's record: exact when the row's
+  `lastShownAt` is also before the window, else a lower bound
+  (`firstShownAt`). This only matters for windows within 24 h of the log's
+  first row; the first night's window is the worst case and its
+  slot-for-slot parity is low for that reason alone.
 - `isNew` at entry: true when another entry of the same camera was active
   at this entry's `enteredAt`, which is the admission rule, then cleared by
   any showing, prior or simulated.
@@ -129,8 +136,16 @@ interface Strip { feed; version; dials: SettingsValues /* deviations */; fromMs;
 strip and the replay strip are one type. `summarize(strip)` returns draws,
 blanks, distinct frames, distinct cameras, repeats, non-sunset share, mean
 and minimum quality, a 10-bucket quality histogram, and draws per camera
-(top 8). `compare(a, b)` counts slots where both strips drew the same
-frame, only when their dwell and offset agree.
+(top 8). `compare(a, b)` reports, only when their dwell and offset agree,
+`same` (slots where both drew the same frame) and `inOrder` (the longest
+common subsequence of the two draw orders). A slot the glass missed shifts
+every later draw by one, so `same` reads low even when the order is right;
+`inOrder` survives that. Measured on 2026-09-06 at the live dials: the
+12:00 PT hour, 13 h into the log, 180 draws, 57 same slot, 152 in order;
+the 13:00 hour, 163 of 180 in order. The aggregates (frames, cameras,
+histogram) match exactly in both, so the residual is local reordering,
+most of it the pre-log seeding fallback above; a window starting a day
+after the log's first row will say whether anything else remains.
 
 ## 5. The CLI
 
@@ -156,8 +171,23 @@ npx vite-node --config vitest.config.ts scripts/solo-replay.ts \
   summaries as a table. `--json` writes `{ actual, replay, summaries }`,
   which is the future studio strip's payload.
 
-First use: tonight's sunset window at rating floor 1, 2.5 and 3, and again
-at rest 8. The numbers go in the PR.
+First use, 2026-09-06 (sunset screen; "tonight" is 23:51–00:30 PT with 28
+frames from 11 cameras; "midday" is 12:00–13:00 PT with 114 frames from
+34 cameras):
+
+| | tonight actual | floor 2.5 | floor 3 | midday actual | floor 2.5 | floor 3 |
+|---|---|---|---|---|---|---|
+| distinct frames | 28 | 19 | 15 | 114 | 85 | 59 |
+| distinct cameras | 11 | 9 | 6 | 34 | 28 | 20 |
+| mean quality | 0.47 | 0.58 | 0.63 | 0.48 | 0.60 | 0.68 |
+| min quality | 0.07 | 0.39 | 0.52 | 0.00 | 0.38 | 0.51 |
+| top camera's share | 23% | 29% | 42% | 9% | 13% | 17% |
+
+`rest` 8 changed nothing in either window: rest only binds when the cycle
+of eligible frames is shorter than the dial, and it never was. solo2 with
+the camera run gives every camera equal draws (35 cameras × 7 at midday)
+but plays each camera's newest frame, not its best, so mean quality falls
+to 0.42; with the floor at 2.5 it recovers to 0.51 with 28 cameras.
 
 ## 6. Error handling
 

--- a/docs/superpowers/specs/2026-09-06-solo-replay-design.md
+++ b/docs/superpowers/specs/2026-09-06-solo-replay-design.md
@@ -60,8 +60,13 @@ for bin and scores.
 has; the advance route passes `version.name`.
 
 Retention: `DRAW_LOG_DAYS` goes from 7 to 30, so the run up to and through
-the show (2026-09-12) survives. Volume at a 20 s dwell is about 8.6 k rows a
-day per screen, half a million rows a month, which is small.
+the show (2026-09-12) survives, and the replay can be pointed at any night
+of it. A 20 s dwell allows at most 4.3 k rows a day per screen; measured on
+2026-09-06 it was about 2.4 k per screen, because a slot the glass never
+advanced through logs nothing. Both screens together that is roughly 4.8 k
+rows a day, so 30 days is about 145 k rows and under 30 MB with indexes,
+against about 6 MB at 7 days. Rows arrive and leave at the same rate in
+steady state, so the per-tick prune does no more work than before.
 
 ## 3. Reading the records
 

--- a/docs/superpowers/specs/2026-09-06-solo-replay-design.md
+++ b/docs/superpowers/specs/2026-09-06-solo-replay-design.md
@@ -1,0 +1,196 @@
+# Solo replay — stamped draws and a counterfactual strip
+
+Date: 2026-09-06. Status: approved in conversation, building. Follows the
+stages-and-tape design (`2026-09-05-solo-stages-and-tape-design.md` §4) and
+the deploy history (`2026-09-05-studio-deploy-history-and-solo-preview-design.md`).
+
+## 1. What this is
+
+Three records answer "what did the glass show, under which dials, out of
+what?" and one pure function turns them into "what would it have shown
+under other dials?":
+
+| Record | Table | State on 2026-09-06 |
+|---|---|---|
+| What we showed | `kiosk_draws` | Live since 23:51 PT tonight; one row per screen per slot; pruned at 7 days |
+| Dials in force | `kiosk_deploys` | Every Deploy since 09-05, all namespaces |
+| What we had access to | `kiosk_bin_entries` | `entered_at` / `removed_at` on every row; removed rows are never deleted, so the pool at any past moment rebuilds from the table |
+
+The gap is that a draw row does not say which version, deploy, or bin
+drew it, and solo2's run frames (the ones a dwell plays besides the chosen
+one) are not logged, although they are marked shown and so shape later
+draws. This spec stamps the draw row, adds a replay function that
+re-runs the engine over the recorded pool, and a CLI that prints the
+actual strip beside the replayed one. The replay's output is shaped as the
+studio tape's data so a later change can mount it as a second strip under
+the fact tape ("with these dials"); that strip is not built here.
+
+The question that prompted it: on the sunset screen at midnight PT, 11 of
+61 draws had quality under 0.10, four of them from one Petersburg camera.
+The rating floor is 1, rule 3 gives every eligible frame one turn per cycle,
+and rest is per frame. Raising the floor shrinks a 23-frame bin to 10 and
+tightens the loop. The replay answers which dial to move, with numbers,
+before it moves on the glass.
+
+## 2. Stamp the draw
+
+Migration `20260906_kiosk_draws_stamp.sql`, forward-only, idempotent,
+**applied before the code merges** (CLAUDE.md rule: the writer swallows its
+own errors, so a missing column loses draws silently, not loudly):
+
+```sql
+alter table kiosk_draws add column if not exists version            text;
+alter table kiosk_draws add column if not exists deploy_id          integer;
+alter table kiosk_draws add column if not exists bin                text;
+alter table kiosk_draws add column if not exists quality            real;
+alter table kiosk_draws add column if not exists detection          real;
+alter table kiosk_draws add column if not exists shown_snapshot_ids bigint[];
+```
+
+`logDraw(feed, slot, entry, version, shown)` writes all of them in the
+one insert. `deploy_id` is `(select max(id) from kiosk_deploys)` inside the
+same statement: the live profile is only ever changed by a Deploy, so the
+newest deploy row is the profile the glass drew with. No extra round trip.
+`shown_snapshot_ids` is every frame the dwell played, the chosen one
+included; `[snapshot_id]` for solo. Rows written before the migration keep
+nulls; readers treat null as "unknown" and fall back to the bin-entry join
+for bin and scores.
+
+`commitAdvance` passes the version name and the `shown` list it already
+has; the advance route passes `version.name`.
+
+Retention: `DRAW_LOG_DAYS` goes from 7 to 30, so the run up to and through
+the show (2026-09-12) survives. Volume at a 20 s dwell is about 8.6 k rows a
+day per screen, half a million rows a month, which is small.
+
+## 3. Reading the records
+
+Two store reads, both in `app/lib/solo/store.ts`:
+
+- `listDrawsBetween(feed, fromMs, toMs)` → `DrawRecord[]` oldest first:
+  slot, shownAt, snapshotId, version, deployId, bin, quality, detection,
+  shownSnapshotIds, joined to the bin entry, snapshot and webcam for the
+  same fields `TapeFrame` carries. Bin and scores come from the stamp when
+  present, else from the join.
+- `listEntriesOverlapping(feed, fromMs, toMs)` → `ReplayEntry[]`: every
+  bin row with `entered_at ≤ to` and (`removed_at` null or `≥ from`), as a
+  `StoredEntry` plus `removedAt`. Scores are the admission-time values the
+  row holds, which is what the engine saw.
+
+## 4. The replay (pure)
+
+`app/lib/solo/replay.ts`. No I/O, no clock.
+
+### 4.1 The pool at a moment
+
+`poolAt(entries, tMs)`: entries with `enteredAt ≤ t` and (`removedAt` null
+or `> t`). The shown state (`tally`, `lastShownAt`, `isNew`) is not read
+from the row, because the row holds today's values; it is rebuilt:
+
+- `seedFromDraws(entries, priorDraws)`: for each prior draw, every id in
+  `shownSnapshotIds` (or the snapshot alone) gets `tally + 1`,
+  `lastShownAt = shownAt`, `isNew = false`. Prior draws are the draws
+  before the window; the CLI fetches one hour of them so rest and recency
+  start true.
+- `isNew` at entry: true when another entry of the same camera was active
+  at this entry's `enteredAt`, which is the admission rule, then cleared by
+  any showing, prior or simulated.
+- The starting `ScreenState`: `lastSnapshotId` is the last prior draw's
+  snapshot; `sunsetStreak` is the count of consecutive sunset-bin draws at
+  the end of the prior draws.
+
+### 4.2 The run
+
+```ts
+replay({ feed, version, dials, entries, priorDraws, fromMs, toMs }): Strip
+```
+
+Slots run from `slotFor(fromMs)` to `slotFor(toMs)` on the **replay
+dials'** dwell and offset, so a replay may use a different dwell than the
+glass did; width-is-time absorbs that on the strip. For each slot:
+`poolAt(boundaryMs(slot))`, then `version.next`, then `version.shown`, then
+the same shown-state update `project` applies (tally, isNew, lastShownAt =
+the slot boundary), then `afterShowing`. A slot with no eligible frame
+yields a `blank` frame, the tape's black block.
+
+### 4.3 The strip
+
+```ts
+interface StripFrame {
+  slot: number; shownAt: number; snapshotId: number | null;   // null = blank
+  webcamId; bin; quality; detection; title; imageUrl; capturedAt;
+  shownSnapshotIds: number[];
+  repeat: boolean;   // seen earlier on this strip
+}
+interface Strip { feed; version; dials: SettingsValues /* deviations */; fromMs; toMs; frames: StripFrame[] }
+```
+
+`actualStrip(draws)` builds the same shape from draw records, so the fact
+strip and the replay strip are one type. `summarize(strip)` returns draws,
+blanks, distinct frames, distinct cameras, repeats, non-sunset share, mean
+and minimum quality, a 10-bucket quality histogram, and draws per camera
+(top 8). `compare(a, b)` counts slots where both strips drew the same
+frame, only when their dwell and offset agree.
+
+## 5. The CLI
+
+`scripts/solo-replay.ts`, run with vite-node so it imports the real engine,
+schemas and store through the `@` alias and the vitest `server-only` stub:
+
+```
+npx vite-node --config vitest.config.ts scripts/solo-replay.ts \
+  --feed sunset --from 2026-09-06T06:51Z --to now \
+  --version solo --deploy 4 --dial ratingFloor=2.5 --dial rest=6 \
+  --json /tmp/replay.json
+```
+
+- `--deploy N` starts from that deploy's namespace for the version;
+  omitted, from the newest. `--dial key=value` overrides on top; values are
+  sanitized through the version's schema. `--version` defaults to the
+  shared `activeVersion` in the chosen deploy.
+- `--from` / `--to` accept ISO or `now`; default the last hour.
+- Loads `.env.local` into `process.env` before importing the store, since
+  `app/lib/db` reads `DATABASE_URL` at import.
+- Prints one line per slot with the actual and replayed frame side by side
+  (time, bin letter, quality, camera, a `≠` where they differ), then both
+  summaries as a table. `--json` writes `{ actual, replay, summaries }`,
+  which is the future studio strip's payload.
+
+First use: tonight's sunset window at rating floor 1, 2.5 and 3, and again
+at rest 8. The numbers go in the PR.
+
+## 6. Error handling
+
+- Missing stamp columns: the insert fails, `logDraw` warns, the glass keeps
+  advancing, the tape loses rows. Hence apply-before-merge.
+- Draws older than the bin history (rows from before 09-04) have no entry to
+  join; they are dropped from the actual strip with a count in the summary.
+- A window before the draw log began replays fine (the pool is older than
+  the log) but the actual strip is empty; the CLI says so.
+- `removedAt` is the cron's tick time, not the moment the camera left the
+  zone; the pool can be up to one tick generous. Noted, not corrected.
+
+## 7. Testing
+
+- `replay.test.ts`: `poolAt` window edges (entered at t, removed at t);
+  seeding tally, lastShownAt, isNew and streak from prior draws; **parity**:
+  draws generated by `project` over a fixture, fed back through
+  `seedFromDraws` + `replay` with the same dials, reproduce the same picks
+  slot for slot; a higher floor changes picks; a different dwell puts frames
+  on the new grid; a blank slot; `summarize` counts; `compare` refuses
+  mismatched dwells.
+- `store.test.ts`: `logDraw` writes the six new columns and the max(id)
+  subselect; `listDrawsBetween` prefers the stamp and falls back to the
+  join; `listEntriesOverlapping` uses both bounds; `commitAdvance` passes
+  version and shown ids through.
+- Advance route test: `commitAdvance` receives `version.name`.
+
+## 8. Out of scope
+
+- The studio strip itself (mounting the replay under the tape). The
+  `Strip` type and `summarize` are its data; a route is a few lines when
+  it is wanted.
+- Scenarios below the bin: different cron floors or zones need the archived
+  snapshots (all 6.8 k a day are archived with scores) and the sweep
+  geometry, which is deterministic from time. Possible later; not here.
+- Per-camera rest, or any new dial. The replay measures dials that exist.

--- a/scripts/solo-replay.ts
+++ b/scripts/solo-replay.ts
@@ -1,0 +1,199 @@
+// scripts/solo-replay.ts — what the glass showed beside what it would have
+// shown under other dials (docs/superpowers/specs/2026-09-06-solo-replay-design.md §5).
+//
+// Runs the real engine, schemas and store through vite-node, so nothing here
+// is a copy that can drift:
+//
+//   npx vite-node --config vitest.config.ts scripts/solo-replay.ts \
+//     --feed sunset --from 2026-09-06T06:51Z --to now \
+//     --version solo --deploy 4 --dial ratingFloor=2.5 --dial rest=6 \
+//     --json /tmp/replay.json
+//
+//   --feed     sunrise | sunset (default sunset)
+//   --from/--to  ISO time or `now`; default the last hour
+//   --deploy   kiosk_deploys id whose dials to start from; default the newest
+//   --version  solo | solo2; default the deploy's shared activeVersion when it
+//              is a solo version, else solo
+//   --dial     key=value on top of the deploy, repeatable; sanitized by the schema
+//   --json     also write { actual, replay, summaries } for the studio strip
+//
+// Read-only. Needs DATABASE_URL in .env.local (read here, before the store
+// is imported, because app/lib/db reads it at import).
+import { readFileSync, writeFileSync } from 'node:fs';
+import type { SettingsSchema, SettingsValues } from '@/app/lib/settings/schema';
+import type { StripFrame } from '@/app/lib/solo/replay';
+
+function loadEnvLocal(): void {
+  let text = '';
+  try { text = readFileSync('.env.local', 'utf8'); } catch { return; }
+  for (const line of text.split('\n')) {
+    const m = line.match(/^\s*([A-Z0-9_]+)\s*=\s*(.*?)\s*$/);
+    if (!m || process.env[m[1]] !== undefined) continue;
+    process.env[m[1]] = m[2].replace(/^(["'])(.*)\1$/, '$2');
+  }
+}
+
+interface Args {
+  feed: 'sunrise' | 'sunset';
+  from: number;
+  to: number;
+  deploy: number | null;
+  version: string | null;
+  dials: Record<string, string>;
+  json: string | null;
+}
+
+function parseTime(s: string | undefined, fallback: number): number {
+  if (!s) return fallback;
+  if (s === 'now') return Date.now();
+  const t = Date.parse(s);
+  if (!Number.isFinite(t)) throw new Error(`cannot read time: ${s}`);
+  return t;
+}
+
+function parseArgs(argv: string[]): Args {
+  const flags = new Map<string, string[]>();
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (!a.startsWith('--')) throw new Error(`unexpected argument: ${a}`);
+    const key = a.slice(2);
+    const val = argv[i + 1] !== undefined && !argv[i + 1].startsWith('--') ? argv[++i] : '';
+    flags.set(key, [...(flags.get(key) ?? []), val]);
+  }
+  const one = (k: string) => flags.get(k)?.at(-1);
+  const feed = one('feed') ?? 'sunset';
+  if (feed !== 'sunrise' && feed !== 'sunset') throw new Error('--feed must be sunrise or sunset');
+  const to = parseTime(one('to'), Date.now());
+  const from = parseTime(one('from'), to - 3_600_000);
+  const dials: Record<string, string> = {};
+  for (const d of flags.get('dial') ?? []) {
+    const m = d.match(/^([A-Za-z0-9]+)=(.*)$/);
+    if (!m) throw new Error(`--dial wants key=value, got: ${d}`);
+    dials[m[1]] = m[2];
+  }
+  const deploy = one('deploy');
+  return {
+    feed, from, to,
+    deploy: deploy ? Number(deploy) : null,
+    version: one('version') ?? null,
+    dials,
+    json: one('json') ?? null,
+  };
+}
+
+/** A dial from the command line, typed the way its knob wants. */
+function typed(schema: SettingsSchema, raw: Record<string, string>): SettingsValues {
+  const out: SettingsValues = {};
+  for (const [k, v] of Object.entries(raw)) {
+    const knob = schema.find((s) => s.key === k);
+    if (!knob) throw new Error(`no such dial: ${k}`);
+    out[k] = knob.kind === 'number' ? Number(v) : knob.kind === 'boolean' ? v === 'true' || v === '1' : v;
+  }
+  return out;
+}
+
+const PT = new Intl.DateTimeFormat('en-US', { timeZone: 'America/Los_Angeles', hourCycle: 'h23', hour: '2-digit', minute: '2-digit', second: '2-digit' });
+const clock = (ms: number) => PT.format(new Date(ms));
+const short = (s: string, n: number) => (s.length > n ? `${s.slice(0, n - 1)}…` : s.padEnd(n));
+const pct = (x: number) => `${Math.round(x * 100)}%`;
+const q3 = (x: number | null) => (x == null ? '  – ' : x.toFixed(2));
+
+function cell(f: StripFrame | undefined): string {
+  if (!f) return short('', 40);
+  if (f.snapshotId == null) return short('(blank)', 40);
+  const bin = f.bin === 'sunset' ? 'S' : 'N';
+  const score = f.bin === 'sunset' ? q3(f.quality) : q3(f.detection);
+  const title = f.title.replace(/^.*?: /, '').replace(/ › .*?: /, ' ');
+  return `${bin} ${score} ${short(title, 28)}${f.repeat ? ' ↺' : '  '}`;
+}
+
+async function main(): Promise<void> {
+  loadEnvLocal();
+  const args = parseArgs(process.argv.slice(2));
+  const [{ listDrawsBetween, listEntriesOverlapping }, { listDeploys }, { SOLO_VERSIONS, resolveSoloVersion },
+    { mergeSettings, stripDefaults }, { SHARED_SCHEMA }, { replay, actualStrip, summarize, compare }] = await Promise.all([
+    import('@/app/lib/solo/store'), import('@/app/lib/settings/deploys'), import('@/app/lib/solo/versions'),
+    import('@/app/lib/settings/schema'), import('@/app/lib/settings/sharedSchema'), import('@/app/lib/solo/replay'),
+  ]);
+
+  const deploys = await listDeploys(200);
+  const deploy = args.deploy == null ? deploys[0] : deploys.find((d) => d.id === args.deploy);
+  if (!deploy) throw new Error(args.deploy == null ? 'no deploys recorded' : `deploy #${args.deploy} not found`);
+  const shared = mergeSettings(SHARED_SCHEMA, deploy.namespaces.shared);
+  const versionName = args.version ?? (resolveSoloVersion(String(shared.activeVersion)) ? String(shared.activeVersion) : 'solo');
+  const version = resolveSoloVersion(versionName);
+  if (!version) throw new Error(`--version must be one of ${Object.keys(SOLO_VERSIONS).join(', ')}`);
+  const overrides = typed(version.schema, args.dials);
+  const values = mergeSettings(version.schema, deploy.namespaces[version.namespace], overrides);
+  const dials = version.dialsFrom(values);
+  const deviations = stripDefaults(version.schema, values);
+
+  // Bins expire at 24 h, so every draw of a frame still in the pool is within a day: the seed is exact from the log.
+  const LOOKBACK_MS = 24 * 3_600_000;
+  const [draws, entries] = await Promise.all([
+    listDrawsBetween(args.feed, args.from - LOOKBACK_MS, args.to),
+    listEntriesOverlapping(args.feed, args.from - LOOKBACK_MS, args.to),
+  ]);
+  const prior = draws.filter((d) => d.shownAt < args.from);
+  const window = draws.filter((d) => d.shownAt >= args.from);
+  const liveDeploy = deploys.find((d) => d.id === window.at(-1)?.deployId) ?? deploy;
+  const liveVersion = resolveSoloVersion(window.at(-1)?.version ?? versionName) ?? version;
+  const liveDials = liveVersion.dialsFrom(mergeSettings(liveVersion.schema, liveDeploy.namespaces[liveVersion.namespace]));
+  const actual = actualStrip(args.feed, window, { dwellS: liveDials.dwellS, offsetS: liveDials.offsetS }, args.from, args.to);
+  const re = replay({ feed: args.feed, version, dials, entries, priorDraws: prior, fromMs: args.from, toMs: args.to });
+  const summaries = { actual: summarize(actual), replay: summarize(re) };
+  const agreement = compare(actual, re);
+
+  const deployLabel = (d: typeof deploy) => `#${d.id}${d.label ? ` ${d.label}` : ''} (${clock(Date.parse(d.deployedAt))} PT)`;
+  console.log(`${args.feed} screen, ${clock(args.from)} → ${clock(args.to)} PT`);
+  console.log(`pool: ${entries.length} bin rows overlapped the window; ${prior.length} prior draws seed the shown state`);
+  console.log(`actual: ${liveVersion.name}, deploy ${deployLabel(liveDeploy)}, dwell ${liveDials.dwellS} s${window.length === 0 ? ' — no draws logged in this window' : ''}`);
+  console.log(`replay: ${version.name}, deploy ${deployLabel(deploy)}` +
+    (Object.keys(deviations).length ? `, dials ${Object.entries(deviations).map(([k, v]) => `${k}=${v}`).join(' ')}` : ', dials at defaults'));
+  console.log('');
+  console.log(`${'slot'.padEnd(9)} ${'actual'.padEnd(40)}   ${'replay'.padEnd(40)}`);
+  const byActual = new Map(actual.frames.map((f) => [f.slot, f]));
+  const byReplay = new Map(re.frames.map((f) => [f.slot, f]));
+  const slots = [...new Set([...byActual.keys(), ...byReplay.keys()])].sort((a, b) => a - b);
+  for (const slot of slots) {
+    const a = byActual.get(slot);
+    const r = byReplay.get(slot);
+    const mark = a && r && agreement ? (a.snapshotId === r.snapshotId ? ' ' : '≠') : ' ';
+    console.log(`${clock((a ?? r)!.shownAt)} ${cell(a)} ${mark} ${cell(r)}`);
+  }
+  console.log('');
+  const rows: [string, string, string][] = [
+    ['draws', String(summaries.actual.draws), String(summaries.replay.draws)],
+    ['blanks', String(summaries.actual.blanks), String(summaries.replay.blanks)],
+    ['distinct frames', String(summaries.actual.distinctFrames), String(summaries.replay.distinctFrames)],
+    ['distinct cameras', String(summaries.actual.distinctCameras), String(summaries.replay.distinctCameras)],
+    ['repeats', String(summaries.actual.repeats), String(summaries.replay.repeats)],
+    ['non-sunset share', pct(summaries.actual.nonSunsetShare), pct(summaries.replay.nonSunsetShare)],
+    ['mean quality', q3(summaries.actual.meanQuality), q3(summaries.replay.meanQuality)],
+    ['min quality', q3(summaries.actual.minQuality), q3(summaries.replay.minQuality)],
+    ['quality deciles', summaries.actual.qualityHistogram.join(' '), summaries.replay.qualityHistogram.join(' ')],
+  ];
+  for (const [k, a, r] of rows) console.log(`${k.padEnd(18)} ${a.padEnd(22)} ${r}`);
+  if (agreement) {
+    console.log(`${'same frame'.padEnd(18)} ${agreement.same} of ${agreement.slots} slots`);
+    console.log(`${'same order'.padEnd(18)} ${agreement.inOrder} of ${Math.min(actual.frames.length, re.frames.length)} draws (a slot the glass missed shifts the rest)`);
+  }
+  else console.log(`${'same frame'.padEnd(18)} (grids differ; slots do not line up)`);
+  console.log('');
+  console.log('draws per camera (actual | replay)');
+  const cams = new Map<number, { title: string; a: number; r: number }>();
+  for (const c of summaries.actual.perCamera) cams.set(c.webcamId, { title: c.title, a: c.draws, r: 0 });
+  for (const c of summaries.replay.perCamera) cams.set(c.webcamId, { ...(cams.get(c.webcamId) ?? { title: c.title, a: 0 }), r: c.draws });
+  for (const [id, c] of [...cams].sort((x, y) => y[1].a + y[1].r - (x[1].a + x[1].r)))
+    console.log(`  ${String(c.a).padStart(3)} | ${String(c.r).padStart(3)}  ${short(c.title.replace(/ › .*?: /, ' '), 60)} (${id})`);
+
+  if (args.json) {
+    writeFileSync(args.json, JSON.stringify({ actual, replay: re, summaries, agreement, dials: deviations }, null, 2));
+    console.log(`\nwrote ${args.json}`);
+  }
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : error);
+  process.exit(1);
+});


### PR DESCRIPTION
## What

A record of what the glass showed, labelled with the dials in force and the pool it drew from, and a replay that re-runs the engine over that pool under other dials. Spec: `docs/superpowers/specs/2026-09-06-solo-replay-design.md`.

- **Stamped draws.** `kiosk_draws` gains `version`, `deploy_id`, `bin`, `quality`, `detection`, `shown_snapshot_ids`, written in the one insert. **Migration `20260906_kiosk_draws_stamp.sql` is already applied** (additive, nullable, idempotent). `migrate:status` on `main` lists it as an orphan until this merges, because the ledger row is real and the file rides on this branch.
- **Replay** (`app/lib/solo/replay.ts`, pure): pool per slot from `entered_at`/`removed_at`, shown state rebuilt from the draw log, the engine run slot by slot, output shaped like the tape (`Strip`). Parity with `project()` proven from empty and seeded histories.
- **CLI** `scripts/solo-replay.ts` via vite-node (imports the real engine, no copy):
  ```
  npx vite-node --config vitest.config.ts scripts/solo-replay.ts \
    --feed sunset --from 2026-09-06T06:51Z --to now --dial ratingFloor=2.5
  ```

## Retention: 7 days to 30

`DRAW_LOG_DAYS` is quadrupled so the replay can be pointed at any night of the run into the show. Flagging it explicitly because database cost is an active concern here. Measured today rather than estimated:

| | 7 days | 30 days |
|---|---|---|
| rows at steady state | ~34k | ~145k |
| total size with indexes | ~6 MB | <30 MB |

Both screens log about 4.8k rows a day combined, not the 8.6k per screen the original migration comment claims: a 20 s dwell allows 4.3k per screen and only about 2.4k land, because a slot the glass never advanced through logs nothing. Rows arrive and leave at the same rate in steady state, so the per-tick prune does no more work than before. Neon billing here is compute-dominated, so tens of megabytes is not a mover.

## What it says (sunset screen, 2026-09-06)

| | tonight actual | floor 2.5 | floor 3 | midday actual | floor 2.5 | floor 3 |
|---|---|---|---|---|---|---|
| distinct frames | 28 | 19 | 15 | 114 | 85 | 59 |
| distinct cameras | 11 | 9 | 6 | 34 | 28 | 20 |
| mean quality | 0.47 | 0.58 | 0.63 | 0.48 | 0.60 | 0.68 |
| min quality | 0.07 | 0.39 | 0.52 | 0.00 | 0.38 | 0.51 |
| top camera's share | 23% | 29% | 42% | 9% | 13% | 17% |

`rest` 8 changes nothing (it only binds when the cycle is shorter than the dial). solo2's camera run gives every camera equal draws but plays the newest frame, not the best: mean quality 0.42 at midday, 0.51 with floor 2.5.

Parity at the live dials: aggregates identical; 152-163 of 180 draws in order. The residual is mostly pre-log seeding, which fades once the log is a day old.

## Verification

2,298 tests pass, `next build` exit 0, lint clean apart from pre-existing warnings. Server-side only: no UI, no kiosk reload needed after merge. Empty file intersection with the one-studio stack (#146/#147/#148), so merge order does not matter.

## Not in this PR

The studio strip under the tape (spec §8). `Strip` and `summarize` are its data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011A6NBJLP5fpC2RydD6phfe
