### PR TITLE
fix(solo): the cron admits every scored non-sunset; the studio dial is the one gate

### DIFF
--- a/app/api/cron/update-cameras/lib/binAdmission.test.ts
+++ b/app/api/cron/update-cameras/lib/binAdmission.test.ts
@@ -23,7 +23,7 @@ vi.mock('@/app/lib/solo/store', () => ({
   pruneDraws: (...a: unknown[]) => pruneDraws(...a),
 }));
 
-import { decideBin, enterBins, maintainBins, BIN_ADMIT_DETECTION_FLOOR } from './binAdmission';
+import { decideBin, enterBins, maintainBins } from './binAdmission';
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -33,16 +33,20 @@ beforeEach(() => {
   removeStale.mockResolvedValue({ leftZone: 0, expired: 0 });
 });
 
-describe('decideBin (fixed cron floors, spec §5.3)', () => {
+describe('decideBin (the studio dial is the only non-sunset gate)', () => {
   it('detection verdict first: a sunset enters the sunset bin whatever its probability looks like', () => {
     expect(decideBin({ binaryIsSunset: true, binaryRawScore: 0.56 })).toBe('sunset');
   });
-  it('a non-sunset at or above the floor enters the non-sunset bin', () => {
-    expect(decideBin({ binaryIsSunset: false, binaryRawScore: BIN_ADMIT_DETECTION_FLOOR })).toBe('non_sunset');
+  it('every scored non-sunset enters the non-sunset bin, a dark frame at 0 included', () => {
+    // The cron used to hold a fixed 0.2 floor. The studio dial could only
+    // narrow from it, so lowering the dial past 0.2 changed nothing and the
+    // sunrise bin sat on two frames while New Zealand scored 0.00 (2026-09-07).
+    expect(decideBin({ binaryIsSunset: false, binaryRawScore: 0.19 })).toBe('non_sunset');
+    expect(decideBin({ binaryIsSunset: false, binaryRawScore: 0 })).toBe('non_sunset');
   });
-  it('below the floor, or with no binary verdict, nothing', () => {
-    expect(decideBin({ binaryIsSunset: false, binaryRawScore: 0.19 })).toBeNull();
+  it('with no binary verdict, nothing', () => {
     expect(decideBin({})).toBeNull();
+    expect(decideBin({ binaryIsSunset: false })).toBeNull();
   });
 });
 

--- a/app/api/cron/update-cameras/lib/binAdmission.ts
+++ b/app/api/cron/update-cameras/lib/binAdmission.ts
@@ -16,20 +16,21 @@ import type { BinKind, Feed } from '@/app/lib/solo/types';
 /**
  * Solo kiosk admission and maintenance, spec §5.3. Runs inside the cron tick.
  *
- * The cron floors are FIXED and generous. The studio dials only narrow from
- * here, so the cron never chases a dial and a dial change is visible within
- * one poll instead of one cron tick.
+ * The cron does not gate non-sunsets by probability: every scored frame in
+ * a feed's zone enters a bin, and the studio's sunset-probability floor dial
+ * is the one gate. A dial change is visible within one poll instead of one
+ * cron tick, and the dial can WIDEN the bin as well as narrow it. Until
+ * 2026-09-07 the cron held a fixed 0.2 floor here and the dial could only
+ * narrow from it, so lowering the dial past 0.2 changed nothing while the
+ * sunrise bin sat on two frames and every New Zealand camera scored 0.00.
  */
-export const BIN_ADMIT_DETECTION_FLOOR = 0.2;
 const MAX_ENTRY_AGE_HOURS = 24;
 const FEEDS: Feed[] = ['sunrise', 'sunset'];
 
-/** Detection verdict first, then the probability floor. Null = not for the bins. */
+/** Detection verdict first, then any scored non-sunset. Null = not scored, so not for the bins. */
 export function decideBin(scored: { binaryIsSunset?: boolean; binaryRawScore?: number }): BinKind | null {
   if (scored.binaryIsSunset === true) return 'sunset';
-  if (typeof scored.binaryRawScore === 'number' && scored.binaryRawScore >= BIN_ADMIT_DETECTION_FLOOR) {
-    return 'non_sunset';
-  }
+  if (typeof scored.binaryRawScore === 'number') return 'non_sunset';
   return null;
 }
 

--- a/app/lib/solo/settingsSchema.ts
+++ b/app/lib/solo/settingsSchema.ts
@@ -58,7 +58,7 @@ export const SOLO_SETTINGS_SCHEMA: SettingsSchema = [
   {
     key: 'detectionFloor', kind: 'number', min: 0, max: 1, step: 0.05, default: 0.3,
     label: 'sunset-probability floor (non-sunsets)', section: 'bins',
-    description: 'A non-sunset frame needs at least this probability of being a sunset (0–1) to be eligible. Raise it to shrink that bin.',
+    description: 'A non-sunset frame needs at least this probability of being a sunset (0–1) to be eligible. This is the only gate: the cron admits every scored frame in the zone, so 0 shows every camera in the window, dark ones included. Raise it to shrink that bin.',
   },
   {
     key: 'sunsetFloor', kind: 'number', min: 0, max: 12, step: 1, default: 6,

--- a/docs/superpowers/specs/2026-09-04-solo-kiosk-design.md
+++ b/docs/superpowers/specs/2026-09-04-solo-kiosk-design.md
@@ -188,12 +188,16 @@ for a feed:
 
 - If `ai_binary_is_sunset` → upload, insert the archive row with
   `intake_reason = 'kiosk_bin'`, enter the **sunset bin**.
-- Else if `ai_binary_score ≥ 0.20` → same, enter the **non-sunset bin**.
-- Else → discard as today.
+- Else if it has an `ai_binary_score` → same, enter the **non-sunset bin**.
+- Else (never scored) → discard as today.
 
-The cron floors are **fixed and generous**. The studio dials only narrow from
-there, so the cron never chases a dial and a dial change is visible within
-one poll instead of one cron tick. A frame already persisted for another
+  Until 2026-09-07 the second rule held a fixed 0.20 floor. It came out
+  because the studio dial could only narrow from it: lowering the dial past
+  0.20 changed nothing while the sunrise bin sat on two frames.
+
+The cron holds no probability floor. The studio dial is the one gate, so
+the cron never chases a dial and a dial change is visible within one poll
+instead of one cron tick, widening the bin as readily as narrowing it. A frame already persisted for another
 reason (disagreement, high rated, trickle) is entered without a second
 upload. The `intake_reason` CHECK constraint gains `'kiosk_bin'`.
 
@@ -355,7 +359,7 @@ Phases 1–4 are wanted before the freeze on 2026-09-10.
   non-sunsets; rule 4 with a single eligible frame; promotion flag clears on
   first showing; tier ties broken by tally then `entered_at`.
 - Admission: a frame the detection head calls a sunset enters the sunset bin
-  regardless of quality; a frame below 0.20 detection is not persisted for
+  regardless of quality; every scored non-sunset in the zone is persisted for
   the bin; a frame already persisted for disagreement is entered without a
   second upload; a second frame from a camera already in the bin is `is_new`.
 - Removal: absence from a poll does not touch the entry; out-of-zone


### PR DESCRIPTION
## Why

The sunrise screen looped Ipikel and Amundsen-Scott every 15 s while the globe showed New Zealand and Australia cameras in the window. Those cameras were captured and scored (0.000–0.046) but never entered the pool: the cron held a fixed 0.2 sunset-probability floor, and the studio's floor dial could only narrow from it. Lowering the dial past 0.2 changed nothing.

## What

- `decideBin` admits every scored non-sunset in a feed's zone. The studio dial is the one gate and can now widen the bin as well as narrow it.
- The dial's description says it is the only gate and that 0 shows every camera in the window, dark ones included.
- The solo kiosk spec's admission rule updated to match.

No migration. No dial default changes: the dial sits at 0.3 until you lower it, so nothing on the glass changes at deploy.

## Test plan

After deploy, in /studio lower **sunset-probability floor** on the solo2 rail toward 0.05 and watch the sunrise bin fill over the next cron ticks. Then measure:

- Pool size: `select count(*), count(distinct webcam_id) from kiosk_bin_entries where removed_at is null` (95 entries / 36 cameras before).
- Extra uploads: `select count(*) from webcam_snapshots where intake_reason = 'kiosk_bin' and created_at > now() - interval '1 day'` (about 1,000/day before). In the last 24 h, 4,876 of the 4,951 under-floor frames were already archived for disagreement, so the added storage should be small, but this is the number to check.
- Decide whether pure night frames belong on the glass, and raise the dial if not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HrGBktZbFk2vfXh5DN9WSV
