### PR TITLE
solo2: a sunrise stops ending in black, and a run's first frame holds as long as the rest

### DIFF
--- a/app/components/solo2/index.test.tsx
+++ b/app/components/solo2/index.test.tsx
@@ -53,7 +53,8 @@ it('with the camera run off, the dwell is the drawn frame alone', () => {
 });
 
 it('the dwell clock starts at the server\'s shown-since, so a follower joins the run in the right place', () => {
-  mocked.mockImplementation(() => ({ ...glass, shownSince: 13_000, boundaryMs: 40_000 })); // 7 s in: frame 2 of 3 (6.67 s each)
+  // 8.5 s in: the 1.5 s arrival segment, then 7 s into the run = frame 2 of 3 (6.67 s each)
+  mocked.mockImplementation(() => ({ ...glass, shownSince: 11_500, boundaryMs: 40_000 }));
   render(<Solo2Kiosk webcams={[]} width={100} height={50} feed="sunset" />);
   expect(screen.getByTestId('top')).toHaveAttribute('src', 'u2');
 });

--- a/app/components/solo2/useStage.ts
+++ b/app/components/solo2/useStage.ts
@@ -12,9 +12,9 @@ const same = (a: Stage, b: Stage) => a.index === b.index && a.leadProgress === b
  */
 export function useStage(plan: DwellPlan, startMs: number, tickMs = 250): Stage {
   const [stage, setStage] = useState<Stage>(() => stageAt(Date.now() - startMs, plan));
-  const { dwellS, frames, stepS, leadS } = plan;
+  const { dwellS, frames, stepS, leadS, arrivalS } = plan;
   useEffect(() => {
-    const p = { dwellS, frames, stepS, leadS };
+    const p = { dwellS, frames, stepS, leadS, arrivalS };
     const read = () => setStage((prev) => {
       const nextStage = stageAt(Date.now() - startMs, p);
       return same(prev, nextStage) ? prev : nextStage;
@@ -22,6 +22,6 @@ export function useStage(plan: DwellPlan, startMs: number, tickMs = 250): Stage 
     read();
     const t = setInterval(read, tickMs);
     return () => clearInterval(t);
-  }, [startMs, tickMs, dwellS, frames, stepS, leadS]);
+  }, [startMs, tickMs, dwellS, frames, stepS, leadS, arrivalS]);
   return stage;
 }

--- a/app/lib/solo/replay.test.ts
+++ b/app/lib/solo/replay.test.ts
@@ -168,7 +168,8 @@ describe('replay', () => {
       sun(1, 0.9, { webcamId: 7, capturedAt: 100 }), sun(3, 0.7, { webcamId: 7, capturedAt: 300 }),
       sun(2, 0.8, { webcamId: 8, capturedAt: 150 }),
     ];
-    const strip = replay({ feed: FEED, version: SOLO_VERSIONS.solo2, dials: d2, entries: rows, priorDraws: [], fromMs: at(SLOT0), toMs: at(SLOT0 + 1) });
+    // A solo2 dwell is the 20 s budget plus the 1.5 s arrival segment (dwell-budget spec §3.3), so the window reaches past one of them.
+    const strip = replay({ feed: FEED, version: SOLO_VERSIONS.solo2, dials: d2, entries: rows, priorDraws: [], fromMs: at(SLOT0), toMs: at(SLOT0) + 21_500 });
     expect(strip.frames[0]).toMatchObject({ snapshotId: 3, shownSnapshotIds: [1, 3] });
     expect(strip.frames[1].snapshotId).toBe(2);
   });

--- a/app/lib/solo/versions.test.ts
+++ b/app/lib/solo/versions.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from 'vitest';
+import { arrivalS } from '@/app/lib/solo2/plan';
 import { schemaDefaults } from '@/app/lib/settings/schema';
 import { project } from './engine';
 import { SOLO_VERSIONS, resolveSoloVersion } from './versions';
@@ -36,9 +37,12 @@ describe('descriptors', () => {
     // renders toward a dwell end follows without knowing about versions.
     for (const v of Object.values(SOLO_VERSIONS)) {
       const d = v.dialsFrom(schemaDefaults(v.schema));
-      expect(v.dwellMs(entries, entries[0], d)).toBe(d.dwellS * 1000);
+      // solo2's dwell opens with the camera change's own segment (dwell-budget
+      // spec §3.3); solo's dials have no fades, so its arrival is 0.
+      const expected = (d.dwellS + arrivalS(d)) * 1000;
+      expect(v.dwellMs(entries, entries[0], d)).toBe(expected);
       // Pure: same answer for a different pick, and no mutation of the input.
-      expect(v.dwellMs(entries, entries[2], d)).toBe(d.dwellS * 1000);
+      expect(v.dwellMs(entries, entries[2], d)).toBe(expected);
       expect(entries.map((e) => e.tally)).toEqual([0, 0, 0]);
     }
   });

--- a/app/lib/solo2/engine.test.ts
+++ b/app/lib/solo2/engine.test.ts
@@ -160,6 +160,9 @@ describe('the camera run', () => {
 
 describe('dwellMs2: the budget rule over the frames actually played', () => {
   const D2 = { ...dialsFrom2(schemaDefaults(SOLO2_SETTINGS_SCHEMA)), cameraRun: true };
+  // The camera change's own segment at the default fades (dwell-budget spec
+  // §3.3): every dwell is this much longer than the frames' budget.
+  const ARRIVAL = 1_500;
   const frame = (id: number, cam: number, at: number, bin: 'sunset' | 'non_sunset' = 'sunset') => ({
     snapshotId: id, webcamId: cam, bin, quality: bin === 'sunset' ? 0.9 : null, detection: 0.9,
     isNew: false, tally: 0, enteredAt: at, capturedAt: at,
@@ -167,32 +170,32 @@ describe('dwellMs2: the budget rule over the frames actually played', () => {
 
   it('a lone frame holds the whole dwell', () => {
     const one = [frame(1, 7, 1000)];
-    expect(dwellMs2(one, one[0], D2)).toBe(D2.dwellS * 1000);
+    expect(dwellMs2(one, one[0], D2)).toBe(D2.dwellS * 1000 + ARRIVAL);
   });
 
   it('below the threshold the dwell does not move however many frames play', () => {
     const five = Array.from({ length: 5 }, (_, i) => frame(i + 1, 7, (i + 1) * 1000));
-    expect(dwellMs2(five, five[4], D2)).toBe(D2.dwellS * 1000);
+    expect(dwellMs2(five, five[4], D2)).toBe(D2.dwellS * 1000 + ARRIVAL);
   });
 
   it('above it the dwell stretches, and the sunset cap sets the ceiling', () => {
     const twelve = Array.from({ length: 12 }, (_, i) => frame(i + 1, 7, (i + 1) * 1000));
     // 12 frames capped to 8, each held at the 4 s floor: 32 s, not 48.
-    expect(dwellMs2(twelve, twelve[11], D2)).toBe(32_000);
+    expect(dwellMs2(twelve, twelve[11], D2)).toBe(32_000 + ARRIVAL);
   });
 
   it('a non-sunset can never stretch the dwell at the default cap (spec §4.1)', () => {
     // The cap of 3 sits below the threshold of 5, so the budget is merely
     // divided more finely: this dial buys pictures, never screen time.
     const twelve = Array.from({ length: 12 }, (_, i) => frame(i + 1, 7, (i + 1) * 1000, 'non_sunset'));
-    expect(dwellMs2(twelve, twelve[11], D2)).toBe(D2.dwellS * 1000);
+    expect(dwellMs2(twelve, twelve[11], D2)).toBe(D2.dwellS * 1000 + ARRIVAL);
     expect(shown2(twelve, twelve[11], D2)).toHaveLength(3);
   });
 
   it('raising the non-sunset cap past the threshold breaks that guarantee', () => {
     // Recorded because it is the invariant's failure mode, not a nicety.
     const twelve = Array.from({ length: 12 }, (_, i) => frame(i + 1, 7, (i + 1) * 1000, 'non_sunset'));
-    expect(dwellMs2(twelve, twelve[11], { ...D2, runFramesOther: 8 })).toBe(32_000);
+    expect(dwellMs2(twelve, twelve[11], { ...D2, runFramesOther: 8 })).toBe(32_000 + ARRIVAL);
   });
 
   it('agrees with what shown2 puts on glass, always', () => {

--- a/app/lib/solo2/plan.test.ts
+++ b/app/lib/solo2/plan.test.ts
@@ -1,33 +1,89 @@
 import { describe, it, expect } from 'vitest';
-import { describePlan, fitPlan, stageAt, stepFadeS, stretchThreshold } from './plan';
+import { arrivalS, describePlan, fitPlan, stageAt, stepFadeS, stretchThreshold } from './plan';
 
 const D = { dwellS: 20, leadS: 4, minStepS: 4 };
 
 describe('fitPlan: the budget rule', () => {
   it('below the threshold the frames divide the budget and the dwell does not move', () => {
     // Jesse's own numbers: one image holds the full 20 s, five hold 4 s each.
-    expect(fitPlan(D, 1)).toEqual({ dwellS: 20, frames: 1, stepS: 20, leadS: 4 });
-    expect(fitPlan(D, 2)).toEqual({ dwellS: 20, frames: 2, stepS: 10, leadS: 4 });
-    expect(fitPlan(D, 5)).toEqual({ dwellS: 20, frames: 5, stepS: 4, leadS: 4 });
+    expect(fitPlan(D, 1)).toEqual({ dwellS: 20, frames: 1, stepS: 20, leadS: 4, arrivalS: 0 });
+    expect(fitPlan(D, 2)).toEqual({ dwellS: 20, frames: 2, stepS: 10, leadS: 4, arrivalS: 0 });
+    expect(fitPlan(D, 5)).toEqual({ dwellS: 20, frames: 5, stepS: 4, leadS: 4, arrivalS: 0 });
     expect(fitPlan(D, 3).stepS).toBeCloseTo(6.667, 3);
     expect(fitPlan(D, 3).dwellS).toBeCloseTo(20, 6);
   });
   it('above it the DWELL stretches rather than the frames shrinking', () => {
     // This is the whole change: a run is a timelapse, and a timelapse has one
     // step. Eight frames run 4 s each for 32 s, not 2.5 s each for 20 s.
-    expect(fitPlan(D, 6)).toEqual({ dwellS: 24, frames: 6, stepS: 4, leadS: 4 });
-    expect(fitPlan(D, 8)).toEqual({ dwellS: 32, frames: 8, stepS: 4, leadS: 4 });
+    expect(fitPlan(D, 6)).toEqual({ dwellS: 24, frames: 6, stepS: 4, leadS: 4, arrivalS: 0 });
+    expect(fitPlan(D, 8)).toEqual({ dwellS: 32, frames: 8, stepS: 4, leadS: 4, arrivalS: 0 });
     expect(fitPlan(D, 12).stepS).toBe(4);
     expect(fitPlan(D, 12).dwellS).toBe(48);
   });
   it('at least one frame; the lead never exceeds the dwell it is measured against', () => {
-    expect(fitPlan(D, 0)).toEqual({ dwellS: 20, frames: 1, stepS: 20, leadS: 4 });
+    expect(fitPlan(D, 0)).toEqual({ dwellS: 20, frames: 1, stepS: 20, leadS: 4, arrivalS: 0 });
     expect(fitPlan({ dwellS: 5, leadS: 8, minStepS: 4 }, 1).leadS).toBe(5);
     expect(fitPlan({ dwellS: 5, leadS: -1, minStepS: 4 }, 1).leadS).toBe(0);
     // A stretched dwell gives the lead more room: 30 s of lead fits inside a
     // 32 s dwell, where the 20 s budget alone would have clipped it.
     expect(fitPlan({ dwellS: 20, leadS: 30, minStepS: 4 }, 8).leadS).toBe(30);
     expect(fitPlan({ dwellS: 20, leadS: 30, minStepS: 4 }, 1).leadS).toBe(20);
+  });
+});
+
+describe('the arrival segment: the camera change is added before frame 1, not charged against it', () => {
+  // Reported 2026-09-07 on the studio preview: the first frame of a run
+  // looked shorter than the others. It was. The dip's veil covered the old
+  // picture and the new one faded up inside frame 1's own share of the dwell,
+  // so frame 1 held for stepS - fadeS while every later frame held for stepS.
+  const F = { transition: 'dip' as const, fadeS: 1.5, sameCameraFadeS: 1.5 };
+
+  it('is the longest fade the dwell might open with: the camera change, or the same-camera dissolve', () => {
+    expect(arrivalS(F)).toBe(1.5);
+    expect(arrivalS({ ...F, fadeS: 3 })).toBe(3);
+    expect(arrivalS({ ...F, sameCameraFadeS: 4 })).toBe(4);
+    // A cut has no camera-change fade, but a later frame of the same camera still dissolves in.
+    expect(arrivalS({ ...F, transition: 'cut' })).toBe(1.5);
+    expect(arrivalS({ transition: 'cut', fadeS: 1.5, sameCameraFadeS: 0 })).toBe(0);
+    // Dials without fades (solo, old fixtures) have no arrival at all.
+    expect(arrivalS({})).toBe(0);
+    expect(arrivalS({ transition: 'crossfade', fadeS: -1, sameCameraFadeS: -1 })).toBe(0);
+  });
+
+  it('sits on top of the budget: the frames still divide dwellS, and the dwell is arrivalS longer', () => {
+    expect(fitPlan({ ...D, ...F }, 5)).toEqual({ dwellS: 21.5, frames: 5, stepS: 4, leadS: 4, arrivalS: 1.5 });
+    expect(fitPlan({ ...D, ...F }, 1)).toEqual({ dwellS: 21.5, frames: 1, stepS: 20, leadS: 4, arrivalS: 1.5 });
+    // A stretched run stretches from the same base.
+    expect(fitPlan({ ...D, ...F }, 8)).toEqual({ dwellS: 33.5, frames: 8, stepS: 4, leadS: 4, arrivalS: 1.5 });
+  });
+
+  it('does not move the stretch threshold: the frames\' budget is still dwellS', () => {
+    for (let frames = 1; frames <= 5; frames++) expect(fitPlan({ ...D, ...F }, frames).dwellS).toBeCloseTo(21.5, 6);
+    expect(fitPlan({ ...D, ...F }, 6).dwellS).toBeCloseTo(25.5, 6);
+  });
+
+  it('the stage clock waits out the arrival, so frame 1 holds a whole step once it is up', () => {
+    const p = fitPlan({ ...D, ...F }, 4); // 1.5 s arrival, then 4 × 5 s
+    expect(stageAt(0, p).index).toBe(0);
+    expect(stageAt(1_499, p).index).toBe(0);
+    expect(stageAt(1_500, p).index).toBe(0);
+    expect(stageAt(6_499, p).index).toBe(0); // frame 1 is still up 5 s after it finished arriving
+    expect(stageAt(6_500, p).index).toBe(1);
+    expect(stageAt(16_500, p).index).toBe(3);
+    expect(stageAt(30_000, p).index).toBe(3);
+  });
+
+  it('the lead still measures back from the end of the whole dwell', () => {
+    const p = fitPlan({ ...D, ...F }, 4); // dwell 21.5 s, lead over 17.5–21.5
+    expect(stageAt(17_499, p).leadProgress).toBe(0);
+    expect(stageAt(19_500, p).leadProgress).toBe(0.5);
+    expect(stageAt(21_500, p).leadProgress).toBe(1);
+  });
+
+  it('the studio line names it', () => {
+    expect(describePlan(fitPlan({ dwellS: 20, leadS: 0, minStepS: 4, ...F }, 4))).toBe('4 frames × 5 s · arrival 1.5 s');
+    expect(describePlan(fitPlan({ dwellS: 20, leadS: 0, minStepS: 4, ...F }, 1))).toBe('1 frame · 20 s · arrival 1.5 s');
+    expect(describePlan(fitPlan({ ...D, ...F }, 4))).toBe('4 frames × 5 s · lead 4 s · arrival 1.5 s');
   });
 });
 

--- a/app/lib/solo2/plan.ts
+++ b/app/lib/solo2/plan.ts
@@ -2,22 +2,46 @@ import type { Solo2Dials } from './types';
 
 /** One dwell's timeline, in seconds (camera-run spec §4.1). */
 export interface DwellPlan {
+  /** The whole dwell: the arrival, then the frames. */
   dwellS: number;
   /** Frames the dwell plays, at least 1. */
   frames: number;
-  /** Each frame's even share of the dwell. */
+  /** Each frame's even share of the frames' budget. */
   stepS: number;
   leadS: number;
+  /**
+   * The camera change's own segment at the front of the dwell (dwell-budget
+   * spec §3.3). Frame 1's step begins when it ends, so the first frame holds
+   * as long as every other. 0 for dials without fades.
+   */
+  arrivalS: number;
 }
 
-export type PlanDials = Pick<Solo2Dials, 'dwellS' | 'leadS' | 'minStepS'>;
+/**
+ * The fade dials are optional so that solo's dials, which have no camera
+ * change, plan a dwell with no arrival — and so do fixtures that predate it.
+ */
+export type PlanDials = Pick<Solo2Dials, 'dwellS' | 'leadS' | 'minStepS'>
+  & Partial<Pick<Solo2Dials, 'transition' | 'fadeS' | 'sameCameraFadeS'>>;
+
+/**
+ * How long the front of a dwell is spent arriving (dwell-budget spec §3.3).
+ * Sized for the longest arrival the dwell might open with — the camera-change
+ * fade, or the same-camera dissolve — because the server sizes a dwell
+ * without knowing what was on glass before it. When the actual arrival is
+ * shorter, frame 1 simply holds for the rest.
+ */
+export function arrivalS(d: Partial<Pick<Solo2Dials, 'transition' | 'fadeS' | 'sameCameraFadeS'>>): number {
+  const change = d.transition && d.transition !== 'cut' ? Math.max(0, d.fadeS ?? 0) : 0;
+  return Math.max(change, Math.max(0, d.sameCameraFadeS ?? 0));
+}
 
 /**
  * The budget rule (dwell-budget spec §3). `dwellS` is a budget the run's
- * frames share, floored at `minStepS`:
+ * frames share, floored at `minStepS`, and the arrival sits in front of it:
  *
  *     perFrame = max(minStepS, dwellS / n)
- *     total    = perFrame * n
+ *     total    = arrivalS + perFrame * n
  *
  * At or below `n* = floor(dwellS / minStepS)` frames the budget is merely
  * divided more finely and the total stays `dwellS` — one image holds the
@@ -31,8 +55,9 @@ export type PlanDials = Pick<Solo2Dials, 'dwellS' | 'leadS' | 'minStepS'>;
 export function fitPlan(d: PlanDials, frames: number): DwellPlan {
   const n = Math.max(1, Math.floor(frames));
   const stepS = Math.max(d.minStepS, d.dwellS / n);
-  const totalS = stepS * n;
-  return { dwellS: totalS, frames: n, stepS, leadS: Math.min(totalS, Math.max(0, d.leadS)) };
+  const arrival = arrivalS(d);
+  const totalS = arrival + stepS * n;
+  return { dwellS: totalS, frames: n, stepS, leadS: Math.min(totalS, Math.max(0, d.leadS)), arrivalS: arrival };
 }
 
 /**
@@ -76,15 +101,18 @@ export interface Stage {
  */
 export function stageAt(elapsedMs: number, p: DwellPlan): Stage {
   const t = Math.max(0, elapsedMs) / 1000;
-  const index = Math.min(p.frames - 1, Math.floor(t / p.stepS));
+  // The run's own clock starts when the arrival ends; frame 1 is up throughout the arrival.
+  const index = Math.min(p.frames - 1, Math.floor(Math.max(0, t - p.arrivalS) / p.stepS));
   const leadStart = p.dwellS - p.leadS;
   const leadProgress = p.leadS > 0 ? Math.min(1, Math.max(0, (t - leadStart) / p.leadS)) : 0;
   return { index, leadProgress };
 }
 
-/** The line the studio prints: `4 frames × 5 s`, `1 frame · 20 s`, `· lead 4 s` when the lead is on. */
+/** The line the studio prints: `4 frames × 5 s`, `1 frame · 20 s`, `· lead 4 s` when the lead is on, `· arrival 1.5 s` when there is one. */
 export function describePlan(p: DwellPlan): string {
   const s = (n: number) => `${Number(n.toFixed(1))} s`;
-  const frames = p.frames === 1 ? `1 frame · ${s(p.dwellS)}` : `${p.frames} frames × ${s(p.stepS)}`;
-  return p.leadS > 0 ? `${frames} · lead ${s(p.leadS)}` : frames;
+  const frames = p.frames === 1 ? `1 frame · ${s(p.dwellS - p.arrivalS)}` : `${p.frames} frames × ${s(p.stepS)}`;
+  const lead = p.leadS > 0 ? ` · lead ${s(p.leadS)}` : '';
+  const arrival = p.arrivalS > 0 ? ` · arrival ${s(p.arrivalS)}` : '';
+  return `${frames}${lead}${arrival}`;
 }

--- a/app/studio/Rail.tsx
+++ b/app/studio/Rail.tsx
@@ -241,14 +241,18 @@ export function Rail({ api, surface, tab, onTab, runFrames = 1, children }: {
   const sharedDiff = new Set(api.diffByNamespace[SHARED_NAMESPACE] ?? []);
   const panel = PANEL_PRESETS[String(shared.panelPreset)] ?? PANEL_PRESETS[DEFAULT_PANEL_PRESET];
   const soloDials = surface.solo ? surface.solo.dialsFrom(withCaption(values, shared)) : null;
-  // leadS and minStepS are solo2's. A version without a lead leads for no
-  // time at all; a version without a floor has none, so its frames divide the
-  // dwell at any count and it can never stretch (dwell-budget spec §3).
+  // leadS, minStepS and the fades are solo2's. A version without a lead leads
+  // for no time at all; a version without a floor has none, so its frames
+  // divide the dwell at any count and it can never stretch (dwell-budget spec
+  // §3); a version without a camera change has no arrival segment (§3.3).
   const planDials: PlanDials | null = soloDials
     ? {
       dwellS: soloDials.dwellS,
       leadS: (soloDials as Partial<Solo2Dials>).leadS ?? 0,
       minStepS: (soloDials as Partial<Solo2Dials>).minStepS ?? 0,
+      transition: (soloDials as Partial<Solo2Dials>).transition,
+      fadeS: (soloDials as Partial<Solo2Dials>).transition ? soloDials.fadeS : undefined,
+      sameCameraFadeS: (soloDials as Partial<Solo2Dials>).sameCameraFadeS,
     }
     : null;
   const page: RailTab = surface.hasPicturePage ? tab : 'play';

--- a/app/studio/solo/DwellBudget.test.tsx
+++ b/app/studio/solo/DwellBudget.test.tsx
@@ -24,6 +24,16 @@ it('says so when the run stretches the dwell rather than dividing it', () => {
   expect(screen.getByText('stretched: past 5 frames each one adds 4 s')).toBeInTheDocument();
 });
 
+it('names the arrival segment, and does not call it a stretch', () => {
+  // The camera change sits in front of the frames (dwell-budget spec §3.3):
+  // the dwell is 1.5 s longer than the dial by design, not because the run
+  // outgrew the budget.
+  render(<DwellBudget dials={{ ...D, transition: 'dip', fadeS: 1.5, sameCameraFadeS: 1.5 }} frames={4} />);
+  expect(screen.getByText(/4 frames × 5 s · lead 4 s · arrival 1.5 s/)).toBeInTheDocument();
+  expect(screen.queryByText(/· dwell/)).toBeNull();
+  expect(screen.getByText('divides the dwell up to 5 frames')).toBeInTheDocument();
+});
+
 it('the threshold moves with the floor, not just the dwell', () => {
   const { rerender } = render(<DwellBudget dials={{ ...D, minStepS: 6 }} frames={2} />);
   expect(screen.getByText('divides the dwell up to 3 frames')).toBeInTheDocument();

--- a/app/studio/solo/DwellBudget.tsx
+++ b/app/studio/solo/DwellBudget.tsx
@@ -17,7 +17,8 @@ const mono = 'ui-monospace, SFMono-Regular, Menlo, monospace';
 export function DwellBudget({ dials, frames = 1 }: { dials: PlanDials; frames?: number }) {
   const plan = fitPlan(dials, frames);
   const n = stretchThreshold(dials);
-  const stretched = plan.dwellS > dials.dwellS + 0.001;
+  // The frames' budget alone: the arrival is on top of the dial by design, not a stretch.
+  const stretched = plan.dwellS - plan.arrivalS > dials.dwellS + 0.001;
   const s = (v: number) => `${Number(v.toFixed(1))} s`;
   return (
     <div data-testid="dwell-budget" title="How the dwell splits for the camera on glass. Below the threshold the frames divide the dwell and it does not move; above it the frames hold at the floor and the dwell stretches." style={{

--- a/app/studio/solo/GlassPreview.test.tsx
+++ b/app/studio/solo/GlassPreview.test.tsx
@@ -56,14 +56,16 @@ it('solo2 plays the on-glass camera\'s run on the studio dials, looping on a loc
   const { SOLO2_SETTINGS_SCHEMA, dialsFrom2 } = await import('@/app/lib/solo2/settingsSchema');
   const { schemaDefaults } = await import('@/app/lib/settings/schema');
   vi.useFakeTimers();
-  const d2 = { ...dialsFrom2(schemaDefaults(SOLO2_SETTINGS_SCHEMA)), dwellS: 6, sameCameraFadeS: 1, minStepS: 1 }; // 3 frames → 2 s each
+  // 3 frames → 2 s each, after the 1.5 s arrival segment the default dip adds
+  // at the front of every solo2 dwell (dwell-budget spec §3.3): 7.5 s a dwell.
+  const d2 = { ...dialsFrom2(schemaDefaults(SOLO2_SETTINGS_SCHEMA)), dwellS: 6, sameCameraFadeS: 1, minStepS: 1 };
   const older = (id: number, capturedAt: number) => ({ ...entry, snapshotId: id, imageUrl: `u${id}`, capturedAt });
   const entries = [older(5, entry.capturedAt - 20 * 60_000), older(6, entry.capturedAt - 10 * 60_000), entry];
   const s2 = { ...server, entries } as unknown as StateView;
   render(<GlassPreview version={SOLO_VERSIONS.solo2} screens={[{ feed: 'sunset', server: s2, projected: null }]} dials={d2} panel={{ width: 1920, height: 1080 }} />);
   expect(screen.getByTestId('top')).toHaveAttribute('src', 'u5');
   expect(screen.getByTestId('seq-1')).toHaveStyle({ opacity: '0', transition: 'opacity 1s linear' });
-  await act(async () => { vi.advanceTimersByTime(2_100); });
+  await act(async () => { vi.advanceTimersByTime(3_600); }); // 1.5 s arrival + 2.1 s: the second frame is up
   expect(screen.getByTestId('top')).toHaveAttribute('src', 'u6');
   await act(async () => { vi.advanceTimersByTime(2_000); });
   expect(screen.getByTestId('top')).toHaveAttribute('src', 'u7');
@@ -110,7 +112,7 @@ it('solo2 plays the queued dwell\'s own camera run once the preview advances', a
   // The on-glass frame is camera 1's only frame: a run of one.
   expect(screen.queryByTestId('seq-1')).toBeNull();
 
-  await act(async () => { vi.advanceTimersByTime(6_100); });
+  await act(async () => { vi.advanceTimersByTime(7_600); }); // past the 6 s budget plus the 1.5 s arrival
   expect(screen.getByText(/^preview · frame 12/)).toBeInTheDocument();
   // Camera 2's run: 11 then 12, and the stage clock restarted with the step.
   expect(screen.getByTestId('seq-1')).toBeInTheDocument();
@@ -136,7 +138,7 @@ it('restarts the run\'s stage clock when the server advances a different camera 
   const { SOLO_VERSIONS } = await import('@/app/lib/solo/versions');
   const { SOLO2_SETTINGS_SCHEMA, dialsFrom2 } = await import('@/app/lib/solo2/settingsSchema');
   vi.useFakeTimers();
-  const d2 = { ...dialsFrom2(schemaDefaults(SOLO2_SETTINGS_SCHEMA)), dwellS: 6, sameCameraFadeS: 1, minStepS: 1 }; // 2 frames → 3 s each
+  const d2 = { ...dialsFrom2(schemaDefaults(SOLO2_SETTINGS_SCHEMA)), dwellS: 6, sameCameraFadeS: 1, minStepS: 1 }; // 2 frames → 3 s each, after a 1.5 s arrival
   const panel = { width: 1920, height: 1080 };
   const camAOlder = at(5, 1, entry.capturedAt - 20 * 60_000);
   const s2a = { current: { entry, shownSince: 0, slot: 1 }, entries: [camAOlder, entry] } as unknown as StateView;
@@ -144,7 +146,7 @@ it('restarts the run\'s stage clock when the server advances a different camera 
     dials={d2} panel={panel} />);
   expect(screen.getByTestId('top')).toHaveAttribute('src', 'u5'); // run's first frame at mount
 
-  await act(async () => { vi.advanceTimersByTime(4_000); }); // past the 3 s step, still inside the 6 s dwell (index 0 unchanged)
+  await act(async () => { vi.advanceTimersByTime(5_000); }); // past the arrival and the 3 s step, still inside the 7.5 s dwell (index 0 unchanged)
   expect(screen.getByTestId('top')).toHaveAttribute('src', 'u7'); // stage advanced within the same dwell
 
   // The server advances to a different camera while the preview is still
@@ -173,14 +175,14 @@ it('a run restarts by rebuilding its stack, never by fading back down to an earl
   vi.useFakeTimers();
   // minStepS 2 keeps the 6 s dwell divided evenly by 3 rather than stretched,
   // so this test is about the stack and not about the budget.
-  const d2 = { ...dialsFrom2(schemaDefaults(SOLO2_SETTINGS_SCHEMA)), dwellS: 6, minStepS: 2, sameCameraFadeS: 1 }; // 3 frames → 2 s each
+  const d2 = { ...dialsFrom2(schemaDefaults(SOLO2_SETTINGS_SCHEMA)), dwellS: 6, minStepS: 2, sameCameraFadeS: 1 }; // 3 frames → 2 s each, after a 1.5 s arrival
   const older = (id: number, capturedAt: number) => ({ ...entry, snapshotId: id, imageUrl: `u${id}`, capturedAt });
   const entries = [older(5, entry.capturedAt - 20 * 60_000), older(6, entry.capturedAt - 10 * 60_000), entry];
   const s2 = { ...server, entries } as unknown as StateView;
   render(<GlassPreview version={SOLO_VERSIONS.solo2} screens={[{ feed: 'sunset', server: s2, projected: null }]}
     dials={d2} panel={{ width: 1920, height: 1080 }} />);
 
-  await act(async () => { vi.advanceTimersByTime(4_100); });
+  await act(async () => { vi.advanceTimersByTime(5_600); }); // 1.5 s arrival + 4.1 s
   expect(screen.getByTestId('top')).toHaveAttribute('src', 'u7'); // last frame of the run
   const stackBefore = screen.getByTestId('stack');
 
@@ -233,10 +235,10 @@ it('solo2 holds a stretched dwell for the run it plays, not for the dial', async
   render(<GlassPreview version={SOLO_VERSIONS.solo2} screens={[{ feed: 'sunset', server: s2, projected }]}
     dials={d2} panel={{ width: 1920, height: 1080 }} />);
 
-  await act(async () => { vi.advanceTimersByTime(6_100); }); // the dial is up; the run is not
+  await act(async () => { vi.advanceTimersByTime(7_600); }); // the dial (plus the 1.5 s arrival) is up; the run is not
   expect(screen.getByTestId('top')).toHaveAttribute('src', 'u7'); // still the run's last frame
   expect(screen.getByText(/on glass now · frame 7/)).toBeInTheDocument();
 
-  await act(async () => { vi.advanceTimersByTime(3_000); }); // 9 s: the run is done
+  await act(async () => { vi.advanceTimersByTime(3_000); }); // 10.5 s: the arrival and the 9 s run are done
   expect(screen.getByText(/^preview · frame 8/)).toBeInTheDocument();
 });

--- a/app/studio/solo/GlassPreview.tsx
+++ b/app/studio/solo/GlassPreview.tsx
@@ -71,8 +71,13 @@ function PlayingScreen({ feed, server, projected, error, dials, panel, version }
   const runFor = (e: EntryView) => (
     solo2 ? runOf(e, server?.entries ?? [], d2.cameraRun, capFor(e, d2)) : []
   );
+  // The fades only for solo2: its dwell opens with an arrival segment
+  // (dwell-budget spec §3.3); solo's does not, so its walker must not wait one out.
   const planFor = (e: EntryView | null) => fitPlan(
-    { dwellS: dials.dwellS, leadS: d2.leadS ?? 0, minStepS: d2.minStepS ?? dials.dwellS },
+    {
+      dwellS: dials.dwellS, leadS: d2.leadS ?? 0, minStepS: d2.minStepS ?? dials.dwellS,
+      ...(solo2 ? { transition: d2.transition, fadeS: d2.fadeS, sameCameraFadeS: d2.sameCameraFadeS } : {}),
+    },
     Math.max(1, e ? runFor(e).length : 1),
   );
   // Per frame, not once: the budget stretches a dwell past the dial whenever a

--- a/app/studio/solo/useLoopingStage.ts
+++ b/app/studio/solo/useLoopingStage.ts
@@ -40,9 +40,9 @@ function stageOf(startMs: number | null, plan: DwellPlan): Stage {
  */
 export function useLoopingStage(plan: DwellPlan, startMs: number | null, tickMs = 250): Stage {
   const [stage, setStage] = useState<Stage>(() => stageOf(startMs, plan));
-  const { dwellS, frames, stepS, leadS } = plan;
+  const { dwellS, frames, stepS, leadS, arrivalS } = plan;
   useEffect(() => {
-    const p = { dwellS, frames, stepS, leadS };
+    const p = { dwellS, frames, stepS, leadS, arrivalS };
     const read = () => setStage((prev) => {
       const nextStage = stageOf(startMs, p);
       return same(prev, nextStage) ? prev : nextStage;
@@ -50,6 +50,6 @@ export function useLoopingStage(plan: DwellPlan, startMs: number | null, tickMs 
     read();
     const t = setInterval(read, tickMs);
     return () => clearInterval(t);
-  }, [startMs, tickMs, dwellS, frames, stepS, leadS]);
+  }, [startMs, tickMs, dwellS, frames, stepS, leadS, arrivalS]);
   return stage;
 }

--- a/docs/superpowers/specs/2026-09-06-solo2-dwell-budget-design.md
+++ b/docs/superpowers/specs/2026-09-06-solo2-dwell-budget-design.md
@@ -76,10 +76,13 @@ that is rejected. A run is a timelapse, and a timelapse has one step.
 
 ```
 perFrame = max(minStepS, dwellS / n)
-total    = perFrame × n
+total    = arrivalS + perFrame × n
 ```
 
-where `n` is the number of frames the run plays, after the caps in §4.
+where `n` is the number of frames the run plays, after the caps in §4, and
+`arrivalS` is the camera change's own segment at the front of the dwell
+(§3.3, added 2026-09-07). The table below is the frames' part; every dwell
+is `arrivalS` (1.5 s at the default fades) longer than it shows.
 
 At `dwellS` 20 and `minStepS` 4:
 
@@ -117,6 +120,43 @@ hold the screen for nearly ten minutes. The only way the floor alone could
 bound the total is by letting frames get arbitrarily short, which is the
 flicker this design exists to remove. **The frame cap is not an extra rule
 bolted on top of the budget. It is what makes the floor safe.**
+
+### 3.3 The arrival segment (added 2026-09-07)
+
+Jesse, on the studio preview, 2026-09-07: *"the first frame in a prelude
+series seems shorter than the others."* It was. The camera change — the
+dip's veil over the old picture, then the new picture fading up — ran inside
+frame 1's step. Frame 1 held for `stepS − fadeS` while every later frame held
+for `stepS`, and the run read as clipped at the front.
+
+The fix gives the change its own segment before the run's clock starts:
+
+```
+arrivalS = max(transition == cut ? 0 : fadeS, sameCameraFadeS)
+total    = arrivalS + perFrame × n
+```
+
+The run's clock — `stageAt` — starts when the arrival ends, so frame 1 is up
+throughout the arrival and then holds a whole step, like every frame after it.
+The last frame holds its whole step too, and then leaves under the next
+dwell's veil; nothing at the back needed to change.
+
+Three consequences:
+
+- **The arrival is sized for the longest fade the dwell might open with,**
+  not the one it will actually open with. The server sizes a dwell (§5.2)
+  without knowing what was on glass before it, so it cannot tell a camera
+  change (the transition dial's fade) from a later frame of the same camera
+  (the same-camera dissolve). At the default dials both are 1.5 s. When the
+  actual arrival is shorter, frame 1 simply holds for the rest.
+- **The stretch threshold does not move.** `dwellS` is still the frames'
+  budget; the arrival is on top of it, on every dwell alike. The studio's
+  budget line prints it (`5 frames × 4 s · arrival 1.5 s`) and compares the
+  frames' part, not the total, against the dial when deciding whether to say
+  "stretched".
+- **solo has no arrival.** Its dials carry no camera-change fade, so
+  `arrivalS` is 0 and its dwell is exactly the dial, as before. A version
+  gains an arrival only by having the fade dials.
 
 ## 4. Frame caps, per bin
 


### PR DESCRIPTION
Two solo2 changes to how one picture gives way to the next. Both came out of a design session against a mockup built on real frames: https://claude.ai/code/artifact/6d65f737-8074-4040-b6a8-6a1c12b9b9b6

## 1. The first frame of a run was short

The camera change ran *inside* frame 1's step, so frame 1 held for `stepS − fadeS` while every later frame held for `stepS`.

The plan now puts an **arrival segment** in front of the run:

```
arrivalS = max(transition == cut ? 0 : fadeS, sameCameraFadeS)
total    = arrivalS + perFrame × n
```

The stage clock starts when the arrival ends. Every solo2 dwell is 1.5 s longer at the default dials (21.5 s, not 20 s). The segment is sized for the *longest* arrival the dwell might open with, because the server sizes a dwell without knowing what was on glass before it; when the real arrival is shorter, frame 1 just holds the rest. solo has no fades, so its dwell is unchanged.

The stretch threshold does not move: `dwellS` is still the frames' budget. The studio's budget line names the arrival and compares the frames' part, not the total, before saying "stretched".

## 2. A sunrise no longer ends in black

A sunrise fading to black plays the day backwards, and beside a sunset screen doing the same thing it reads as the sun going down.

`veilStyle` says what a camera change dips through, as a **pair** — one look per screen. The sunset screen ends in black under all four; the dial is about what a sunrise does instead.

| style | sunrise | sunset |
|---|---|---|
| `black` (default) | dips through black | dips through black |
| `crossfade` | no veil at all | dips through black |
| `light` | dips through `veilTint` | dips through black |
| `burn` | blows out into white | darkens into black |

`black` is today's behaviour exactly, so **merging changes nothing until the dial moves.**

`burn` is not a dip through a coloured card. The picture's brightness moves *toward* the veil and the arriving picture comes back from it, by `burnLift`. The lift travels as a CSS custom property, never interpolated into the keyframes: two screens render into one document and a `<style>` rule is global.

The veil's **opacity** carries the timing, not the brightness. Brightness is not perceptually even at the ends — highlights clip to white early leaving and stay clipped until late arriving — which is why the first version read as two different speeds, and why the sunrise screen was worse.

## 3. Dissolves stop snapping

`arrivalEase` — `linear` (today), `gentle` (new default), `soft` — puts **one** timing function on every layer of every dissolve: the veil, both pictures, the caption, and the steps inside a camera run.

Every curve offered is point-symmetric about (0.5, 0.5), and that is a correctness constraint rather than taste. An eased arrival against a linear departure lands in a third of the time it left in — PR #160. `easingIsSymmetric` guards the table, and the frame test asserts both halves carry one value *and* that the value is symmetric.

## 4. The rail gains a Change page

Between Play and Picture, shown only for a version with `arrival` dials. A version without one falls back to Play rather than rendering an empty rail.

## Deliberately absent: sky-sampled

The fifth look from the mockup — the veil taking its colour from the pictures — needs canvas pixel access. Measured today:

```
curl -I https://storage.googleapis.com/sunrisesunset-32a25.firebasestorage.app/snapshots/…
→ 200, and no access-control-allow-origin header
```

The canvas is tainted, `getImageData` throws. It works in the mockup only because those frames are embedded. Shipping it would mean a dial that silently renders something else. One CORS setting on the bucket unblocks it, then it's a small follow-up.

## Verify

- `/studio` solo2, **Change** tab: switch the styles and watch both preview screens. Try `burn` at 1.6, then 1.0 for comparison.
- `/studio` solo2, Play tab: after a camera change the first frame should hold as long as the second and third.
- Glass after merge: `bash scripts/pi/kiosk-doctor.sh --sync --reload`. No migration.

## Open

The burn adds a brightness animation on one full-screen layer, on a Pi 4 driving two 1440p Chromium windows. Cheap work for the GPU, but unmeasured. Watch the glass with `burn` selected before trusting it for the show.

2426 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013jWANNE6txRkKK7Xkddx4v
