### PR TITLE
fix(solo2): a dip comes up on the same ramp it goes down on

### DIFF
--- a/app/components/solo2/Solo2Frame.test.tsx
+++ b/app/components/solo2/Solo2Frame.test.tsx
@@ -91,7 +91,7 @@ it('cut shows no previous layer; crossfade keeps it and animates the top; dip ad
   expect(screen.getAllByRole('presentation').map((i) => i.getAttribute('src'))).toEqual(['u3']);
   rerender(<Solo2Frame entry={e} run={[e]} previous={prev} stage={one} plan={plan} dials={{ ...D, transition: 'crossfade', fadeS: 2 }} width={100} height={50} />);
   expect(screen.getAllByRole('presentation').map((i) => i.getAttribute('src'))).toEqual(['u0', 'u3']);
-  expect(screen.getByTestId('stack')).toHaveStyle({ animation: 'solo2-fade-in 2s ease both' });
+  expect(screen.getByTestId('stack')).toHaveStyle({ animation: 'solo2-fade-in 2s linear both' });
   expect(screen.queryByTestId('dip')).toBeNull();
   rerender(<Solo2Frame entry={e} run={[e]} previous={prev} stage={one} plan={plan} dials={{ ...D, transition: 'dip', fadeS: 2 }} width={100} height={50} />);
   expect(screen.getByTestId('dip')).toHaveStyle({ animation: 'solo2-dip 1s linear both' });
@@ -103,7 +103,7 @@ it('a change to the same camera dissolves over the same-camera fade, never throu
     dials={{ ...D, transition: 'dip', fadeS: 4, sameCameraFadeS: 1 }} width={100} height={50} />);
   expect(screen.getAllByRole('presentation').map((i) => i.getAttribute('src'))).toEqual(['u0', 'u3']);
   expect(screen.queryByTestId('dip')).toBeNull();
-  expect(screen.getByTestId('stack')).toHaveStyle({ animation: 'solo2-fade-in 1s ease both' });
+  expect(screen.getByTestId('stack')).toHaveStyle({ animation: 'solo2-fade-in 1s linear both' });
 });
 
 it('the defaults dip through black between cameras', () => {
@@ -126,7 +126,7 @@ it('the caption arrives on the picture’s transition: the same animation, and t
   const one = { index: 0, leadProgress: 0 };
   const { rerender } = render(<Solo2Frame entry={e} run={[e]} previous={prev} stage={one} plan={plan}
     dials={{ ...D, transition: 'crossfade', fadeS: 2 }} width={1920} height={1080} />);
-  expect(screen.getByTestId('caption-layer')).toHaveStyle({ animation: 'solo2-fade-in 2s ease both' });
+  expect(screen.getByTestId('caption-layer')).toHaveStyle({ animation: 'solo2-fade-in 2s linear both' });
   expect(screen.getByTestId('caption-layer').style.animation).toBe(screen.getByTestId('stack').style.animation);
   expect(screen.getByText('Old pier')).toBeInTheDocument(); // the words being left behind
 
@@ -147,7 +147,20 @@ it('on a dip the veil covers the outgoing caption, and the new words fade in aft
   // Painted in this order, so the veil hides the old words rather than sitting behind them.
   expect(out.compareDocumentPosition(veil) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
   expect(veil.compareDocumentPosition(arriving) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
-  expect(arriving).toHaveStyle({ animation: 'solo2-fade-in 1s ease 1s both' });
+  expect(arriving).toHaveStyle({ animation: 'solo2-fade-in 1s linear 1s both' });
+});
+
+it('a dip goes down and comes up on the same ramp: the veil and the arriving picture share duration and timing function', () => {
+  const prev = { ...e, snapshotId: 0, webcamId: 99, imageUrl: 'u0' };
+  render(<Solo2Frame entry={e} run={[e]} previous={prev} stage={{ index: 0, leadProgress: 0 }} plan={plan}
+    dials={{ ...D, transition: 'dip', fadeS: 2 }} width={100} height={50} />);
+  // An eased up-ramp against a linear down-ramp is what made the new picture
+  // read as arriving three times faster than the old one left.
+  const [, downDuration, downEasing] = screen.getByTestId('dip').style.animation.split(' ');
+  const [, upDuration, upEasing] = screen.getByTestId('stack').style.animation.split(' ');
+  expect(upDuration).toBe(downDuration);
+  expect(upEasing).toBe(downEasing);
+  expect(upEasing).toBe('linear');
 });
 
 it('inside a run only the clock moves: the old time fades out, the new one in, and the words are not remounted', () => {

--- a/app/components/solo2/Solo2Frame.tsx
+++ b/app/components/solo2/Solo2Frame.tsx
@@ -89,9 +89,14 @@ export function Solo2Frame({ entry, run, previous, stage, plan, dials, width, he
 
   const arrive = arrival(entry, previous, dials);
   const showPrevious = arrive.kind !== 'cut' && !!previous;
+  // Linear, like the veil under it and like the in-run step above it. An
+  // eased ramp is not the same ramp run backwards: `ease` puts the picture at
+  // 80% brightness halfway through and spends the rest of the fade crawling
+  // the last 20%, so against a linear fade to black the picture reads as
+  // arriving in a third of the time it leaves in. Every dissolve here is linear.
   const inAnimation =
-    arrive.kind === 'crossfade' ? `solo2-fade-in ${arrive.fadeS}s ease both`
-    : arrive.kind === 'dip' ? `solo2-fade-in ${arrive.fadeS / 2}s ease ${arrive.fadeS / 2}s both`
+    arrive.kind === 'crossfade' ? `solo2-fade-in ${arrive.fadeS}s linear both`
+    : arrive.kind === 'dip' ? `solo2-fade-in ${arrive.fadeS / 2}s linear ${arrive.fadeS / 2}s both`
     : undefined;
 
   // The lead: a slow push over the last seconds, driven by the clock stage

--- a/app/components/solo2/index.test.tsx
+++ b/app/components/solo2/index.test.tsx
@@ -66,7 +66,7 @@ it('a new frame on glass arrives with the old one as its previous in the same re
   rerender(<Solo2Kiosk webcams={[]} width={100} height={50} feed="sunset" settings={{ transition: 'crossfade' }} />);
   // The previous frame (camera 7's drawn frame) sits underneath and the crossfade is on the stack, from the first render.
   expect(screen.getAllByRole('presentation').map((i) => i.getAttribute('src'))).toEqual(['u3', 'u9']);
-  expect(screen.getByTestId('stack')).toHaveStyle({ animation: 'solo2-fade-in 1.5s ease both' });
+  expect(screen.getByTestId('stack')).toHaveStyle({ animation: 'solo2-fade-in 1.5s linear both' });
   expect(screen.getByTestId('top')).toHaveAttribute('src', 'u9');
 });
 


### PR DESCRIPTION
Jesse on /studio solo2: with the crossfade dip, "the old images or preludes are going out slowly, and then the new image is coming in really quickly."

## What it was

The dip's black veil fades in `linear`. The arriving picture faded in with `ease`. An eased ramp is not the same ramp run backwards.

Measured in Chrome, sampling composited brightness at the default 1.5 s dip:

| ramp | timing fn | crosses half brightness at |
|---|---|---|
| out (black veil) | `linear` | 50% of its 750 ms |
| in (new picture) | `ease` | 29% of its 750 ms |

The incoming picture was at 80% brightness by the halfway mark and spent the second half of its fade crawling the last 20%. So the old picture left on a steady ramp and the new one arrived in about a third of the time.

## What changed

The arrival is `linear`, matching the veil under it and the in-run step above it. Every dissolve in solo2 is now linear. This applies to the `crossfade` transition too, where the same front-loaded ramp was making arrivals feel abrupt. The caption follows automatically because it shares the picture's animation string.

No dial changes, no schema changes, no migration. `fadeS` still means down plus up.

## Verification

- New test pins the veil and the arriving stack to the same duration and timing function; it fails on the old `ease`.
- Three tests that pinned the literal animation string updated.
- `npm run test` 2359 passed, `npm run build` exits 0.
- Remaining check is Jesse's eyes on /studio solo2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013pPvtbmZYXMfYtVXoix697
