### PR TITLE
fix(solo): main does not build — replay script assumes a deploy always has deployedAt

### DIFF
--- a/scripts/solo-replay.ts
+++ b/scripts/solo-replay.ts
@@ -144,7 +144,11 @@ async function main(): Promise<void> {
   const summaries = { actual: summarize(actual), replay: summarize(re) };
   const agreement = compare(actual, re);
 
-  const deployLabel = (d: typeof deploy) => `#${d.id}${d.label ? ` ${d.label}` : ''} (${clock(Date.parse(d.deployedAt))} PT)`;
+  // A row with no deployedAt is a saved take: dialled and kept, never sent to
+  // the glass (takes spec, PR #147). Replaying one is legitimate and is the
+  // point of a take, so name it rather than pretending it was deployed.
+  const deployLabel = (d: typeof deploy) => `#${d.id}${d.label ? ` ${d.label}` : ''} `
+    + (d.deployedAt ? `(deployed ${clock(Date.parse(d.deployedAt))} PT)` : `(take, saved ${clock(Date.parse(d.createdAt))} PT)`);
   console.log(`${args.feed} screen, ${clock(args.from)} → ${clock(args.to)} PT`);
   console.log(`pool: ${entries.length} bin rows overlapped the window; ${prior.length} prior draws seed the shown state`);
   console.log(`actual: ${liveVersion.name}, deploy ${deployLabel(liveDeploy)}, dwell ${liveDials.dwellS} s${window.length === 0 ? ' — no draws logged in this window' : ''}`);


### PR DESCRIPTION
## Main does not build right now

`npm run build` on `main` at 2445afb8a fails:

```
./scripts/solo-replay.ts:147:106
Type error: Argument of type 'string | null' is not assignable to parameter of type 'string'.
```

**Cause, and why review missed it.** #147 made `kiosk_deploys.deployed_at` nullable so a take can be dialled and kept without going to the glass, which makes `DeployRow.deployedAt` a `string | null`. `scripts/solo-replay.ts`, merged in parallel as #149, passes it straight to `Date.parse`. Neither PR touched a file the other touched, so a file-level conflict audit came back clean. The coupling was through a shared type, which is the gap worth remembering.

The studio's own `DeployHistory.tsx` already handled the null correctly. My script was the only broken consumer; I grepped every `deployedAt` use to confirm.

**The fix.** A take is a legitimate thing to replay, and arguably the point of a take, so the label names it instead of pretending it was deployed:

```
replay: solo2, deploy #5 (deployed 17:02:20 PT), dials at defaults
replay: solo2, deploy #9 my rhythm take (take, saved 14:31:02 PT), dials ...
```

**Verified.** `next build` compiles and generates all 39 pages. The CLI runs against production and prints the deployed form correctly.

Please merge ahead of anything else; every deploy is failing until this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011A6NBJLP5fpC2RydD6phfe
