### PR TITLE
feat(caption): grays reach black, a time gap, and links for the three lines

### DIFF
--- a/app/components/solo/Caption.tsx
+++ b/app/components/solo/Caption.tsx
@@ -3,7 +3,7 @@
 import type { CSSProperties } from 'react';
 import type { Feed, SoloDials } from '@/app/lib/solo/types';
 import {
-  FONT_STACKS, LINE_HEIGHT, captionBox, captionLines, captionScale, formatTime, gray, splitTime,
+  FONT_STACKS, LINE_HEIGHT, captionBox, captionLines, captionScale, formatTime, gray, lineGaps, splitTime,
   type CaptionEntry, type Rect,
 } from '@/app/lib/solo/caption';
 
@@ -45,10 +45,13 @@ export function Caption({ entry, dials, picture, width, feed, step }: {
   const box = captionBox(dials, picture, width);
   const overlay = dials.captionLayout === 'overlay';
   const inline = dials.timeLine === 'inline';
+  // Margins, not a flex gap: the time line can be pushed further down than
+  // the place line is, and captionHeight adds up the same two numbers.
+  const gaps = lineGaps(dials);
 
   const block: CSSProperties = {
     position: 'absolute', left: box.left, top: box.top, bottom: box.bottom, width: box.width, maxWidth: box.maxWidth,
-    textAlign: box.textAlign, display: 'flex', flexDirection: 'column', gap: dials.lineGap * s,
+    textAlign: box.textAlign, display: 'flex', flexDirection: 'column',
     fontFamily: FONT_STACKS[dials.font], whiteSpace: 'nowrap',
     textShadow: overlay ? '0 1px 4px #000' : undefined,
   };
@@ -102,13 +105,17 @@ export function Caption({ entry, dials, picture, width, feed, step }: {
           {lines.title}
         </div>
         {(lines.place || (inline && time)) && (
-          <div data-testid="caption-place" style={{ ...line, fontSize: dials.placeSize * s, color: gray(dials.placeGray), lineHeight: LINE_HEIGHT.place }}>
+          <div data-testid="caption-place" style={{ ...line, marginTop: gaps.place * s, fontSize: dials.placeSize * s, color: gray(dials.placeGray), lineHeight: LINE_HEIGHT.place }}>
             {lines.place}
             {inline && time && lines.place ? <span style={{ color: gray(dials.timeGray) }}> · </span> : null}
             {inline ? time : null}
           </div>
         )}
-        {!inline && time && <div style={{ ...line, lineHeight: LINE_HEIGHT.time }}>{time}</div>}
+        {!inline && time && (
+          <div data-testid="caption-time-line" style={{ ...line, marginTop: gaps.time * s, lineHeight: LINE_HEIGHT.time }}>
+            {time}
+          </div>
+        )}
       </div>
     </>
   );

--- a/app/components/solo/SoloFrame.test.tsx
+++ b/app/components/solo/SoloFrame.test.tsx
@@ -33,6 +33,29 @@ it('caption sizes are glass pixels: the dialled px on a 1920 panel, and the gray
   expect(screen.getByTestId('caption')).toHaveStyle({ left: '125px', top: '1028px', maxWidth: '1671px' });
 });
 
+it('the line gap spaces every line after the first; the time gap pushes the time further down still', () => {
+  const { rerender } = render(<SoloFrame entry={e} previous={null} fadeS={0}
+    dials={{ ...D, lineGap: 6, timeGap: 0 }} width={1920} height={1080} />);
+  expect(screen.getByTestId('caption-place')).toHaveStyle({ marginTop: '6px' });
+  expect(screen.getByTestId('caption-time-line')).toHaveStyle({ marginTop: '6px' });
+  rerender(<SoloFrame entry={e} previous={null} fadeS={0}
+    dials={{ ...D, lineGap: 6, timeGap: 14 }} width={1920} height={1080} />);
+  expect(screen.getByTestId('caption-place')).toHaveStyle({ marginTop: '6px' });
+  expect(screen.getByTestId('caption-time-line')).toHaveStyle({ marginTop: '20px' });
+  // glass pixels like every other caption size: half the panel, half the gaps
+  rerender(<SoloFrame entry={e} previous={null} fadeS={0}
+    dials={{ ...D, lineGap: 6, timeGap: 14 }} width={960} height={540} />);
+  expect(screen.getByTestId('caption-time-line')).toHaveStyle({ marginTop: '10px' });
+});
+
+it('a gray dialled to 0 draws the line black', () => {
+  render(<SoloFrame entry={e} previous={null} fadeS={0}
+    dials={{ ...D, titleGray: 0, placeGray: 0, timeGray: 0 }} width={1920} height={1080} />);
+  expect(screen.getByTestId('caption-title')).toHaveStyle({ color: 'rgb(0, 0, 0)' });
+  expect(screen.getByTestId('caption-place')).toHaveStyle({ color: 'rgb(0, 0, 0)' });
+  expect(screen.getByTestId('caption-time')).toHaveStyle({ color: 'rgb(0, 0, 0)' });
+});
+
 it('on a half-size panel everything halves', () => {
   render(<SoloFrame entry={e} previous={null} fadeS={0} dials={D} width={960} height={540} />);
   expect(screen.getByRole('presentation')).toHaveStyle({ width: '836px', height: '470px' });

--- a/app/lib/solo/caption.test.ts
+++ b/app/lib/solo/caption.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { captionBox, captionHeight, captionLines, displayTitle, drawFactor, formatTime, gray, pictureRect, splitTime } from './caption';
+import { captionBox, captionHeight, captionLines, displayTitle, drawFactor, formatTime, gray, lineGaps, pictureRect, splitTime } from './caption';
 
 // 02:42 UTC on 2026-09-05 is 7:42 pm the evening before in Mazatlán (UTC−7).
 const AT = Date.UTC(2026, 8, 5, 2, 42);
@@ -138,8 +138,16 @@ describe('splitTime', () => {
   });
 });
 
+describe('lineGaps', () => {
+  it('the time carries the line gap plus its own, so it can sit apart from the two lines above it', () => {
+    expect(lineGaps({ lineGap: 0, timeGap: 0 })).toEqual({ place: 0, time: 0 });
+    expect(lineGaps({ lineGap: 4, timeGap: 0 })).toEqual({ place: 4, time: 4 });
+    expect(lineGaps({ lineGap: 4, timeGap: 12 })).toEqual({ place: 4, time: 16 });
+  });
+});
+
 describe('captionHeight', () => {
-  const d = { titleSize: 21, placeSize: 17, timeSize: 12, lineGap: 0, timeLine: 'own' as const };
+  const d = { titleSize: 21, placeSize: 17, timeSize: 12, lineGap: 0, timeGap: 0, timeLine: 'own' as const };
   const lines = { place: 'Norrbotten County, Sweden', time: '7:42 pm there' };
   it('adds the lines that will exist at the glass line heights, plus the gaps between them, at scale', () => {
     // title 21 × 1.15 + place 17 × 1.3 + time 12 × 1.3
@@ -149,9 +157,19 @@ describe('captionHeight', () => {
     expect(captionHeight({ ...d, lineGap: 4 }, lines, 1)).toBeCloseTo(61.85 + 8);
     expect(captionHeight(d, lines, 0.5)).toBeCloseTo(61.85 / 2);
   });
+  it('the time gap pushes the time line down and the block grows by exactly that much', () => {
+    expect(captionHeight({ ...d, timeGap: 10 }, lines, 1)).toBeCloseTo(61.85 + 10);
+    expect(captionHeight({ ...d, lineGap: 4, timeGap: 10 }, lines, 1)).toBeCloseTo(61.85 + 8 + 10);
+    // with no place line the time is still the line that carries the extra gap
+    expect(captionHeight({ ...d, timeGap: 10 }, { place: '', time: '7:42 pm' }, 1)).toBeCloseTo(21 * 1.15 + 12 * 1.3 + 10);
+    expect(captionHeight({ ...d, timeGap: 10 }, lines, 0.5)).toBeCloseTo((61.85 + 10) / 2);
+  });
   it('an inline time shares the place line, and makes one when there is no place', () => {
     expect(captionHeight({ ...d, timeLine: 'inline' }, lines, 1)).toBeCloseTo(21 * 1.15 + 17 * 1.3);
     expect(captionHeight({ ...d, timeLine: 'inline' }, { place: '', time: '7:42 pm' }, 1)).toBeCloseTo(21 * 1.15 + 17 * 1.3);
+  });
+  it('an inline time ignores the time gap: there is no time line to push down', () => {
+    expect(captionHeight({ ...d, timeLine: 'inline', timeGap: 30 }, lines, 1)).toBeCloseTo(21 * 1.15 + 17 * 1.3);
   });
 });
 

--- a/app/lib/solo/caption.ts
+++ b/app/lib/solo/caption.ts
@@ -170,20 +170,34 @@ export interface CaptionBox {
 export const LINE_HEIGHT = { title: 1.15, place: 1.3, time: 1.3 } as const;
 
 /**
+ * The space above each caption line, in glass pixels: nothing above the first
+ * line, `lineGap` above any line after it, and `timeGap` on top of that above
+ * the time when the time has a line of its own. Caption.tsx draws these as
+ * margins and captionHeight adds them up, so the two always agree about how
+ * far the block reaches.
+ */
+export function lineGaps(
+  d: Pick<SoloDials, 'lineGap' | 'timeGap'>,
+): { place: number; time: number } {
+  return { place: d.lineGap, time: d.lineGap + d.timeGap };
+}
+
+/**
  * How tall the caption block will be, in CSS pixels at scale `s`: the lines
  * that will exist (the title always; the place line when there is a place or
  * an inline time; the time on its own line unless inline) at the line heights
- * Caption draws with, plus the line gap between them.
+ * Caption draws with, plus the gap above each line after the first.
  */
 export function captionHeight(
-  d: Pick<SoloDials, 'titleSize' | 'placeSize' | 'timeSize' | 'lineGap' | 'timeLine'>,
+  d: Pick<SoloDials, 'titleSize' | 'placeSize' | 'timeSize' | 'lineGap' | 'timeGap' | 'timeLine'>,
   lines: Pick<CaptionLines, 'place' | 'time'>, s: number,
 ): number {
   const inline = d.timeLine === 'inline';
-  const heights = [d.titleSize * LINE_HEIGHT.title];
-  if (lines.place || (inline && lines.time)) heights.push(d.placeSize * LINE_HEIGHT.place);
-  if (!inline && lines.time) heights.push(d.timeSize * LINE_HEIGHT.time);
-  return (heights.reduce((a, b) => a + b, 0) + d.lineGap * (heights.length - 1)) * s;
+  const gaps = lineGaps(d);
+  let total = d.titleSize * LINE_HEIGHT.title;
+  if (lines.place || (inline && lines.time)) total += gaps.place + d.placeSize * LINE_HEIGHT.place;
+  if (!inline && lines.time) total += gaps.time + d.timeSize * LINE_HEIGHT.time;
+  return total * s;
 }
 
 /**

--- a/app/lib/solo/captionSchema.test.ts
+++ b/app/lib/solo/captionSchema.test.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect } from 'vitest';
-import { CAPTION_SCHEMA, CAPTION_SECTION, captionDialsFrom, withCaption } from './captionSchema';
+import {
+  CAPTION_SCHEMA, CAPTION_SECTION, captionDialsFrom, linkedCaptionGroup, linkedCaptionValues, withCaption,
+} from './captionSchema';
 import { mergeSettings, schemaDefaults } from '@/app/lib/settings/schema';
 
 describe('CAPTION_SCHEMA', () => {
@@ -9,7 +11,7 @@ describe('CAPTION_SCHEMA', () => {
       font: 'system', feedPrefix: true, titleClean: 'compass',
       titleSize: 21, titleWeight: '300', titleGray: 71,
       placeSize: 17, placeGray: 57, lineGap: 0,
-      timeStyle: '12h-there', timeLine: 'own', timeSize: 12, timeGray: 46,
+      timeStyle: '12h-there', timeLine: 'own', timeGap: 0, timeSize: 12, timeGray: 46,
     });
   });
 
@@ -24,6 +26,54 @@ describe('CAPTION_SCHEMA', () => {
         expect(k.default, k.key).toBeLessThanOrEqual(k.max);
       }
     }
+  });
+});
+
+describe('the gray dials', () => {
+  it('every gray reaches 0, so any caption line can be taken all the way to black', () => {
+    for (const key of ['titleGray', 'placeGray', 'timeGray']) {
+      const knob = CAPTION_SCHEMA.find((k) => k.key === key);
+      expect(knob?.kind, key).toBe('number');
+      expect(knob && knob.kind === 'number' && knob.min, key).toBe(0);
+    }
+  });
+});
+
+describe('linkedCaptionValues', () => {
+  const sizes = { titleSize: 21, placeSize: 17, timeSize: 12 };
+  const grays = { titleGray: 71, placeGray: 57, timeGray: 46 };
+
+  it('names the group a caption key belongs to, and nothing for the rest', () => {
+    expect(linkedCaptionGroup('placeSize')).toBe('size');
+    expect(linkedCaptionGroup('timeGray')).toBe('gray');
+    expect(linkedCaptionGroup('lineGap')).toBe(null);
+    expect(linkedCaptionGroup('captionGap')).toBe(null);
+  });
+
+  it('sizes scale by the ratio the dragged one moved, so the hierarchy holds', () => {
+    // 21 → 42 is 2×: 17 → 34 and 12 → 24.
+    expect(linkedCaptionValues('size', 'titleSize', 42, sizes)).toEqual({ placeSize: 34, timeSize: 24 });
+    // dragging a smaller line scales the bigger ones the same way: 12 → 6 is a half.
+    expect(linkedCaptionValues('size', 'timeSize', 6, sizes)).toEqual({ titleSize: 11, placeSize: 9 });
+  });
+
+  it('grays shift by the points the dragged one moved, so the contrast steps hold', () => {
+    expect(linkedCaptionValues('gray', 'titleGray', 81, grays)).toEqual({ placeGray: 67, timeGray: 56 });
+    expect(linkedCaptionValues('gray', 'placeGray', 47, grays)).toEqual({ titleGray: 61, timeGray: 36 });
+  });
+
+  it('a sibling that reaches the end of its own slider stops there while the others carry on', () => {
+    // title 71 → 0 is −71 points; place floors at 0 and so does time.
+    expect(linkedCaptionValues('gray', 'titleGray', 0, grays)).toEqual({ placeGray: 0, timeGray: 0 });
+    // time tops out at 90 while place still has room.
+    expect(linkedCaptionValues('gray', 'titleGray', 100, grays)).toEqual({ placeGray: 86, timeGray: 75 });
+    // sizes floor at their own minimums: title 10, place 8.
+    expect(linkedCaptionValues('size', 'timeSize', 8, sizes)).toEqual({ titleSize: 14, placeSize: 11 });
+  });
+
+  it('says nothing when the dial did not move, or when the value it moved from is missing', () => {
+    expect(linkedCaptionValues('size', 'titleSize', 21, sizes)).toEqual({});
+    expect(linkedCaptionValues('gray', 'titleGray', 80, {})).toEqual({});
   });
 });
 

--- a/app/lib/solo/captionSchema.ts
+++ b/app/lib/solo/captionSchema.ts
@@ -73,7 +73,7 @@ export const CAPTION_SCHEMA: SettingsSchema = [
     description: '300 light, 400 regular, 500 medium, 600 semibold.',
   },
   {
-    key: 'titleGray', kind: 'number', min: 40, max: 100, step: 1, default: 71,
+    key: 'titleGray', kind: 'number', min: 0, max: 100, step: 1, default: 71,
     label: 'title gray (%)', section: CAPTION_SECTION,
     description: '100 is white.',
   },
@@ -83,14 +83,14 @@ export const CAPTION_SCHEMA: SettingsSchema = [
     description: 'The region and country line.',
   },
   {
-    key: 'placeGray', kind: 'number', min: 30, max: 100, step: 1, default: 57,
+    key: 'placeGray', kind: 'number', min: 0, max: 100, step: 1, default: 57,
     label: 'place gray (%)', section: CAPTION_SECTION,
     description: '100 is white.',
   },
   {
     key: 'lineGap', kind: 'number', min: 0, max: 24, step: 1, default: 0,
     label: 'line gap (px)', section: CAPTION_SECTION,
-    description: 'Extra space between the caption\'s lines.',
+    description: 'Extra space above every caption line after the first.',
   },
   {
     key: 'timeStyle', kind: 'enum', options: ['off', '12h', '12h-there', '24h', 'sun', '12h-sun'], default: '12h-there',
@@ -103,16 +103,71 @@ export const CAPTION_SCHEMA: SettingsSchema = [
     description: 'own: the time on its own line under the place. inline: after the place with a middle dot.',
   },
   {
+    key: 'timeGap', kind: 'number', min: 0, max: 60, step: 1, default: 0,
+    label: 'time gap (px)', section: CAPTION_SECTION,
+    description: 'Extra space above the time line only, on top of the line gap, so the time can sit apart from the title and the place instead of evenly under them. Nothing when the time is inline.',
+  },
+  {
     key: 'timeSize', kind: 'number', min: 8, max: 32, step: 1, default: 12,
     label: 'time size (px)', section: CAPTION_SECTION,
     description: 'The time line.',
   },
   {
-    key: 'timeGray', kind: 'number', min: 20, max: 90, step: 1, default: 46,
+    key: 'timeGray', kind: 'number', min: 0, max: 90, step: 1, default: 46,
     label: 'time gray (%)', section: CAPTION_SECTION,
     description: '100 would be white; keep it quieter than the place.',
   },
 ] as const;
+
+/**
+ * The three title / place / time dials the studio can drive as one, per
+ * group. Editing state, not glass state: the caption draws from three
+ * independent numbers whether or not the studio was linking them, so nothing
+ * about a link is stored or deployed.
+ */
+export const LINKED_CAPTION_KEYS = {
+  size: ['titleSize', 'placeSize', 'timeSize'],
+  gray: ['titleGray', 'placeGray', 'timeGray'],
+} as const;
+
+export type LinkedCaptionGroup = keyof typeof LINKED_CAPTION_KEYS;
+
+/** Which linked group a caption key belongs to, or null for the rest of them. */
+export function linkedCaptionGroup(key: string): LinkedCaptionGroup | null {
+  for (const group of Object.keys(LINKED_CAPTION_KEYS) as LinkedCaptionGroup[]) {
+    if ((LINKED_CAPTION_KEYS[group] as readonly string[]).includes(key)) return group;
+  }
+  return null;
+}
+
+const CAPTION_KNOBS = new Map(CAPTION_SCHEMA.map((k) => [k.key, k]));
+
+/**
+ * What the other two dials of a linked group become when one of them moves
+ * from its value in `values` to `next`. Sizes are pixels, so they scale by
+ * the same ratio and the hierarchy between the three lines survives a drag;
+ * grays are already percents of white, so they shift by the same number of
+ * points and the contrast steps between the lines survive one. Each result is
+ * rounded and clamped into its own dial's range, so a line that reaches an
+ * end stops there while the others keep moving — dragging back does not
+ * restore it, which is what a slider that has hit its floor should do.
+ */
+export function linkedCaptionValues(
+  group: LinkedCaptionGroup, changed: string, next: number, values: SettingsValues,
+): Record<string, number> {
+  const out: Record<string, number> = {};
+  const from = Number(values[changed]);
+  if (!Number.isFinite(from) || !Number.isFinite(next) || from === next) return out;
+  for (const key of LINKED_CAPTION_KEYS[group]) {
+    if (key === changed) continue;
+    const knob = CAPTION_KNOBS.get(key);
+    const was = Number(values[key]);
+    if (!knob || knob.kind !== 'number' || !Number.isFinite(was)) continue;
+    const moved = group === 'size' ? (from === 0 ? was : was * next / from) : was + (next - from);
+    out[key] = Math.min(knob.max, Math.max(knob.min, Math.round(moved)));
+  }
+  return out;
+}
 
 /** Typed view of merged caption values (mergeSettings over CAPTION_SCHEMA). */
 export function captionDialsFrom(values: SettingsValues): CaptionDials {
@@ -133,6 +188,7 @@ export function captionDialsFrom(values: SettingsValues): CaptionDials {
     lineGap: values.lineGap as number,
     timeStyle: values.timeStyle as TimeStyle,
     timeLine: values.timeLine as TimeLine,
+    timeGap: values.timeGap as number,
     timeSize: values.timeSize as number,
     timeGray: values.timeGray as number,
   };

--- a/app/lib/solo/settingsSchema.test.ts
+++ b/app/lib/solo/settingsSchema.test.ts
@@ -20,7 +20,7 @@ describe('SOLO_SETTINGS_SCHEMA', () => {
       font: 'system', feedPrefix: true, titleClean: 'compass',
       titleSize: 21, titleWeight: '300', titleGray: 71,
       placeSize: 17, placeGray: 57, lineGap: 0,
-      timeStyle: '12h-there', timeLine: 'own', timeSize: 12, timeGray: 46,
+      timeStyle: '12h-there', timeLine: 'own', timeGap: 0, timeSize: 12, timeGray: 46,
     });
   });
 

--- a/app/lib/solo/types.ts
+++ b/app/lib/solo/types.ts
@@ -72,6 +72,8 @@ export interface CaptionDials {
   lineGap: number;
   timeStyle: TimeStyle;
   timeLine: TimeLine;
+  /** Extra space above the time line, on top of lineGap; own-line time only. */
+  timeGap: number;
   timeSize: number;
   timeGray: number;
 }

--- a/app/studio/Rail.test.tsx
+++ b/app/studio/Rail.test.tsx
@@ -55,6 +55,33 @@ describe('Rail, solo kind', () => {
     fireEvent.change(screen.getByLabelText('title size (px)'), { target: { value: '30' } });
     expect(a.setKnob).toHaveBeenCalledWith('shared', 'titleSize', 30);
   });
+  it('with sizes linked, one size drag scales the other two; unlinked, it moves alone', () => {
+    const a = api();
+    render(<Rail api={a} surface={STUDIO_SURFACES.solo} tab="picture" onTab={noop} />);
+    fireEvent.change(screen.getByLabelText('title size (px)'), { target: { value: '42' } });
+    expect(a.setKnob).toHaveBeenCalledTimes(1);
+    expect(a.setKnob).toHaveBeenCalledWith('shared', 'titleSize', 42);
+
+    fireEvent.click(screen.getByLabelText('sizes'));
+    fireEvent.change(screen.getByLabelText('title size (px)'), { target: { value: '42' } });
+    // 21 → 42 is 2×, so place 17 → 34 and time 12 → 24.
+    expect(a.setKnob).toHaveBeenCalledWith('shared', 'placeSize', 34);
+    expect(a.setKnob).toHaveBeenCalledWith('shared', 'timeSize', 24);
+    // the grays are a link of their own and stay put
+    expect(a.setKnob).not.toHaveBeenCalledWith('shared', 'placeGray', expect.anything());
+  });
+  it('with grays linked, one gray drag shifts the other two by the same points', () => {
+    const a = api();
+    render(<Rail api={a} surface={STUDIO_SURFACES.solo} tab="picture" onTab={noop} />);
+    fireEvent.click(screen.getByLabelText('grays'));
+    fireEvent.change(screen.getByLabelText('title gray (%)'), { target: { value: '81' } });
+    expect(a.setKnob).toHaveBeenCalledWith('shared', 'titleGray', 81);
+    expect(a.setKnob).toHaveBeenCalledWith('shared', 'placeGray', 67);
+    expect(a.setKnob).toHaveBeenCalledWith('shared', 'timeGray', 56);
+    // a caption dial outside the two groups is never carried along
+    fireEvent.change(screen.getByLabelText('gap (px)'), { target: { value: '20' } });
+    expect(a.setKnob).toHaveBeenLastCalledWith('shared', 'captionGap', 20);
+  });
   it('solo2 shows the dwell readout after the camera-run knob', () => {
     render(<Rail api={api()} surface={STUDIO_SURFACES.solo2} tab="play" onTab={noop} runFrames={3} />);
     expect(screen.getByTestId('dwell-budget')).toBeInTheDocument();

--- a/app/studio/Rail.tsx
+++ b/app/studio/Rail.tsx
@@ -4,7 +4,10 @@ import { Fragment, useState, type CSSProperties, type ReactNode } from 'react';
 import type { StudioSettingsApi } from './useStudioSettings';
 import type { StudioSurface } from './surfaces';
 import { SHARED_NAMESPACE } from '@/app/lib/settings/sharedSchema';
-import { CAPTION_SCHEMA, CAPTION_SECTION, withCaption } from '@/app/lib/solo/captionSchema';
+import {
+  CAPTION_SCHEMA, CAPTION_SECTION, linkedCaptionGroup, linkedCaptionValues, withCaption,
+  type LinkedCaptionGroup,
+} from '@/app/lib/solo/captionSchema';
 import { SOURCE_FRAME, drawFactor, pictureRect } from '@/app/lib/solo/caption';
 import { PANEL_PRESETS, DEFAULT_PANEL_PRESET, type PanelSize } from '@/app/kiosk/panelPreview';
 import type { KnobDescriptor, KnobValue, SettingsSchema, SettingsValues } from '@/app/lib/settings/schema';
@@ -218,6 +221,40 @@ function GroupHeader({ title, color, hint, section, onReset, asSummary = false, 
 }
 
 /**
+ * The caption's two links, above its dials. With one on, dragging any of the
+ * three title / place / time dials in that group carries the other two: the
+ * sizes by the same ratio, the grays by the same number of points, so the
+ * block is re-scaled or re-dimmed as a whole instead of three sliders at a
+ * time. It is editing state only — it lives for as long as the page does and
+ * nothing about it is stored or deployed.
+ */
+function CaptionLinks({ linked, onToggle }: {
+  linked: Record<LinkedCaptionGroup, boolean>;
+  onToggle: (group: LinkedCaptionGroup, on: boolean) => void;
+}) {
+  const groups: { group: LinkedCaptionGroup; label: string; hint: string }[] = [
+    { group: 'size', label: 'sizes', hint: 'Move one of the title, place and time sizes and the other two scale by the same ratio, keeping the hierarchy between the lines. A size that reaches the end of its own slider stops there.' },
+    { group: 'gray', label: 'grays', hint: 'Move one of the title, place and time grays and the other two shift by the same number of points, keeping the contrast steps between the lines. A gray that reaches the end of its own slider stops there.' },
+  ];
+  return (
+    <div data-testid="caption-links" style={{
+      display: 'flex', alignItems: 'center', gap: 10, padding: '2px 4px 6px',
+      fontSize: 11, color: '#8b95a7',
+    }}>
+      <span>link title · place · time</span>
+      {groups.map(({ group, label, hint }) => (
+        <span key={group} style={{ display: 'inline-flex', alignItems: 'center', gap: 4 }}>
+          <input id={`rail-link-${group}`} type="checkbox" checked={linked[group]}
+            onChange={(e) => onToggle(group, e.target.checked)} />
+          <LabeledControl id={`rail-link-${group}`} description={hint}
+            style={{ color: '#8b95a7', fontSize: 11, cursor: 'help' }}>{label}</LabeledControl>
+        </span>
+      ))}
+    </div>
+  );
+}
+
+/**
  * The one dial rail (one-studio spec §2.3). It renders whatever schema the
  * surface hands it: a solo version's two coloured groups plus the shared
  * picture page, or a mosaic version's sections as collapsible groups. No
@@ -259,11 +296,31 @@ export function Rail({ api, surface, tab, onTab, runFrames = 1, children }: {
   // Which collapsible groups are open. Unvisited sections fall back to
   // "the first one", so the rail opens the same way it always did.
   const [opened, setOpened] = useState<Record<string, boolean>>({});
+  // Which caption groups are linked. Editing state: never written to a namespace.
+  const [linked, setLinked] = useState<Record<LinkedCaptionGroup, boolean>>({ size: false, gray: false });
 
-  const knob = (k: KnobDescriptor, target: { ns: string; values: SettingsValues; diff: Set<string> }) => (
+  // A caption write, plus its linked siblings. `shared` is what the rail is
+  // already rendering, so the ratio the sizes scale by is measured against
+  // the values on screen; the siblings go out in the same event, which
+  // useStudioSettings merges through its ref rather than one overwriting
+  // the other.
+  const setCaptionKnob = (key: string, v: KnobValue) => {
+    api.setKnob(SHARED_NAMESPACE, key, v);
+    const group = linkedCaptionGroup(key);
+    if (!group || !linked[group] || typeof v !== 'number') return;
+    for (const [sibling, value] of Object.entries(linkedCaptionValues(group, key, v, shared))) {
+      api.setKnob(SHARED_NAMESPACE, sibling, value);
+    }
+  };
+
+  const knob = (k: KnobDescriptor, target: {
+    ns: string; values: SettingsValues; diff: Set<string>;
+    /** Owns the write when set, so a page can carry sibling dials along with it. */
+    onChange?: (key: string, v: KnobValue) => void;
+  }) => (
     <Fragment key={k.key}>
       <Control knob={k} value={target.values[k.key]} differs={target.diff.has(k.key)}
-        onChange={(v) => api.setKnob(target.ns, k.key, v)} />
+        onChange={(v) => (target.onChange ? target.onChange(k.key, v) : api.setKnob(target.ns, k.key, v))} />
       {k.key === 'pictureHeight' && soloDials && <PictureReadout dials={soloDials} panel={panel} />}
       {k.key === 'cameraRun' && planDials && <DwellBudget dials={planDials} frames={runFrames} />}
     </Fragment>
@@ -315,7 +372,10 @@ export function Rail({ api, surface, tab, onTab, runFrames = 1, children }: {
         <section>
           <GroupHeader {...CAPTION_GROUP} section={CAPTION_SECTION}
             onReset={() => api.resetSection(SHARED_NAMESPACE, CAPTION_SECTION)} />
-          {CAPTION_SCHEMA.map((k) => knob(k, { ns: SHARED_NAMESPACE, values: shared, diff: sharedDiff }))}
+          <CaptionLinks linked={linked} onToggle={(g, on) => setLinked((l) => ({ ...l, [g]: on }))} />
+          {CAPTION_SCHEMA.map((k) => knob(k, {
+            ns: SHARED_NAMESPACE, values: shared, diff: sharedDiff, onChange: setCaptionKnob,
+          }))}
         </section>
       )}
       <div style={{ marginTop: 'auto', paddingTop: 10 }}>{children}</div>


### PR DESCRIPTION
Three things the caption could not do while you were dialling it in on glass.

## The grays reach black

They stopped at 40 (title), 30 (place) and 20 (time). All three floor at 0 now, so any caption line can be taken all the way down. The time's ceiling stays at 90: it is meant to sit quieter than the place.

## A gap for the time line alone

One line gap spaced every line evenly, so the time could not be set apart from the title and the place. A new `timeGap` dial adds space above the time line only, on top of the line gap. It does nothing when the time is inline, because then there is no time line to push down. Default 0, so nothing moves until you drag it.

`Caption.tsx` now draws the gaps as margins rather than a flex gap, and `lineGaps()` is the one place both it and `captionHeight` read them from, so the drawn block and the measured block cannot disagree.

## Linked sizes and grays

Two checkboxes at the top of the Picture page. With one on, dragging any of the three dials in that group carries the other two:

- **sizes** scale by the same ratio, so the hierarchy between the lines survives a drag
- **grays** shift by the same number of points, so the contrast steps between the lines survive one

A sibling that reaches the end of its own slider stops there. The link is editing state that lives on the rail: it is never stored, never deployed, and the glass still draws from three independent numbers, so no version can drift on it.

## Verification

`npm run test` (2415 passing), `npm run lint`, `npm run build` all green. New coverage for the gray floors, the gap arithmetic in `captionHeight` and in the rendered margins, the link math including clamping, and the rail wiring.

No migration. Not yet looked at signed-in, and not yet on glass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019dqJA4E1zc1qM9WEnxN7Mg
