### PR TITLE
fix(solo): refill last_shown_slot after the deploy, and read both draw-log shapes

### DIFF
--- a/database/migrations/20260907_kiosk_bin_last_shown_slot_refill.sql
+++ b/database/migrations/20260907_kiosk_bin_last_shown_slot_refill.sql
@@ -1,0 +1,51 @@
+-- Solo kiosk: close the deploy-window gap in last_shown_slot.
+-- (dwell-budget spec §6.1.2)
+--
+-- RUN THIS AFTER the code that writes last_shown_slot is LIVE, not before.
+-- That ordering is the whole point of the file.
+--
+-- Between the first migration applying and the new code deploying, production
+-- runs the old commitAdvance: it writes last_shown_at and knows nothing about
+-- last_shown_slot. Every frame drawn in that window is left with a timestamp
+-- and a NULL draw number, at roughly three a minute across both feeds.
+--
+-- What that actually costs, measured against the code rather than assumed:
+-- isResting reads only last_shown_slot and treats NULL as never shown, so
+-- rest is WAIVED for those rows. It is not a queue jump. Rule 3's first key
+-- is compareRecency, which reads last_shown_at, and the old code keeps that
+-- accurate — so an affected frame still sorts by how recently it was shown
+-- and lands at the BACK of its bin, which is most of what rest would have
+-- done. The gap is worth closing; it is not the least-recently-shown
+-- regression of 2026-09-05 returning.
+--
+-- Once the new code is live nothing new is orphaned, and the draw log covers
+-- the whole window, so running this as the last step of the deploy closes it
+-- to zero. Safe to run repeatedly: it only ever fills NULLs.
+--
+--   node scripts/apply-migration.mjs database/migrations/20260907_kiosk_bin_last_shown_slot_refill.sql
+--   node scripts/apply-migration.mjs database/migrations/20260907_kiosk_bin_last_shown_slot_refill.sql --apply
+
+-- Reads BOTH shapes of draw row, which the first backfill did not.
+-- shown_snapshot_ids only exists from 2026-09-06 23:44Z; 3,555 earlier rows
+-- have it NULL and were invisible to the array-only version. Falling back to
+-- the drawn frame's snapshot_id rescues those, the way listDrawsBetween
+-- already reads the log. A frame shown only inside a camera run appears in
+-- the array alone, so both sources are needed, not either one.
+UPDATE kiosk_bin_entries e
+SET last_shown_slot = d.slot
+FROM (
+  SELECT feed, snapshot_id, max(slot) AS slot
+  FROM (
+    SELECT feed, unnest(shown_snapshot_ids) AS snapshot_id, slot
+    FROM kiosk_draws
+    WHERE shown_snapshot_ids IS NOT NULL
+    UNION ALL
+    SELECT feed, snapshot_id, slot
+    FROM kiosk_draws
+  ) all_shown
+  GROUP BY feed, snapshot_id
+) d
+WHERE e.feed = d.feed
+  AND e.snapshot_id = d.snapshot_id
+  AND e.last_shown_at IS NOT NULL
+  AND e.last_shown_slot IS NULL;

--- a/docs/superpowers/specs/2026-09-06-solo2-dwell-budget-design.md
+++ b/docs/superpowers/specs/2026-09-06-solo2-dwell-budget-design.md
@@ -456,6 +456,39 @@ is meaningful only with a fetch timestamp attached and goes stale in a cached
 response; an instant does not. The tape's `Playhead` becomes `sinceMs` plus
 `endsAtMs` with no dial involved.
 
+### 6.1.2 The deploy window orphans rows; refill after, not before
+
+Found by the replay session on 2026-09-06, measured on production.
+
+The migration lands before the code. In between, production runs the old
+`commitAdvance`, which writes `last_shown_at` and knows nothing about
+`last_shown_slot`, so every frame drawn in that window keeps a timestamp and
+a NULL draw number — about three a minute across both feeds, against an
+active pool of roughly 169 rows.
+
+**What it costs, measured against the code rather than assumed.**
+`isResting` treats NULL as never shown, so rest is **waived** for those rows.
+That is the whole effect. It is not a queue jump: rule 3's first key is
+`compareRecency`, which reads `last_shown_at`, and the old code keeps that
+accurate, so an affected frame still sorts by how recently it was shown and
+lands at the **back** of its bin. That is most of what rest would have done
+anyway. The review that found this predicted a return of the
+least-recently-shown regression of 2026-09-05; it would not, because that
+regression was about rule 3's ordering key and this touches only rule 2's
+filter. The gap is real and worth closing, and it is smaller than that.
+
+**The fix is an ordering, not code.** Run
+`20260907_kiosk_bin_last_shown_slot_refill.sql` as the **last** step of the
+deploy, after the new code is live. Nothing is orphaned once it is, and the
+draw log covers the whole window, so the gap closes to zero. It only fills
+NULLs, so it is safe to run again if the deploy is slow.
+
+That refill also reads the draw log in both shapes, which the first backfill
+did not: `shown_snapshot_ids` only exists from 2026-09-06 23:44Z and 3,555
+earlier rows have it NULL. Falling back to the drawn frame's `snapshot_id`
+rescues those, and the array is still needed for a frame shown only inside a
+camera run.
+
 ### 6.2 Every consumer of the grid
 
 Eleven non-test files read `slotFor`, `boundaryMs`, `nextBoundaryMs` or


### PR DESCRIPTION
A follow-up to #154, which merged before this was written.

## The gap

The first migration applied at 01:59Z; the code that writes `last_shown_slot`
merged after it. In between, production ran the old `commitAdvance`, which
writes `last_shown_at` and knows nothing about the new column. Every frame drawn
in that window kept a timestamp and a NULL draw number, at about three a minute
against an active pool of ~169 rows. Found by the solo-replay session, measured
on production.

## What it actually costs

Narrower than it first looks, and worth stating precisely because the review
that found it predicted something worse.

`isResting` treats NULL as never shown, so **rest is waived** for those rows.
That is the entire effect. It is not a queue jump. Rule 3's first key is
`compareRecency`, which reads `last_shown_at`, and the old code keeps that
accurate — so an affected frame still sorts by how recently it was shown and
lands at the **back** of its bin, which is most of what rest would have done.

The 2026-09-05 least-recently-shown regression was about rule 3's ordering key.
This touches only rule 2's filter, so it is not that returning.

## The fix is an ordering

Run this **last**, after the #154 deploy is live. Nothing is orphaned once the
new code is running, and the draw log covers the whole window, so the gap closes
to zero. It only ever fills NULLs, so it is safe to run again if the deploy is
slow.

## It also reads both draw-log shapes

The first backfill unnested `shown_snapshot_ids` only. That column exists from
2026-09-06 23:44Z and 3,555 earlier rows have it NULL, so they were invisible to
it. This falls back to the drawn frame's `snapshot_id`, the way
`listDrawsBetween` already reads the log. Both sources are needed, not either:
a frame shown only inside a camera run appears in the array alone.

## Migration

`database/migrations/20260907_kiosk_bin_last_shown_slot_refill.sql`, to be
applied after the deploy rather than before the merge. Idempotent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T2b6QWdbpC2PixShXJqDz8
