### PR TITLE
feat(studio): show the frames the most-frames cap cuts, greyed and clickable

### DIFF
--- a/app/studio/StudioClient.tsx
+++ b/app/studio/StudioClient.tsx
@@ -7,7 +7,8 @@ import { mergeSettings } from '@/app/lib/settings/schema';
 import { SHARED_NAMESPACE } from '@/app/lib/settings/sharedSchema';
 import { withCaption } from '@/app/lib/solo/captionSchema';
 import { SOLO_VERSIONS, type SoloVersionSpec } from '@/app/lib/solo/versions';
-import { runOf } from '@/app/lib/solo2/run';
+import { capFor, runOf } from '@/app/lib/solo2/run';
+import type { Solo2Dials } from '@/app/lib/solo2/types';
 import { Header } from './Header';
 import { Rail, type RailTab } from './Rail';
 import { DeployHistory } from './DeployHistory';
@@ -85,7 +86,7 @@ export function StudioClient() {
   // solo2's dwell readout reads the camera on glass: the longer run of the two screens.
   const runFrames = solo?.name === 'solo2' && studioDials
     ? Math.max(1, ...[sunset, sunrise].map((s) => (s.server?.current
-      ? runOf(s.server.current.entry, s.server.entries, (studioDials as { cameraRun?: boolean }).cameraRun !== false).length
+      ? runOf(s.server.current.entry, s.server.entries, (studioDials as Solo2Dials).cameraRun !== false, capFor(s.server.current.entry, studioDials as Solo2Dials)).length
       : 0)))
     : 1;
 

--- a/app/studio/solo/EntryRow.tsx
+++ b/app/studio/solo/EntryRow.tsx
@@ -23,7 +23,15 @@ export const MIN_FRAME_PX = 14;
 export interface Run {
   /** The camera's earlier frames, oldest first; the row's own entry plays last. */
   earlier: EntryView[];
-  /** Each frame's even share of the dwell. */
+  /**
+   * The camera's frames older still, which the most-frames cap leaves out
+   * (run.ts `runOf`): oldest first. Drawn dim, so the operator can see what
+   * a higher cap would add — and click them to look.
+   */
+  skipped?: EntryView[];
+  /** The dial that set the cap, for the cut rows' hover text: `most frames, sunset · 8`. */
+  capLabel?: string;
+  /** Each frame's share of the dwell, after the budget rule (plan.ts `fitPlan`). */
   stepS: number;
 }
 
@@ -45,9 +53,12 @@ const clock = (e: EntryView) => formatTime('12h', e.capturedAt, e.timezone, null
  * the newest one in capture order, each its own light box labelled `i/k`
  * with its local time, all inside one bin-coloured border, so a dwell that
  * plays several pictures reads as one box. With `rowS` the row is as tall
- * as the time it gets on glass. Dimming means the frame will not be shown
- * (it is below a floor); a repeat IS shown again, so it keeps full strength
- * and a red tag says so.
+ * as the time it gets on glass. Frames of the camera that the most-frames
+ * cap cuts sit above the run, dimmer still, with a CUT tag: the glass never
+ * plays them, but a click still opens one, which is how an operator decides
+ * whether the cap is too low. Dimming means the frame will not be shown
+ * (it is below a floor, or over the cap); a repeat IS shown again, so it
+ * keeps full strength and a red tag says so.
  */
 export function EntryRow({
   entry: e, feed, place, reason, onGlass = false, repeat = false, role, run, rowS, onClick,
@@ -69,7 +80,8 @@ export function EntryRow({
 }) {
   const scores = scoreLine(e);
   const placeText = [[e.city, e.country].filter(Boolean).join(', '), clock(e)].filter(Boolean).join(' · ');
-  const grouped = !!run && run.earlier.length > 0;
+  const skipped = run?.skipped ?? [];
+  const grouped = !!run && (run.earlier.length > 0 || skipped.length > 0);
   const k = grouped ? run.earlier.length + 1 : 1;
   const title =
     `${e.title} · ${placeText}. Frame ${e.snapshotId}, ${feed} feed` +
@@ -78,6 +90,7 @@ export function EntryRow({
     (!e.eligible ? 'Below the floor dial; not eligible. ' : '') +
     (repeat ? 'Already appears earlier in the queue; this is a repeat showing. ' : '') +
     (grouped ? `The newest of ${k} frames of this camera; the dwell plays all ${k}, oldest first, ${Number(run.stepS.toFixed(1))} s each. ` : '') +
+    (skipped.length > 0 ? `${skipped.length} older frame${skipped.length === 1 ? '' : 's'} over the most-frames cap; the glass skips them. ` : '') +
     `Shown ${e.tally} time${e.tally === 1 ? '' : 's'} today.`;
   const ring = onGlass ? '0 0 0 2px #f5a344' : undefined;
   const stepPx = grouped ? Math.max(MIN_FRAME_PX, run.stepS * PX_PER_S) : undefined;
@@ -112,11 +125,29 @@ export function EntryRow({
   if (!grouped) return main;
 
   return (
-    <div role="group" aria-label={`${e.title}: ${k} frames in one dwell`} style={{
+    <div role="group" aria-label={`${e.title}: ${k} frame${k === 1 ? '' : 's'} in one dwell${skipped.length > 0 ? `, ${skipped.length} cut` : ''}`} style={{
       border: `2px solid ${COLOR[e.bin]}`, borderRadius: 6, padding: 3, marginBottom: 4,
       background: '#0b0e14', boxShadow: ring, display: 'flex', flexDirection: 'column', gap: 3,
       opacity: e.stage.kind === 'underFloor' ? 0.45 : 1,
     }}>
+      {skipped.map((f) => {
+        const t = clock(f) ?? `${Math.max(1, Math.round((e.capturedAt - f.capturedAt) / 60_000))} min earlier`;
+        return (
+          <button key={f.snapshotId} type="button" onClick={() => onClick(f)}
+            title={`${f.title} · ${t}. Frame ${f.snapshotId}, not played: over the ${run.capLabel ?? 'most-frames cap'}. Raise the dial to add it to the run.`}
+            style={{
+              display: 'flex', gap: 5, alignItems: 'center', width: '100%', boxSizing: 'border-box', height: MIN_FRAME_PX,
+              textAlign: 'left', border: `1px dashed ${LIGHT}`, borderRadius: 4, padding: '0 3px', opacity: 0.35,
+              background: '#0e1119', fontFamily: mono, fontSize: 9, color: '#9aa3b2', cursor: 'pointer',
+            }}>
+            {/* eslint-disable-next-line @next/next/no-img-element */}
+            <img src={f.imageUrl} alt="" style={{ height: '100%', aspectRatio: '16/9', objectFit: 'cover', borderRadius: 2, display: 'block' }} />
+            <span style={{ whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>
+              <b style={{ color: '#c3cad6' }}>CUT</b> · {t}
+            </span>
+          </button>
+        );
+      })}
       {run.earlier.map((f, i) => {
         const t = clock(f) ?? `${Math.max(1, Math.round((e.capturedAt - f.capturedAt) / 60_000))} min earlier`;
         return (

--- a/app/studio/solo/FeedColumn.test.tsx
+++ b/app/studio/solo/FeedColumn.test.tsx
@@ -1,5 +1,5 @@
 import { it, expect, vi } from 'vitest';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, within } from '@testing-library/react';
 import { FeedColumn } from './FeedColumn';
 import { dialsFrom, SOLO_SETTINGS_SCHEMA } from '@/app/lib/solo/settingsSchema';
 import { schemaDefaults } from '@/app/lib/settings/schema';
@@ -137,4 +137,34 @@ it('solo2 with the camera run off lists every frame for itself', async () => {
   expect(screen.queryByRole('group')).toBeNull();
   expect(screen.getAllByText('cam1').length).toBeGreaterThan(0);
   expect(screen.getAllByText('cam2').length).toBeGreaterThan(0);
+});
+
+it('solo2 greys out the frames of a camera that the most-frames cap cuts, keeps them clickable, and sizes the run by the budget rule', async () => {
+  const { SOLO_VERSIONS } = await import('@/app/lib/solo/versions');
+  const { SOLO2_SETTINGS_SCHEMA, dialsFrom2 } = await import('@/app/lib/solo2/settingsSchema');
+  // Defaults: dwell 20 s, floor 4 s, most frames sunset 8. Ten frames of one camera: the glass plays the newest 8.
+  const d2 = { ...dialsFrom2(schemaDefaults(SOLO2_SETTINGS_SCHEMA)), ratingFloor: 1 };
+  const at = Date.UTC(2026, 8, 5, 2, 42);
+  const es = Array.from({ length: 10 }, (_, i) => ({
+    ...entry(i + 1, 'sunset', 0.5 + i * 0.01, 7), capturedAt: at - (10 - i) * 60_000, timezone: 'America/Mazatlan',
+  }));
+  const v = buildStateView({ feed: 'sunrise', dials: d2, entries: es, screen: null,
+    nowMs: 0, admitted: { sunset: 0, nonSunset: 0 }, zone: { minDeg: -24, maxDeg: -2 }, version: SOLO_VERSIONS.solo2 });
+  const onSelect = vi.fn();
+  render(<FeedColumn feed="sunrise" server={v} projected={v} liveDials={d2} nowMs={0} version={SOLO_VERSIONS.solo2} onSelect={onSelect} />);
+  const group = screen.getAllByRole('group')[0];
+  // The two oldest are cut and say so; the eight played are numbered 1/8 … 8/8, at the 4 s floor (20 s / 8 = 2.5 s would be under it).
+  expect(group).toHaveTextContent(/CUT.*CUT.*1\/8.*7\/8.*8\/8/s);
+  const cut = within(group).getAllByTitle(/not played/);
+  expect(cut).toHaveLength(2);
+  expect(cut[0].getAttribute('title')).toMatch(/most frames, sunset.*8/);
+  expect(cut[0]).toHaveStyle({ opacity: '0.35' });
+  expect(within(group).getByTitle(/1 of 8 in this dwell, 4 s/)).toBeInTheDocument();
+  expect(group.getAttribute('aria-label')).toBe('cam10: 8 frames in one dwell, 2 cut');
+  // A cut frame is still a way into the pop-up, with every frame of the camera in capture order around it.
+  fireEvent.click(cut[0]);
+  expect(onSelect).toHaveBeenCalledWith(expect.objectContaining({ snapshotId: 1 }), 'sunrise',
+    expect.arrayContaining(Array.from({ length: 10 }, (_, i) => expect.objectContaining({ snapshotId: i + 1 }))));
+  const list = onSelect.mock.calls[0][2].map((e: { snapshotId: number }) => e.snapshotId);
+  expect(list.indexOf(1)).toBeLessThan(list.indexOf(3));
 });

--- a/app/studio/solo/FeedColumn.test.tsx
+++ b/app/studio/solo/FeedColumn.test.tsx
@@ -29,14 +29,16 @@ it('draws the on-glass frame at the top of the queue and keeps queued frames out
   expect(screen.queryByRole('group')).toBeNull();
 });
 
-it('each bin is three labelled stages with counts, even when a stage is empty', () => {
+it('each bin is three labelled stages with counts, even when a stage is empty; a bin the queue emptied says so instead', () => {
   const v = view();
   render(<FeedColumn feed="sunset" server={v} projected={v} liveDials={D} nowMs={5_000} onSelect={vi.fn()} />);
-  // Frame 4 (rating 1.4) is under the sunset floor; nothing rests; both bins render all three labels.
-  expect(screen.getAllByText('IN LINE · 0')).toHaveLength(2);
-  expect(screen.getAllByText('RESTING · 0')).toHaveLength(2);
+  // Frame 4 (rating 1.4) is under the sunset floor; nothing rests; the sunset bin renders all three labels.
+  expect(screen.getByText('IN LINE · 0')).toBeInTheDocument();
+  expect(screen.getByText('RESTING · 0')).toBeInTheDocument();
   expect(screen.getByText('UNDER FLOOR · 1')).toBeInTheDocument();
-  expect(screen.getByText('UNDER FLOOR · 0')).toBeInTheDocument();
+  // The non-sunset bin's only frame (3) is in the queue, so the bin is one line, not three zeros.
+  expect(screen.getByTestId('bin-emptied-non_sunset')).toHaveTextContent('its one frame is in the queue');
+  expect(screen.queryByText('UNDER FLOOR · 0')).toBeNull();
   expect(screen.getByText('rating 1.4 < 3.2')).toBeInTheDocument();
   expect(screen.getByText(/^on glass · shown ×/)).toBeInTheDocument();
 });
@@ -167,4 +169,27 @@ it('solo2 greys out the frames of a camera that the most-frames cap cuts, keeps 
     expect.arrayContaining(Array.from({ length: 10 }, (_, i) => expect.objectContaining({ snapshotId: i + 1 }))));
   const list = onSelect.mock.calls[0][2].map((e: { snapshotId: number }) => e.snapshotId);
   expect(list.indexOf(1)).toBeLessThan(list.indexOf(3));
+});
+
+it('a bin the queue has emptied says so in one line instead of three zero stages', async () => {
+  const { SOLO_VERSIONS } = await import('@/app/lib/solo/versions');
+  const { SOLO2_SETTINGS_SCHEMA, dialsFrom2 } = await import('@/app/lib/solo2/settingsSchema');
+  const d2 = { ...dialsFrom2(schemaDefaults(SOLO2_SETTINGS_SCHEMA)), ratingFloor: 1 };
+  const at = Date.UTC(2026, 8, 5, 2, 42);
+  // Two sunset cameras, both drawn by an 8-deep queue; one non-sunset camera under its floor stays in its bin.
+  const es = [
+    { ...entry(1, 'sunset', 0.8, 7), capturedAt: at, timezone: 'America/Mazatlan' },
+    { ...entry(2, 'sunset', 0.9, 9), capturedAt: at, timezone: 'America/Mazatlan' },
+    { ...entry(3, 'non_sunset', 0.1, 11), capturedAt: at, timezone: 'America/Mazatlan' },
+  ];
+  const v = buildStateView({ feed: 'sunrise', dials: d2, entries: es, screen: null,
+    nowMs: 0, admitted: { sunset: 0, nonSunset: 0 }, zone: { minDeg: -24, maxDeg: -2 }, version: SOLO_VERSIONS.solo2 });
+  render(<FeedColumn feed="sunrise" server={v} projected={v} liveDials={d2} nowMs={0} version={SOLO_VERSIONS.solo2} onSelect={vi.fn()} />);
+  expect(screen.getByTestId('bin-emptied-sunset')).toHaveTextContent('all 2 cameras are in the queue');
+  // Cameras, not draws: the heading still counts the queue's draws.
+  expect(screen.getByText(/Sunset bin · 0 waiting · \d+ queued/)).toBeInTheDocument();
+  expect(screen.queryByTestId('bin-emptied-non_sunset')).toBeNull();
+  // The emptied bin has no stage boxes; the other bin keeps its three.
+  expect(screen.getAllByText(/^IN LINE · /)).toHaveLength(1);
+  expect(screen.getByText('UNDER FLOOR · 1')).toBeInTheDocument();
 });

--- a/app/studio/solo/FeedColumn.tsx
+++ b/app/studio/solo/FeedColumn.tsx
@@ -4,7 +4,9 @@ import { useEffect, useState, type ReactNode } from 'react';
 import type { EntryView, StateView } from '@/app/api/kiosk/solo/view';
 import type { Feed, SoloDials } from '@/app/lib/solo/types';
 import type { SoloVersionSpec } from '@/app/lib/solo/versions';
-import { cameraGroups, representative, runOf } from '@/app/lib/solo2/run';
+import { cameraGroups, capFor, representative, runOf } from '@/app/lib/solo2/run';
+import { fitPlan } from '@/app/lib/solo2/plan';
+import { SOLO2_SETTINGS_SCHEMA } from '@/app/lib/solo2/settingsSchema';
 import type { Solo2Dials } from '@/app/lib/solo2/types';
 import type { Stage } from '@/app/lib/solo/stages';
 import { EntryRow, type Run } from './EntryRow';
@@ -60,8 +62,12 @@ const stageOf = (e: EntryView): StageKind =>
 /** One row of a column: a frame, or a camera (its newest frame with the run it plays first). */
 interface Box { entry: EntryView; run?: Run }
 
-/** The frames a box stands for, in the order the dwell plays them. */
-const framesOf = (b: Box): EntryView[] => [...(b.run?.earlier ?? []), b.entry];
+/** The frames a box stands for, in capture order: the cut ones first, then the run as the dwell plays it. */
+const framesOf = (b: Box): EntryView[] => [...(b.run?.skipped ?? []), ...(b.run?.earlier ?? []), b.entry];
+
+const capDial = (bin: 'sunset' | 'non_sunset') => bin === 'sunset' ? 'runFramesSunset' : 'runFramesOther';
+const capLabelOf = (bin: 'sunset' | 'non_sunset', cap: number) =>
+  `${SOLO2_SETTINGS_SCHEMA.find((k) => k.key === capDial(bin))?.label ?? 'most frames'} · ${cap}`;
 
 const TAPE_OPEN_KEY = 'studio.tape.open';
 
@@ -118,17 +124,35 @@ export function FeedColumn({ feed, server, projected, liveDials, nowMs, version,
   const rowS = d2 ? d2.dwellS : undefined;
   const grouping = !!d2?.cameraRun;
   const all: EntryView[] = [...projected.bins.sunset, ...projected.bins.nonSunset, ...queue];
-  const runFor = (frames: EntryView[]): Run | undefined =>
-    d2 && frames.length > 1 ? { earlier: frames.slice(0, -1), stepS: d2.dwellS / frames.length } : undefined;
+  /**
+   * The run a dwell of `e` plays, as the glass plays it: the same cap and the
+   * same budget rule as solo2/index.tsx, so a box is as tall as its time on
+   * glass — and the frames the cap cuts, so the box also shows what a higher
+   * cap would add. Before this the studio stacked every frame of the camera
+   * and divided the dwell by all of them; the glass was playing the newest 8.
+   */
+  const runFor = (e: EntryView): Run | undefined => {
+    if (!d2) return undefined;
+    const cap = capFor(e, d2);
+    const played = runOf(e, all, true, cap);
+    const playedIds = new Set(played.map((f) => f.snapshotId));
+    const skipped = runOf(e, all, true).filter((f) => !playedIds.has(f.snapshotId));
+    if (played.length <= 1 && skipped.length === 0) return undefined;
+    return { earlier: played.slice(0, -1), skipped, capLabel: capLabelOf(e.bin, cap), stepS: fitPlan(d2, played.length).stepS };
+  };
 
   // The queue: each draw with the run it plays.
-  const queueBoxes: Box[] = queue.map((e) => ({ entry: e, run: grouping ? runFor(runOf(e, all, true)) : undefined }));
+  const queueBoxes: Box[] = queue.map((e) => ({ entry: e, run: grouping ? runFor(e) : undefined }));
   // The bins: every frame for itself, or one box per camera not already in the queue.
   const queuedCameras = new Set(queue.map((e) => e.webcamId));
   const binBoxes: Box[] = grouping
     ? [...cameraGroups([...projected.bins.sunset, ...projected.bins.nonSunset]).values()]
       .filter((frames) => !queuedCameras.has(frames[0].webcamId))
-      .map((frames) => ({ entry: representative(frames), run: runFor(frames) }))
+      .map((frames) => {
+        // The bin's box is the camera's representative; its run is what a dwell of it would play.
+        const entry = representative(frames);
+        return { entry, run: runFor(entry) };
+      })
     : [...projected.bins.sunset, ...projected.bins.nonSunset].map((e) => ({ entry: e }));
   const binOf = (bin: 'sunset' | 'non_sunset') => binBoxes.filter((b) => b.entry.bin === bin);
   const qSun = queue.filter((e) => e.bin === 'sunset').length;

--- a/app/studio/solo/FeedColumn.tsx
+++ b/app/studio/solo/FeedColumn.tsx
@@ -159,12 +159,27 @@ export function FeedColumn({ feed, server, projected, liveDials, nowMs, version,
   const qNon = queue.length - qSun;
   const seen = new Set<number>();
 
+  // How many distinct items of a bin the queue holds: cameras with the run on, frames with it off.
+  const queuedOf = (bin: 'sunset' | 'non_sunset') =>
+    new Set(queue.filter((e) => e.bin === bin).map((e) => (grouping ? e.webcamId : e.snapshotId))).size;
+
   const column = (bin: 'sunset' | 'non_sunset', color: string, title: string, hint: string) => {
     const boxes = binOf(bin);
     const list = boxes.flatMap(framesOf);
+    const queuedHere = queuedOf(bin);
+    const unit = grouping ? 'camera' : 'frame';
+    // A bin the queue has emptied says so in one line. Three `· 0` stages under
+    // a heading that already says `6 queued` read as a broken view (2026-09-06).
+    const emptied = boxes.length === 0 && queuedHere > 0;
     return (
       <Bin color={color} title={`${title} · ${boxes.length} waiting · ${bin === 'sunset' ? qSun : qNon} queued`} hint={hint}>
-        {STAGE_KINDS.map((kind) => {
+        {emptied && (
+          <div data-testid={`bin-emptied-${bin}`} title="Every item of this bin is in the queue on the right, so nothing waits here. A queued item leaves its bin."
+            style={{ fontSize: 10, color, fontFamily: mono, padding: '4px 2px', cursor: 'help' }}>
+            {queuedHere === 1 ? `its one ${unit} is in the queue` : `all ${queuedHere} ${unit}s are in the queue`}
+          </div>
+        )}
+        {!emptied && STAGE_KINDS.map((kind) => {
           const rows = boxes.filter((b) => stageOf(b.entry) === kind);
           return (
             <StageBox key={kind} kind={kind} color={color} count={rows.length}>

--- a/app/studio/solo/Tape.test.tsx
+++ b/app/studio/solo/Tape.test.tsx
@@ -162,3 +162,17 @@ it('with no past and nothing on glass it renders a blank, the seam, and the proj
   expect(screen.getByTestId('tape-next-0')).toBeInTheDocument();
   expect(screen.getByText(/no draws logged yet/)).toBeInTheDocument();
 });
+
+it('a projected dwell shows the frames the cap cut as dim stubs before the run, taking no time of the dwell', () => {
+  const earlier = [entry(7), entry(8)];
+  const skipped = [entry(5), entry(6)];
+  render(<Tape past={[]} current={entry(3)} next={[entry(4)]} nextSequences={[{ earlier, skipped, stepS: 5 }]}
+    pastDials={D} nextDials={D} onSelect={vi.fn()} />);
+  const group = screen.getByTestId('tape-next-0-group');
+  const ids = [...group.querySelectorAll('[data-testid^="tape-next-0"]')].map((n) => n.getAttribute('data-testid'));
+  expect(ids).toEqual(['tape-next-0-cut-5', 'tape-next-0-cut-6', 'tape-next-0-pre-7', 'tape-next-0-pre-8', 'tape-next-0']);
+  expect(screen.getByTestId('tape-next-0-cut-5')).toHaveStyle({ opacity: '0.35' });
+  expect(screen.getByTestId('tape-next-0-cut-5').getAttribute('title')).toMatch(/not played/);
+  // The run's own frames still add up to the dwell: 2 × 5 s + the chosen one's 10 s.
+  expect(screen.getByTestId('tape-next-0')).toHaveStyle({ width: `${20 * PX_PER_S - 2 * 5 * PX_PER_S}px` });
+});

--- a/app/studio/solo/Tape.tsx
+++ b/app/studio/solo/Tape.tsx
@@ -21,6 +21,8 @@ export const THUMB_H = 48;
 const PLAYHEAD_ANIM = 'tape-playhead';
 /** A block never draws narrower than this, whatever its time says. */
 const MIN_BLOCK_PX = 14;
+/** A frame the cap cut takes no time on glass, so its stub has a fixed width that stands for none. */
+const CUT_STUB_PX = 8;
 /** A past frame that stayed on glass longer than this many dwells was held (nothing else eligible). */
 const HELD_AFTER = 1.5;
 /** …and its block is capped here so one long hold does not push everything off screen. */
@@ -35,8 +37,8 @@ const clock = (ms: number) => new Date(ms).toLocaleTimeString([], { hour: 'numer
 const place = (f: { city: string; country: string }) => [f.city, f.country].filter(Boolean).join(', ');
 const secs = (s: number) => `${Number.isInteger(s) ? s : s.toFixed(1)} s`;
 
-function Thumb({ testId, src, color, width, dashed = false, ring = false, repeat = false, title, onClick, children }: {
-  testId: string; src: string; color: string; width: number; dashed?: boolean; ring?: boolean; repeat?: boolean;
+function Thumb({ testId, src, color, width, dashed = false, dim = false, ring = false, repeat = false, title, onClick, children }: {
+  testId: string; src: string; color: string; width: number; dashed?: boolean; dim?: boolean; ring?: boolean; repeat?: boolean;
   title: string; onClick?: () => void; children?: ReactNode;
 }) {
   return (
@@ -44,7 +46,7 @@ function Thumb({ testId, src, color, width, dashed = false, ring = false, repeat
       flex: 'none', width, height: THUMB_H, padding: 0, background: '#000', cursor: onClick ? 'pointer' : 'default',
       borderWidth: 1.5, borderStyle: dashed ? 'dashed' : 'solid', borderColor: color, borderTopColor: repeat ? REPEAT : color,
       borderTopWidth: repeat ? 3 : 1.5, borderRadius: 3, boxShadow: ring ? RING : undefined, boxSizing: 'border-box',
-      position: 'relative', overflow: 'hidden',
+      position: 'relative', overflow: 'hidden', opacity: dim ? 0.35 : 1,
     }}>
       {/* eslint-disable-next-line @next/next/no-img-element */}
       <img src={src} alt="" style={{ width: '100%', height: '100%', objectFit: 'cover', display: 'block' }} />
@@ -106,8 +108,9 @@ function Playhead({ sinceMs, endsAtMs, nowMs }: { sinceMs: number | null; endsAt
  * else was eligible, reads as a wide block); the frame on glass wears the
  * orange ring; a seam separates fact from the projection, whose blocks are
  * dashed and one dwell wide. A crossfade is an orange X straddling the cut,
- * as wide as the fade dial. A solo2 dwell with a prelude shows its earlier
- * frames as narrow sub-blocks before the chosen one. A frame already seen
+ * as wide as the fade dial. A solo2 dwell with a camera run shows its earlier
+ * frames as narrow sub-blocks before the chosen one, and the frames the
+ * most-frames cap cut as dim stubs before those. A frame already seen
  * earlier on the strip carries a red top edge, the REPEAT tag's colour. When
  * nothing is on glass the seam is preceded by a black blank. Scrolls
  * sideways; on mount and whenever the past grows, the seam is brought to
@@ -229,9 +232,15 @@ export function Tape({ past, current, currentSince, currentEndsAt, next, nextSeq
     const mainWidth = Math.max(MIN_BLOCK_PX, total - (seq?.earlier.length ?? 0) * stepPx);
     const title = `draw ${i + 1} · ${e.title}${place(e) ? ` · ${place(e)}` : ''}`
       + (seq && seq.earlier.length > 0 ? ` · after ${seq.earlier.length} earlier frame${seq.earlier.length === 1 ? '' : 's'} of this camera, ${secs(seq.stepS)} each` : '');
-    if (seq && seq.earlier.length > 0) {
+    const cut = seq?.skipped ?? [];
+    if (seq && (seq.earlier.length > 0 || cut.length > 0)) {
       blocks.push(
         <div key={`next-${i}`} data-testid={`tape-next-${i}-group`} style={{ flex: 'none', display: 'flex', gap: 1 }}>
+          {/* Cut by the most-frames cap: no time on the strip, only a dim stub so the operator sees what a higher cap adds. */}
+          {cut.map((f) => (
+            <Thumb key={`cut-${f.snapshotId}`} testId={`tape-next-${i}-cut-${f.snapshotId}`} src={f.imageUrl} width={CUT_STUB_PX} color="#2a3242" dashed dim
+              title={`not played · ${f.title} · over the ${seq.capLabel ?? 'most-frames cap'}`} onClick={() => onSelect(f)} />
+          ))}
           {seq.earlier.map((f) => (
             <Thumb key={f.snapshotId} testId={`tape-next-${i}-pre-${f.snapshotId}`} src={f.imageUrl} width={stepPx} color="#2a3242" dashed
               title={`run · ${f.title} · ${secs(seq.stepS)}`} />


### PR DESCRIPTION
## What

With solo2's camera run on, the studio's queue rows, bin boxes and tape stacked **every** frame of a camera, while the glass (and the playing preview) play only the newest `most frames` (8 sunset / 3 non-sunset). Jesse saw sunsets in the studio that never reached the glass and could not tell which.

Now a camera box shows the frames the cap cuts **above** the run, at 35% with a dashed border and a `CUT` tag, at the minimum row height (they take no glass time). They stay clickable and sit in the column's pop-up list, so ←/→ steps through them. The played frames number `1/8 … 8/8`. The hover text names the dial and its value (`most frames, sunset · 8`).

Also fixed on the way, same cause:
- **Row height is the budget rule now** (`fitPlan`), not `dwell / all frames`. A stretched 8-frame run is as tall in the queue as it is long on glass.
- **Tape** draws the cut frames as dim 8 px stubs before the run's sub-blocks; the run's widths still sum to the dwell.
- **Rail dwell readout** (`N frames × S s`) counts the capped run, matching the glass.

## Files

`app/studio/solo/FeedColumn.tsx` (cap-aware `runFor`), `EntryRow.tsx` (`Run.skipped`, `capLabel`, cut rows), `Tape.tsx` (stubs), `StudioClient.tsx` (readout cap).

## Verification

- vitest: 2379 passed, including two new tests (10-frame camera at cap 8 → 2 cut rows, click reports frame 1 with all 10 in capture order; tape stub order and dwell width).
- lint clean for the touched files. `tsc` errors are the pre-existing jest-dom matcher noise in test files, none in touched files.
- **Not done:** a signed-in look at /studio on a solo2 profile with camera run on. Jesse to eyeball.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KysULmTcELT6df7bPMuWRV
