### PR TITLE
fix(solo): the words dissolve with the picture, and inside a run only the clock moves

### DIFF
--- a/app/components/solo/Caption.tsx
+++ b/app/components/solo/Caption.tsx
@@ -3,8 +3,13 @@
 import type { CSSProperties } from 'react';
 import type { Feed, SoloDials } from '@/app/lib/solo/types';
 import {
-  FONT_STACKS, LINE_HEIGHT, captionBox, captionLines, captionScale, gray, type CaptionEntry, type Rect,
+  FONT_STACKS, LINE_HEIGHT, captionBox, captionLines, captionScale, formatTime, gray, type CaptionEntry, type Rect,
 } from '@/app/lib/solo/caption';
+
+const TIME_KEYFRAMES = `
+@keyframes solo-time-out { from { opacity: 1 } to { opacity: 0 } }
+@keyframes solo-time-in { from { opacity: 0 } to { opacity: 1 } }
+`;
 
 /**
  * The words under (or over) a solo frame, drawn from the caption dials. Shared
@@ -12,7 +17,7 @@ import {
  * the frame. Null when the place dial is off. Everything positional comes
  * from lib/solo/caption.ts, so this is layout only.
  */
-export function Caption({ entry, dials, picture, width, feed }: {
+export function Caption({ entry, dials, picture, width, feed, step }: {
   entry: CaptionEntry;
   dials: SoloDials;
   /** Where the picture sits on the panel, from pictureRect. */
@@ -22,6 +27,14 @@ export function Caption({ entry, dials, picture, width, feed }: {
   height?: number;
   /** The screen this caption is for, so the prefix dial can name it. */
   feed?: Feed;
+  /**
+   * The frame the time is stepping from, inside a camera run. Every frame of
+   * a run is the same camera, so the title and the place hold still and only
+   * the clock moves: the old time fades out over the first half of `fadeS`,
+   * the new one in over the second, never overlapping. Absent on a dwell's
+   * first frame, where the whole caption arrives with the picture instead.
+   */
+  step?: { from: CaptionEntry; fadeS: number } | null;
 }) {
   const lines = captionLines(entry, dials, feed);
   if (!lines) return null;
@@ -37,27 +50,57 @@ export function Caption({ entry, dials, picture, width, feed }: {
     textShadow: overlay ? '0 1px 4px #000' : undefined,
   };
   const line: CSSProperties = { overflow: 'hidden', textOverflow: 'ellipsis' };
-  const time = lines.time ? (
-    <span data-testid="caption-time" style={{ fontSize: dials.timeSize * s, color: gray(dials.timeGray), fontVariantNumeric: 'tabular-nums' }}>
+  const timeFace: CSSProperties = {
+    fontSize: dials.timeSize * s, color: gray(dials.timeGray), fontVariantNumeric: 'tabular-nums',
+  };
+
+  // The clock the step is leaving, read with this caption's own dials so the
+  // two ends of the fade are always the same format.
+  const from = step && step.fadeS > 0
+    ? formatTime(dials.timeStyle, step.from.capturedAt, step.from.timezone, step.from.sunAltitudeDeg)
+    : null;
+  // Two frames of the same minute say the same thing; nothing to fade.
+  const stepping = !!from && !!lines.time && from !== lines.time;
+  const half = stepping && step ? step.fadeS / 2 : 0;
+
+  const timeText = (
+    <span data-testid="caption-time" key={lines.time} style={
+      stepping ? { ...timeFace, display: 'inline-block', animation: `solo-time-in ${half}s ease ${half}s both` } : timeFace
+    }>
       {lines.time}
     </span>
-  ) : null;
+  );
+  const time = !lines.time ? null : stepping ? (
+    // The outgoing clock rides on top of the incoming one, which holds the
+    // line's width so nothing around it moves while the two swap.
+    <span style={{ position: 'relative', display: 'inline-block' }}>
+      {timeText}
+      <span data-testid="caption-time-out" key={from} aria-hidden style={{
+        ...timeFace, position: 'absolute', left: 0, top: 0, animation: `solo-time-out ${half}s ease both`,
+      }}>
+        {from}
+      </span>
+    </span>
+  ) : timeText;
 
   return (
-    <div data-testid="caption" style={block}>
-      <div data-testid="caption-title" style={{
-        ...line, fontSize: dials.titleSize * s, fontWeight: Number(dials.titleWeight), color: gray(dials.titleGray), lineHeight: LINE_HEIGHT.title,
-      }}>
-        {lines.title}
-      </div>
-      {(lines.place || (inline && time)) && (
-        <div data-testid="caption-place" style={{ ...line, fontSize: dials.placeSize * s, color: gray(dials.placeGray), lineHeight: LINE_HEIGHT.place }}>
-          {lines.place}
-          {inline && time && lines.place ? <span style={{ color: gray(dials.timeGray) }}> · </span> : null}
-          {inline ? time : null}
+    <>
+      {stepping && <style>{TIME_KEYFRAMES}</style>}
+      <div data-testid="caption" style={block}>
+        <div data-testid="caption-title" style={{
+          ...line, fontSize: dials.titleSize * s, fontWeight: Number(dials.titleWeight), color: gray(dials.titleGray), lineHeight: LINE_HEIGHT.title,
+        }}>
+          {lines.title}
         </div>
-      )}
-      {!inline && time && <div style={{ ...line, lineHeight: LINE_HEIGHT.time }}>{time}</div>}
-    </div>
+        {(lines.place || (inline && time)) && (
+          <div data-testid="caption-place" style={{ ...line, fontSize: dials.placeSize * s, color: gray(dials.placeGray), lineHeight: LINE_HEIGHT.place }}>
+            {lines.place}
+            {inline && time && lines.place ? <span style={{ color: gray(dials.timeGray) }}> · </span> : null}
+            {inline ? time : null}
+          </div>
+        )}
+        {!inline && time && <div style={{ ...line, lineHeight: LINE_HEIGHT.time }}>{time}</div>}
+      </div>
+    </>
   );
 }

--- a/app/components/solo/SoloFrame.test.tsx
+++ b/app/components/solo/SoloFrame.test.tsx
@@ -94,3 +94,15 @@ it('names the screen before the title when the prefix dial is on, and only then'
   rerender(<SoloFrame entry={e} previous={null} fadeS={0} dials={D} width={1920} height={1080} />);
   expect(screen.getByTestId('caption-title')).not.toHaveTextContent(/Sunrise|Sunset/);
 });
+
+it('the caption crossfades on the picture’s dial, and cuts with it at zero', () => {
+  const prev = { ...e, snapshotId: 0, imageUrl: 'u0', title: 'Zadar › East' };
+  const { rerender } = render(<SoloFrame entry={e} previous={prev} fadeS={3} dials={D} width={1920} height={1080} />);
+  expect(screen.getByTestId('caption-layer')).toHaveStyle({ animation: 'solo-fade-in 3s ease' });
+  expect(screen.getByTestId('caption-prev')).toHaveTextContent('Zadar');
+
+  // At a cut there is nothing to dissolve, so the old words are never drawn.
+  rerender(<SoloFrame entry={e} previous={prev} fadeS={0} dials={D} width={1920} height={1080} />);
+  expect(screen.queryByTestId('caption-prev')).toBeNull();
+  expect(screen.getByTestId('caption-layer').style.animation).toBe('');
+});

--- a/app/components/solo/SoloFrame.tsx
+++ b/app/components/solo/SoloFrame.tsx
@@ -12,8 +12,9 @@ const mono = 'ui-monospace, SFMono-Regular, Menlo, monospace';
  * One frame on the panel: full-bleed when the caption layout is overlay,
  * inset on black when it is inset (lib/solo/caption.ts says where). The
  * previous frame sits underneath so a fade dial above zero crossfades
- * instead of cutting; at zero the top layer is simply there. Overlays are
- * what the live dials say and nothing else.
+ * instead of cutting; at zero the top layer is simply there. The caption
+ * crossfades on the same dial, so the words never cut while the picture
+ * dissolves. Overlays are what the live dials say and nothing else.
  */
 export function SoloFrame({ entry, previous, fadeS, dials, width, height, feed }: {
   entry: EntryView;
@@ -30,6 +31,9 @@ export function SoloFrame({ entry, previous, fadeS, dials, width, height, feed }
     position: 'absolute', left: picture.left, top: picture.top, width: picture.width, height: picture.height, objectFit: 'cover',
   } as const;
   const scale = Math.max(1, Math.min(width, height) / 540); // score overlay text scales with the panel
+  // The caption is panel-relative, not picture-relative, so its layers span
+  // the panel rather than the picture box. Never a click target.
+  const captionLayer = { position: 'absolute', inset: 0, pointerEvents: 'none' } as const;
   return (
     <div style={{ position: 'relative', width, height, background: '#000', overflow: 'hidden' }}>
       {previous && (
@@ -49,7 +53,18 @@ export function SoloFrame({ entry, previous, fadeS, dials, width, height, feed }
         }}
       />
       <style>{'@keyframes solo-fade-in { from { opacity: 0 } to { opacity: 1 } }'}</style>
-      <Caption entry={entry} dials={dials} picture={picture} width={width} height={height} feed={feed} />
+      {previous && fadeS > 0 && (
+        // The words being left behind, under the arriving caption. Only while
+        // the dial fades: at a cut they would sit under identical text.
+        <div key={`caption-prev-${previous.snapshotId}`} data-testid="caption-prev" style={captionLayer}>
+          <Caption entry={previous} dials={dials} picture={picture} width={width} height={height} feed={feed} />
+        </div>
+      )}
+      <div key={`caption-${entry.snapshotId}`} data-testid="caption-layer" style={{
+        ...captionLayer, animation: fadeS > 0 ? `solo-fade-in ${fadeS}s ease` : undefined,
+      }}>
+        <Caption entry={entry} dials={dials} picture={picture} width={width} height={height} feed={feed} />
+      </div>
       {(dials.showScores || dials.showRank || dials.showTally) && (
         <div style={{
           position: 'absolute', right: 24 * scale, bottom: 20 * scale, color: '#fff',

--- a/app/components/solo2/Solo2Frame.test.tsx
+++ b/app/components/solo2/Solo2Frame.test.tsx
@@ -120,3 +120,67 @@ it('the lead pushes the frame in by progress and lands the next frame still', ()
     dials={{ ...D, leadS: 4, leadScale: 1.04 }} width={100} height={50} />);
   expect(screen.getByTestId('push')).toHaveStyle({ transform: 'scale(1.0000)', transition: 'none' });
 });
+
+it('the caption arrives on the picture’s transition: the same animation, and the outgoing words underneath', () => {
+  const prev = { ...e, snapshotId: 0, webcamId: 99, imageUrl: 'u0', title: 'Old pier' };
+  const one = { index: 0, leadProgress: 0 };
+  const { rerender } = render(<Solo2Frame entry={e} run={[e]} previous={prev} stage={one} plan={plan}
+    dials={{ ...D, transition: 'crossfade', fadeS: 2 }} width={1920} height={1080} />);
+  expect(screen.getByTestId('caption-layer')).toHaveStyle({ animation: 'solo2-fade-in 2s ease both' });
+  expect(screen.getByTestId('caption-layer').style.animation).toBe(screen.getByTestId('stack').style.animation);
+  expect(screen.getByText('Old pier')).toBeInTheDocument(); // the words being left behind
+
+  // A cut has nothing to dissolve: no outgoing caption, no animation.
+  rerender(<Solo2Frame entry={e} run={[e]} previous={prev} stage={one} plan={plan}
+    dials={{ ...D, transition: 'cut' }} width={1920} height={1080} />);
+  expect(screen.getByTestId('caption-layer').style.animation).toBe('');
+  expect(screen.queryByTestId('caption-prev')).toBeNull();
+});
+
+it('on a dip the veil covers the outgoing caption, and the new words fade in after it', () => {
+  const prev = { ...e, snapshotId: 0, webcamId: 99, imageUrl: 'u0' };
+  render(<Solo2Frame entry={e} run={[e]} previous={prev} stage={{ index: 0, leadProgress: 0 }} plan={plan}
+    dials={{ ...D, transition: 'dip', fadeS: 2 }} width={1920} height={1080} />);
+  const out = screen.getByTestId('caption-prev');
+  const veil = screen.getByTestId('dip');
+  const arriving = screen.getByTestId('caption-layer');
+  // Painted in this order, so the veil hides the old words rather than sitting behind them.
+  expect(out.compareDocumentPosition(veil) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+  expect(veil.compareDocumentPosition(arriving) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+  expect(arriving).toHaveStyle({ animation: 'solo2-fade-in 1s ease 1s both' });
+});
+
+it('inside a run only the clock moves: the old time fades out, the new one in, and the words are not remounted', () => {
+  // A real run is one camera, so every frame carries the same words.
+  const sameCam = run.map((f) => ({ ...f, title: 'Pier' }));
+  const { rerender } = render(<Solo2Frame entry={e} run={sameCam} previous={null} stage={{ index: 1, leadProgress: 0 }} plan={plan}
+    dials={{ ...D, sameCameraFadeS: 1 }} width={1920} height={1080} />);
+  expect(screen.getByTestId('caption-time')).toHaveTextContent('7:32 pm there');
+  expect(screen.getByTestId('caption-time')).toHaveStyle({ animation: 'solo-time-in 0.5s ease 0.5s both' });
+  expect(screen.getByTestId('caption-time-out')).toHaveTextContent('7:22 pm there');
+  expect(screen.getByTestId('caption-time-out')).toHaveStyle({ animation: 'solo-time-out 0.5s ease both' });
+
+  // Stepping again keeps the very same caption element: the title and the
+  // place hold still while the clock swaps under them.
+  const held = screen.getByTestId('caption-layer');
+  rerender(<Solo2Frame entry={e} run={sameCam} previous={null} stage={{ index: 2, leadProgress: 0 }} plan={plan}
+    dials={{ ...D, sameCameraFadeS: 1 }} width={1920} height={1080} />);
+  expect(screen.getByTestId('caption-layer')).toBe(held);
+  expect(screen.getByTestId('caption-time')).toHaveTextContent('7:42 pm there');
+  expect(screen.getByTestId('caption-time-out')).toHaveTextContent('7:32 pm there');
+});
+
+it('a run’s first frame has no clock to leave', () => {
+  render(<Solo2Frame entry={e} run={run} previous={null} stage={{ index: 0, leadProgress: 0 }} plan={plan}
+    dials={{ ...D, sameCameraFadeS: 1 }} width={1920} height={1080} />);
+  expect(screen.queryByTestId('caption-time-out')).toBeNull();
+  expect(screen.getByTestId('caption-time').style.animation).toBe('');
+});
+
+it('two frames of one minute say the same time, so nothing fades', () => {
+  const sameMinute = [{ ...e, snapshotId: 1, imageUrl: 'u1' }, e]; // both taken at AT
+  render(<Solo2Frame entry={e} run={sameMinute} previous={null} stage={{ index: 1, leadProgress: 0 }} plan={plan}
+    dials={{ ...D, sameCameraFadeS: 1 }} width={1920} height={1080} />);
+  expect(screen.queryByTestId('caption-time-out')).toBeNull();
+  expect(screen.getByTestId('caption-time').style.animation).toBe('');
+});

--- a/app/components/solo2/Solo2Frame.tsx
+++ b/app/components/solo2/Solo2Frame.tsx
@@ -40,7 +40,10 @@ export function arrival(
  * clock-driven stage has reached it and dissolving in over the same-camera
  * fade capped at its share. The caption and the score overlays follow the
  * frame that is up, so the words and the score on glass are always those of
- * the picture on glass.
+ * the picture on glass. The caption arrives on the picture's own transition —
+ * the outgoing words sit under the veil, the new ones fade in with the new
+ * frame — and inside a run, where every frame is the same camera, the title
+ * and the place hold still while only the clock steps.
  */
 export function Solo2Frame({ entry, run, previous, stage, plan, dials, width, height, feed }: {
   /** The drawn frame: the run's last. */
@@ -64,6 +67,9 @@ export function Solo2Frame({ entry, run, previous, stage, plan, dials, width, he
   const pictureLayer = {
     position: 'absolute', left: picture.left, top: picture.top, width: picture.width, height: picture.height, objectFit: 'cover',
   } as const;
+  // The caption is panel-relative, not picture-relative, so its layers span
+  // the panel rather than the picture box. Never a click target.
+  const captionLayer = { position: 'absolute', inset: 0, pointerEvents: 'none' } as const;
   const scale = Math.max(1, Math.min(width, height) / 540); // score overlay text scales with the panel
   const sequence: RunFrame[] = run.length > 0 ? run : [entry];
   const shown = Math.min(stage.index, sequence.length - 1);
@@ -96,6 +102,13 @@ export function Solo2Frame({ entry, run, previous, stage, plan, dials, width, he
         // eslint-disable-next-line @next/next/no-img-element
         <img key={`prev-${previous.snapshotId}`} src={previous.imageUrl} alt="" role="presentation" style={pictureLayer} />
       )}
+      {showPrevious && (
+        // The words being left behind, under the veil and under the arriving
+        // caption, so the caption dissolves exactly as the picture does.
+        <div key={`caption-prev-${previous.snapshotId}`} data-testid="caption-prev" style={captionLayer}>
+          <Caption entry={previous} dials={dials} picture={picture} width={width} height={height} feed={feed} />
+        </div>
+      )}
       {arrive.kind === 'dip' && showPrevious && (
         <div key={`dip-${entry.snapshotId}`} data-testid="dip" style={{
           ...layer, background: '#000', animation: `solo2-dip ${arrive.fadeS / 2}s linear both`,
@@ -115,7 +128,12 @@ export function Solo2Frame({ entry, run, previous, stage, plan, dials, width, he
           ))}
         </div>
       </div>
-      <Caption entry={up} dials={dials} picture={picture} width={width} height={height} feed={feed} />
+      {/* keyed like the stack, so the words arrive with the picture and once
+          per dwell; inside the dwell only the clock moves. */}
+      <div key={`caption-${entry.snapshotId}`} data-testid="caption-layer" style={{ ...captionLayer, animation: inAnimation }}>
+        <Caption entry={up} dials={dials} picture={picture} width={width} height={height} feed={feed}
+          step={shown > 0 ? { from: sequence[shown - 1], fadeS: stepFade } : null} />
+      </div>
       {(dials.showScores || dials.showRank || dials.showTally) && (
         <div style={{
           position: 'absolute', right: 24 * scale, bottom: 20 * scale, color: '#fff',


### PR DESCRIPTION
The caption sat outside every transition. While the picture dipped through black or crossfaded, the title, the place and the time cut instantly. And inside a camera run — where every step is another frame of the same camera — the clock swapped with no treatment at all.

Two changes, one idea: **the words belong to the picture.**

**The caption rides the picture's arrival.** The outgoing caption is drawn under the veil alongside the outgoing frame, and the arriving one carries the same animation as the stack, keyed the same way. It dips or crossfades exactly as the picture does, and cuts when the picture cuts. A test asserts the two animations are the same string, and that the veil is painted between the old words and the new.

**Inside a run only the clock moves.** The caption layer is keyed by the dwell's drawn frame, so a step does not remount it: the title and the place hold still. The time fades out over the first half of the same-camera fade and the new one in over the second, never overlapping — a straight dissolve would smear two near-identical strings. Two frames of the same minute say the same thing, so nothing fades.

`solo` gets the arrival half for parity; it has no run.

## Verified

- `npm run test` — 287 files, 2313 tests pass. Six new tests; four of them fail against the pre-change source (checked by stashing it).
- Driven in a real browser against production data at `dell-l`: the caption box lands at the same `top: 921px / left: 308px` as before, the caption layer's animation string matches the stack's, and a live run step was caught with `solo-time-out` carrying the outgoing clock while the title held.
- `npm run lint` — no new warnings.
- `npm run build` still fails on `scripts/solo-replay.ts`, which is #150's pre-existing break and touches none of these files.

## Not covered

The `/studio` preview uses the same component, so it should follow, but it needs a signed-in look. After merge: `bash scripts/pi/kiosk-doctor.sh --sync --reload`, then `scripts/wt.sh rm fix/solo2-caption-fades`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NARpc9xyCfFjqwSy4u9TZD
