### PR TITLE
fix(solo2): a dwell rebuilds its stack, so a run never dissolves back to its oldest frame

### DIFF
--- a/app/components/solo2/Solo2Frame.tsx
+++ b/app/components/solo2/Solo2Frame.tsx
@@ -45,9 +45,17 @@ export function arrival(
  * frame — and inside a run, where every frame is the same camera, the title
  * and the place hold still while only the clock steps.
  */
-export function Solo2Frame({ entry, run, previous, stage, plan, dials, width, height, feed }: {
+export function Solo2Frame({ entry, run, previous, stage, plan, dials, width, height, feed, dwellKey }: {
   /** The drawn frame: the run's last. */
   entry: EntryView;
+  /**
+   * What identifies this dwell, so a new one rebuilds rather than fades. The
+   * drawn frame is not enough on its own: the studio preview replays the same
+   * frame whenever there is no queue behind it, and a run that restarts inside
+   * a mounted stack lowers `shown`, leaving the layers above it to dissolve
+   * away and reveal the oldest picture. Callers pass the dwell's start.
+   */
+  dwellKey?: string | number;
   /** What the dwell plays, oldest first, `entry` last (run.ts `runOf`). */
   run: RunFrame[];
   previous: ViewEntry | null;
@@ -75,6 +83,8 @@ export function Solo2Frame({ entry, run, previous, stage, plan, dials, width, he
   const shown = Math.min(stage.index, sequence.length - 1);
   const up = sequence[shown];
   const rank = up.rank ?? entry.rank;
+  // Every per-dwell key hangs off this, so one dwell is one stack.
+  const dwellId = dwellKey ?? entry.snapshotId;
   const stepFade = Math.min(Math.max(0, dials.sameCameraFadeS), plan.stepS);
 
   const arrive = arrival(entry, previous, dials);
@@ -110,12 +120,12 @@ export function Solo2Frame({ entry, run, previous, stage, plan, dials, width, he
         </div>
       )}
       {arrive.kind === 'dip' && showPrevious && (
-        <div key={`dip-${entry.snapshotId}`} data-testid="dip" style={{
+        <div key={`dip-${dwellId}`} data-testid="dip" style={{
           ...layer, background: '#000', animation: `solo2-dip ${arrive.fadeS / 2}s linear both`,
         }} />
       )}
       {/* keyed by the drawn frame so the arrival runs once per dwell; the stage only changes opacities inside */}
-      <div key={`stack-${entry.snapshotId}`} data-testid="stack" style={{ ...pictureLayer, animation: inAnimation }}>
+      <div key={`stack-${dwellId}`} data-testid="stack" style={{ ...pictureLayer, animation: inAnimation }}>
         <div style={pushStyle} data-testid="push">
           {sequence.map((f, i) => (
             <div key={f.snapshotId} data-testid={`seq-${i}`} style={{
@@ -130,7 +140,7 @@ export function Solo2Frame({ entry, run, previous, stage, plan, dials, width, he
       </div>
       {/* keyed like the stack, so the words arrive with the picture and once
           per dwell; inside the dwell only the clock moves. */}
-      <div key={`caption-${entry.snapshotId}`} data-testid="caption-layer" style={{ ...captionLayer, animation: inAnimation }}>
+      <div key={`caption-${dwellId}`} data-testid="caption-layer" style={{ ...captionLayer, animation: inAnimation }}>
         <Caption entry={up} dials={dials} picture={picture} width={width} height={height} feed={feed}
           step={shown > 0 ? { from: sequence[shown - 1], fadeS: stepFade } : null} />
       </div>

--- a/app/components/solo2/index.tsx
+++ b/app/components/solo2/index.tsx
@@ -79,7 +79,7 @@ export function Solo2Kiosk(props: MosaicProps) {
   return (
     <div style={{ position: 'relative', width: props.width, height: props.height, background: '#000' }}>
       {current ? (
-        <Solo2Frame entry={current} run={run} previous={previous} stage={stage} plan={plan} dials={dials}
+        <Solo2Frame entry={current} run={run} previous={previous} stage={stage} plan={plan} dials={dials} dwellKey={dwell.startMs}
           width={props.width} height={props.height} feed={props.feed} />
       ) : null}
       {debug && (

--- a/app/studio/solo/GlassPreview.test.tsx
+++ b/app/studio/solo/GlassPreview.test.tsx
@@ -171,7 +171,9 @@ it('a run restarts by rebuilding its stack, never by fading back down to an earl
   const { SOLO_VERSIONS } = await import('@/app/lib/solo/versions');
   const { SOLO2_SETTINGS_SCHEMA, dialsFrom2 } = await import('@/app/lib/solo2/settingsSchema');
   vi.useFakeTimers();
-  const d2 = { ...dialsFrom2(schemaDefaults(SOLO2_SETTINGS_SCHEMA)), dwellS: 6, sameCameraFadeS: 1 }; // 3 frames → 2 s each
+  // minStepS 2 keeps the 6 s dwell divided evenly by 3 rather than stretched,
+  // so this test is about the stack and not about the budget.
+  const d2 = { ...dialsFrom2(schemaDefaults(SOLO2_SETTINGS_SCHEMA)), dwellS: 6, minStepS: 2, sameCameraFadeS: 1 }; // 3 frames → 2 s each
   const older = (id: number, capturedAt: number) => ({ ...entry, snapshotId: id, imageUrl: `u${id}`, capturedAt });
   const entries = [older(5, entry.capturedAt - 20 * 60_000), older(6, entry.capturedAt - 10 * 60_000), entry];
   const s2 = { ...server, entries } as unknown as StateView;

--- a/app/studio/solo/GlassPreview.test.tsx
+++ b/app/studio/solo/GlassPreview.test.tsx
@@ -159,3 +159,32 @@ it('restarts the run\'s stage clock when the server advances a different camera 
     dials={d2} panel={panel} />);
   expect(screen.getByTestId('top')).toHaveAttribute('src', 'u20'); // camera B's run, first frame — the stage restarted
 });
+
+// The reported bug: at the end of a run the preview "fades up to an earlier
+// image". A run restarting inside a mounted stack lowers `shown`, and the
+// layers above it carry an opacity transition, so they dissolve away and
+// reveal the oldest frame underneath instead of the run simply beginning
+// again. A dwell must therefore rebuild its stack, not fade back down it —
+// including when the preview replays the very same drawn frame, which is what
+// it does whenever there is no projected queue.
+it('a run restarts by rebuilding its stack, never by fading back down to an earlier frame', async () => {
+  const { SOLO_VERSIONS } = await import('@/app/lib/solo/versions');
+  const { SOLO2_SETTINGS_SCHEMA, dialsFrom2 } = await import('@/app/lib/solo2/settingsSchema');
+  vi.useFakeTimers();
+  const d2 = { ...dialsFrom2(schemaDefaults(SOLO2_SETTINGS_SCHEMA)), dwellS: 6, sameCameraFadeS: 1 }; // 3 frames → 2 s each
+  const older = (id: number, capturedAt: number) => ({ ...entry, snapshotId: id, imageUrl: `u${id}`, capturedAt });
+  const entries = [older(5, entry.capturedAt - 20 * 60_000), older(6, entry.capturedAt - 10 * 60_000), entry];
+  const s2 = { ...server, entries } as unknown as StateView;
+  render(<GlassPreview version={SOLO_VERSIONS.solo2} screens={[{ feed: 'sunset', server: s2, projected: null }]}
+    dials={d2} panel={{ width: 1920, height: 1080 }} />);
+
+  await act(async () => { vi.advanceTimersByTime(4_100); });
+  expect(screen.getByTestId('top')).toHaveAttribute('src', 'u7'); // last frame of the run
+  const stackBefore = screen.getByTestId('stack');
+
+  await act(async () => { vi.advanceTimersByTime(2_000); }); // the dwell ends and replays
+  expect(screen.getByTestId('top')).toHaveAttribute('src', 'u5'); // back to the oldest frame
+  // Rebuilt, so the later frames are simply gone rather than dissolving away
+  // on top of the oldest one.
+  expect(screen.getByTestId('stack')).not.toBe(stackBefore);
+});

--- a/app/studio/solo/GlassPreview.tsx
+++ b/app/studio/solo/GlassPreview.tsx
@@ -94,7 +94,7 @@ function PlayingScreen({ feed, server, projected, error, dials, panel, version }
         {dwell.entry ? (
           <StudioPanelFrame panel={panel}>
             {solo2 ? (
-              <Solo2Frame entry={dwell.entry} run={run} previous={dwell.previous} stage={stage} plan={plan} dials={d2}
+              <Solo2Frame entry={dwell.entry} run={run} previous={dwell.previous} stage={stage} plan={plan} dials={d2} dwellKey={dwell.startMs}
                 width={panel.width} height={panel.height} feed={feed} />
             ) : (
               // No key: SoloFrame's fade is a mount animation on an <img> keyed

--- a/app/studio/solo/useLoopingStage.test.ts
+++ b/app/studio/solo/useLoopingStage.test.ts
@@ -13,15 +13,13 @@ beforeEach(() => {
 afterEach(() => vi.useRealTimers());
 
 describe('useLoopingStage', () => {
-  it('starts at the first frame, walks the run, and wraps at the dwell', () => {
+  it('walks the run of the dwell it is given', () => {
     const { result } = renderHook(() => useLoopingStage(plan, NOW));
     expect(result.current.index).toBe(0);
     act(() => { vi.advanceTimersByTime(2_000); });
     expect(result.current.index).toBe(1);
     act(() => { vi.advanceTimersByTime(2_000); });
     expect(result.current.index).toBe(2);
-    act(() => { vi.advanceTimersByTime(2_000); });
-    expect(result.current.index).toBe(0); // round again
   });
 
   it('restarts when the dwell start changes', () => {
@@ -33,24 +31,25 @@ describe('useLoopingStage', () => {
     expect(result.current.index).toBe(0);
   });
 
-  // The bug: the preview's dwell walker ticks at 250 ms, so it notices a
-  // boundary up to a tick late and back-dates `startMs` to the exact boundary.
-  // A stage clock that started at mount instead of at that start ran a tick
-  // behind the dwell, so it wrapped to frame 0 while the dwell was still on
-  // its last frame — the run flashed an earlier picture just before the
-  // camera changed, and the last frame was short by the same amount.
-  it('is phase-locked to the dwell: a dwell that began a tick ago is already a tick in', () => {
+  it('is phase-locked to the dwell: one that began a tick ago is already a tick in', () => {
     const { result } = renderHook(() => useLoopingStage(plan, NOW - 2_500));
     expect(result.current.index).toBe(1); // 2.5 s in, not 0
   });
 
-  it('never wraps early: the last frame holds right up to the dwell it belongs to', () => {
-    // The dwell began 250 ms before this clock was mounted, the lag the
-    // walker's tick can introduce.
-    const { result } = renderHook(() => useLoopingStage(plan, NOW - 250));
-    act(() => { vi.advanceTimersByTime(5_450); }); // 5.7 s into a 6 s dwell
-    expect(result.current.index).toBe(2); // still the last frame
-    act(() => { vi.advanceTimersByTime(300); }); // 6.0 s in: the wrap, on the dwell's clock
-    expect(result.current.index).toBe(0);
+  // The reported bug. `useSoloPreview` owns when a dwell ends and ticks at
+  // 250 ms, so for up to a tick past the dwell it is still on the old one. A
+  // stage that wrapped on its own clock reset the run to frame 0 inside a
+  // stack that had not been rebuilt, and the frames above dissolved away to
+  // reveal the oldest picture — the run "fading up to an earlier image".
+  // Holding the last frame leaves the restart to the walker, in the one
+  // commit that also brings the new dwell.
+  it('holds the last frame past the dwell instead of wrapping itself', () => {
+    const { result } = renderHook(() => useLoopingStage(plan, NOW - 6_100));
+    expect(result.current.index).toBe(2);
+  });
+
+  it('still holds it far past the dwell, however late the walker is', () => {
+    const { result } = renderHook(() => useLoopingStage(plan, NOW - 60_000));
+    expect(result.current.index).toBe(2);
   });
 });

--- a/app/studio/solo/useLoopingStage.ts
+++ b/app/studio/solo/useLoopingStage.ts
@@ -5,29 +5,38 @@ import { stageAt, type DwellPlan, type Stage } from '@/app/lib/solo2/plan';
 
 const same = (a: Stage, b: Stage) => a.index === b.index && a.leadProgress === b.leadProgress;
 
-/** Where a dwell that began at `startMs` is now, wrapping at the plan's dwell. */
+/**
+ * Where a dwell that began at `startMs` is now. Clamped at the dwell, never
+ * wrapped: the walker owns when a dwell ends, and it ticks at 250 ms, so a
+ * stage that wrapped on its own clock reached frame 0 while the walker still
+ * had the old dwell. Holding the last frame instead means the run restarts in
+ * the same commit that brings the new dwell.
+ */
 function stageOf(startMs: number | null, plan: DwellPlan): Stage {
   if (startMs == null) return stageAt(0, plan);
   const period = Math.max(1, plan.dwellS * 1000);
-  return stageAt(Math.max(0, Date.now() - startMs) % period, plan);
+  return stageAt(Math.min(Math.max(0, Date.now() - startMs), period - 1), plan);
 }
 
 /**
  * The studio's dwell clock (camera-run spec §5.1): where the dwell that began
- * at `startMs` has got to, wrapping at the plan's dwell so the preview plays a
- * run over and over at the studio's dwell while the glass keeps the live one.
- * No server call. Kept in its own file so the one-studio preview can lift it
- * as a move.
+ * at `startMs` has got to, so the preview plays a run at the studio's dwell
+ * while the glass keeps the live one. The looping belongs to the walker; this
+ * only says where the current dwell stands. No server call. Kept in its own
+ * file so the one-studio preview can lift it as a move.
  *
  * `startMs` is the dwell's own start, not the moment this clock mounted, and
  * that distinction is the whole point. The preview's walker (`useSoloPreview`)
  * ticks at 250 ms, so it notices a boundary up to a tick late and back-dates
  * the new dwell to the exact boundary. A clock that started when it mounted
- * therefore ran that lag *behind* the dwell and wrapped to frame 0 while the
- * dwell was still on its last frame: the run flashed an earlier picture just
- * before the camera changed, and the last frame was short by the same amount.
- * Reading the dwell's own start phase-locks the two, so the wrap and the
- * camera change land together.
+ * therefore ran that lag *behind* the dwell it was timing. Reading the dwell's
+ * own start phase-locks the two.
+ *
+ * Phase-locking alone was not enough, because two clocks ticking separately
+ * can still disagree for a tick: this one would reach the end of the dwell
+ * before the walker moved the dwell on, reset the run to frame 0, and leave
+ * the stack dissolving back down to its oldest picture. So this clock no
+ * longer wraps at all — see `stageOf`.
  */
 export function useLoopingStage(plan: DwellPlan, startMs: number | null, tickMs = 250): Stage {
   const [stage, setStage] = useState<Stage>(() => stageOf(startMs, plan));


### PR DESCRIPTION
**Recovers the commit PR #155 left behind.** #155 merged while I was still pushing to its branch, so only its first commit, the clock phase-lock, reached `main`. The commit that actually fixes what Jesse reported did not. This is that commit, cherry-picked onto current `main`, plus one fixture fix for the dwell budget that landed in between.

## The bug

The preview "fades up to an earlier image" at the end of a camera run. **Fading** is the clue: a cut means a remount, a fade means a transition ran on an element that stayed mounted. So this was never the clock.

A run stacks its frames oldest at the bottom, each fading in as the stage reaches it. Lower `shown` inside a stack that is still mounted and every layer above it goes opaque-to-clear at once, dissolving away to reveal the oldest frame underneath.

The stack was keyed on the drawn frame, which is not what identifies a dwell. The studio preview replays the same drawn frame every dwell whenever there is no projected queue behind it, so the key never changed and every replay dissolved backwards.

## The fix

`Solo2Frame` takes `dwellKey` and both callers pass the dwell's start: one dwell, one stack. The stage also clamps at its last frame rather than wrapping, because the walker owns when a dwell ends and two clocks ticking separately can disagree for a tick.

## Verified

- 286 files, 2358 tests pass; build clean.
- The two new tests fail against #155's merged state, which is the check that matters here.
- The fixture commit: the budget floors each frame at `minStepS`, so 6 s over 3 frames now stretches to 7.5 s. Pinning `minStepS` to 2 keeps that test about the stack rather than the budget.

## Worth a look, not mine to change

`GlassPreview` drives the walker with `dials.dwellS` but the stage with `plan.dwellS`, and since #156 those differ whenever a run stretches past the floor. The walker would move the dwell on while the stage is still mid-run, cutting a stretched run short in the preview. That belongs to the dwell-budget lane.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NARpc9xyCfFjqwSy4u9TZD
