### PR TITLE
feat(studio): the tape is readable — taller blocks, a playhead, and one time scale

### DIFF
--- a/app/studio/solo/EntryRow.tsx
+++ b/app/studio/solo/EntryRow.tsx
@@ -5,13 +5,17 @@ import type { Feed } from '@/app/lib/solo/types';
 import { formatTime } from '@/app/lib/solo/caption';
 import { scoreLine } from '@/app/lib/solo/scores';
 import type { Role } from '@/app/lib/solo2/types';
+import { PX_PER_S } from './timeScale';
 
 const COLOR = { sunset: '#7ee2ac', non_sunset: '#c3cad6' } as const;
 const mono = 'ui-monospace, SFMono-Regular, Menlo, monospace';
 const LIGHT = '#2a3242';
 
-/** Height is time on the solo2 studio: this many pixels per second of glass. */
-export const PX_PER_S = 4;
+/**
+ * Height is time in the queue, at the rate the tape draws it as width, so one
+ * dwell is one length in both surfaces. The constant lives in `./timeScale`.
+ */
+export { PX_PER_S };
 /** A frame's share shorter than this many pixels would hide its thumbnail. */
 export const MIN_FRAME_PX = 14;
 

--- a/app/studio/solo/Tape.test.tsx
+++ b/app/studio/solo/Tape.test.tsx
@@ -1,6 +1,7 @@
 import { it, expect, vi } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
-import { Tape, TAPE_PX_PER_S } from './Tape';
+import { Tape, THUMB_H } from './Tape';
+import { PX_PER_S } from './timeScale';
 import type { EntryView, TapeEntry } from '@/app/api/kiosk/solo/view';
 
 const entry = (id: number, bin: 'sunset' | 'non_sunset' = 'sunset'): EntryView => ({
@@ -21,23 +22,69 @@ it('lays out past, current, seam, and projected in order, outlined by bin', () =
     pastDials={D} nextDials={D} onSelect={vi.fn()} />);
   const strip = screen.getByTestId('tape');
   const ids = [...strip.querySelectorAll('[data-testid^="tape-"]')].map((n) => n.getAttribute('data-testid'));
-  expect(ids).toEqual(['tape-past-1-10', 'tape-past-2-11', 'tape-past-1-12', 'tape-current', 'tape-seam', 'tape-next-0', 'tape-next-1']);
+  expect(ids).toEqual(['tape-scale', 'tape-past-1-10', 'tape-past-2-11', 'tape-past-1-12',
+    'tape-current', 'tape-playhead', 'tape-seam', 'tape-next-0', 'tape-next-1']);
   expect(screen.getByTestId('tape-past-1-10')).toHaveStyle({ borderLeftColor: '#7ee2ac' });
   expect(screen.getByTestId('tape-past-2-11')).toHaveStyle({ borderLeftColor: '#c3cad6' });
   expect(screen.getByTestId('tape-current')).toHaveStyle({ boxShadow: '0 0 0 2px #f5a344' });
   expect(screen.getByTestId('tape-next-0')).toHaveStyle({ borderLeftStyle: 'dashed' });
 });
 
+it('the playhead sits where the dwell has got to, and rides one CSS animation rather than a tick', () => {
+  vi.useFakeTimers();
+  vi.setSystemTime(since + 5_000); // 5 s into a 20 s dwell
+  render(<Tape past={past} current={entry(3)} currentSince={since} next={[entry(4)]}
+    pastDials={D} nextDials={D} onSelect={vi.fn()} />);
+  const head = screen.getByTestId('tape-playhead');
+  // Static position is correct on its own, so reduced motion still reads true.
+  expect(head).toHaveStyle({ left: '25%' });
+  // The motion: a whole dwell, started 5 s ago, parked at the end when a frame is held.
+  expect(head).toHaveStyle({ animationDuration: '20s', animationDelay: '-5s', animationFillMode: 'forwards' });
+  vi.useRealTimers();
+});
+
+it('a frame held past its dwell parks the playhead at the right edge, and no playhead without a start time', () => {
+  vi.useFakeTimers();
+  vi.setSystemTime(since + 50_000); // 50 s into a 20 s dwell: held
+  const { unmount } = render(<Tape past={past} current={entry(3)} currentSince={since} next={[entry(4)]}
+    pastDials={D} nextDials={D} onSelect={vi.fn()} />);
+  expect(screen.getByTestId('tape-playhead')).toHaveStyle({ left: '100%' });
+  unmount();
+  render(<Tape past={past} current={entry(3)} currentSince={null} next={[entry(4)]}
+    pastDials={D} nextDials={D} onSelect={vi.fn()} />);
+  expect(screen.queryByTestId('tape-playhead')).toBeNull();
+  vi.useRealTimers();
+});
+
+it('blocks are tall enough to read: height is the same for a block, the blank and the strip', () => {
+  const { unmount } = render(<Tape past={past} current={entry(3)} currentSince={since} next={[entry(4)]}
+    pastDials={D} nextDials={D} onSelect={vi.fn()} />);
+  // Height carries no meaning on the tape, so it is spent on legibility: tall
+  // enough that a 20 s block, 80 px wide, is close to an uncropped 16:9 frame.
+  expect(THUMB_H).toBeGreaterThanOrEqual(20 * PX_PER_S * (9 / 16));
+  expect(screen.getByTestId('tape-past-1-10')).toHaveStyle({ height: `${THUMB_H}px` });
+  expect(screen.getByTestId('tape-current')).toHaveStyle({ height: `${THUMB_H}px` });
+  unmount();
+  render(<Tape past={[]} current={null} next={[]} pastDials={D} nextDials={D} onSelect={vi.fn()} />);
+  expect(screen.getByTestId('tape-blank')).toHaveStyle({ height: `${THUMB_H}px` });
+});
+
+it('the strip names its scale so size does not have to be inferred', () => {
+  render(<Tape past={past} current={entry(3)} currentSince={since} next={[]} pastDials={D} nextDials={D} onSelect={vi.fn()} />);
+  expect(screen.getByTestId('tape-scale')).toHaveTextContent(`${PX_PER_S} px/s`);
+  expect(screen.getByTestId('tape-scale').getAttribute('title')).toMatch(/on the glass it means quality/);
+});
+
 it('width is time: a dwell is dwellS × px/s; a frame held on glass is wider and says so; the projection is one dwell each', () => {
   const held = [drawn(1, 10, 0), drawn(2, 11, 20_000), drawn(3, 12, 40_000)];
   // Frame 3 stayed 60 s (three dwells) before the current frame took over.
   render(<Tape past={held} current={entry(9)} currentSince={100_000} next={[entry(4)]} pastDials={D} nextDials={{ dwellS: 30, fadeS: 0 }} onSelect={vi.fn()} />);
-  expect(screen.getByTestId('tape-past-1-10')).toHaveStyle({ width: `${20 * TAPE_PX_PER_S}px` });
-  expect(screen.getByTestId('tape-past-3-12')).toHaveStyle({ width: `${60 * TAPE_PX_PER_S}px` });
+  expect(screen.getByTestId('tape-past-1-10')).toHaveStyle({ width: `${20 * PX_PER_S}px` });
+  expect(screen.getByTestId('tape-past-3-12')).toHaveStyle({ width: `${60 * PX_PER_S}px` });
   expect(screen.getByTestId('tape-held')).toBeInTheDocument();
   expect(screen.getByTestId('tape-past-3-12').getAttribute('title')).toMatch(/on glass 60 s · held/);
   expect(screen.getByTestId('tape-past-1-10').getAttribute('title')).toMatch(/on glass 20 s$/);
-  expect(screen.getByTestId('tape-next-0')).toHaveStyle({ width: `${30 * TAPE_PX_PER_S}px` });
+  expect(screen.getByTestId('tape-next-0')).toHaveStyle({ width: `${30 * PX_PER_S}px` });
 });
 
 it('a crossfade is an X as wide as the fade dial, straddling every cut; fade 0 draws none', () => {
@@ -45,8 +92,8 @@ it('a crossfade is an X as wide as the fade dial, straddling every cut; fade 0 d
     pastDials={{ dwellS: 20, fadeS: 2 }} nextDials={{ dwellS: 20, fadeS: 4 }} onSelect={vi.fn()} />);
   // past→past ×2, past→current, current→next, next→next
   expect(screen.getAllByTestId(/^tape-fade-/)).toHaveLength(5);
-  expect(screen.getByTestId('tape-fade-0')).toHaveStyle({ width: `${2 * TAPE_PX_PER_S}px` });
-  expect(screen.getByTestId('tape-fade-3')).toHaveStyle({ width: `${4 * TAPE_PX_PER_S}px` });
+  expect(screen.getByTestId('tape-fade-0')).toHaveStyle({ width: `${2 * PX_PER_S}px` });
+  expect(screen.getByTestId('tape-fade-3')).toHaveStyle({ width: `${4 * PX_PER_S}px` });
   expect(screen.getByTestId('tape-fade-3').getAttribute('title')).toMatch(/crossfade 4 s/);
   unmount();
   render(<Tape past={past} current={entry(3)} currentSince={since} next={[entry(4)]} pastDials={D} nextDials={D} onSelect={vi.fn()} />);
@@ -82,7 +129,7 @@ it('a projected dwell with a camera run shows the earlier frames as narrow sub-b
   const ids = [...group.querySelectorAll('[data-testid^="tape-next-0"]')].map((n) => n.getAttribute('data-testid'));
   expect(ids).toEqual(['tape-next-0-pre-7', 'tape-next-0-pre-8', 'tape-next-0']);
   expect(screen.getByTestId('tape-next-0-pre-7')).toHaveStyle({ width: '6px' }); // 1.5 s × 3 px = 4.5, floored to the legible minimum
-  expect(screen.getByTestId('tape-next-0')).toHaveStyle({ width: `${20 * TAPE_PX_PER_S - 12}px` });
+  expect(screen.getByTestId('tape-next-0')).toHaveStyle({ width: `${20 * PX_PER_S - 12}px` });
   expect(screen.getByTestId('tape-next-0').getAttribute('title')).toMatch(/after 2 earlier frames of this camera, 1.5 s each/);
 });
 

--- a/app/studio/solo/Tape.tsx
+++ b/app/studio/solo/Tape.tsx
@@ -1,17 +1,24 @@
 'use client';
 
-import { useEffect, useRef, type ReactNode } from 'react';
+import { useEffect, useRef, useState, type ReactNode } from 'react';
 import type { EntryView, TapeEntry } from '@/app/api/kiosk/solo/view';
 import type { BinKind } from '@/app/lib/solo/types';
 import type { Run } from './EntryRow';
+import { PX_PER_S, SCALE_LABEL, SCALE_NOTE } from './timeScale';
 
 const COLOR: Record<BinKind, string> = { sunset: '#7ee2ac', non_sunset: '#c3cad6' };
 const REPEAT = '#8b2e2e';
 const RING = '0 0 0 2px #f5a344';
 const mono = 'ui-monospace, SFMono-Regular, Menlo, monospace';
-export const THUMB_H = 22;
-/** Width is time on the tape: this many pixels per second of glass. */
-export const TAPE_PX_PER_S = 3;
+/**
+ * Width is time on the tape, so height carries no meaning and can be spent
+ * entirely on legibility. At 22 px a block was a letterbox slice with most of
+ * the sky cropped away; 48 is close to uncropped at the default dwell, where
+ * a block is 80 px wide.
+ */
+export const THUMB_H = 48;
+/** The keyframes the playhead rides; defined once inside the strip. */
+const PLAYHEAD_ANIM = 'tape-playhead';
 /** A block never draws narrower than this, whatever its time says. */
 const MIN_BLOCK_PX = 14;
 /** A past frame that stayed on glass longer than this many dwells was held (nothing else eligible). */
@@ -48,12 +55,41 @@ function Thumb({ testId, src, color, width, dashed = false, ring = false, repeat
 
 /** The Final Cut "X": the seconds during which both pictures are on glass. */
 function Fade({ testId, seconds }: { testId: string; seconds: number }) {
-  const width = Math.max(4, seconds * TAPE_PX_PER_S);
+  const width = Math.max(4, seconds * PX_PER_S);
   return (
     <div data-testid={testId} title={`crossfade ${secs(seconds)}: both pictures on glass`} style={{
       flex: 'none', width, height: THUMB_H, marginLeft: -width / 2, marginRight: -width / 2, position: 'relative', zIndex: 1,
       background: 'linear-gradient(135deg, rgba(245,163,68,0) 0%, rgba(245,163,68,0.55) 50%, rgba(245,163,68,0) 100%)',
       borderLeft: '1px solid rgba(245,163,68,0.8)', borderRight: '1px solid rgba(245,163,68,0.8)', boxSizing: 'border-box',
+    }} />
+  );
+}
+
+/**
+ * Where the glass is inside the current dwell: a line that starts at the left
+ * edge of the on-glass block and reaches the seam as the picture changes.
+ *
+ * The motion is one CSS animation, not a JavaScript tick, so nothing re-renders
+ * while it travels. Duration is the whole dwell and the delay is minus the time
+ * already elapsed, which starts it part-way through; `forwards` parks it at the
+ * right edge when a frame is held past its dwell, which the block's `held` mark
+ * explains. `left` is also set inline, so a reader with reduced motion gets the
+ * line at its true position without it moving.
+ *
+ * `nowMs` is read once on mount rather than during render, because a clock read
+ * during render disagrees between the server and the client and React reports
+ * that as a hydration mismatch.
+ */
+function Playhead({ sinceMs, dwellS, nowMs }: { sinceMs: number | null; dwellS: number; nowMs: number | null }) {
+  if (sinceMs == null || nowMs == null || dwellS <= 0) return null;
+  const elapsedS = Math.max(0, (nowMs - sinceMs) / 1000);
+  const pct = Math.min(100, (elapsedS / dwellS) * 100);
+  return (
+    <span data-testid="tape-playhead" aria-hidden style={{
+      position: 'absolute', top: 0, bottom: 0, width: 2, left: `${pct}%`, background: '#fff',
+      boxShadow: '0 0 4px rgba(255,255,255,0.9)', pointerEvents: 'none',
+      animationName: PLAYHEAD_ANIM, animationDuration: `${dwellS}s`, animationTimingFunction: 'linear',
+      animationDelay: `${-elapsedS}s`, animationFillMode: 'forwards',
     }} />
   );
 }
@@ -95,13 +131,18 @@ export function Tape({ past, current, currentSince, next, nextSequences, pastDia
     s.scrollLeft = Math.max(0, m.offsetLeft - s.clientWidth * (2 / 3));
   }, [past.length, current?.snapshotId]);
 
+  // Read once per frame on glass, after mount. The playhead's own motion is
+  // CSS, so this never ticks; it only re-anchors when the picture changes.
+  const [nowMs, setNowMs] = useState<number | null>(null);
+  useEffect(() => { setNowMs(Date.now()); }, [currentSince, current?.snapshotId]);
+
   const seen = new Set<number>();
   const repeatOf = (id: number) => {
     const r = seen.has(id);
     seen.add(id);
     return r;
   };
-  const dwellPx = (d: TapeDials) => Math.max(MIN_BLOCK_PX, d.dwellS * TAPE_PX_PER_S);
+  const dwellPx = (d: TapeDials) => Math.max(MIN_BLOCK_PX, d.dwellS * PX_PER_S);
 
   const blocks: ReactNode[] = [];
   let fades = 0;
@@ -115,7 +156,7 @@ export function Tape({ past, current, currentSince, next, nextSequences, pastDia
     const onGlassS = Math.max(0, (endMs - f.shownAt) / 1000);
     const dwells = pastDials.dwellS > 0 ? onGlassS / pastDials.dwellS : 1;
     const held = dwells > HELD_AFTER;
-    const width = Math.max(MIN_BLOCK_PX, Math.min(dwells, MAX_DWELLS) * pastDials.dwellS * TAPE_PX_PER_S);
+    const width = Math.max(MIN_BLOCK_PX, Math.min(dwells, MAX_DWELLS) * pastDials.dwellS * PX_PER_S);
     blocks.push(
       <Thumb key={`${f.snapshotId}-${f.slot}`} testId={`tape-past-${f.snapshotId}-${f.slot}`} src={f.imageUrl} width={width}
         color={COLOR[f.bin]} repeat={repeatOf(f.snapshotId)} onClick={() => onSelect(f)}
@@ -131,7 +172,9 @@ export function Tape({ past, current, currentSince, next, nextSequences, pastDia
     blocks.push(
       <Thumb key="current" testId="tape-current" src={current.imageUrl} width={dwellPx(pastDials)} color={COLOR[current.bin]} ring
         repeat={repeatOf(current.snapshotId)} onClick={() => onSelect(current)}
-        title={`on glass${currentSince ? ` since ${clock(currentSince)}` : ''} · ${current.title}${place(current) ? ` · ${place(current)}` : ''}`} />,
+        title={`on glass${currentSince ? ` since ${clock(currentSince)}` : ''} · ${current.title}${place(current) ? ` · ${place(current)}` : ''}`}>
+        <Playhead sinceMs={currentSince ?? null} dwellS={pastDials.dwellS} nowMs={nowMs} />
+      </Thumb>,
     );
   } else {
     blocks.push(
@@ -149,7 +192,7 @@ export function Tape({ past, current, currentSince, next, nextSequences, pastDia
   next.forEach((e, i) => {
     fade(nextDials.fadeS);
     const seq = nextSequences?.[i];
-    const stepPx = seq ? Math.max(6, seq.stepS * TAPE_PX_PER_S) : 0;
+    const stepPx = seq ? Math.max(6, seq.stepS * PX_PER_S) : 0;
     const total = dwellPx(nextDials);
     const mainWidth = Math.max(MIN_BLOCK_PX, total - (seq?.earlier.length ?? 0) * stepPx);
     const title = `draw ${i + 1} · ${e.title}${place(e) ? ` · ${place(e)}` : ''}`
@@ -174,8 +217,18 @@ export function Tape({ past, current, currentSince, next, nextSequences, pastDia
   });
 
   return (
-    <div ref={strip} data-testid="tape" title="The tape: width is time. Past draws, the frame on glass, then the projected next draws."
+    <div ref={strip} data-testid="tape"
+      title={`The tape: past draws, the frame on glass, then the projected next draws. ${SCALE_NOTE}`}
       style={{ display: 'flex', alignItems: 'center', overflowX: 'auto', padding: '4px 2px', minHeight: THUMB_H + 12 }}>
+      <style>{
+        `@keyframes ${PLAYHEAD_ANIM} { from { left: 0% } to { left: 100% } }`
+        + ` @media (prefers-reduced-motion: reduce) { [data-testid="tape-playhead"] { animation: none } }`
+      }</style>
+      {/* Sticks to the left edge while the strip scrolls, so the scale is readable without hovering. */}
+      <span data-testid="tape-scale" title={SCALE_NOTE} style={{
+        position: 'sticky', left: 0, zIndex: 2, flex: 'none', alignSelf: 'stretch', display: 'grid', placeItems: 'center',
+        fontFamily: mono, fontSize: 9, color: '#4b5568', background: '#0e1119', padding: '0 5px', cursor: 'help',
+      }}>{SCALE_LABEL}</span>
       {past.length === 0 && (
         <span style={{ fontFamily: mono, fontSize: 9.5, color: '#4b5568', whiteSpace: 'nowrap', paddingRight: 6 }}>no draws logged yet</span>
       )}

--- a/app/studio/solo/timeScale.ts
+++ b/app/studio/solo/timeScale.ts
@@ -1,0 +1,24 @@
+/**
+ * One scale for time across the solo studio.
+ *
+ * Size means **time on glass** everywhere in this studio, and it is drawn on
+ * whichever axis the surface has spare: width on the tape, height in the
+ * queue. Until 2026-09-06 those were two different rates, 3 px/s on the tape
+ * and 4 px/s in the queue, which made a twenty second dwell a different
+ * length in two surfaces sitting inches apart. They share this constant now,
+ * so one dwell is one length wherever it is drawn.
+ *
+ * Worth keeping straight, because it is the other half of the same question:
+ * on the **glass**, size means quality, since the mosaic sizes a tile by its
+ * score. In the **studio**, size means time. `SCALE_NOTE` says so on the
+ * surfaces themselves rather than leaving it to be inferred.
+ */
+export const PX_PER_S = 4;
+
+/** The short label a surface prints so its scale is readable without hovering. */
+export const SCALE_LABEL = `${PX_PER_S} px/s`;
+
+/** The long form, for the title of any surface that draws time as size. */
+export const SCALE_NOTE =
+  `Size is time on glass at ${PX_PER_S} px per second: width on the tape, height in the queue. `
+  + 'In the studio size means time; on the glass it means quality.';


### PR DESCRIPTION
Three changes to make the tape readable. Four files, no migration, no kiosk reload.

## Height: 22 to 48

Width is time on the tape, so height means nothing and was the one axis free to spend on legibility. At 22 px each block was a letterbox slice with most of the sky cropped away. At the default dwell a block is 80 px wide, so 48 is close to an uncropped 16:9 frame.

## A playhead

The seam already marked where fact turns into projection, but nothing showed where inside the current dwell the glass actually is: a block looked identical one second in and nineteen seconds in. The playhead starts at the left edge of the on-glass block and reaches the seam exactly as the picture changes, so the seam becomes an arrival rather than just a divider.

It is one CSS animation, not a JavaScript tick, so nothing re-renders while it travels. Duration is the whole dwell and the delay is minus the elapsed time, which starts it part-way through. Fill-mode `forwards` parks it at the right edge when a frame is held past its dwell, which the existing `held` mark already explains. The inline `left` offset is set as well, so a reader with reduced motion sees the true position without motion. The clock is read once on mount rather than during render, because a render-time clock read disagrees between server and client and React reports that as a hydration mismatch.

## One time scale

Time was drawn two different ways in surfaces sitting inches apart:

| Surface | Axis | Was | Now |
|---|---|---|---|
| Tape | width | 3 px/s | 4 px/s |
| Queue rows | height | 4 px/s | 4 px/s |

Same quantity, two rates, nothing labelling either. Both now import `PX_PER_S` from a new `timeScale.ts`, so one dwell is one length wherever it is drawn. That module also records the convention the studio never stated anywhere: **in the studio size means time, on the glass it means quality**, since the mosaic sizes a tile by its score. The strip prints its own scale in the corner, sticky so it survives scrolling, rather than leaving it to be inferred.

## Verification

2,311 tests pass, 287 files. Lint clean on the changed files. `next build` compiles and generates all 39 pages.

One caveat on the build: this branch is cut from a `main` that does not compile, because of an unrelated break fixed in #150. To prove these changes are sound I applied that one-line fix locally, built green, and reverted it, so it is not in this diff. **Merge #150 first.**

The remaining `tsc` complaints in the two touched test files are the pre-existing jest-dom matcher typing gap: main already has 41 of them in those files and my new assertions add 7 more of the same kind. The source files are clean. Worth fixing project-wide separately.

## Not here

Fold toggles for the bins and previews, and the comparison strip. Both were blocked behind the one-studio stack, which has since merged, so they are unblocked now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011A6NBJLP5fpC2RydD6phfe
