### PR TITLE
fix(studio): the preview's run clock is phase-locked to the dwell, so it stops wrapping early

### DIFF
--- a/app/studio/solo/useLoopingStage.test.ts
+++ b/app/studio/solo/useLoopingStage.test.ts
@@ -4,16 +4,17 @@ import { useLoopingStage } from './useLoopingStage';
 import { fitPlan } from '@/app/lib/solo2/plan';
 
 const plan = fitPlan({ dwellS: 6, leadS: 0 }, 3); // 2 s a frame
+const NOW = 100_000;
 
 beforeEach(() => {
   vi.useFakeTimers();
-  vi.setSystemTime(new Date(100_000));
+  vi.setSystemTime(new Date(NOW));
 });
 afterEach(() => vi.useRealTimers());
 
 describe('useLoopingStage', () => {
   it('starts at the first frame, walks the run, and wraps at the dwell', () => {
-    const { result } = renderHook(() => useLoopingStage(plan, 1));
+    const { result } = renderHook(() => useLoopingStage(plan, NOW));
     expect(result.current.index).toBe(0);
     act(() => { vi.advanceTimersByTime(2_000); });
     expect(result.current.index).toBe(1);
@@ -22,12 +23,34 @@ describe('useLoopingStage', () => {
     act(() => { vi.advanceTimersByTime(2_000); });
     expect(result.current.index).toBe(0); // round again
   });
-  it('restarts when the key changes', () => {
-    const { result, rerender } = renderHook((p: { key: number }) => useLoopingStage(plan, p.key), { initialProps: { key: 1 } });
+
+  it('restarts when the dwell start changes', () => {
+    const { result, rerender } = renderHook((p: { start: number }) => useLoopingStage(plan, p.start), { initialProps: { start: NOW } });
     act(() => { vi.advanceTimersByTime(4_000); });
     expect(result.current.index).toBe(2);
-    rerender({ key: 2 });
+    rerender({ start: NOW + 4_000 });
     act(() => { vi.advanceTimersByTime(0); });
+    expect(result.current.index).toBe(0);
+  });
+
+  // The bug: the preview's dwell walker ticks at 250 ms, so it notices a
+  // boundary up to a tick late and back-dates `startMs` to the exact boundary.
+  // A stage clock that started at mount instead of at that start ran a tick
+  // behind the dwell, so it wrapped to frame 0 while the dwell was still on
+  // its last frame — the run flashed an earlier picture just before the
+  // camera changed, and the last frame was short by the same amount.
+  it('is phase-locked to the dwell: a dwell that began a tick ago is already a tick in', () => {
+    const { result } = renderHook(() => useLoopingStage(plan, NOW - 2_500));
+    expect(result.current.index).toBe(1); // 2.5 s in, not 0
+  });
+
+  it('never wraps early: the last frame holds right up to the dwell it belongs to', () => {
+    // The dwell began 250 ms before this clock was mounted, the lag the
+    // walker's tick can introduce.
+    const { result } = renderHook(() => useLoopingStage(plan, NOW - 250));
+    act(() => { vi.advanceTimersByTime(5_450); }); // 5.7 s into a 6 s dwell
+    expect(result.current.index).toBe(2); // still the last frame
+    act(() => { vi.advanceTimersByTime(300); }); // 6.0 s in: the wrap, on the dwell's clock
     expect(result.current.index).toBe(0);
   });
 });

--- a/app/studio/solo/useLoopingStage.ts
+++ b/app/studio/solo/useLoopingStage.ts
@@ -5,28 +5,42 @@ import { stageAt, type DwellPlan, type Stage } from '@/app/lib/solo2/plan';
 
 const same = (a: Stage, b: Stage) => a.index === b.index && a.leadProgress === b.leadProgress;
 
+/** Where a dwell that began at `startMs` is now, wrapping at the plan's dwell. */
+function stageOf(startMs: number | null, plan: DwellPlan): Stage {
+  if (startMs == null) return stageAt(0, plan);
+  const period = Math.max(1, plan.dwellS * 1000);
+  return stageAt(Math.max(0, Date.now() - startMs) % period, plan);
+}
+
 /**
- * The studio's dwell clock (camera-run spec §5.1): a local clock that starts
- * at 0 whenever `key` changes and wraps at the plan's dwell, so the preview
- * plays a run over and over at the studio's dwell while the glass holds on
- * the live one. No server call. Kept in its own file so the one-studio
- * preview can lift it as a move.
+ * The studio's dwell clock (camera-run spec §5.1): where the dwell that began
+ * at `startMs` has got to, wrapping at the plan's dwell so the preview plays a
+ * run over and over at the studio's dwell while the glass keeps the live one.
+ * No server call. Kept in its own file so the one-studio preview can lift it
+ * as a move.
+ *
+ * `startMs` is the dwell's own start, not the moment this clock mounted, and
+ * that distinction is the whole point. The preview's walker (`useSoloPreview`)
+ * ticks at 250 ms, so it notices a boundary up to a tick late and back-dates
+ * the new dwell to the exact boundary. A clock that started when it mounted
+ * therefore ran that lag *behind* the dwell and wrapped to frame 0 while the
+ * dwell was still on its last frame: the run flashed an earlier picture just
+ * before the camera changed, and the last frame was short by the same amount.
+ * Reading the dwell's own start phase-locks the two, so the wrap and the
+ * camera change land together.
  */
-export function useLoopingStage(plan: DwellPlan, key: string | number | null, tickMs = 250): Stage {
-  const [start, setStart] = useState(() => Date.now());
-  const [stage, setStage] = useState<Stage>(() => stageAt(0, plan));
+export function useLoopingStage(plan: DwellPlan, startMs: number | null, tickMs = 250): Stage {
+  const [stage, setStage] = useState<Stage>(() => stageOf(startMs, plan));
   const { dwellS, frames, stepS, leadS } = plan;
-  useEffect(() => { setStart(Date.now()); }, [key]);
   useEffect(() => {
     const p = { dwellS, frames, stepS, leadS };
-    const period = Math.max(1, dwellS * 1000);
     const read = () => setStage((prev) => {
-      const nextStage = stageAt((Date.now() - start) % period, p);
+      const nextStage = stageOf(startMs, p);
       return same(prev, nextStage) ? prev : nextStage;
     });
     read();
     const t = setInterval(read, tickMs);
     return () => clearInterval(t);
-  }, [start, tickMs, dwellS, frames, stepS, leadS]);
+  }, [startMs, tickMs, dwellS, frames, stepS, leadS]);
   return stage;
 }


### PR DESCRIPTION
The studio preview flashed an earlier picture just before a camera change, and its last frame was short by the same amount.

## Cause

The preview runs two clocks. `useSoloPreview` walks the queue and ticks at 250 ms, so it notices a boundary up to a tick late — then correctly back-dates the new dwell to the exact boundary. `useLoopingStage` then started its own clock at `Date.now()`, the moment it mounted, which is that lag *after* the dwell actually began.

Both clocks have the same period, so a stage clock running a tick behind reached its own wrap while the dwell was still on its last frame. The run reset to frame 0 and the earliest picture sat there for the remainder of the dwell. The size of the flash is the difference between two independent tick offsets, which is why it came and went rather than happening every time.

## Fix

The hook takes the dwell's own `startMs` instead of an opaque key, and measures from it. The wrap and the camera change now land together. The single production caller already passed `dwell.startMs`, so only the meaning of the value changes, and the parameter is renamed to say so.

## Verified

- Two new tests pin the behaviour. A dwell that began a tick ago reports itself a tick in, and the last frame holds to the dwell it belongs to rather than ending 250 ms short. The first fails against the old hook; the second is written so it also fails against it.
- The two existing tests passed an arbitrary number as an opaque key, so they now pass real start times. Their assertions are unchanged.
- `npm run test` — 288 files, 2333 tests pass. `npm run build` compiles. No new lint findings.

## Not in this PR

The glass was measured and ruled out, not assumed: sampling `/kiosk/sunset` at frame rate across three dwell boundaries showed even steps and a clean reset to frame 0, with no stale frame. `useStage` reads the server's `shownSince`, so it was already phase-locked.

Camera runs are still uncapped and bin-agnostic — `runOf` returns every earlier frame of the camera regardless of bin, so a non-sunset camera with many frames splits the dwell as finely as a sunset one. That is the subject of the parked dwell-budget design and is deliberately not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NARpc9xyCfFjqwSy4u9TZD
