### PR TITLE
fix(solo): a screen whose frame aged out of the pool advances again

### DIFF
--- a/app/components/solo/useSoloGlass.test.tsx
+++ b/app/components/solo/useSoloGlass.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { renderHook, act } from '@testing-library/react';
-import { useSoloGlass } from './useSoloGlass';
+import { RETRY_MS, STATE_REFRESH_MS, useSoloGlass } from './useSoloGlass';
 import { dialsFrom, SOLO_SETTINGS_SCHEMA } from '@/app/lib/solo/settingsSchema';
 import { schemaDefaults } from '@/app/lib/settings/schema';
 
@@ -100,5 +100,95 @@ describe('useSoloGlass', () => {
     await advance(20_000);
     expect(result.current.error).toMatch(/500/);
     expect(result.current.current?.snapshotId).toBe(1);
+  });
+  // The 2026-09-06 sunrise wedge: the frame on glass aged out of the pool,
+  // so `current` came back null while the screen row kept its slot. The tab
+  // fell back to slot 1, the server rejected it (400: not near 89437690), and
+  // the hook never tried again. The screen sat dark for 50 minutes with a
+  // full queue.
+  it('recovers the screen slot when nothing is on glass, rather than posting slot 1', async () => {
+    const SLOT = 89437689;
+    fetchMock.mockImplementation(async (url: string, init?: RequestInit) => {
+      const body = init?.body ? JSON.parse(String(init.body)) : undefined;
+      calls.push({ url, body });
+      if (url.includes('/advance')) {
+        return body.slot === SLOT + 1
+          ? { ok: true, json: async () => ({ advanced: true, ...state(2, [3], SLOT + 1) }) }
+          : { ok: false, status: 400, json: async () => ({ error: `slot ${body.slot} is not near ${SLOT + 1}` }) };
+      }
+      return { ok: true, json: async () => state(null, [2], SLOT) };
+    });
+    const { result } = renderHook(() => useSoloGlass({ feed: 'sunrise', dials: D, drive: true, dozing: false }));
+    await flush();
+    expect(result.current.current).toBeNull();
+    // Nothing is on glass, so there is no dwell to wait out: it advances now.
+    await advance(1_000);
+    const posted = calls.filter((c) => c.url.includes('/advance')).map((c) => (c.body as { slot: number }).slot);
+    expect(posted).toEqual([SLOT + 1]);
+    expect(result.current.current?.snapshotId).toBe(2);
+    expect(result.current.error).toBeNull();
+  });
+  it('retries a rejected advance at the next tick instead of latching on the slot', async () => {
+    let attempts = 0;
+    // A server: once the advance lands, the state reflects it.
+    let served = state(1, [2]);
+    fetchMock.mockImplementation(async (url: string, init?: RequestInit) => {
+      calls.push({ url, body: init?.body ? JSON.parse(String(init.body)) : undefined });
+      if (url.includes('/advance')) {
+        attempts += 1;
+        if (attempts === 1) return { ok: false, status: 500, json: async () => ({}) };
+        served = state(2, [3], 1);
+        return { ok: true, json: async () => ({ advanced: true, ...served }) };
+      }
+      return { ok: true, json: async () => served };
+    });
+    const { result } = renderHook(() => useSoloGlass({ feed: 'sunrise', dials: D, drive: true, dozing: false }));
+    await flush();
+    await advance(DWELL_MS + 100);
+    expect(result.current.error).toMatch(/500/);
+    expect(result.current.current?.snapshotId).toBe(1);
+    await advance(STATE_REFRESH_MS);
+    expect(calls.filter((c) => c.url.includes('/advance')).map((c) => c.body)).toEqual([
+      { feed: 'sunrise', slot: 1, version: 'solo' },
+      { feed: 'sunrise', slot: 1, version: 'solo' },
+    ]);
+    expect(result.current.current?.snapshotId).toBe(2);
+    expect(result.current.error).toBeNull();
+  });
+  it('paces retries while the advance keeps failing, and never spins', async () => {
+    fetchMock.mockImplementation(async (url: string, init?: RequestInit) => {
+      calls.push({ url, body: init?.body ? JSON.parse(String(init.body)) : undefined });
+      return url.includes('/advance')
+        ? { ok: false, status: 500, json: async () => ({}) }
+        : { ok: true, json: async () => state(1, [2]) };
+    });
+    renderHook(() => useSoloGlass({ feed: 'sunrise', dials: D, drive: true, dozing: false }));
+    await flush();
+    await advance(DWELL_MS + 100);
+    expect(calls.filter((c) => c.url.includes('/advance'))).toHaveLength(1);
+    // act() flushes a fire's re-arm only when it returns, so walk the clock
+    // in steps; every step is a chance to fire, and the pace bounds the count.
+    const steps = 12;
+    for (let i = 0; i < steps; i += 1) await advance(RETRY_MS / 2);
+    const posts = calls.filter((c) => c.url.includes('/advance')).length;
+    expect(posts).toBeGreaterThanOrEqual(3);
+    expect(posts).toBeLessThanOrEqual(1 + steps / 2 + 1);
+  });
+  it('waits for the next state refresh when the server had nothing to show', async () => {
+    fetchMock.mockImplementation(async (url: string, init?: RequestInit) => {
+      calls.push({ url, body: init?.body ? JSON.parse(String(init.body)) : undefined });
+      // The server accepted the slot but drew nothing: the screen stays where it was.
+      return url.includes('/advance')
+        ? { ok: true, json: async () => ({ advanced: false, ...state(1, [], 0) }) }
+        : { ok: true, json: async () => state(1, [], 0) };
+    });
+    renderHook(() => useSoloGlass({ feed: 'sunrise', dials: D, drive: true, dozing: false }));
+    await flush();
+    await advance(DWELL_MS + 100);
+    expect(calls.filter((c) => c.url.includes('/advance'))).toHaveLength(1);
+    await advance(STATE_REFRESH_MS / 2);
+    expect(calls.filter((c) => c.url.includes('/advance'))).toHaveLength(1);
+    await advance(STATE_REFRESH_MS);
+    expect(calls.filter((c) => c.url.includes('/advance'))).toHaveLength(2);
   });
 });

--- a/app/components/solo/useSoloGlass.ts
+++ b/app/components/solo/useSoloGlass.ts
@@ -5,7 +5,9 @@ import type { EntryView, StateView, ViewEntry } from '@/app/api/kiosk/solo/view'
 import type { Feed } from '@/app/lib/solo/types';
 import type { SoloVersionName } from '@/app/lib/solo/versions';
 
-const STATE_REFRESH_MS = 60_000;
+export const STATE_REFRESH_MS = 60_000;
+/** The least time between two fires of the dwell timer, so a failed advance retries rather than spins. */
+export const RETRY_MS = 5_000;
 
 export interface SoloGlass {
   current: EntryView | null;
@@ -49,7 +51,13 @@ export function useSoloGlass({ feed, drive, dozing, version = 'solo' }: {
   const [view, setView] = useState<StateView | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [tick, setTick] = useState(0);
-  const lastSlotPosted = useRef<number | null>(null);
+  // Set only while an advance is on the wire. It was once the last slot
+  // posted, and that latch never reopened: one rejected post (a 400 for a
+  // screen whose frame had aged out of the pool, 2026-09-06) and the screen
+  // could never advance again without a reload.
+  const inFlight = useRef(false);
+  // The timer may not fire again before this instant, whatever the dwell says.
+  const notBeforeMs = useRef(0);
   const driveRef = useRef(drive);
   const dozingRef = useRef(dozing);
   driveRef.current = drive;
@@ -86,18 +94,26 @@ export function useSoloGlass({ feed, drive, dozing, version = 'solo' }: {
   // know it; deriving it here would duplicate engine logic and drift
   // silently. Re-armed after every fire and whenever the published end moves.
   const endsAtMs = view?.current?.endsAtMs ?? null;
-  const currentSlot = view?.current?.slot ?? null;
+  // The slot belongs to the SCREEN, not to the frame on it: the state view
+  // publishes it as schedule.slot even when `current` is null because the
+  // frame on glass aged out of the pool. Reading it off `current` is what
+  // sent slot 1 for a screen at 89437689.
+  const screenSlot = view?.schedule.slot ?? null;
   useEffect(() => {
-    // No state yet, or a screen with nothing on it: poll rather than guess a
-    // boundary. The state refresh above is what recovers from this.
-    const wait = endsAtMs == null ? STATE_REFRESH_MS : Math.max(1, endsAtMs - Date.now());
+    // No state yet: nothing to post, the state refresh above is what recovers.
+    if (screenSlot == null) return;
+    // Nothing on glass means no dwell to wait out; the server projects from
+    // now in that case too, so advance now.
+    const dueMs = endsAtMs ?? Date.now();
+    const wait = Math.max(1, dueMs - Date.now(), notBeforeMs.current - Date.now());
     const t = setTimeout(async () => {
       // The slot is a counter now, not a function of the clock: the next draw
       // is simply the one after the one on glass. Monotonic per feed, which is
       // what kiosk_draws' (feed, slot) primary key needs.
-      const slot = (currentSlot ?? 0) + 1;
-      if (driveRef.current && !dozingRef.current && lastSlotPosted.current !== slot) {
-        lastSlotPosted.current = slot;
+      const slot = screenSlot + 1;
+      notBeforeMs.current = Date.now() + RETRY_MS;
+      if (driveRef.current && !dozingRef.current && !inFlight.current) {
+        inFlight.current = true;
         try {
           const res = await fetch('/api/kiosk/solo/advance', {
             method: 'POST',
@@ -106,24 +122,31 @@ export function useSoloGlass({ feed, drive, dozing, version = 'solo' }: {
           });
           if (!res.ok) throw new Error(`advance ${res.status}`);
           const v = (await res.json()) as StateView & { advanced: boolean };
+          // The server accepted the slot but the screen did not move (nothing
+          // eligible to draw). The pool only changes when the cron admits, so
+          // asking again before the next state refresh is asking the same
+          // question.
+          if (v.schedule.slot === screenSlot) notBeforeMs.current = Date.now() + STATE_REFRESH_MS;
           setView(v);
           setError(null);
           if (v.next[0]) void preload(v.next[0].imageUrl);
         } catch (e) {
           setError(String(e));
+        } finally {
+          inFlight.current = false;
         }
       }
       setTick((n) => n + 1); // re-arm
     }, wait);
     return () => clearTimeout(t);
-  }, [feed, version, endsAtMs, currentSlot, tick]);
+  }, [feed, version, endsAtMs, screenSlot, tick]);
 
   return {
     current: view?.current?.entry ?? null,
     shownSince: view?.current?.shownSince ?? null,
     endsAtMs,
     next: view?.next[0] ?? null,
-    slot: currentSlot ?? 0,
+    slot: screenSlot ?? 0,
     boundaryMs: endsAtMs ?? Date.now(),
     error,
     queueLength: view?.next.length ?? 0,


### PR DESCRIPTION
## The sunrise screen wedged dark for 50 minutes with a full queue

Opening-night risk (show Fri 2026-09-12). Measured 2026-09-06 ~21:55 PT: sunrise `current: null`, 8 queued, last draw 50 min earlier; sunset advancing normally. A sunrise Chromium tab **was** open on the Pi (34 h uptime, live GPU process), so this is a code bug, not an operational one.

### Root cause (reproduced, not reasoned)

1. The frame on glass (snapshot 164212) aged out of the pool, so `view.ts` resolved `current` to null while the screen row kept slot 89437689 (`schedule.slot` still publishes it).
2. `useSoloGlass` read the slot off `current`, fell back to 0, and posted slot 1.
3. The advance route rejects a slot not within tolerance of stored+1. Reproduced against production with the exact post the tab makes:
   ```
   POST /api/kiosk/solo/advance {"feed":"sunrise","slot":1,"version":"solo2"}
   HTTP 400 {"error":"slot 1 is not near 89437690"}
   ```
4. The hook set `lastSlotPosted` before the fetch and gated on it, so after one rejection it never posted again. A reload was the only way out, and only until the next age-out.

The same latch also wedged a screen whenever a post landed with nothing eligible to draw (`advanced: false` with the same slot), and a failed post with a frame on glass re-armed the timer at 1 ms until the next refresh.

### Fix

- The slot is the **screen's**: read `schedule.slot`, which is published whether or not anything is on glass.
- Nothing on glass means no dwell to wait out: advance now rather than in a minute (the server projects from now in that case too).
- The latch becomes an in-flight flag, so a rejected or failed post retries at the next tick.
- Fires are paced ≥ `RETRY_MS` (5 s) apart so unlatching cannot become a hot loop, and a post the server accepted without moving the screen backs off to the next state refresh.

### Tests

Four new tests in `useSoloGlass.test.tsx`, written failing first: slot recovery with `current` null, retry after a 500, bounded retry pace, and empty-pool backoff. Full suite 2377/2377, lint clean, `next build` passes. Branch is based on the current `origin/main` tip, so the merge result is what was built.

### After merge

`bash scripts/pi/kiosk-doctor.sh --sync --reload` once the deploy builds. The Pi's tabs run the build they loaded; the reload is also what unwedges sunrise right now.

Not touched: PR #161's `GlassPreview.tsx` / `useSoloPreview.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01487senMdzWCs1nDj9zXGFu
