### PR TITLE
feat(sweep): move the terminator ring from -13 to -5 degrees

### DIFF
--- a/app/api/cron/update-cameras/lib/dailyDigest.test.ts
+++ b/app/api/cron/update-cameras/lib/dailyDigest.test.ts
@@ -246,13 +246,13 @@ function summaryWithDayRing(): SweepDigestSummary {
 
 describe('sweptAltitudeSpan', () => {
   it('is the base ring alone when nothing escalated', () => {
-    expect(sweptAltitudeSpan([ringStat(0)])).toEqual({ min: -24, max: -2 });
+    expect(sweptAltitudeSpan([ringStat(0)])).toEqual({ min: -16, max: 6 });
   });
 
-  it('reaches golden hour once the day-side ring ran', () => {
+  it('reaches into daylight once the day-side ring ran', () => {
     expect(sweptAltitudeSpan([ringStat(0), ringStat(15.75)])).toEqual({
-      min: -24,
-      max: 13.75,
+      min: -16,
+      max: 21.75,
     });
   });
 
@@ -306,7 +306,7 @@ describe('formatSweepLine', () => {
   });
 
   it('prints the swept altitude span in degrees, not ring offsets', () => {
-    expect(formatSweepLine(summaryWithDayRing())).toContain('-24° to +14°');
+    expect(formatSweepLine(summaryWithDayRing())).toContain('-16° to +22°');
   });
 
   it('shows a partial-escalation ring share against the base ring\'s ticks, not just the full-day hull', () => {

--- a/app/api/cron/update-cameras/lib/sweepGeometry.test.ts
+++ b/app/api/cron/update-cameras/lib/sweepGeometry.test.ts
@@ -15,21 +15,21 @@ beforeEach(() => {
 
 describe('sweptZone', () => {
   it('is the base ring alone when only the base ring swept', () => {
-    expect(sweptZone([0])).toEqual({ minDeg: -24, maxDeg: -2 });
+    expect(sweptZone([0])).toEqual({ minDeg: -16, maxDeg: 6 });
   });
 
   it('includes every ring that swept this tick, escalations included', () => {
     // The 2026-09-05 sunrise bug: the sweep escalated to +15.75 for a thin
     // sunrise feed and admitted golden-hour cameras at +1..+11, but the
-    // removal zone counted only the guaranteed rings (-24..-2), so every one
-    // of them was evicted three ticks later. Admission and removal must read
-    // the same band.
-    expect(sweptZone([0, 15.75, -15.75])).toEqual({ minDeg: -39.75, maxDeg: 13.75 });
+    // removal zone counted only the guaranteed rings (then -24..-2), so every
+    // one of them was evicted three ticks later. Admission and removal must
+    // read the same band.
+    expect(sweptZone([0, 15.75, -15.75])).toEqual({ minDeg: -31.75, maxDeg: 21.75 });
   });
 
   it('always contains the base ring, even if telemetry omitted it', () => {
-    expect(sweptZone([15.75])).toEqual({ minDeg: -24, maxDeg: 13.75 });
-    expect(sweptZone([])).toEqual({ minDeg: -24, maxDeg: -2 });
+    expect(sweptZone([15.75])).toEqual({ minDeg: -16, maxDeg: 21.75 });
+    expect(sweptZone([])).toEqual({ minDeg: -16, maxDeg: 6 });
   });
 });
 
@@ -46,20 +46,19 @@ describe('coverageSpan', () => {
 describe('sweepGeometry', () => {
   it('records the base ring alone when nothing is forced', () => {
     const g = sweepGeometry([]);
-    expect(g.baseAltitudeDeg).toBe(-13);
+    expect(g.baseAltitudeDeg).toBe(-5);
     expect(g.searchRadiusDeg).toBe(11);
     expect(g.forcedOffsetsDeg).toBe('');
-    expect(g.coverageMinDeg).toBe(-24);
-    expect(g.coverageMaxDeg).toBe(-2);
+    expect(g.coverageMinDeg).toBe(-16);
+    expect(g.coverageMaxDeg).toBe(6);
   });
 
-  it('widens the recorded coverage to golden hour when the day ring is forced', () => {
-    // This is the number the whole measurement is about: the guaranteed pool
-    // has to contain 0 to +6 degrees, where 19.7% of frames are good, versus
-    // 1.0% at the base ring.
+  it('widens the recorded coverage into daylight when the day ring is forced', () => {
+    // The base ring covers the quality peak on its own since 2026-09-07; a
+    // forced day ring extends the guaranteed band, and the record says so.
     const g = sweepGeometry([15.75]);
-    expect(g.coverageMinDeg).toBe(-24);
-    expect(g.coverageMaxDeg).toBe(13.75);
+    expect(g.coverageMinDeg).toBe(-16);
+    expect(g.coverageMaxDeg).toBe(21.75);
   });
 
   it('gives different configurations different signatures', () => {

--- a/app/api/cron/update-cameras/lib/sweepGeometry.ts
+++ b/app/api/cron/update-cameras/lib/sweepGeometry.ts
@@ -9,8 +9,9 @@ import {
  * The ring angles a tick actually ran with.
  *
  * Stored beside the counters because offset_deg alone is not a fact about the
- * sky. +15.75 means +2.75 degrees of solar altitude only while the base ring
- * is at -13, and this configuration is expected to move. Without this record,
+ * sky. +15.75 meant +2.75 degrees of solar altitude while the base ring was
+ * at -13 and means +10.75 now that it is at -5; it moved once on 2026-09-07
+ * and is expected to move again. Without this record,
  * comparing a day of counters against a day from before a change silently
  * compares two different experiments.
  */

--- a/app/api/cron/update-cameras/lib/terminatorSweep.ts
+++ b/app/api/cron/update-cameras/lib/terminatorSweep.ts
@@ -78,10 +78,10 @@ export interface SweepOptions {
    *
    * The floor-based trigger asks "is a panel too empty to look at". This asks
    * a different question: "does the pool reach the altitudes where sunsets
-   * actually happen". Good frames peak at 0 to +6 degrees solar altitude and
-   * the base ring at -13 never sees them, so the day-side ring is worth
-   * paying for even when nothing is thin. Additive to the floor trigger,
-   * never a replacement for it.
+   * actually happen". Written when the base ring sat at -13 and missed the
+   * -10..+8 quality peak entirely; since the ring moved to -5 on 2026-09-07
+   * the base ring covers the peak and this is a plain widener. Additive to
+   * the floor trigger, never a replacement for it.
    *
    * Empty or absent means today's behaviour exactly.
    */

--- a/app/api/cron/update-cameras/route.test.ts
+++ b/app/api/cron/update-cameras/route.test.ts
@@ -652,7 +652,7 @@ describe('GET /api/cron/update-cameras', () => {
       forcedOffsetsDeg: '',
     });
     expect(maintainBinsMock).toHaveBeenCalledWith(
-      expect.objectContaining({ zone: { minDeg: -24, maxDeg: -2 } }),
+      expect.objectContaining({ zone: { minDeg: -16, maxDeg: 6 } }),
     );
   });
 
@@ -669,7 +669,7 @@ describe('GET /api/cron/update-cameras', () => {
     const res = await GET(makeReq());
     expect(res.status).toBe(200);
     expect(maintainBinsMock).toHaveBeenCalledWith(
-      expect.objectContaining({ zone: { minDeg: -39.75, maxDeg: 13.75 } }),
+      expect.objectContaining({ zone: { minDeg: -31.75, maxDeg: 21.75 } }),
     );
   });
 

--- a/app/api/cron/update-cameras/route.ts
+++ b/app/api/cron/update-cameras/route.ts
@@ -130,11 +130,10 @@ export async function GET(req: Request) {
     classify: classifyWebcamsByPhase,
     floor: TERMINATOR_CAMERA_FLOOR,
     offsets: TERMINATOR_WIDEN_OFFSETS_DEG,
-    // Phase 1 of the pool-coverage spec: force the golden-hour ring so the
-    // pool reaches 0 to +6 degrees, where good frames actually are, instead
-    // of only the -24 to -2 band the base ring covers. Roughly doubles Windy
-    // boxes per tick, which is the cost the measurement window exists to
-    // price.
+    // Phase 1 of the pool-coverage spec: force the day-side ring every tick.
+    // Written when the base ring sat at -13 and missed the quality peak; the
+    // base ring covers the peak itself since 2026-09-07, so the switch is now
+    // a plain camera-count widener. Roughly doubles Windy boxes per tick.
     forcedOffsets,
     // Escalation rings are the first thing sacrificed on a slow tick: the
     // scoring loop below needs the remaining budget more than the pool needs

--- a/app/api/kiosk/solo/advance/route.test.ts
+++ b/app/api/kiosk/solo/advance/route.test.ts
@@ -49,10 +49,10 @@ afterEach(() => {
 describe('POST /api/kiosk/solo/advance', () => {
   it('echoes the zone the cron last aged entries against, falling back to the guaranteed rings', async () => {
     expect((await (await post({ feed: 'sunrise', slot: 0 })).json()).zone)
-      .toEqual({ minDeg: -24, maxDeg: -2 });
-    getSweptZone.mockResolvedValue({ minDeg: -39.75, maxDeg: 13.75 });
+      .toEqual({ minDeg: -16, maxDeg: 6 });
+    getSweptZone.mockResolvedValue({ minDeg: -31.75, maxDeg: 21.75 });
     expect((await (await post({ feed: 'sunrise', slot: 0 })).json()).zone)
-      .toEqual({ minDeg: -39.75, maxDeg: 13.75 });
+      .toEqual({ minDeg: -31.75, maxDeg: 21.75 });
   });
   it('rejects bad bodies', async () => {
     expect((await post({})).status).toBe(400);

--- a/app/api/kiosk/solo/state/route.test.ts
+++ b/app/api/kiosk/solo/state/route.test.ts
@@ -86,7 +86,7 @@ describe('GET /api/kiosk/solo/state', () => {
     expect(res.status).toBe(200);
     const body = await res.json();
     expect(body.dials.dwellS).toBe(30);
-    expect(body.zone).toEqual({ minDeg: -24, maxDeg: -2 });
+    expect(body.zone).toEqual({ minDeg: -16, maxDeg: 6 });
     expect(requireOwner).not.toHaveBeenCalled();
   });
   it('studio profile is owner-gated and projects with studio dials', async () => {

--- a/app/components/mosaic/v2/engine/horizontalPlace.test.ts
+++ b/app/components/mosaic/v2/engine/horizontalPlace.test.ts
@@ -48,12 +48,12 @@ describe('altitudeToUnit — direction per feed', () => {
 
 describe('altitudeToUnit — clamping', () => {
   it('clamps a sun outside the window to the edge, never past it', () => {
-    // The widening rings sweep near +2.75 and -28.75, both outside the window.
+    // The widening rings sweep near +10.75 and -20.75, both outside the window.
     // They belong at an edge; they must not compute a position off the panel.
-    expect(altitudeToUnit(2.75, -24, -2, 'sunset')).toBe(0);
-    expect(altitudeToUnit(-28.75, -24, -2, 'sunset')).toBe(1);
-    expect(altitudeToUnit(2.75, -24, -2, 'sunrise')).toBe(1);
-    expect(altitudeToUnit(-28.75, -24, -2, 'sunrise')).toBe(0);
+    expect(altitudeToUnit(10.75, -16, 6, 'sunset')).toBe(0);
+    expect(altitudeToUnit(-20.75, -16, 6, 'sunset')).toBe(1);
+    expect(altitudeToUnit(10.75, -16, 6, 'sunrise')).toBe(1);
+    expect(altitudeToUnit(-20.75, -16, 6, 'sunrise')).toBe(0);
   });
 });
 

--- a/app/components/mosaic/v3/engine/axis.test.ts
+++ b/app/components/mosaic/v3/engine/axis.test.ts
@@ -4,29 +4,29 @@ import { TERMINATOR_POOL_COVERAGE_DEG, TERMINATOR_SUN_ALTITUDE_DEG } from '@/app
 import { V3_SETTINGS_SCHEMA } from '../settingsSchema';
 import type { SizedTile } from './types';
 
-const cfg: AxisConfig = { axisNightEdgeDeg: -24, axisDayEdgeDeg: -2 };
+const cfg: AxisConfig = { axisNightEdgeDeg: -16, axisDayEdgeDeg: 6 };
 
 const sized = (over: Partial<SizedTile> = {}): SizedTile => ({
   id: 1, lat: 0, lng: 0, srcWidth: 400, srcHeight: 224,
-  passes: true, score: 0.8, sunAltitudeDeg: -13,
+  passes: true, score: 0.8, sunAltitudeDeg: -5,
   width: 200, height: 112, pinnedToFloor: false,
   ...over,
 });
 
 describe('altitudeToUnit', () => {
   it('puts the pool ring at the centre of the panel on both feeds', () => {
-    expect(altitudeToUnit(-13, cfg, 'sunset')).toBeCloseTo(0.5, 6);
-    expect(altitudeToUnit(-13, cfg, 'sunrise')).toBeCloseTo(0.5, 6);
+    expect(altitudeToUnit(-5, cfg, 'sunset')).toBeCloseTo(0.5, 6);
+    expect(altitudeToUnit(-5, cfg, 'sunrise')).toBeCloseTo(0.5, 6);
   });
 
   it('puts the day side on the LEFT for sunset and the RIGHT for sunrise', () => {
     // Spec §3: west stays on the left, so the day edge swaps between feeds.
-    expect(altitudeToUnit(-2, cfg, 'sunset')).toBeCloseTo(0, 6);
-    expect(altitudeToUnit(-2, cfg, 'sunrise')).toBeCloseTo(1, 6);
+    expect(altitudeToUnit(6, cfg, 'sunset')).toBeCloseTo(0, 6);
+    expect(altitudeToUnit(6, cfg, 'sunrise')).toBeCloseTo(1, 6);
   });
 
   it('clamps altitudes outside the window to an edge rather than widening it', () => {
-    expect(altitudeToUnit(10, cfg, 'sunrise')).toBe(1);
+    expect(altitudeToUnit(20, cfg, 'sunrise')).toBe(1);
     expect(altitudeToUnit(-90, cfg, 'sunrise')).toBe(0);
   });
 
@@ -35,7 +35,7 @@ describe('altitudeToUnit', () => {
   });
 
   it('degenerates to the centre rather than dividing by zero', () => {
-    expect(altitudeToUnit(-13, { axisNightEdgeDeg: -2, axisDayEdgeDeg: -2 }, 'sunset')).toBe(0.5);
+    expect(altitudeToUnit(-5, { axisNightEdgeDeg: 6, axisDayEdgeDeg: 6 }, 'sunset')).toBe(0.5);
   });
 });
 
@@ -48,8 +48,8 @@ describe('tileX', () => {
 
   it('keeps a tile inside the panel at both edges', () => {
     const wide = sized({ width: 900 });
-    expect(tileX({ ...wide, sunAltitudeDeg: -2 }, 1080, cfg, 'sunset')).toBe(0);
-    expect(tileX({ ...wide, sunAltitudeDeg: -24 }, 1080, cfg, 'sunset')).toBe(180);
+    expect(tileX({ ...wide, sunAltitudeDeg: 6 }, 1080, cfg, 'sunset')).toBe(0);
+    expect(tileX({ ...wide, sunAltitudeDeg: -16 }, 1080, cfg, 'sunset')).toBe(180);
   });
 
   it('parks an unknown moment at the centre instead of an edge', () => {
@@ -61,9 +61,9 @@ describe('tileX', () => {
     // Documents the real relationship the centre-line overlay relies on:
     // tileCentre = unit * W + w * (0.5 - unit). An earlier comment claimed the
     // two always coincide; they coincide only at unit 0.5.
-    const offCentre: AxisConfig = { axisNightEdgeDeg: -24, axisDayEdgeDeg: -6 };
-    const unit = altitudeToUnit(-13, offCentre, 'sunrise');
-    const t = sized({ sunAltitudeDeg: -13, width: 200 });
+    const offCentre: AxisConfig = { axisNightEdgeDeg: -16, axisDayEdgeDeg: 2 };
+    const unit = altitudeToUnit(-5, offCentre, 'sunrise');
+    const t = sized({ sunAltitudeDeg: -5, width: 200 });
     const line = unit * 1080;
     const tileCentre = tileX(t, 1080, offCentre, 'sunrise') + t.width / 2;
     expect(unit).toBeCloseTo(11 / 18, 6);

--- a/app/components/mosaic/v3/engine/realPool.test.ts
+++ b/app/components/mosaic/v3/engine/realPool.test.ts
@@ -104,11 +104,17 @@ describe('the real pool, on the real axis', () => {
     // 13 x 480 drew 5 / evicted 37 here and showed 1 of the 4 real sunsets;
     // 8 x 240 (decided 2026-09-03) shows 3 of 4. Update these numbers when
     // the dials move again.
+    //
+    // Ring moved to -5 on 2026-09-07 (axis now -16..+6). This fixture was
+    // captured under the old -24..-2 ring, so a third of its cameras sit
+    // below the new night edge, clamp onto it and collide: 7 drawn / 35
+    // evicted, 2 of the 4 real sunsets. A drift tripwire only; recapture
+    // the fixture from the new ring before reading these as a tuning result.
     const layout = compose(sunset, viewport, cfg, 'sunset');
-    expect(layout.tiles.length).toBe(8);
-    expect(layout.evicted.length).toBe(34);
-    expect(layout.tiles.filter((t) => t.passes).length).toBe(3);
-    expect(compose(sunrise, viewport, cfg, 'sunrise').tiles.length).toBe(9);
+    expect(layout.tiles.length).toBe(7);
+    expect(layout.evicted.length).toBe(35);
+    expect(layout.tiles.filter((t) => t.passes).length).toBe(2);
+    expect(compose(sunrise, viewport, cfg, 'sunrise').tiles.length).toBe(8);
   });
 
   it('keeps every drawn tile inside the panel horizontally', () => {

--- a/app/components/mosaic/v3/overlays/CentreLine.tsx
+++ b/app/components/mosaic/v3/overlays/CentreLine.tsx
@@ -5,8 +5,8 @@ import { altitudeToUnit, type AxisConfig } from '../engine/axis';
  * The terminator zone made visible.
  *
  * Screen centre is the POOL's ring at TERMINATOR_SUN_ALTITUDE_DEG, not the
- * geometric terminator at 0 degrees — zero is outside the window today and
- * clamps (spec §3).
+ * geometric terminator at 0 degrees. Zero is inside the window since the
+ * ring moved to -5 on 2026-09-07, but it is still not the centre (spec §3).
  *
  * The line sits at `unit * width`: the ring's position on the full-width
  * axis, where a zero-width tile would centre. Real tiles are placed on a

--- a/app/components/mosaic/v3/overlays/overlays.test.tsx
+++ b/app/components/mosaic/v3/overlays/overlays.test.tsx
@@ -147,7 +147,7 @@ describe('ModelReadout', () => {
 });
 
 describe('CentreLine', () => {
-  const cfg = { axisNightEdgeDeg: -24, axisDayEdgeDeg: -2 };
+  const cfg = { axisNightEdgeDeg: -16, axisDayEdgeDeg: 6 };
 
   it('marks the pool ring at the middle of the panel', () => {
     render(<CentreLine cfg={cfg} feed="sunset" width={1080} height={1920} />);
@@ -155,12 +155,12 @@ describe('CentreLine', () => {
   });
 
   it('follows the axis dials rather than assuming the middle', () => {
-    // A window whose ring is not centred: across -16 to -4, the ring at -13
+    // A window whose ring is not centred: across -8 to +4, the ring at -5
     // sits a quarter of the way up from the night edge, so on the sunrise
     // feed the line lands at 0.25 * width.
     render(
       <CentreLine
-        cfg={{ axisNightEdgeDeg: -16, axisDayEdgeDeg: -4 }}
+        cfg={{ axisNightEdgeDeg: -8, axisDayEdgeDeg: 4 }}
         feed="sunrise" width={1200} height={1920}
       />
     );
@@ -169,6 +169,6 @@ describe('CentreLine', () => {
 
   it('names the altitude it is marking', () => {
     render(<CentreLine cfg={cfg} feed="sunset" width={1080} height={1920} />);
-    expect(screen.getByTestId('v3-centre-line').textContent).toContain('-13');
+    expect(screen.getByTestId('v3-centre-line').textContent).toContain('-5');
   });
 });

--- a/app/components/mosaic/v3/settingsSchema.test.ts
+++ b/app/components/mosaic/v3/settingsSchema.test.ts
@@ -76,8 +76,9 @@ describe('V3_SETTINGS_SCHEMA', () => {
     expect(byKey.hysteresisMargin).toBe(0.05);
     expect(byKey.minDwellMs).toBe(90_000);
     // Spec §6: the window's current derived values, now held as dials.
-    expect(byKey.axisNightEdgeDeg).toBe(-24);
-    expect(byKey.axisDayEdgeDeg).toBe(-2);
+    // -16..+6 is the pool band since the ring moved to -5 on 2026-09-07.
+    expect(byKey.axisNightEdgeDeg).toBe(-16);
+    expect(byKey.axisDayEdgeDeg).toBe(6);
   });
 
   it('carries no dial the v3 engine cannot act on', () => {
@@ -97,7 +98,7 @@ describe('configFromSettings', () => {
     expect(cfg.gateThreshold).toBe(0.55);
     expect(cfg.maxTiles).toBe(0);
     expect(cfg.bandCount).toBe(8);
-    expect(cfg.axisDayEdgeDeg).toBe(-2);
+    expect(cfg.axisDayEdgeDeg).toBe(6);
   });
 
   it('carries dial changes through', () => {

--- a/app/components/mosaic/v3/settingsSchema.ts
+++ b/app/components/mosaic/v3/settingsSchema.ts
@@ -87,12 +87,12 @@ export const V3_SETTINGS_SCHEMA: SettingsSchema = [
     description: 'Latitude mapped to the bottom of the panel.',
   },
   {
-    key: 'axisNightEdgeDeg', kind: 'number', min: -40, max: 0, step: 0.5, default: -24,
+    key: 'axisNightEdgeDeg', kind: 'number', min: -40, max: 0, step: 0.5, default: -16,
     label: 'night edge (deg)', section: 'arrangement',
     description: 'Solar altitude at the deep-twilight edge of the panel. Frames deeper than this clamp to the edge rather than widening the axis.',
   },
   {
-    key: 'axisDayEdgeDeg', kind: 'number', min: -30, max: 20, step: 0.5, default: -2,
+    key: 'axisDayEdgeDeg', kind: 'number', min: -30, max: 20, step: 0.5, default: 6,
     label: 'day edge (deg)', section: 'arrangement',
     description: 'Solar altitude at the day-side edge of the panel. Narrowing the window spreads a pool that crowds into one third of the glass; widening it past what the sweep gathers just leaves dead space.',
   },

--- a/app/components/mosaic/v4/engine/axis.test.ts
+++ b/app/components/mosaic/v4/engine/axis.test.ts
@@ -4,29 +4,29 @@ import { TERMINATOR_POOL_COVERAGE_DEG, TERMINATOR_SUN_ALTITUDE_DEG } from '@/app
 import { V4_SETTINGS_SCHEMA } from '../settingsSchema';
 import type { SizedTile } from './types';
 
-const cfg: AxisConfig = { axisNightEdgeDeg: -24, axisDayEdgeDeg: -2 };
+const cfg: AxisConfig = { axisNightEdgeDeg: -16, axisDayEdgeDeg: 6 };
 
 const sized = (over: Partial<SizedTile> = {}): SizedTile => ({
   id: 1, lat: 0, lng: 0, srcWidth: 400, srcHeight: 224,
-  passes: true, score: 0.8, sunAltitudeDeg: -13,
+  passes: true, score: 0.8, sunAltitudeDeg: -5,
   width: 200, height: 112, pinnedToFloor: false,
   ...over,
 });
 
 describe('altitudeToUnit', () => {
   it('puts the pool ring at the centre of the panel on both feeds', () => {
-    expect(altitudeToUnit(-13, cfg, 'sunset')).toBeCloseTo(0.5, 6);
-    expect(altitudeToUnit(-13, cfg, 'sunrise')).toBeCloseTo(0.5, 6);
+    expect(altitudeToUnit(-5, cfg, 'sunset')).toBeCloseTo(0.5, 6);
+    expect(altitudeToUnit(-5, cfg, 'sunrise')).toBeCloseTo(0.5, 6);
   });
 
   it('puts the day side on the LEFT for sunset and the RIGHT for sunrise', () => {
     // Spec §3: west stays on the left, so the day edge swaps between feeds.
-    expect(altitudeToUnit(-2, cfg, 'sunset')).toBeCloseTo(0, 6);
-    expect(altitudeToUnit(-2, cfg, 'sunrise')).toBeCloseTo(1, 6);
+    expect(altitudeToUnit(6, cfg, 'sunset')).toBeCloseTo(0, 6);
+    expect(altitudeToUnit(6, cfg, 'sunrise')).toBeCloseTo(1, 6);
   });
 
   it('clamps altitudes outside the window to an edge rather than widening it', () => {
-    expect(altitudeToUnit(10, cfg, 'sunrise')).toBe(1);
+    expect(altitudeToUnit(20, cfg, 'sunrise')).toBe(1);
     expect(altitudeToUnit(-90, cfg, 'sunrise')).toBe(0);
   });
 
@@ -35,7 +35,7 @@ describe('altitudeToUnit', () => {
   });
 
   it('degenerates to the centre rather than dividing by zero', () => {
-    expect(altitudeToUnit(-13, { axisNightEdgeDeg: -2, axisDayEdgeDeg: -2 }, 'sunset')).toBe(0.5);
+    expect(altitudeToUnit(-5, { axisNightEdgeDeg: 6, axisDayEdgeDeg: 6 }, 'sunset')).toBe(0.5);
   });
 });
 
@@ -48,8 +48,8 @@ describe('tileX', () => {
 
   it('keeps a tile inside the panel at both edges', () => {
     const wide = sized({ width: 900 });
-    expect(tileX({ ...wide, sunAltitudeDeg: -2 }, 1080, cfg, 'sunset')).toBe(0);
-    expect(tileX({ ...wide, sunAltitudeDeg: -24 }, 1080, cfg, 'sunset')).toBe(180);
+    expect(tileX({ ...wide, sunAltitudeDeg: 6 }, 1080, cfg, 'sunset')).toBe(0);
+    expect(tileX({ ...wide, sunAltitudeDeg: -16 }, 1080, cfg, 'sunset')).toBe(180);
   });
 
   it('parks an unknown moment at the centre instead of an edge', () => {
@@ -61,9 +61,9 @@ describe('tileX', () => {
     // Documents the real relationship the centre-line overlay relies on:
     // tileCentre = unit * W + w * (0.5 - unit). An earlier comment claimed the
     // two always coincide; they coincide only at unit 0.5.
-    const offCentre: AxisConfig = { axisNightEdgeDeg: -24, axisDayEdgeDeg: -6 };
-    const unit = altitudeToUnit(-13, offCentre, 'sunrise');
-    const t = sized({ sunAltitudeDeg: -13, width: 200 });
+    const offCentre: AxisConfig = { axisNightEdgeDeg: -16, axisDayEdgeDeg: 2 };
+    const unit = altitudeToUnit(-5, offCentre, 'sunrise');
+    const t = sized({ sunAltitudeDeg: -5, width: 200 });
     const line = unit * 1080;
     const tileCentre = tileX(t, 1080, offCentre, 'sunrise') + t.width / 2;
     expect(unit).toBeCloseTo(11 / 18, 6);

--- a/app/components/mosaic/v4/engine/realPool.test.ts
+++ b/app/components/mosaic/v4/engine/realPool.test.ts
@@ -114,11 +114,17 @@ describe('the real pool, on the real axis', () => {
     // admitted/evicted SET is identical with and without the taper. The
     // taper is exercised on this fixture; it just doesn't move these
     // particular counts.
+    //
+    // Ring moved to -5 on 2026-09-07 (axis now -16..+6). This fixture was
+    // captured under the old -24..-2 ring, so a third of its cameras sit
+    // below the new night edge, clamp onto it and collide: 7 drawn / 35
+    // evicted, 3 of the 4 real sunsets. A drift tripwire only; recapture
+    // the fixture from the new ring before reading these as a tuning result.
     const layout = compose(sunset, viewport, cfg, 'sunset');
-    expect(layout.tiles.length).toBe(8);
-    expect(layout.evicted.length).toBe(34);
+    expect(layout.tiles.length).toBe(7);
+    expect(layout.evicted.length).toBe(35);
     expect(layout.tiles.filter((t) => t.passes).length).toBe(3);
-    expect(compose(sunrise, viewport, cfg, 'sunrise').tiles.length).toBe(9);
+    expect(compose(sunrise, viewport, cfg, 'sunrise').tiles.length).toBe(8);
   });
 
   it('keeps every drawn tile inside the panel horizontally', () => {

--- a/app/components/mosaic/v4/engine/sizing.test.ts
+++ b/app/components/mosaic/v4/engine/sizing.test.ts
@@ -4,7 +4,7 @@ import { v4Config } from './testConfig';
 import type { TileInput, V4Config } from './types';
 
 const tile = (id: number, passes: boolean, score: number | null): TileInput => ({
-  id, lat: 0, lng: 0, srcWidth: 400, srcHeight: 300, passes, score, sunAltitudeDeg: -13,
+  id, lat: 0, lng: 0, srcWidth: 400, srcHeight: 300, passes, score, sunAltitudeDeg: -5,
 });
 
 const cfg = (over: Partial<V4Config> = {}): V4Config =>

--- a/app/components/mosaic/v4/overlays/CentreLine.tsx
+++ b/app/components/mosaic/v4/overlays/CentreLine.tsx
@@ -5,8 +5,8 @@ import { altitudeToUnit, type AxisConfig } from '../engine/axis';
  * The terminator zone made visible.
  *
  * Screen centre is the POOL's ring at TERMINATOR_SUN_ALTITUDE_DEG, not the
- * geometric terminator at 0 degrees — zero is outside the window today and
- * clamps (spec §3).
+ * geometric terminator at 0 degrees. Zero is inside the window since the
+ * ring moved to -5 on 2026-09-07, but it is still not the centre (spec §3).
  *
  * The line sits at `unit * width`: the ring's position on the full-width
  * axis, where a zero-width tile would centre. Real tiles are placed on a

--- a/app/components/mosaic/v4/overlays/overlays.test.tsx
+++ b/app/components/mosaic/v4/overlays/overlays.test.tsx
@@ -231,7 +231,7 @@ describe('ModelReadout', () => {
 });
 
 describe('CentreLine', () => {
-  const cfg = { axisNightEdgeDeg: -24, axisDayEdgeDeg: -2 };
+  const cfg = { axisNightEdgeDeg: -16, axisDayEdgeDeg: 6 };
 
   it('marks the pool ring at the middle of the panel', () => {
     render(<CentreLine cfg={cfg} feed="sunset" width={1080} height={1920} />);
@@ -239,12 +239,12 @@ describe('CentreLine', () => {
   });
 
   it('follows the axis dials rather than assuming the middle', () => {
-    // A window whose ring is not centred: across -16 to -4, the ring at -13
+    // A window whose ring is not centred: across -8 to +4, the ring at -5
     // sits a quarter of the way up from the night edge, so on the sunrise
     // feed the line lands at 0.25 * width.
     render(
       <CentreLine
-        cfg={{ axisNightEdgeDeg: -16, axisDayEdgeDeg: -4 }}
+        cfg={{ axisNightEdgeDeg: -8, axisDayEdgeDeg: 4 }}
         feed="sunrise" width={1200} height={1920}
       />
     );
@@ -253,6 +253,6 @@ describe('CentreLine', () => {
 
   it('names the altitude it is marking', () => {
     render(<CentreLine cfg={cfg} feed="sunset" width={1080} height={1920} />);
-    expect(screen.getByTestId('v4-centre-line').textContent).toContain('-13');
+    expect(screen.getByTestId('v4-centre-line').textContent).toContain('-5');
   });
 });

--- a/app/components/mosaic/v4/settingsSchema.test.ts
+++ b/app/components/mosaic/v4/settingsSchema.test.ts
@@ -76,8 +76,9 @@ describe('V4_SETTINGS_SCHEMA', () => {
     expect(byKey.hysteresisMargin).toBe(0.05);
     expect(byKey.minDwellMs).toBe(90_000);
     // Spec §6: the window's current derived values, now held as dials.
-    expect(byKey.axisNightEdgeDeg).toBe(-24);
-    expect(byKey.axisDayEdgeDeg).toBe(-2);
+    // -16..+6 is the pool band since the ring moved to -5 on 2026-09-07.
+    expect(byKey.axisNightEdgeDeg).toBe(-16);
+    expect(byKey.axisDayEdgeDeg).toBe(6);
   });
 
   it('carries no dial the v4 engine cannot act on', () => {
@@ -97,7 +98,7 @@ describe('configFromSettings', () => {
     expect(cfg.gateThreshold).toBe(0.55);
     expect(cfg.maxTiles).toBe(0);
     expect(cfg.bandCount).toBe(8);
-    expect(cfg.axisDayEdgeDeg).toBe(-2);
+    expect(cfg.axisDayEdgeDeg).toBe(6);
   });
 
   it('carries dial changes through', () => {

--- a/app/components/mosaic/v4/settingsSchema.ts
+++ b/app/components/mosaic/v4/settingsSchema.ts
@@ -97,12 +97,12 @@ export const V4_SETTINGS_SCHEMA: SettingsSchema = [
     description: 'Latitude mapped to the bottom of the panel.',
   },
   {
-    key: 'axisNightEdgeDeg', kind: 'number', min: -40, max: 0, step: 0.5, default: -24,
+    key: 'axisNightEdgeDeg', kind: 'number', min: -40, max: 0, step: 0.5, default: -16,
     label: 'night edge (deg)', section: 'arrangement',
     description: 'Solar altitude at the deep-twilight edge of the panel. Frames deeper than this clamp to the edge rather than widening the axis.',
   },
   {
-    key: 'axisDayEdgeDeg', kind: 'number', min: -30, max: 20, step: 0.5, default: -2,
+    key: 'axisDayEdgeDeg', kind: 'number', min: -30, max: 20, step: 0.5, default: 6,
     label: 'day edge (deg)', section: 'arrangement',
     description: 'Solar altitude at the day-side edge of the panel. Narrowing the window spreads a pool that crowds into one third of the glass; widening it past what the sweep gathers just leaves dead space.',
   },

--- a/app/lib/masterConfig.test.ts
+++ b/app/lib/masterConfig.test.ts
@@ -106,9 +106,12 @@ describe('TERMINATOR_DAY_SIDE_OFFSETS_DEG', () => {
     expect(TERMINATOR_DAY_SIDE_OFFSETS_DEG).toEqual([15.75]);
   });
 
-  it('puts its ring inside the measured quality peak', () => {
+  it('still gathers from the measured quality peak', () => {
+    // The base ring covers the peak (-10..+8) itself since 2026-09-07; the
+    // day ring is the thin-feed escape hatch and must not have drifted so
+    // far into daylight that its box misses the peak entirely.
     const altitude = TERMINATOR_SUN_ALTITUDE_DEG + TERMINATOR_DAY_SIDE_OFFSETS_DEG[0];
-    expect(altitude).toBeGreaterThan(0);
-    expect(altitude).toBeLessThan(6);
+    expect(altitude - SEARCH_RADIUS_DEG).toBeLessThanOrEqual(0);
+    expect(altitude + SEARCH_RADIUS_DEG).toBeGreaterThanOrEqual(8);
   });
 });

--- a/app/lib/masterConfig.ts
+++ b/app/lib/masterConfig.ts
@@ -17,12 +17,21 @@ export const TERMINATOR_PRECISION_DEG = 12; // Terminator ring precision in degr
 // 13 works
 // 11 works
 
-// Base sun altitude used for the terminator ring radius: radius = 90 - sunAltitude
-// Keep default at 0 to match current terminator behavior (sun at horizon).
-export const TERMINATOR_SUN_ALTITUDE_DEG = -13;
-// was 0 and one of the lines was on the exact terminator line
-// -10 works when precision is 14 and radius is 11
-// -8 showed too much day time
+// Base sun altitude the sweep ring sits at: radius = 90 - sunAltitude from
+// the subsolar point. The pool gathers within SEARCH_RADIUS_DEG of it, so
+// this is the centre of the solar-altitude band the glass can ever show.
+//
+// -5 was chosen 2026-09-07 from 46k Claude-rated frames and 9.1k gold labels
+// (scripts/altitude-quality-report.mjs). Good frames peak from -10 to +8
+// degrees and fall to 1-3% below -13. Share of good frames each window can
+// see, at equal Windy cost:
+//   ring -13 (-24..-2)  55%   ring -8 (-19..+3)  71%   ring -5 (-16..+6)  86%
+// Sweeping the day ring as a second ring reaches 100% for 1.7x the boxes,
+// almost all of them spent on the dead -24..-16 band, so the ring moved
+// instead. History: 0 put a line on the geometric terminator; -13 was tuned
+// for how the ring looked on the globe ("-8 showed too much day time"), not
+// for what the pool caught.
+export const TERMINATOR_SUN_ALTITUDE_DEG = -5;
 
 // Search radius per Windy API call, in degrees. The query box spans
 // 2 x this value, and Windy's clusters endpoint caps the north-south span
@@ -52,10 +61,13 @@ export const TERMINATOR_RETENTION_GRACE_MS = 20 * 60_000;
 export const TERMINATOR_SWEEP_FAILED_HOLD_RATIO = 0.5;
 
 // Extra rings to sweep when a feed is under the floor, tried in this order.
-// radius = 90 - (sunAltitude + offset), so POSITIVE MOVES TOWARD DAY: +15.75
-// puts the ring near +2.75 degrees solar altitude (golden hour, which the base
-// ring at -13 misses entirely), and -15.75 puts it near -28.75 (deep night,
-// where the detection gate floors the frames anyway). Day side first.
+// radius = 90 - (sunAltitude + offset), so POSITIVE MOVES TOWARD DAY. With
+// the base ring at -5, +15.75 puts the day ring near +10.75 (daylight, but its
+// box still reaches down to the -0.25 edge of the quality peak) and -15.75
+// puts the night ring near -20.75 (deep night, where the detection gate
+// floors the frames anyway). Day side first. Before the base ring moved on
+// 2026-09-07 the day ring sat at +2.75; the escalation is a camera-count
+// escape hatch for a thin feed, and it still adds cameras from there.
 //
 // The magnitude is EMPIRICAL, not derived. Measured 2026-09-02 at
 // SEARCH_RADIUS_DEG = 11: a 3-degree offset returned 26-35% cameras the base

--- a/docs/superpowers/plans/2026-09-07-ring-to-golden-hour.md
+++ b/docs/superpowers/plans/2026-09-07-ring-to-golden-hour.md
@@ -1,0 +1,67 @@
+# Move the sweep ring to -5 degrees
+
+**Date:** 2026-09-07. **Decision:** `TERMINATOR_SUN_ALTITUDE_DEG` moves from
+-13 to -5, so the pool gathers -16 to +6 degrees of solar altitude instead
+of -24 to -2. Same Windy cost. The v3/v4 axis dials move with it.
+
+## Why
+
+The 2026-09-02 coverage spec measured that good frames peak from -10 to +8
+degrees and recommended sweeping a second, day-side ring rather than moving
+the base ring. Two things changed since:
+
+1. The forced-day-ring measurement window the opening-night runbook scheduled
+   never ran. `sweep_force_day_ring` has been off since 2026-09-03. The only
+   day-ring data is from natural sunrise escalation: gate pass 14-16% on the
+   day ring against 7% on the base ring.
+2. The glass runs `solo` / `solo2`, one frame per screen. The symmetric
+   grow-then-shrink arc that made the spec want both sides of the peak is a
+   v3 mosaic need, and v3 is not on the glass.
+
+Re-measured 2026-09-07 with `scripts/altitude-quality-report.mjs` (46k
+Claude-rated frames, good = llm_quality >= 0.5) plus 9.1k gold labels:
+
+| Option | Good frames it can see | Good rate inside | Windy boxes | Good per box |
+| --- | --- | --- | --- | --- |
+| Ring -13 (-24..-2), before | 55% | 7.5% | 1.0x | 0.55 |
+| Ring -8 (-19..+3) | 71% | 9.0% | 1.0x | 0.71 |
+| **Ring -5 (-16..+6)** | **86%** | **10.7%** | **1.0x** | **0.86** |
+| Two rings (-24..+13.75) | 100% | 9.8% | 1.7x | 0.58 |
+
+Gold labels agree on the shape: below -15 degrees under 2% of labeled frames
+rate 4 or higher; at -12 to -6 it is 15-17%. The -24..-16 band is where 40%
+of the two-ring option's extra boxes go, and it yields 1-3% good frames.
+
+The "100%" row is an artefact of sampling: the archive only holds frames from
+where the pool has ever swept. The three windows compared are all inside the
+sampled range, so the comparison between them is fair.
+
+The old comment "-8 showed too much day time" was about how the ring line
+looked on the globe, not what the pool caught.
+
+## What moves together
+
+- `TERMINATOR_SUN_ALTITUDE_DEG` -13 -> -5. `TERMINATOR_POOL_COVERAGE_DEG`
+  derives from it and becomes -16..+6.
+- v3 and v4 `axisNightEdgeDeg` -24 -> -16, `axisDayEdgeDeg` -2 -> +6. The
+  axis coverage test is the tripwire that ties these to the constant. No
+  stored studio row overrides them (checked `kiosk_settings` 2026-09-07).
+- Escalation offsets stay at +/-15.75 (the measured magnitude). The day
+  ring now sits at +10.75 and the night ring at -20.75. `masterConfig.test`
+  now asserts the day ring's box still reaches the peak rather than that
+  the ring itself sits inside it.
+- `kiosk_sweep_zone` is rewritten by the cron on the first tick after
+  deploy; solo bins age against it, so cameras at -24..-16 leave the pool
+  within the 20-minute retention grace. The map's ring line reads the same
+  constant and shifts with it.
+- `realPool` fixtures were captured under the old ring and now crowd the
+  night edge; their pinned counts are re-measured, not predicted. Recapture
+  before reading them as a tuning result.
+
+## Verify after deploy
+
+- `daily_sweep_geometry` gets a new signature row `base-5_r11_...` with
+  coverage -16..+6.
+- `daily_sweep_ring_stats` base ring `frames_gate_passed / frames_scored`
+  should rise from ~7% toward 10%+ over the next full day.
+- Active pool (`terminator_webcam_state`) altitude spread sits in -16..+6.


### PR DESCRIPTION
## What

Moves the terminator sweep ring from -13° to -5° solar altitude. The pool now gathers -16° to +6° instead of -24° to -2°, at the same Windy box count. The v3/v4 axis dial defaults move with it.

## Why

Half of the old window (-24° to -16°) yields 1–3% good frames. Good frames peak from -10° to +8°. Measured today with `scripts/altitude-quality-report.mjs` over 46k Claude-rated frames plus 9.1k gold labels:

| Option | Good frames it can see | Good rate inside | Windy boxes |
| --- | --- | --- | --- |
| Ring -13 (before) | 55% | 7.5% | 1.0x |
| **Ring -5 (this PR)** | **86%** | **10.7%** | **1.0x** |
| Two rings (the Sept 2 spec's plan) | 100% | 9.8% | 1.7x |

The two-ring plan was written for the v3 grow-then-shrink arc; the glass runs solo2 and does not need the night tail. Full reasoning: `docs/superpowers/plans/2026-09-07-ring-to-golden-hour.md`.

## What moves together

- `TERMINATOR_SUN_ALTITUDE_DEG` -13 → -5; `TERMINATOR_POOL_COVERAGE_DEG` derives.
- v3/v4 `axisNightEdgeDeg` -24 → -16, `axisDayEdgeDeg` -2 → +6 (the axis coverage test is the tripwire). No stored `kiosk_settings` row overrides these.
- Escalation offsets unchanged (±15.75, the measured magnitude); the day ring now sits at +10.75. `masterConfig.test` asserts its box still reaches the peak.
- `kiosk_sweep_zone` is rewritten by the cron on the first tick; solo bins age against it, so -24..-16 cameras leave within the 20-min grace.
- realPool fixtures were captured under the old ring; their counts are re-measured (7/35), not predicted.

No migration. Tests: 2380 passed. tsc/lint noise is unchanged from main.

## Verify after deploy

- `daily_sweep_geometry` gets a `base-5_r11_…` row with coverage -16..+6.
- Base-ring `frames_gate_passed / frames_scored` in `daily_sweep_ring_stats` rises from ~7% toward 10%+ over a full day.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ay5xqr1nbSzysfRVaPjNwo
