### PR TITLE
feat(globe): draw the sweep rings and Windy boxes behind owner toggles

### DIFF
--- a/app/api/cron/update-cameras/lib/windyApi.ts
+++ b/app/api/cron/update-cameras/lib/windyApi.ts
@@ -4,40 +4,13 @@
  */
 
 import type { Location, WindyWebcam } from '@/app/lib/types';
+import { boundingBox } from '@/app/lib/sweepBox';
 import {
   SEARCH_RADIUS_DEG,
   WINDY_FETCH_STAGGER_WITHIN_BATCH_MS,
 } from '@/app/lib/masterConfig';
 
-export interface BoundingBox {
-  northLat: number;
-  southLat: number;
-  eastLon: number;
-  westLon: number;
-}
-
-/**
- * Query box for one ring point, clamped to the ranges Windy accepts.
- *
- * Verified live 2026-09-02: the clusters endpoint 400s on northLat > 90,
- * southLat < -90, eastLon > 180 or westLon < -180, and `fetchWebcamsFor`
- * turns that into a silent empty array. The ring genuinely reaches both
- * the pole and the antimeridian, so ~2 of 31 boxes per sweep were being
- * lost that way.
- *
- * Clamping shrinks the box rather than wrapping it, so a box straddling
- * the antimeridian loses the sliver on the far side. Splitting into two
- * boxes would recover it; not done here because that stretch is open
- * ocean and a shrunken box still beats a 400.
- */
-export function boundingBox(loc: Location, radiusDeg: number): BoundingBox {
-  return {
-    northLat: Math.min(90, loc.lat + radiusDeg),
-    southLat: Math.max(-90, loc.lat - radiusDeg),
-    eastLon: Math.min(180, loc.lng + radiusDeg),
-    westLon: Math.max(-180, loc.lng - radiusDeg),
-  };
-}
+export { boundingBox, type BoundingBox } from '@/app/lib/sweepBox';
 
 /**
  * One box's answer, with the status that produced it.

--- a/app/api/sweep-zone/route.test.ts
+++ b/app/api/sweep-zone/route.test.ts
@@ -1,0 +1,43 @@
+// @vitest-environment node
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { TERMINATOR_POOL_COVERAGE_DEG } from '@/app/lib/masterConfig';
+
+const getSweptZone = vi.fn();
+const isFlagEnabled = vi.fn();
+vi.mock('server-only', () => ({}));
+vi.mock('@/app/lib/db', () => ({ sql: vi.fn() }));
+vi.mock('@/app/lib/solo/store', () => ({ getSweptZone: () => getSweptZone() }));
+vi.mock('@/app/lib/runtimeFlags', () => ({
+  isFlagEnabled: () => isFlagEnabled(),
+  SWEEP_FORCE_DAY_RING: 'sweep_force_day_ring',
+}));
+
+import { GET } from './route';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  isFlagEnabled.mockResolvedValue(false);
+});
+
+describe('GET /api/sweep-zone', () => {
+  it('returns the zone the cron last recorded', async () => {
+    getSweptZone.mockResolvedValue({ minDeg: -16, maxDeg: 21.75 });
+    const body = await (await GET()).json();
+    expect(body).toEqual({ zone: { minDeg: -16, maxDeg: 21.75 }, recorded: true, forcedDayRing: false });
+  });
+
+  it('falls back to the guaranteed rings and says so when nothing is recorded', async () => {
+    getSweptZone.mockResolvedValue(null);
+    const body = await (await GET()).json();
+    expect(body.zone).toEqual({ minDeg: TERMINATOR_POOL_COVERAGE_DEG.min, maxDeg: TERMINATOR_POOL_COVERAGE_DEG.max });
+    expect(body.recorded).toBe(false);
+  });
+
+  it('widens the fallback to the day ring when the force flag is on', async () => {
+    getSweptZone.mockResolvedValue(null);
+    isFlagEnabled.mockResolvedValue(true);
+    const body = await (await GET()).json();
+    expect(body.forcedDayRing).toBe(true);
+    expect(body.zone.maxDeg).toBeGreaterThan(TERMINATOR_POOL_COVERAGE_DEG.max);
+  });
+});

--- a/app/api/sweep-zone/route.ts
+++ b/app/api/sweep-zone/route.ts
@@ -1,0 +1,27 @@
+import { NextResponse } from 'next/server';
+import { getSweptZone } from '@/app/lib/solo/store';
+import { isFlagEnabled, SWEEP_FORCE_DAY_RING } from '@/app/lib/runtimeFlags';
+import { sweepGeometry } from '@/app/api/cron/update-cameras/lib/sweepGeometry';
+import { TERMINATOR_DAY_SIDE_OFFSETS_DEG } from '@/app/lib/masterConfig';
+
+export const dynamic = 'force-dynamic';
+export const runtime = 'nodejs';
+
+/**
+ * The solar-altitude band the cron last swept, for the globe's sweep
+ * overlay. Same source and same fallback as the solo state route: the zone
+ * the cron recorded on its last tick, else the guaranteed rings. Read-only,
+ * public, and no bigger than the two numbers the overlay needs.
+ */
+export async function GET() {
+  const [zone, forcedDayRing] = await Promise.all([
+    getSweptZone(),
+    isFlagEnabled(SWEEP_FORCE_DAY_RING),
+  ]);
+  const geometry = sweepGeometry(forcedDayRing ? TERMINATOR_DAY_SIDE_OFFSETS_DEG : []);
+  return NextResponse.json({
+    zone: zone ?? { minDeg: geometry.coverageMinDeg, maxDeg: geometry.coverageMaxDeg },
+    recorded: zone !== null,
+    forcedDayRing,
+  });
+}

--- a/app/components/Map/SimpleMap.tsx
+++ b/app/components/Map/SimpleMap.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect, useRef } from 'react';
 import { useMap } from './hooks/useMap';
 import { useSetWebcamMarkers } from './hooks/useSetWebcamMarkers';
 import { useUpdateTerminatorRing } from './hooks/useUpdateTerminatorRing';
+import { useSweepOverlay } from './hooks/useSweepOverlay';
 import { useMapInteractionPause } from './hooks/useMapInteractionPause';
 import 'mapbox-gl/dist/mapbox-gl.css';
 import type { Location } from '../../lib/types';
@@ -61,6 +62,9 @@ export default function SimpleMap({
     precisionDeg: TERMINATOR_PRECISION_DEG, // Match cron job precision
     searchRadiusDegrees: SEARCH_RADIUS_DEG, // Match cron job search radius
   });
+
+  // The sweep, drawn on request from the Ops tab: rings, boxes, swept state.
+  useSweepOverlay(map, mapLoaded, currentTime);
 
   const {
     currentWebcam: nextLatitudeNorthSunsetWebCam,

--- a/app/components/Map/hooks/useSweepOverlay.ts
+++ b/app/components/Map/hooks/useSweepOverlay.ts
@@ -1,0 +1,123 @@
+'use client';
+
+import { useEffect, useMemo } from 'react';
+import type { Map as MapboxMap, GeoJSONSource } from 'mapbox-gl';
+import useSWR from 'swr';
+import { sweepOverlayFeatures, sweepRings, type SweptZone } from '../lib/sweepOverlay';
+import { anyRingShown, useSweepOverlayStore } from '@/app/store/useSweepOverlayStore';
+
+interface SweepZoneResponse {
+  zone: SweptZone;
+  recorded: boolean;
+  forcedDayRing: boolean;
+}
+
+const fetcher = (url: string) =>
+  fetch(url).then((r) => {
+    if (!r.ok) throw new Error(`sweep-zone ${r.status}`);
+    return r.json() as Promise<SweepZoneResponse>;
+  });
+
+const LINES_SOURCE = 'sweep-rings-source';
+const LINES_LAYER = 'sweep-rings-layer';
+const BOXES_SOURCE = 'sweep-boxes-source';
+const BOXES_FILL_LAYER = 'sweep-boxes-fill-layer';
+const BOXES_LINE_LAYER = 'sweep-boxes-line-layer';
+
+/** Warm for the base ring, cool for day, deep for night; faint until swept. */
+const RING_COLOR: mapboxgl.Expression = [
+  'case',
+  ['==', ['get', 'offsetDeg'], 0], '#fbbf24',
+  ['>', ['get', 'offsetDeg'], 0], '#60a5fa',
+  '#a78bfa',
+];
+const SWEPT_OPACITY: mapboxgl.Expression = ['case', ['get', 'swept'], 0.9, 0.3];
+const SWEPT_FILL_OPACITY: mapboxgl.Expression = ['case', ['get', 'swept'], 0.12, 0.04];
+
+/**
+ * Draws the sweep on the globe: every ring the cron can query, its Windy
+ * boxes on request, and whether each ring ran on the last tick. Nothing is
+ * added to the map until a toggle asks for it, so the public globe is
+ * untouched by default.
+ */
+export function useSweepOverlay(map: MapboxMap | null, mapLoaded: boolean, currentTime: Date) {
+  const toggles = useSweepOverlayStore();
+  // Remembered toggles must draw without the Ops tab being open.
+  useEffect(() => { toggles.hydrate(); }, [toggles]);
+  const active = anyRingShown(toggles);
+
+  // Poll only while something is drawn; the cron rewrites the zone each tick.
+  const { data } = useSWR(active ? '/api/sweep-zone' : null, fetcher, {
+    refreshInterval: 60_000,
+    revalidateOnFocus: false,
+  });
+  const zone = data?.zone ?? null;
+
+  const features = useMemo(() => {
+    if (!active) return null;
+    const rings = sweepRings(zone).filter((r) =>
+      r.offsetDeg === 0 ? toggles.showBase : r.offsetDeg > 0 ? toggles.showDay : toggles.showNight,
+    );
+    return sweepOverlayFeatures(currentTime, rings, toggles.showBoxes);
+  }, [active, zone, currentTime, toggles.showBase, toggles.showDay, toggles.showNight, toggles.showBoxes]);
+
+  useEffect(() => {
+    if (!map || !mapLoaded) return;
+    const remove = () => {
+      try {
+        for (const id of [BOXES_FILL_LAYER, BOXES_LINE_LAYER, LINES_LAYER]) {
+          if (map.getLayer(id)) map.removeLayer(id);
+        }
+        for (const id of [BOXES_SOURCE, LINES_SOURCE]) {
+          if (map.getSource(id)) map.removeSource(id);
+        }
+      } catch {
+        // the map is being disposed
+      }
+    };
+    if (!features) { remove(); return; }
+    const apply = () => {
+      try {
+        const lines = map.getSource(LINES_SOURCE) as GeoJSONSource | undefined;
+        if (lines) lines.setData(features.lines);
+        else map.addSource(LINES_SOURCE, { type: 'geojson', data: features.lines });
+        const boxes = map.getSource(BOXES_SOURCE) as GeoJSONSource | undefined;
+        if (boxes) boxes.setData(features.boxes);
+        else map.addSource(BOXES_SOURCE, { type: 'geojson', data: features.boxes });
+
+        if (!map.getLayer(BOXES_FILL_LAYER)) {
+          map.addLayer({
+            id: BOXES_FILL_LAYER, type: 'fill', source: BOXES_SOURCE,
+            paint: { 'fill-color': RING_COLOR, 'fill-opacity': SWEPT_FILL_OPACITY },
+          });
+        }
+        if (!map.getLayer(BOXES_LINE_LAYER)) {
+          map.addLayer({
+            id: BOXES_LINE_LAYER, type: 'line', source: BOXES_SOURCE,
+            paint: { 'line-color': RING_COLOR, 'line-width': 1, 'line-opacity': SWEPT_OPACITY },
+          });
+        }
+        if (!map.getLayer(LINES_LAYER)) {
+          map.addLayer({
+            id: LINES_LAYER, type: 'line', source: LINES_SOURCE,
+            paint: { 'line-color': RING_COLOR, 'line-width': 2, 'line-opacity': SWEPT_OPACITY },
+          });
+        }
+      } catch (error) {
+        console.warn('[sweepOverlay] layer update failed:', error);
+      }
+    };
+    // addSource throws until the style is in. isStyleLoaded() stays false
+    // while tiles are still arriving and style.load has usually fired before
+    // this effect subscribes, so wait on idle, which fires once the map has
+    // nothing left to load and again after every later change.
+    if (map.isStyleLoaded()) apply();
+    else map.once('idle', apply);
+    return () => {
+      map.off('idle', apply);
+      remove();
+    };
+  }, [map, mapLoaded, features]);
+
+  return { zone, recorded: data?.recorded ?? false, forcedDayRing: data?.forcedDayRing ?? false };
+}

--- a/app/components/Map/lib/sweepOverlay.test.ts
+++ b/app/components/Map/lib/sweepOverlay.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect } from 'vitest';
+import { ringQueryPoints, sweepOverlayFeatures, sweepRings } from './sweepOverlay';
+import {
+  SEARCH_RADIUS_DEG,
+  TERMINATOR_POOL_COVERAGE_DEG,
+  TERMINATOR_SUN_ALTITUDE_DEG,
+  TERMINATOR_WIDEN_OFFSETS_DEG,
+} from '@/app/lib/masterConfig';
+
+const time = new Date('2026-09-07T18:30:00Z');
+const base = TERMINATOR_POOL_COVERAGE_DEG;
+const [day, night] = TERMINATOR_WIDEN_OFFSETS_DEG;
+
+describe('sweepRings', () => {
+  it('lists the base ring first and every escalation ring in config order', () => {
+    const rings = sweepRings(null);
+    expect(rings.map((r) => r.offsetDeg)).toEqual([0, ...TERMINATOR_WIDEN_OFFSETS_DEG]);
+    expect(rings[0].altitudeDeg).toBe(TERMINATOR_SUN_ALTITUDE_DEG);
+    expect(rings[1].altitudeDeg).toBe(TERMINATOR_SUN_ALTITUDE_DEG + day);
+  });
+
+  it('marks only the base ring swept when the cron has recorded no zone', () => {
+    expect(sweepRings(null).map((r) => r.swept)).toEqual([true, false, false]);
+  });
+
+  it('marks only the base ring swept when the zone is exactly the base coverage', () => {
+    expect(sweepRings({ minDeg: base.min, maxDeg: base.max }).map((r) => r.swept))
+      .toEqual([true, false, false]);
+  });
+
+  it('reads a zone wider on the day side as the day ring having swept', () => {
+    const zone = { minDeg: base.min, maxDeg: TERMINATOR_SUN_ALTITUDE_DEG + day + SEARCH_RADIUS_DEG };
+    const [, dayRing, nightRing] = sweepRings(zone);
+    expect(dayRing.swept).toBe(true);
+    expect(nightRing.swept).toBe(false);
+  });
+
+  it('reads a zone wider on the night side as the night ring having swept', () => {
+    const zone = { minDeg: TERMINATOR_SUN_ALTITUDE_DEG + night - SEARCH_RADIUS_DEG, maxDeg: base.max };
+    const [, dayRing, nightRing] = sweepRings(zone);
+    expect(dayRing.swept).toBe(false);
+    expect(nightRing.swept).toBe(true);
+  });
+});
+
+describe('ringQueryPoints', () => {
+  it('yields the same points the cron queries: no duplicates at the seam', () => {
+    const points = ringQueryPoints(time, 0);
+    const keys = new Set(points.map((p) => `${p.lat.toFixed(6)},${p.lng.toFixed(6)}`));
+    expect(keys.size).toBe(points.length);
+    expect(points.length).toBeGreaterThan(20);
+  });
+
+  it('moves the whole ring when the offset changes', () => {
+    const a = ringQueryPoints(time, 0);
+    const b = ringQueryPoints(time, day);
+    expect(b).not.toEqual(a);
+  });
+});
+
+describe('sweepOverlayFeatures', () => {
+  it('draws one line per ring and carries the ring props on it', () => {
+    const rings = sweepRings(null);
+    const out = sweepOverlayFeatures(time, rings, false);
+    expect(out.lines.features).toHaveLength(3);
+    expect(out.lines.features[1].properties).toEqual({
+      offsetDeg: day, altitudeDeg: TERMINATOR_SUN_ALTITUDE_DEG + day, swept: false,
+    });
+    expect(out.boxes.features).toHaveLength(0);
+  });
+
+  it('draws one box per query point when boxes are on', () => {
+    const [baseRing] = sweepRings(null);
+    const out = sweepOverlayFeatures(time, [baseRing], true);
+    expect(out.boxes.features).toHaveLength(ringQueryPoints(time, 0).length);
+  });
+
+  it('draws each box as the clamped lat/lng rectangle the cron sends', () => {
+    const [baseRing] = sweepRings(null);
+    const out = sweepOverlayFeatures(time, [baseRing], true);
+    for (const box of out.boxes.features) {
+      const ring = box.geometry.coordinates[0];
+      expect(ring).toHaveLength(5);
+      expect(ring[0]).toEqual(ring[4]);
+      const lons = ring.map((c) => c[0]);
+      const lats = ring.map((c) => c[1]);
+      expect(Math.max(...lons) - Math.min(...lons)).toBeLessThanOrEqual(2 * SEARCH_RADIUS_DEG + 1e-9);
+      expect(Math.max(...lats) - Math.min(...lats)).toBeLessThanOrEqual(2 * SEARCH_RADIUS_DEG + 1e-9);
+      expect(Math.max(...lats)).toBeLessThanOrEqual(90);
+      expect(Math.min(...lons)).toBeGreaterThanOrEqual(-180);
+    }
+  });
+
+  it('draws nothing when no rings are asked for', () => {
+    const out = sweepOverlayFeatures(time, [], true);
+    expect(out.lines.features).toHaveLength(0);
+    expect(out.boxes.features).toHaveLength(0);
+  });
+});

--- a/app/components/Map/lib/sweepOverlay.ts
+++ b/app/components/Map/lib/sweepOverlay.ts
@@ -1,0 +1,136 @@
+import type { Feature, FeatureCollection, LineString, Polygon } from 'geojson';
+import type { Location } from '@/app/lib/types';
+import {
+  SEARCH_RADIUS_DEG,
+  TERMINATOR_POOL_COVERAGE_DEG,
+  TERMINATOR_PRECISION_DEG,
+  TERMINATOR_SUN_ALTITUDE_DEG,
+  TERMINATOR_WIDEN_OFFSETS_DEG,
+} from '@/app/lib/masterConfig';
+import { boundingBox } from '@/app/lib/sweepBox';
+import { subsolarPoint } from './subsolarLocation';
+import { createTerminatorRing, terminatorPolygon } from './terminatorRing';
+
+/**
+ * The sweep, drawn: which rings the cron can query and whether each one ran
+ * on the last tick.
+ *
+ * The base ring always sweeps. The escalation rings in
+ * TERMINATOR_WIDEN_OFFSETS_DEG run only when a feed is thin (or the day ring
+ * is forced), so their line is faint until the cron's recorded zone says
+ * they swept. The zone is the only live signal the cron leaves behind
+ * (kiosk_sweep_zone, rewritten every tick), and it encodes the rings by
+ * arithmetic: a zone wider than the base ring's coverage means an
+ * escalation ring ran.
+ */
+export interface SweepRing {
+  offsetDeg: number;
+  /** Solar altitude the ring sits at: base altitude plus the offset. */
+  altitudeDeg: number;
+  /** Did the last recorded tick sweep this ring? Base is always true. */
+  swept: boolean;
+}
+
+export interface SweptZone {
+  minDeg: number;
+  maxDeg: number;
+}
+
+/** Half a degree of slack: the zone is NUMERIC(6,2) and rings are quarter-degree. */
+const ZONE_EPS = 0.01;
+
+/**
+ * Every ring in config, flagged by whether the recorded zone shows it swept.
+ * A null zone (cron never recorded one, table missing) marks only the base
+ * ring as swept, which is what the sweep guarantees anyway.
+ */
+export function sweepRings(zone: SweptZone | null): SweepRing[] {
+  const base: SweepRing = { offsetDeg: 0, altitudeDeg: TERMINATOR_SUN_ALTITUDE_DEG, swept: true };
+  const escalations = TERMINATOR_WIDEN_OFFSETS_DEG.map((offsetDeg): SweepRing => {
+    const altitudeDeg = TERMINATOR_SUN_ALTITUDE_DEG + offsetDeg;
+    const swept =
+      zone !== null &&
+      (offsetDeg > 0
+        ? zone.maxDeg > TERMINATOR_POOL_COVERAGE_DEG.max + ZONE_EPS
+        : zone.minDeg < TERMINATOR_POOL_COVERAGE_DEG.min - ZONE_EPS);
+    return { offsetDeg, altitudeDeg, swept };
+  });
+  return [base, ...escalations];
+}
+
+/**
+ * The points the cron queries Windy at for one ring: the ring at the cron's
+ * precision, sunrise and sunset halves joined, duplicates at the seam
+ * dropped. Same construction as the cron's sweep.
+ */
+export function ringQueryPoints(time: Date, offsetDeg: number): Location[] {
+  const { raHours, gmstHours } = subsolarPoint(time);
+  const ring = createTerminatorRing(
+    time, raHours, gmstHours, TERMINATOR_PRECISION_DEG, TERMINATOR_SUN_ALTITUDE_DEG, offsetDeg,
+  );
+  const byKey = new Map<string, Location>();
+  for (const point of [...ring.sunriseCoords, ...ring.sunsetCoords]) {
+    const key = `${point.lat.toFixed(6)},${point.lng.toFixed(6)}`;
+    if (!byKey.has(key)) byKey.set(key, point);
+  }
+  return [...byKey.values()];
+}
+
+export interface RingProps {
+  offsetDeg: number;
+  altitudeDeg: number;
+  swept: boolean;
+}
+
+export interface SweepOverlay {
+  lines: FeatureCollection<LineString, RingProps>;
+  boxes: FeatureCollection<Polygon, RingProps>;
+}
+
+/** Fine enough that the ring reads as a circle on the globe; 2 deg like the base line. */
+const LINE_PRECISION_DEG = 2;
+
+/**
+ * GeoJSON for the rings asked for: one line per ring, and if `showBoxes`,
+ * one lat/lng rectangle per query point. Boxes are drawn as four-corner
+ * polygons on purpose: Mapbox's globe projects Mercator geometry, so a
+ * straight edge is a parallel or a meridian, which is exactly the box Windy
+ * receives.
+ */
+export function sweepOverlayFeatures(
+  time: Date,
+  rings: SweepRing[],
+  showBoxes: boolean,
+): SweepOverlay {
+  const lines: Feature<LineString, RingProps>[] = [];
+  const boxes: Feature<Polygon, RingProps>[] = [];
+  for (const ring of rings) {
+    const props: RingProps = { offsetDeg: ring.offsetDeg, altitudeDeg: ring.altitudeDeg, swept: ring.swept };
+    const polygon = terminatorPolygon(time, LINE_PRECISION_DEG, TERMINATOR_SUN_ALTITUDE_DEG, ring.offsetDeg);
+    lines.push({
+      type: 'Feature',
+      properties: props,
+      geometry: { type: 'LineString', coordinates: polygon.coordinates[0] },
+    });
+    if (!showBoxes) continue;
+    for (const point of ringQueryPoints(time, ring.offsetDeg)) {
+      const b = boundingBox(point, SEARCH_RADIUS_DEG);
+      boxes.push({
+        type: 'Feature',
+        properties: props,
+        geometry: {
+          type: 'Polygon',
+          coordinates: [[
+            [b.westLon, b.southLat], [b.eastLon, b.southLat],
+            [b.eastLon, b.northLat], [b.westLon, b.northLat],
+            [b.westLon, b.southLat],
+          ]],
+        },
+      });
+    }
+  }
+  return {
+    lines: { type: 'FeatureCollection', features: lines },
+    boxes: { type: 'FeatureCollection', features: boxes },
+  };
+}

--- a/app/components/Ops/OpsPanels.tsx
+++ b/app/components/Ops/OpsPanels.tsx
@@ -5,6 +5,7 @@ import { Sparkline } from './Sparkline';
 import { UsageChart } from './UsageChart';
 import { DozeControl } from './DozeControl';
 import { CalibrationPanel } from './CalibrationPanel';
+import { SweepOverlayControl } from './SweepOverlayControl';
 
 function Stat({
   label,
@@ -34,6 +35,7 @@ export function OpsPanels({ data }: { data: OpsStatsResponse }) {
   return (
     <>
       <DozeControl />
+      <SweepOverlayControl />
       {!latest ? (
         <Typography sx={{ color: '#9ca3af', p: 2 }}>No data yet.</Typography>
       ) : (

--- a/app/components/Ops/SweepOverlayControl.test.tsx
+++ b/app/components/Ops/SweepOverlayControl.test.tsx
@@ -1,0 +1,33 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { SweepOverlayControl } from './SweepOverlayControl';
+import { DEFAULT_TOGGLES, useSweepOverlayStore } from '@/app/store/useSweepOverlayStore';
+import { TERMINATOR_SUN_ALTITUDE_DEG } from '@/app/lib/masterConfig';
+
+beforeEach(() => {
+  window.localStorage.clear();
+  useSweepOverlayStore.setState({ ...DEFAULT_TOGGLES, hydrated: false });
+});
+
+describe('SweepOverlayControl', () => {
+  it('names each ring by its solar altitude and starts every switch off', () => {
+    render(<SweepOverlayControl />);
+    const base = screen.getByRole('switch', { name: `base ring ${TERMINATOR_SUN_ALTITUDE_DEG}°` });
+    expect(base).not.toBeChecked();
+    expect(screen.getByRole('switch', { name: /day ring \+/ })).not.toBeChecked();
+    expect(screen.getByRole('switch', { name: /night ring -/ })).not.toBeChecked();
+    expect(screen.getByRole('switch', { name: 'Windy boxes' })).not.toBeChecked();
+  });
+
+  it('flips the store when a switch is toggled', () => {
+    render(<SweepOverlayControl />);
+    fireEvent.click(screen.getByRole('switch', { name: /day ring/ }));
+    expect(useSweepOverlayStore.getState().showDay).toBe(true);
+  });
+
+  it('shows what was remembered from a previous visit', () => {
+    window.localStorage.setItem('sweep-overlay-toggles', JSON.stringify({ showBoxes: true }));
+    render(<SweepOverlayControl />);
+    expect(screen.getByRole('switch', { name: 'Windy boxes' })).toBeChecked();
+  });
+});

--- a/app/components/Ops/SweepOverlayControl.tsx
+++ b/app/components/Ops/SweepOverlayControl.tsx
@@ -1,0 +1,57 @@
+'use client';
+
+import { useEffect } from 'react';
+import { Box, FormControlLabel, Switch, Typography } from '@mui/material';
+import {
+  TERMINATOR_POOL_COVERAGE_DEG,
+  TERMINATOR_SUN_ALTITUDE_DEG,
+  TERMINATOR_WIDEN_OFFSETS_DEG,
+} from '@/app/lib/masterConfig';
+import { useSweepOverlayStore, type SweepOverlayToggles } from '@/app/store/useSweepOverlayStore';
+
+const fmt = (deg: number) => `${deg > 0 ? '+' : ''}${deg}°`;
+
+/**
+ * Owner switches that draw the sweep on the globe. Each row names the ring
+ * by the solar altitude it sits at, because that is the number the pool
+ * spec and the axis dials talk in; the offset is an implementation detail.
+ */
+export function SweepOverlayControl() {
+  const store = useSweepOverlayStore();
+  useEffect(() => { store.hydrate(); }, [store]);
+  const dayOffset = TERMINATOR_WIDEN_OFFSETS_DEG.find((o) => o > 0);
+  const nightOffset = TERMINATOR_WIDEN_OFFSETS_DEG.find((o) => o < 0);
+
+  const row = (key: keyof SweepOverlayToggles, label: string) => (
+    <FormControlLabel
+      key={key}
+      control={
+        <Switch
+          size="small"
+          checked={store[key]}
+          onChange={(e) => store.set(key, e.target.checked)}
+          inputProps={{ 'aria-label': label }}
+        />
+      }
+      label={<Typography sx={{ color: '#d1d5db', fontSize: 14 }}>{label}</Typography>}
+    />
+  );
+
+  return (
+    <Box sx={{ mb: 2 }}>
+      <Typography variant="caption" sx={{ color: '#9ca3af' }}>
+        Sweep on the globe (pool gathers {fmt(TERMINATOR_POOL_COVERAGE_DEG.min)} to{' '}
+        {fmt(TERMINATOR_POOL_COVERAGE_DEG.max)} solar altitude)
+      </Typography>
+      <Box sx={{ display: 'flex', flexWrap: 'wrap', columnGap: 2 }}>
+        {row('showBase', `base ring ${fmt(TERMINATOR_SUN_ALTITUDE_DEG)}`)}
+        {dayOffset !== undefined && row('showDay', `day ring ${fmt(TERMINATOR_SUN_ALTITUDE_DEG + dayOffset)}`)}
+        {nightOffset !== undefined && row('showNight', `night ring ${fmt(TERMINATOR_SUN_ALTITUDE_DEG + nightOffset)}`)}
+        {row('showBoxes', 'Windy boxes')}
+      </Box>
+      <Typography variant="caption" sx={{ color: '#6b7280' }}>
+        Escalation rings draw faint until the last tick actually swept them.
+      </Typography>
+    </Box>
+  );
+}

--- a/app/lib/sweepBox.ts
+++ b/app/lib/sweepBox.ts
@@ -1,0 +1,28 @@
+import type { Location } from '@/app/lib/types';
+
+export interface BoundingBox {
+  northLat: number;
+  southLat: number;
+  eastLon: number;
+  westLon: number;
+}
+
+/**
+ * The lat/lng box one Windy query covers around a ring point. Shared by the
+ * cron that sends it and the globe overlay that draws it, so the picture on
+ * the map is the query, not an approximation of it.
+ *
+ * Clamped at the poles and the antimeridian: Windy rejects a box that crosses
+ * either with a 400, and about 2 of 31 boxes per sweep sat there. Clamping
+ * shrinks the box rather than wrapping it, so a box straddling the
+ * antimeridian loses the sliver on the far side; that stretch is open ocean
+ * and a shrunken box still beats a 400.
+ */
+export function boundingBox(loc: Location, radiusDeg: number): BoundingBox {
+  return {
+    northLat: Math.min(90, loc.lat + radiusDeg),
+    southLat: Math.max(-90, loc.lat - radiusDeg),
+    eastLon: Math.min(180, loc.lng + radiusDeg),
+    westLon: Math.max(-180, loc.lng - radiusDeg),
+  };
+}

--- a/app/store/useSweepOverlayStore.test.ts
+++ b/app/store/useSweepOverlayStore.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  anyRingShown,
+  DEFAULT_TOGGLES,
+  SWEEP_OVERLAY_STORAGE_KEY,
+  useSweepOverlayStore,
+} from './useSweepOverlayStore';
+
+beforeEach(() => {
+  window.localStorage.clear();
+  useSweepOverlayStore.setState({ ...DEFAULT_TOGGLES, hydrated: false });
+});
+
+describe('useSweepOverlayStore', () => {
+  it('starts with everything off', () => {
+    expect(anyRingShown(useSweepOverlayStore.getState())).toBe(false);
+    expect(useSweepOverlayStore.getState().showBoxes).toBe(false);
+  });
+
+  it('remembers a toggle in localStorage', () => {
+    useSweepOverlayStore.getState().set('showDay', true);
+    expect(JSON.parse(window.localStorage.getItem(SWEEP_OVERLAY_STORAGE_KEY)!)).toEqual({
+      ...DEFAULT_TOGGLES, showDay: true,
+    });
+  });
+
+  it('hydrates from what was stored, once', () => {
+    window.localStorage.setItem(SWEEP_OVERLAY_STORAGE_KEY, JSON.stringify({ showBase: true, showBoxes: true }));
+    useSweepOverlayStore.getState().hydrate();
+    expect(useSweepOverlayStore.getState().showBase).toBe(true);
+    expect(useSweepOverlayStore.getState().showBoxes).toBe(true);
+    useSweepOverlayStore.getState().set('showBase', false);
+    window.localStorage.setItem(SWEEP_OVERLAY_STORAGE_KEY, JSON.stringify({ showBase: true }));
+    useSweepOverlayStore.getState().hydrate();
+    expect(useSweepOverlayStore.getState().showBase).toBe(false);
+  });
+
+  it('ignores junk in storage and renders the defaults', () => {
+    window.localStorage.setItem(SWEEP_OVERLAY_STORAGE_KEY, '{not json');
+    useSweepOverlayStore.getState().hydrate();
+    expect(useSweepOverlayStore.getState()).toMatchObject(DEFAULT_TOGGLES);
+    window.localStorage.setItem(SWEEP_OVERLAY_STORAGE_KEY, JSON.stringify({ showBase: 'yes' }));
+    useSweepOverlayStore.setState({ hydrated: false });
+    useSweepOverlayStore.getState().hydrate();
+    expect(useSweepOverlayStore.getState().showBase).toBe(false);
+  });
+
+  it('boxes alone draw nothing: a ring has to be shown', () => {
+    expect(anyRingShown({ ...DEFAULT_TOGGLES, showBoxes: true })).toBe(false);
+    expect(anyRingShown({ ...DEFAULT_TOGGLES, showNight: true })).toBe(true);
+  });
+});

--- a/app/store/useSweepOverlayStore.ts
+++ b/app/store/useSweepOverlayStore.ts
@@ -1,0 +1,83 @@
+'use client';
+
+import { create } from 'zustand';
+
+/**
+ * Owner toggles for drawing the sweep on the globe. Off by default; each
+ * viewer's choice is remembered in localStorage, which can be absent or
+ * throw (private window, thumbnail capture), so every touch is guarded and
+ * the store renders correctly with nothing stored.
+ */
+export interface SweepOverlayToggles {
+  /** The base ring line. */
+  showBase: boolean;
+  /** The day-side escalation ring. */
+  showDay: boolean;
+  /** The night-side escalation ring. */
+  showNight: boolean;
+  /** The Windy query boxes on every ring that is shown. */
+  showBoxes: boolean;
+}
+
+type State = SweepOverlayToggles & {
+  hydrated: boolean;
+  set: (key: keyof SweepOverlayToggles, value: boolean) => void;
+  /** Read localStorage once on the client; a no-op after the first call. */
+  hydrate: () => void;
+};
+
+export const SWEEP_OVERLAY_STORAGE_KEY = 'sweep-overlay-toggles';
+
+export const DEFAULT_TOGGLES: SweepOverlayToggles = {
+  showBase: false,
+  showDay: false,
+  showNight: false,
+  showBoxes: false,
+};
+
+function readStored(): Partial<SweepOverlayToggles> {
+  try {
+    const raw = window.localStorage.getItem(SWEEP_OVERLAY_STORAGE_KEY);
+    if (!raw) return {};
+    const parsed: unknown = JSON.parse(raw);
+    if (!parsed || typeof parsed !== 'object') return {};
+    const out: Partial<SweepOverlayToggles> = {};
+    for (const key of Object.keys(DEFAULT_TOGGLES) as (keyof SweepOverlayToggles)[]) {
+      const v = (parsed as Record<string, unknown>)[key];
+      if (typeof v === 'boolean') out[key] = v;
+    }
+    return out;
+  } catch {
+    return {};
+  }
+}
+
+function writeStored(toggles: SweepOverlayToggles): void {
+  try {
+    window.localStorage.setItem(SWEEP_OVERLAY_STORAGE_KEY, JSON.stringify(toggles));
+  } catch {
+    // storage unavailable: the toggle still works for this page load
+  }
+}
+
+const pick = (s: State): SweepOverlayToggles => ({
+  showBase: s.showBase, showDay: s.showDay, showNight: s.showNight, showBoxes: s.showBoxes,
+});
+
+export const useSweepOverlayStore = create<State>()((set, get) => ({
+  ...DEFAULT_TOGGLES,
+  hydrated: false,
+  set: (key, value) => {
+    set({ [key]: value } as Partial<State>);
+    writeStored(pick(get()));
+  },
+  hydrate: () => {
+    if (get().hydrated) return;
+    set({ ...readStored(), hydrated: true });
+  },
+}));
+
+/** True when any ring is asked for, i.e. the map has something to draw. */
+export function anyRingShown(t: SweepOverlayToggles): boolean {
+  return t.showBase || t.showDay || t.showNight;
+}


### PR DESCRIPTION
## What

The sweep that fills the pool, drawn on the globe. Four switches on the Ops tab, off by default and remembered per browser:

- **base ring** (amber), **day ring** (blue), **night ring** (purple): the ring at its solar altitude, named by altitude rather than offset.
- **Windy boxes**: the lat/lng rectangle each query actually sends, one per ring point, for every ring that is shown.

Escalation rings draw faint until the zone the cron recorded on its last tick says they swept. That zone comes from a new read-only `GET /api/sweep-zone`, same source and fallback as the solo state route, polled once a minute only while something is drawn.

## Why

The old ring line was one gray circle at 0 opacity and the search-circle layer was hardcoded off. Circles also misstate the coverage: the cron sends 22° lat/lng squares, and at high latitude a circle and a square disagree badly. The overlay now shares the cron's own box helper (moved to `app/lib/sweepBox.ts`, re-exported from the cron module), so the picture is the query.

## Notes

- Nothing is added to the map until a toggle is on; the public globe is untouched.
- Layers wait on the map's `idle` event. `isStyleLoaded()` stays false while tiles load and `style.load` has fired before the effect subscribes, so the first cut never drew.
- Stacks cleanly on #165 (ring move): the labels and coverage span read the constants, so they follow whichever merges first.
- Verified in a browser with toggles set through localStorage (Ops tab is owner-only). Signed-in look at the switches themselves is still yours.

Tests: 2402 passed (22 new). Lint and tsc clean on the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ay5xqr1nbSzysfRVaPjNwo
