### PR TITLE
fix(studio): the glass preview plays the queue, and a dwell lasts as long as its run

### DIFF
--- a/app/studio/solo/GlassPreview.test.tsx
+++ b/app/studio/solo/GlassPreview.test.tsx
@@ -190,3 +190,30 @@ it('a run restarts by rebuilding its stack, never by fading back down to an earl
   // on top of the oldest one.
   expect(screen.getByTestId('stack')).not.toBe(stackBefore);
 });
+
+it('plays the queue when the glass is dark, and never calls a queued frame `on glass now`', async () => {
+  vi.useFakeTimers();
+  // `current` is null whenever the on-glass frame has aged out of the pool
+  // (view.ts resolves it by id against the live entries), which is the state
+  // a screen sits in whenever nothing is advancing it. The queue is fine.
+  const dark = { current: null, entries: [] } as unknown as StateView;
+  const projected = { next: [at(8, 2), at(9, 3)] } as unknown as StateView;
+  const { container } = render(<GlassPreview screens={[{ feed: 'sunrise', server: dark, projected }]}
+    dials={{ ...D, dwellS: 4 }} panel={{ width: 1920, height: 1080 }} />);
+
+  expect(screen.queryByText('no frame to preview')).toBeNull();
+  expect([...container.querySelectorAll('img')].map((i) => i.getAttribute('src'))).toEqual(['u8']);
+  // The glass really is dark, so the status says so rather than claiming the queue is on it.
+  expect(screen.getByText(/^nothing on glass · preview · frame 8 · next in \d+ s$/)).toBeInTheDocument();
+
+  await act(async () => { vi.advanceTimersByTime(4_100); });
+  expect(screen.getByText(/^nothing on glass · preview · frame 9/)).toBeInTheDocument();
+});
+
+it('a screen with neither a frame on glass nor a queue still says it has nothing to draw', () => {
+  const dark = { current: null, entries: [] } as unknown as StateView;
+  render(<GlassPreview screens={[{ feed: 'sunrise', server: dark, projected: { next: [] } as unknown as StateView }]}
+    dials={D} panel={{ width: 1920, height: 1080 }} />);
+  expect(screen.getByText('no frame to preview')).toBeInTheDocument();
+  expect(screen.getByText('nothing on glass')).toBeInTheDocument();
+});

--- a/app/studio/solo/GlassPreview.test.tsx
+++ b/app/studio/solo/GlassPreview.test.tsx
@@ -217,3 +217,26 @@ it('a screen with neither a frame on glass nor a queue still says it has nothing
   expect(screen.getByText('no frame to preview')).toBeInTheDocument();
   expect(screen.getByText('nothing on glass')).toBeInTheDocument();
 });
+
+it('solo2 holds a stretched dwell for the run it plays, not for the dial', async () => {
+  const { SOLO_VERSIONS } = await import('@/app/lib/solo/versions');
+  const { SOLO2_SETTINGS_SCHEMA, dialsFrom2 } = await import('@/app/lib/solo2/settingsSchema');
+  vi.useFakeTimers();
+  // 3 frames against a 3 s floor: the budget cannot divide 6 s that finely, so
+  // the dwell STRETCHES to 9 s (dwell-budget spec §3). The walker has to wait
+  // for the run it is actually playing.
+  const d2 = { ...dialsFrom2(schemaDefaults(SOLO2_SETTINGS_SCHEMA)), dwellS: 6, minStepS: 3, sameCameraFadeS: 1 };
+  const older = (id: number, capturedAt: number) => ({ ...entry, snapshotId: id, imageUrl: `u${id}`, capturedAt });
+  const entries = [older(5, entry.capturedAt - 20 * 60_000), older(6, entry.capturedAt - 10 * 60_000), entry];
+  const s2 = { ...server, entries } as unknown as StateView;
+  const projected = { next: [at(8, 2)] } as unknown as StateView;
+  render(<GlassPreview version={SOLO_VERSIONS.solo2} screens={[{ feed: 'sunset', server: s2, projected }]}
+    dials={d2} panel={{ width: 1920, height: 1080 }} />);
+
+  await act(async () => { vi.advanceTimersByTime(6_100); }); // the dial is up; the run is not
+  expect(screen.getByTestId('top')).toHaveAttribute('src', 'u7'); // still the run's last frame
+  expect(screen.getByText(/on glass now · frame 7/)).toBeInTheDocument();
+
+  await act(async () => { vi.advanceTimersByTime(3_000); }); // 9 s: the run is done
+  expect(screen.getByText(/^preview · frame 8/)).toBeInTheDocument();
+});

--- a/app/studio/solo/GlassPreview.tsx
+++ b/app/studio/solo/GlassPreview.tsx
@@ -61,28 +61,37 @@ function PlayingScreen({ feed, server, projected, error, dials, panel, version }
   // eight frames deep.
   const queue = projected?.next ?? [];
   const order: EntryView[] = current ? [current, ...queue] : queue;
-  const dwell = useSoloPreview(order, dials.dwellS);
-  const now = useNow();
 
-  // Hooks run on both versions; only solo2 reads the stage.
+  // Only solo2 reads the stage, but the run and the plan are what say how long
+  // a dwell lasts, so they are derived for every version before the walker.
   const solo2 = version.name === 'solo2';
   const d2 = dials as Solo2Dials;
   // The same capped run and the same budget rule the glass uses, so the
   // preview steps at the rate the glass will (dwell-budget spec §3, §4).
-  const run = solo2 && dwell.entry
-    ? runOf(dwell.entry, server?.entries ?? [], d2.cameraRun, capFor(dwell.entry, d2))
-    : [];
-  const plan = fitPlan(
-    { dwellS: dials.dwellS, leadS: d2.leadS ?? 0, minStepS: d2.minStepS ?? dials.dwellS },
-    Math.max(1, run.length),
+  const runFor = (e: EntryView) => (
+    solo2 ? runOf(e, server?.entries ?? [], d2.cameraRun, capFor(e, d2)) : []
   );
+  const planFor = (e: EntryView | null) => fitPlan(
+    { dwellS: dials.dwellS, leadS: d2.leadS ?? 0, minStepS: d2.minStepS ?? dials.dwellS },
+    Math.max(1, e ? runFor(e).length : 1),
+  );
+  // Per frame, not once: the budget stretches a dwell past the dial whenever a
+  // run has more frames than the floor can divide it into, so a walker on the
+  // dial alone cut a stretched run short — the preview jumped to the next
+  // camera mid-timelapse while the glass played the run out.
+  const dwell = useSoloPreview(order, (e) => planFor(e).dwellS);
+  const now = useNow();
+
+  const run = dwell.entry ? runFor(dwell.entry) : [];
+  const plan = planFor(dwell.entry);
   // Keyed on the dwell start, not the index: the start changes on every step
   // AND every restart (a server advance while sitting at index 0 still gets
   // a fresh start), but never on a bare tick, so this is the one value that
   // means "the dwell actually changed."
   const stage = useLoopingStage(plan, dwell.startMs);
 
-  const remainingS = Math.max(0, Math.ceil((dwell.startMs + dials.dwellS * 1000 - now) / 1000));
+  // This dwell's own length, so the countdown agrees with when the walker will move.
+  const remainingS = Math.max(0, Math.ceil((dwell.startMs + plan.dwellS * 1000 - now) / 1000));
   // Index 0 is the on-glass frame only when there IS one; with a dark glass
   // it is the first queued frame, and saying `on glass now` there would be a
   // lie about the thing this header exists to keep in sight.

--- a/app/studio/solo/GlassPreview.tsx
+++ b/app/studio/solo/GlassPreview.tsx
@@ -54,7 +54,13 @@ function PlayingScreen({ feed, server, projected, error, dials, panel, version }
   dials: SoloDials; panel: { width: number; height: number }; version: SoloVersionSpec;
 }) {
   const current = server?.current?.entry ?? null;
-  const order: EntryView[] = current ? [current, ...(projected?.next ?? [])] : [];
+  // The queue plays whether or not anything is on glass. `current` is resolved
+  // by id against the live pool (view.ts), so it goes null the moment the
+  // on-glass frame ages out — which is where a screen sits any time nothing is
+  // advancing it. Gating the whole order on it blanked a screen whose queue was
+  // eight frames deep.
+  const queue = projected?.next ?? [];
+  const order: EntryView[] = current ? [current, ...queue] : queue;
   const dwell = useSoloPreview(order, dials.dwellS);
   const now = useNow();
 
@@ -77,10 +83,14 @@ function PlayingScreen({ feed, server, projected, error, dials, panel, version }
   const stage = useLoopingStage(plan, dwell.startMs);
 
   const remainingS = Math.max(0, Math.ceil((dwell.startMs + dials.dwellS * 1000 - now) / 1000));
+  // Index 0 is the on-glass frame only when there IS one; with a dark glass
+  // it is the first queued frame, and saying `on glass now` there would be a
+  // lie about the thing this header exists to keep in sight.
+  const dark = current ? '' : 'nothing on glass · ';
   const status = dwell.entry
-    ? (dwell.index === 0
+    ? (current && dwell.index === 0
       ? `on glass now · frame ${dwell.entry.snapshotId}`
-      : `preview · frame ${dwell.entry.snapshotId} · next in ${remainingS} s`)
+      : `${dark}preview · frame ${dwell.entry.snapshotId} · next in ${remainingS} s`)
     : error ?? 'nothing on glass';
 
   return (

--- a/app/studio/solo/useSoloPreview.test.ts
+++ b/app/studio/solo/useSoloPreview.test.ts
@@ -175,4 +175,35 @@ describe('useSoloPreview', () => {
     expect(result.current.entry?.snapshotId).toBe(2);
     expect(result.current.startMs).toBe(T0 + 5_000);
   });
+
+  // A solo2 dwell is only as long as ITS OWN frame's run. Once a run has more
+  // frames than the step floor allows, the budget stretches the dwell past the
+  // dial (plan.dwellS), so one shared period cannot find the boundary.
+  const stretched = (e: EntryView) => (e.snapshotId === 2 ? 20 : DWELL);
+
+  it('gives every frame its own dwell, so a stretched run is not cut short at the dial', () => {
+    const order = [entry(1), entry(2), entry(3)];
+    const { result } = renderHook(() => useSoloPreview(order, stretched));
+    act(() => { vi.advanceTimersByTime(DWELL * 1000); });
+    expect(result.current.entry?.snapshotId).toBe(2);
+    // The dial's 8 s comes and goes twice over; frame 2 holds, because its run is 20 s.
+    act(() => { vi.advanceTimersByTime(DWELL * 1000); });
+    expect(result.current.entry?.snapshotId).toBe(2);
+    act(() => { vi.advanceTimersByTime(12_000); }); // 20 s into frame 2, at last
+    expect(result.current.entry?.snapshotId).toBe(3);
+    expect(result.current.startMs).toBe(T0 + (DWELL + 20) * 1000);
+  });
+
+  it('catches up over mixed dwells in one jump, counting each frame by its own length', () => {
+    const order = [entry(1), entry(2), entry(3), entry(4)]; // 8 + 20 + 8 + 8 = 44 s a lap
+    const { result } = renderHook(() => useSoloPreview(order, stretched));
+    act(() => {
+      // A lap, then frame 1's 8 s and frame 2's 20 s, and a second into frame 3.
+      vi.setSystemTime(new Date(T0 + 44_000 + 28_000 + 1_000));
+      vi.advanceTimersByTime(250);
+    });
+    expect(result.current.index).toBe(2);
+    expect(result.current.startMs).toBe(T0 + 44_000 + 28_000);
+    expect(result.current.previous?.snapshotId).toBe(1);
+  });
 });

--- a/app/studio/solo/useSoloPreview.ts
+++ b/app/studio/solo/useSoloPreview.ts
@@ -21,12 +21,22 @@ const empty = (startMs: number): PreviewDwell => ({ entry: null, previous: null,
 
 /**
  * A local clock through `order` (the on-glass frame first, then the projected
- * queue) at `dwellS` per frame, wrapping at the end. It calls nothing: the
- * studio preview plays on the studio's dials while the glass keeps its own
- * clock. When `order[0]` changes — the server advanced — the clock restarts
- * at index 0 with the frame that was showing as `previous`.
+ * queue), wrapping at the end. It calls nothing: the studio preview plays on
+ * the studio's dials while the glass keeps its own clock. When `order[0]`
+ * changes — the server advanced — the clock restarts at index 0 with the frame
+ * that was showing as `previous`.
+ *
+ * `dwellS` is a number when every frame holds for the same time, and a
+ * function of the frame when they do not. solo2 needs the function: a dwell is
+ * as long as the run it plays, and once a run has more frames than the step
+ * floor can divide the budget into, the dwell STRETCHES past the dial
+ * (`fitPlan`'s `plan.dwellS`). A single shared period cannot find that
+ * boundary, so a stretched run was cut short here while the glass played it
+ * whole.
  */
-export function useSoloPreview(order: EntryView[], dwellS: number, tickMs = 250): PreviewDwell {
+export function useSoloPreview(
+  order: EntryView[], dwellS: number | ((entry: EntryView) => number), tickMs = 250,
+): PreviewDwell {
   const [dwell, setDwell] = useState<PreviewDwell>(() => (
     order.length === 0 ? empty(Date.now()) : { entry: order[0], previous: null, startMs: Date.now(), index: 0 }
   ));
@@ -42,13 +52,17 @@ export function useSoloPreview(order: EntryView[], dwellS: number, tickMs = 250)
       : { entry: order[0], previous: dwell.entry, startMs: Date.now(), index: 0 });
   }
 
-  // The interval reads the latest order without being torn down and rebuilt
-  // on every parent render (a studio dial in motion would starve the tick).
+  // The interval reads the latest order and dwell without being torn down and
+  // rebuilt on every parent render (a studio dial in motion would starve the
+  // tick, and a caller's dwell function is a fresh closure every time).
   const latest = useRef(order);
+  const dwellMs = useRef<(entry: EntryView) => number>(() => 0);
   useEffect(() => { latest.current = order; });
+  useEffect(() => {
+    dwellMs.current = (entry) => Math.max(1, (typeof dwellS === 'function' ? dwellS(entry) : dwellS) * 1000);
+  });
 
   useEffect(() => {
-    const period = Math.max(1, dwellS * 1000);
     const tick = () => {
       // Captured once per real tick, outside the updater: a functional
       // setState update can be queued and evaluated later rather than at
@@ -67,15 +81,28 @@ export function useSoloPreview(order: EntryView[], dwellS: number, tickMs = 250)
         // step per tick: after a long pause (backgrounded tab, sleep) a
         // one-step-per-tick catch-up would replay every intermediate fade
         // and restart the stage clock at each step — a flicker storm.
-        const steps = Math.floor((nowMs - prev.startMs) / period);
-        if (steps < 1) return prev;
-        const next = (prev.index + steps) % now.length;
-        return { entry: now[next], previous: prev.entry, startMs: prev.startMs + steps * period, index: next };
+        //
+        // Frames no longer share a period, so the jump is a lap skip and then
+        // at most one walk of the order, counting each frame by its own dwell.
+        // It all happens inside the updater, so however far behind the clock
+        // is, ONE state change commits and no intermediate dwell is rendered.
+        const periods = now.map((e) => dwellMs.current(e));
+        const lap = periods.reduce((a, b) => a + b, 0);
+        let index = prev.index;
+        let startMs = prev.startMs;
+        const laps = Math.floor((nowMs - startMs) / lap);
+        if (laps > 0) startMs += laps * lap;
+        while (nowMs - startMs >= periods[index]) {
+          startMs += periods[index];
+          index = (index + 1) % now.length;
+        }
+        if (index === prev.index && startMs === prev.startMs) return prev;
+        return { entry: now[index], previous: prev.entry, startMs, index };
       });
     };
     const t = setInterval(tick, Math.max(1, tickMs));
     return () => clearInterval(t);
-  }, [dwellS, tickMs]);
+  }, [tickMs]);
 
   return dwell;
 }


### PR DESCRIPTION
Two bugs in the studio's glass preview. Both make the preview disagree with the glass.

## 1. A dark screen threw away a full queue

Jesse: "the sunrise images is showing no frame to view, but there's a bunch of stellar images in the on-glass next up bin/queue."

The preview built its play order as `current ? [current, ...next] : []`, so a null `current` discarded the queue entirely and the panel read "no frame to preview."

`current` is not a health flag. `view.ts` resolves it by looking the screen's stored snapshot id up in the live pool, so it goes null the moment the on-glass frame ages out of the bins. That is where any screen sits whenever nothing is advancing it.

Measured against production while diagnosing:

| feed | `current` | `next` | `entries` | screen row |
|---|---|---|---|---|
| sunrise | null | 8 | 84 | snapshot 164212, shown 38 min earlier, no longer in the pool |
| sunset | present | 8 | 36 | advancing normally |

The order is now the queue, with the on-glass frame in front of it when there is one. The status line gains a `nothing on glass` prefix in that state, because index 0 is only "on glass now" when something actually is, and that header exists to keep the live truth in sight.

## 2. A stretched run got cut short

The walker advanced on `dials.dwellS`; the run's stage clock ran on `plan.dwellS`. Those diverge by design. `fitPlan` floors a frame's share at `minStepS`, so a run with more frames than the budget divides that finely stretches the dwell: eight frames against a 4 s floor occupy 32 s, not the 20 s on the dial. The preview jumped to the next camera mid-timelapse while the glass played the run out whole.

Passing `plan.dwellS` back to the walker closes a cycle: dwell to run to plan to dwell. Broken by giving `useSoloPreview` a **function** of the frame instead of one period. The duration of the frame it has already chosen is knowable; the duration of every frame up front is not.

Its long-pause catch-up becomes a lap skip plus at most one walk of the order, since there is no longer a single period to divide by. It still commits exactly one state change, so no intermediate dwell renders and no fade replays. The countdown reads from the same plan, so `next in N s` now agrees with when the walker will move.

## Verification

- Five new tests, each confirmed failing first: queue-plays-when-dark, the honest status line, both-empty still says nothing to draw, per-frame dwell holds a stretched run, and mixed-dwell catch-up.
- `npm run test` 2373 passed, `npm run lint` clean, `npm run build` exits 0.
- Not yet verified: Jesse's signed-in eyes on /studio, which is where both symptoms were reported.

## Not fixed here

Sunrise has had nothing on glass for 38 minutes because nothing is advancing that screen. That is an operational question about the sunrise kiosk tab, not a code bug, and this PR only stops the studio from going blank because of it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013pPvtbmZYXMfYtVXoix697
