### PR TITLE
feat(solo2): a sunrise stops ending in black, and dissolves stop snapping

### DIFF
--- a/app/components/solo2/Solo2Frame.test.tsx
+++ b/app/components/solo2/Solo2Frame.test.tsx
@@ -1,9 +1,13 @@
-import { it, expect } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { cleanup, render, screen } from '@testing-library/react';
 import { Solo2Frame } from './Solo2Frame';
 import { dialsFrom2, SOLO2_SETTINGS_SCHEMA } from '@/app/lib/solo2/settingsSchema';
 import { schemaDefaults } from '@/app/lib/settings/schema';
 import { fitPlan } from '@/app/lib/solo2/plan';
+import { ARRIVAL_EASES, VEIL_TINTS, easingIsSymmetric } from '@/app/lib/solo2/veil';
+
+/** The curve the default dials put on every layer of a dissolve. */
+const E = ARRIVAL_EASES.gentle;
 
 const D = dialsFrom2(schemaDefaults(SOLO2_SETTINGS_SCHEMA));
 const AT = Date.UTC(2026, 8, 5, 2, 42); // 7:42 pm in Mazatlán
@@ -49,16 +53,16 @@ it('the run is stacked: frames up to the stage are opaque, later ones transparen
   const layers = () => screen.getAllByTestId(/^seq-/).map((l) => [l.getAttribute('data-testid'), l.style.opacity, l.style.transition]);
   expect(layers()).toEqual([
     ['seq-0', '1', 'none'],
-    ['seq-1', '1', 'opacity 1s linear'],
-    ['seq-2', '0', 'opacity 1s linear'],
+    ['seq-1', '1', `opacity 1s ${E}`],
+    ['seq-2', '0', `opacity 1s ${E}`],
   ]);
   const short = fitPlan({ ...D, dwellS: 3, minStepS: 1 }, 3); // 1 s a frame
   rerender(<Solo2Frame entry={e} run={run} previous={null} stage={last} plan={short}
     dials={{ ...D, sameCameraFadeS: 5 }} width={1920} height={1080} />);
   expect(layers()).toEqual([
     ['seq-0', '1', 'none'],
-    ['seq-1', '1', 'opacity 0.5s linear'], // half of the 1 s step, so the frame is still for the other half
-    ['seq-2', '1', 'opacity 0.5s linear'],
+    ['seq-1', '1', `opacity 0.5s ${E}`], // half of the 1 s step, so the frame is still for the other half
+    ['seq-2', '1', `opacity 0.5s ${E}`],
   ]);
   expect(screen.getByTestId('top')).toHaveAttribute('src', 'u3');
   rerender(<Solo2Frame entry={e} run={run} previous={null} stage={last} plan={plan}
@@ -91,10 +95,10 @@ it('cut shows no previous layer; crossfade keeps it and animates the top; dip ad
   expect(screen.getAllByRole('presentation').map((i) => i.getAttribute('src'))).toEqual(['u3']);
   rerender(<Solo2Frame entry={e} run={[e]} previous={prev} stage={one} plan={plan} dials={{ ...D, transition: 'crossfade', fadeS: 2 }} width={100} height={50} />);
   expect(screen.getAllByRole('presentation').map((i) => i.getAttribute('src'))).toEqual(['u0', 'u3']);
-  expect(screen.getByTestId('stack')).toHaveStyle({ animation: 'solo2-fade-in 2s linear both' });
+  expect(screen.getByTestId('stack')).toHaveStyle({ animation: `solo2-fade-in 2s ${E} both` });
   expect(screen.queryByTestId('dip')).toBeNull();
   rerender(<Solo2Frame entry={e} run={[e]} previous={prev} stage={one} plan={plan} dials={{ ...D, transition: 'dip', fadeS: 2 }} width={100} height={50} />);
-  expect(screen.getByTestId('dip')).toHaveStyle({ animation: 'solo2-dip 1s linear both' });
+  expect(screen.getByTestId('dip')).toHaveStyle({ animation: `solo2-dip 1s ${E} both` });
 });
 
 it('a change to the same camera dissolves over the same-camera fade, never through black', () => {
@@ -103,13 +107,13 @@ it('a change to the same camera dissolves over the same-camera fade, never throu
     dials={{ ...D, transition: 'dip', fadeS: 4, sameCameraFadeS: 1 }} width={100} height={50} />);
   expect(screen.getAllByRole('presentation').map((i) => i.getAttribute('src'))).toEqual(['u0', 'u3']);
   expect(screen.queryByTestId('dip')).toBeNull();
-  expect(screen.getByTestId('stack')).toHaveStyle({ animation: 'solo2-fade-in 1s linear both' });
+  expect(screen.getByTestId('stack')).toHaveStyle({ animation: `solo2-fade-in 1s ${E} both` });
 });
 
 it('the defaults dip through black between cameras', () => {
   const prev = { ...e, snapshotId: 0, webcamId: 99, imageUrl: 'u0' };
   render(<Solo2Frame entry={e} run={[e]} previous={prev} stage={{ index: 0, leadProgress: 0 }} plan={plan} dials={D} width={100} height={50} />);
-  expect(screen.getByTestId('dip')).toHaveStyle({ animation: 'solo2-dip 0.75s linear both' });
+  expect(screen.getByTestId('dip')).toHaveStyle({ animation: `solo2-dip 0.75s ${E} both` });
 });
 
 it('the lead pushes the frame in by progress and lands the next frame still', () => {
@@ -126,7 +130,7 @@ it('the caption arrives on the picture’s transition: the same animation, and t
   const one = { index: 0, leadProgress: 0 };
   const { rerender } = render(<Solo2Frame entry={e} run={[e]} previous={prev} stage={one} plan={plan}
     dials={{ ...D, transition: 'crossfade', fadeS: 2 }} width={1920} height={1080} />);
-  expect(screen.getByTestId('caption-layer')).toHaveStyle({ animation: 'solo2-fade-in 2s linear both' });
+  expect(screen.getByTestId('caption-layer')).toHaveStyle({ animation: `solo2-fade-in 2s ${E} both` });
   expect(screen.getByTestId('caption-layer').style.animation).toBe(screen.getByTestId('stack').style.animation);
   expect(screen.getByText('Old pier')).toBeInTheDocument(); // the words being left behind
 
@@ -147,20 +151,100 @@ it('on a dip the veil covers the outgoing caption, and the new words fade in aft
   // Painted in this order, so the veil hides the old words rather than sitting behind them.
   expect(out.compareDocumentPosition(veil) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
   expect(veil.compareDocumentPosition(arriving) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
-  expect(arriving).toHaveStyle({ animation: 'solo2-fade-in 1s linear 1s both' });
+  expect(arriving).toHaveStyle({ animation: `solo2-fade-in 1s ${E} 1s both` });
 });
 
 it('a dip goes down and comes up on the same ramp: the veil and the arriving picture share duration and timing function', () => {
   const prev = { ...e, snapshotId: 0, webcamId: 99, imageUrl: 'u0' };
   render(<Solo2Frame entry={e} run={[e]} previous={prev} stage={{ index: 0, leadProgress: 0 }} plan={plan}
     dials={{ ...D, transition: 'dip', fadeS: 2 }} width={100} height={50} />);
-  // An eased up-ramp against a linear down-ramp is what made the new picture
-  // read as arriving three times faster than the old one left.
-  const [, downDuration, downEasing] = screen.getByTestId('dip').style.animation.split(' ');
-  const [, upDuration, upEasing] = screen.getByTestId('stack').style.animation.split(' ');
-  expect(upDuration).toBe(downDuration);
-  expect(upEasing).toBe(downEasing);
-  expect(upEasing).toBe('linear');
+  // An up-ramp of a different shape from the down-ramp is what made the new
+  // picture read as arriving three times faster than the old one left. The
+  // curve is a dial now, so what must hold is that the two halves share it AND
+  // that it is symmetric — an asymmetric curve runs a different shape backwards
+  // even when both halves name it.
+  const parse = (css: string) => {
+    const m = css.match(/^(\S+) (\S+) (.*?)( \d[\d.]*s)? both$/);
+    return m && { duration: m[2], easing: m[3] };
+  };
+  const down = parse(screen.getByTestId('dip').style.animation);
+  const up = parse(screen.getByTestId('stack').style.animation);
+  expect(down).toBeTruthy();
+  expect(up && up.duration).toBe(down && down.duration);
+  expect(up && up.easing).toBe(down && down.easing);
+  expect(easingIsSymmetric(String(up && up.easing))).toBe(true);
+});
+
+describe('what the change dips through', () => {
+  const prev = { ...e, snapshotId: 0, webcamId: 99, imageUrl: 'u0' };
+  const dip = (extra: Partial<typeof D>, feed: 'sunrise' | 'sunset' = 'sunrise') => {
+    render(<Solo2Frame entry={e} run={[e]} previous={prev} stage={{ index: 0, leadProgress: 0 }} plan={plan}
+      dials={{ ...D, transition: 'dip', fadeS: 2, ...extra }} width={100} height={50} feed={feed} />);
+  };
+
+  it('black, the default, is what both screens have always done', () => {
+    dip({});
+    expect(screen.getByTestId('dip')).toHaveStyle({ background: '#000000' });
+  });
+
+  it('light dips the sunrise through its tint and leaves the sunset ending in black', () => {
+    dip({ veilStyle: 'light', veilTint: 'dawn' });
+    expect(screen.getByTestId('dip')).toHaveStyle({ background: VEIL_TINTS.dawn });
+    cleanup();
+    dip({ veilStyle: 'light', veilTint: 'dawn' }, 'sunset');
+    expect(screen.getByTestId('dip')).toHaveStyle({ background: '#000000' });
+  });
+
+  it('crossfade takes the veil off the sunrise screen entirely; the sunset screen still dips', () => {
+    dip({ veilStyle: 'crossfade' });
+    expect(screen.queryByTestId('dip')).toBeNull();
+    // Not a cut: the outgoing picture stays, and the new one dissolves over the WHOLE fade.
+    expect(screen.getByTestId('prev')).toBeInTheDocument();
+    expect(screen.getByTestId('stack')).toHaveStyle({ animation: `solo2-fade-in 2s ${E} both` });
+    cleanup();
+    dip({ veilStyle: 'crossfade' }, 'sunset');
+    expect(screen.getByTestId('dip')).toHaveStyle({ background: '#000000' });
+  });
+
+  it('burn moves the picture toward the veil, each screen toward its own end', () => {
+    dip({ veilStyle: 'burn', burnLift: 1.6 });
+    expect(screen.getByTestId('dip')).toHaveStyle({ background: '#ffffff' });
+    expect(screen.getByTestId('prev').style.animation).toBe(`solo2-burn-out 1s ${E} both`);
+    expect(screen.getByTestId('stack').style.animation)
+      .toBe(`solo2-fade-in 1s ${E} 1s both, solo2-burn-in 1s ${E} 1s both`);
+    // Carried as a custom property, never baked into the keyframes: two screens
+    // share one document, and a `<style>` rule is global.
+    expect(screen.getByTestId('prev').style.getPropertyValue('--solo2-lift')).toBe('1.6');
+    cleanup();
+    dip({ veilStyle: 'burn', burnLift: 1.6 }, 'sunset');
+    expect(screen.getByTestId('dip')).toHaveStyle({ background: '#000000' });
+    expect(screen.getByTestId('stack').style.getPropertyValue('--solo2-lift')).toBe('0');
+  });
+
+  it('no burn animation at all when the lift asks for nothing', () => {
+    dip({ veilStyle: 'burn', burnLift: 1 });
+    expect(screen.getByTestId('prev').style.animation).toBe('');
+    expect(screen.getByTestId('stack').style.animation).toBe(`solo2-fade-in 1s ${E} 1s both`);
+  });
+
+  it('the veil stays inside the picture unless it is told to flood the panel', () => {
+    dip({ veilStyle: 'light', veilCovers: 'panel' });
+    expect(screen.getByTestId('dip')).toHaveStyle({ width: '100%', height: '100%' });
+    cleanup();
+    // Inside the picture: the veil takes the picture box, the same one the stack sits in.
+    dip({ veilStyle: 'light' });
+    const veil = screen.getByTestId('dip').style;
+    const stack = screen.getByTestId('stack').style;
+    expect(veil.width).toBe(stack.width);
+    expect(veil.left).toBe(stack.left);
+    expect(veil.width).not.toBe('100%');
+  });
+
+  it('the ease dial reaches the steps inside a run, not just the change between cameras', () => {
+    render(<Solo2Frame entry={e} run={run} previous={null} stage={{ index: 1, leadProgress: 0 }} plan={plan}
+      dials={{ ...D, sameCameraFadeS: 1, arrivalEase: 'soft' }} width={100} height={50} feed="sunrise" />);
+    expect(screen.getByTestId('seq-1')).toHaveStyle({ transition: `opacity 1s ${ARRIVAL_EASES.soft}` });
+  });
 });
 
 it('inside a run only the clock moves, and inside the clock only the part that changed: the two readings crossfade over the same seconds', () => {

--- a/app/components/solo2/Solo2Frame.tsx
+++ b/app/components/solo2/Solo2Frame.tsx
@@ -6,6 +6,7 @@ import { scoreLine } from '@/app/lib/solo/scores';
 import type { Feed } from '@/app/lib/solo/types';
 import { Caption } from '@/app/components/solo/Caption';
 import { stepFadeS, type DwellPlan, type Stage } from '@/app/lib/solo2/plan';
+import { arrivalLook } from '@/app/lib/solo2/veil';
 import type { Solo2Dials } from '@/app/lib/solo2/types';
 
 const mono = 'ui-monospace, SFMono-Regular, Menlo, monospace';
@@ -13,9 +14,17 @@ const mono = 'ui-monospace, SFMono-Regular, Menlo, monospace';
 /** A frame of the run: a view entry, with its bin rank when the caller has one. */
 export type RunFrame = ViewEntry & { rank?: number };
 
+/**
+ * The lift rides on a custom property rather than being baked into the
+ * keyframes, because two screens render two Solo2Frames on one studio page
+ * and a `<style>` rule is global: keyframes carrying an interpolated number
+ * would have the second screen's burn silently overwrite the first's.
+ */
 const KEYFRAMES = `
 @keyframes solo2-fade-in { from { opacity: 0 } to { opacity: 1 } }
 @keyframes solo2-dip { from { opacity: 0 } to { opacity: 1 } }
+@keyframes solo2-burn-out { from { filter: brightness(1) } to { filter: brightness(var(--solo2-lift, 1)) } }
+@keyframes solo2-burn-in { from { filter: brightness(var(--solo2-lift, 1)) } to { filter: brightness(1) } }
 `;
 
 /**
@@ -87,17 +96,37 @@ export function Solo2Frame({ entry, run, previous, stage, plan, dials, width, he
   const dwellId = dwellKey ?? entry.snapshotId;
   const stepFade = stepFadeS(dials.sameCameraFadeS, plan);
 
-  const arrive = arrival(entry, previous, dials);
+  // What this screen's change dips through (veil.ts). `veilStyle` only bites
+  // on a dip: it is the dial that says what a SUNRISE does instead of ending
+  // in black, and a screen set to crossfade or cut is already not ending in
+  // black. A null veil turns this screen's dip into a crossfade — that is the
+  // asymmetry the whole dial exists for, one screen crossfading while the
+  // other still dips.
+  const look = arrivalLook(feed ?? 'sunset', dials);
+  const dipped = arrival(entry, previous, dials);
+  const arrive = dipped.kind === 'dip' && look.veilColor === null
+    ? { kind: 'crossfade' as const, fadeS: dipped.fadeS }
+    : dipped;
   const showPrevious = arrive.kind !== 'cut' && !!previous;
-  // Linear, like the veil under it and like the in-run step above it. An
-  // eased ramp is not the same ramp run backwards: `ease` puts the picture at
-  // 80% brightness halfway through and spends the rest of the fade crawling
-  // the last 20%, so against a linear fade to black the picture reads as
-  // arriving in a third of the time it leaves in. Every dissolve here is linear.
+  // ONE timing function for every layer of the change. A dissolve is two
+  // animations, one leaving and one arriving, and they stay matched only
+  // while they are the same shape run in opposite directions — an eased
+  // arrival against a linear departure lands in a third of the time it left
+  // in (PR #160). Every curve `arrivalEase` offers is symmetric, so this
+  // single value can go on all of them.
+  const ease = look.ease;
   const inAnimation =
-    arrive.kind === 'crossfade' ? `solo2-fade-in ${arrive.fadeS}s linear both`
-    : arrive.kind === 'dip' ? `solo2-fade-in ${arrive.fadeS / 2}s linear ${arrive.fadeS / 2}s both`
+    arrive.kind === 'crossfade' ? `solo2-fade-in ${arrive.fadeS}s ${ease} both`
+    : arrive.kind === 'dip' ? `solo2-fade-in ${arrive.fadeS / 2}s ${ease} ${arrive.fadeS / 2}s both`
     : undefined;
+  // The picture moves toward the veil rather than merely being covered by it:
+  // up into white on a sunrise, down into black on a sunset. That is what
+  // separates an exposure from a dip through a coloured card. Only on a dip,
+  // and only when the lift asks for something.
+  const burning = arrive.kind === 'dip' && look.lift !== 1;
+  const burnOut = burning ? `solo2-burn-out ${arrive.fadeS / 2}s ${ease} both` : undefined;
+  const burnIn = burning ? `solo2-burn-in ${arrive.fadeS / 2}s ${ease} ${arrive.fadeS / 2}s both` : undefined;
+  const liftVar = burning ? ({ '--solo2-lift': String(look.lift) } as React.CSSProperties) : undefined;
 
   // The lead: a slow push over the last seconds, driven by the clock stage
   // so a late tab is in sync. No transition when the progress is 0, so a
@@ -115,7 +144,8 @@ export function Solo2Frame({ entry, run, previous, stage, plan, dials, width, he
       <style>{KEYFRAMES}</style>
       {showPrevious && (
         // eslint-disable-next-line @next/next/no-img-element
-        <img key={`prev-${previous.snapshotId}`} src={previous.imageUrl} alt="" role="presentation" style={pictureLayer} />
+        <img key={`prev-${previous.snapshotId}`} src={previous.imageUrl} alt="" role="presentation" data-testid="prev"
+          style={{ ...pictureLayer, ...liftVar, animation: burnOut }} />
       )}
       {showPrevious && (
         // The words being left behind, under the veil and under the arriving
@@ -124,18 +154,24 @@ export function Solo2Frame({ entry, run, previous, stage, plan, dials, width, he
           <Caption entry={previous} dials={dials} picture={picture} width={width} height={height} feed={feed} />
         </div>
       )}
-      {arrive.kind === 'dip' && showPrevious && (
+      {arrive.kind === 'dip' && showPrevious && look.veilColor && (
         <div key={`dip-${dwellId}`} data-testid="dip" style={{
-          ...layer, background: '#000', animation: `solo2-dip ${arrive.fadeS / 2}s linear both`,
+          ...(look.covers === 'panel' ? layer : pictureLayer),
+          background: look.veilColor, animation: `solo2-dip ${arrive.fadeS / 2}s ${ease} both`,
         }} />
       )}
       {/* keyed by the drawn frame so the arrival runs once per dwell; the stage only changes opacities inside */}
-      <div key={`stack-${dwellId}`} data-testid="stack" style={{ ...pictureLayer, animation: inAnimation }}>
+      <div key={`stack-${dwellId}`} data-testid="stack" style={{
+        ...pictureLayer, ...liftVar,
+        animation: [inAnimation, burnIn].filter(Boolean).join(', ') || undefined,
+      }}>
         <div style={pushStyle} data-testid="push">
           {sequence.map((f, i) => (
             <div key={f.snapshotId} data-testid={`seq-${i}`} style={{
               ...layer, opacity: i <= shown ? 1 : 0,
-              transition: i > 0 && stepFade > 0 ? `opacity ${stepFade}s linear` : 'none',
+              // The same curve as the camera change: a step inside a run is a
+              // dissolve too, and Jesse asked for both to stop snapping.
+              transition: i > 0 && stepFade > 0 ? `opacity ${stepFade}s ${ease}` : 'none',
             }}>
               {/* eslint-disable-next-line @next/next/no-img-element */}
               <img src={f.imageUrl} alt="" role="presentation" data-testid={i === shown ? 'top' : undefined} style={layer} />

--- a/app/components/solo2/index.test.tsx
+++ b/app/components/solo2/index.test.tsx
@@ -1,4 +1,5 @@
 import { it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { ARRIVAL_EASES } from '@/app/lib/solo2/veil';
 import { render, screen } from '@testing-library/react';
 import { Solo2Kiosk } from './index';
 
@@ -67,7 +68,8 @@ it('a new frame on glass arrives with the old one as its previous in the same re
   rerender(<Solo2Kiosk webcams={[]} width={100} height={50} feed="sunset" settings={{ transition: 'crossfade' }} />);
   // The previous frame (camera 7's drawn frame) sits underneath and the crossfade is on the stack, from the first render.
   expect(screen.getAllByRole('presentation').map((i) => i.getAttribute('src'))).toEqual(['u3', 'u9']);
-  expect(screen.getByTestId('stack')).toHaveStyle({ animation: 'solo2-fade-in 1.5s linear both' });
+  expect(screen.getByTestId('stack'))
+    .toHaveStyle({ animation: `solo2-fade-in 1.5s ${ARRIVAL_EASES.gentle} both` });
   expect(screen.getByTestId('top')).toHaveAttribute('src', 'u9');
 });
 

--- a/app/lib/solo2/settingsSchema.ts
+++ b/app/lib/solo2/settingsSchema.ts
@@ -1,7 +1,7 @@
 import type { NumberKnob, SettingsSchema, SettingsValues } from '@/app/lib/settings/schema';
 import { SOLO_SETTINGS_SCHEMA } from '@/app/lib/solo/settingsSchema';
 import { dialsFrom } from '@/app/lib/solo/settingsSchema';
-import type { Screens, Solo2Dials, Transition } from './types';
+import type { ArrivalEase, Screens, Solo2Dials, Transition, VeilCovers, VeilStyle, VeilTint } from './types';
 
 export const SOLO2_NAMESPACE = 'solo2';
 
@@ -64,6 +64,32 @@ export const SOLO2_SETTINGS_SCHEMA: SettingsSchema = [
     label: 'lead scale', section: 'glass',
     description: 'How far the push goes by the moment of the change. 1.03 is barely felt; 1.10 is a visible zoom.',
   },
+  // ---- arrival: what a camera change dips through (its own rail page) ----
+  {
+    key: 'veilStyle', kind: 'enum', options: ['black', 'crossfade', 'light', 'burn'], default: 'black',
+    label: 'the change', section: 'arrival',
+    description: 'What a camera change dips through. The sunset screen ends in black under all four; this dial is about what a SUNRISE does instead, because a sunrise fading to black plays the day backwards. black: both screens dip through black, as today. crossfade: the sunrise screen never goes dark, one dawn dissolving into the next. light: the sunrise screen dips through the tint below. burn: the picture itself moves toward its veil — the sunrise blows out into white, the sunset darkens into black.',
+  },
+  {
+    key: 'veilTint', kind: 'enum', options: ['white', 'dawn', 'sky', 'dim'], default: 'dawn',
+    label: 'light tint', section: 'arrival',
+    description: 'Which light a `light` sunrise dips through. Pure white on a 27-inch panel in a dark room reads as a camera flash; dawn and dim are the room-safe ones. Ignored by the other three.',
+  },
+  {
+    key: 'burnLift', kind: 'number', min: 1, max: 3, step: 0.1, default: 1.6,
+    label: 'burn', section: 'arrival',
+    description: 'How hard an exposure pushes the picture toward its veil. 1 is a plain dip through white — the picture is covered, never brightened. 1.6 blows the sky out first and the dark ground last, which is what reads as overexposure. Past about 2 the picture is white long before the veil is, and the change looks lopsided again. Ignored unless the change is `burn`.',
+  },
+  {
+    key: 'veilCovers', kind: 'enum', options: ['picture', 'panel'], default: 'picture',
+    label: 'veil covers', section: 'arrival',
+    description: 'Whether the veil stays inside the picture or floods the black surround with it too. Invisible while the veil is black; it is the light and burn styles that make it a choice.',
+  },
+  {
+    key: 'arrivalEase', kind: 'enum', options: ['linear', 'gentle', 'soft'], default: 'gentle',
+    label: 'ease', section: 'arrival',
+    description: 'How a dissolve starts and stops — the camera change and the steps inside a run alike. linear moves at one rate throughout, which is what makes a change feel like it snaps in. gentle and soft ramp in and out. Every curve here is symmetric, so the leaving half and the arriving half stay the same shape run opposite ways; an eased arrival against a linear departure lands in a third of the time it left in.',
+  },
   solo('showPlace'),
   solo('showScores'),
   solo('showRank'),
@@ -100,6 +126,11 @@ export function dialsFrom2(values: SettingsValues): Solo2Dials {
     minStepS: values.minStepS as number,
     runFramesSunset: values.runFramesSunset as number,
     runFramesOther: values.runFramesOther as number,
+    veilStyle: values.veilStyle as VeilStyle,
+    veilTint: values.veilTint as VeilTint,
+    burnLift: values.burnLift as number,
+    veilCovers: values.veilCovers as VeilCovers,
+    arrivalEase: values.arrivalEase as ArrivalEase,
     valleys: values.valleys as number,
     screens: values.screens as Screens,
   };

--- a/app/lib/solo2/types.ts
+++ b/app/lib/solo2/types.ts
@@ -6,6 +6,18 @@ export type Transition = 'cut' | 'crossfade' | 'dip';
 /** The time part of the caption moved to the solo dials with the caption section; re-exported for older imports. */
 export type { TimeStyle } from '@/app/lib/solo/types';
 
+/** What a camera change dips through (arrival-look spec §2). A pair: one look per screen. */
+export type VeilStyle = 'black' | 'crossfade' | 'light' | 'burn';
+
+/** The tint a `light` sunrise dips through (veil.ts `VEIL_TINTS`). */
+export type VeilTint = 'white' | 'dawn' | 'sky' | 'dim';
+
+/** Whether the veil spans the panel or only the picture inside it. */
+export type VeilCovers = 'picture' | 'panel';
+
+/** The timing function both halves of every dissolve share (veil.ts `ARRIVAL_EASES`). */
+export type ArrivalEase = 'linear' | 'gentle' | 'soft';
+
 /** Whether the two screens peak on the same beat or opposite ones (spec §3). */
 export type Screens = 'together' | 'alternate';
 
@@ -41,6 +53,19 @@ export interface Solo2Dials extends SoloDials {
    * buys pictures, never screen time (spec §4.1).
    */
   runFramesOther: number;
+  /** What a camera change dips through; the sunset screen stays black under all of them. */
+  veilStyle: VeilStyle;
+  /** The tint a `light` sunrise dips through. Ignored by every other style. */
+  veilTint: VeilTint;
+  /** How far an exposure pushes the picture toward its veil. Ignored unless `burn`. */
+  burnLift: number;
+  veilCovers: VeilCovers;
+  /**
+   * The timing function every layer of a dissolve shares — the camera change
+   * and the steps inside a run alike. Symmetric by construction so the two
+   * halves cannot drift apart (veil.ts).
+   */
+  arrivalEase: ArrivalEase;
   // bins
   valleys: number;
   screens: Screens;

--- a/app/lib/solo2/veil.test.ts
+++ b/app/lib/solo2/veil.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from 'vitest';
+import { ARRIVAL_EASES, VEIL_TINTS, arrivalLook, bezierPoints, easingIsSymmetric } from './veil';
+import type { Solo2Dials } from './types';
+
+const D: Pick<Solo2Dials, 'veilStyle' | 'veilTint' | 'burnLift' | 'veilCovers' | 'arrivalEase'> = {
+  veilStyle: 'black', veilTint: 'dawn', burnLift: 1.6, veilCovers: 'picture', arrivalEase: 'gentle',
+};
+
+describe('the four looks, per screen', () => {
+  it('black is what both screens do today', () => {
+    expect(arrivalLook('sunrise', D)).toMatchObject({ veilColor: '#000000', lift: 1 });
+    expect(arrivalLook('sunset', D)).toMatchObject({ veilColor: '#000000', lift: 1 });
+  });
+
+  it('crossfade takes the veil off the sunrise screen and leaves the sunset one ending in black', () => {
+    const d = { ...D, veilStyle: 'crossfade' as const };
+    expect(arrivalLook('sunrise', d).veilColor).toBeNull();
+    expect(arrivalLook('sunset', d).veilColor).toBe('#000000');
+  });
+
+  it('light dips a sunrise through the chosen tint; the sunset screen never changes colour', () => {
+    const d = { ...D, veilStyle: 'light' as const };
+    expect(arrivalLook('sunrise', d).veilColor).toBe(VEIL_TINTS.dawn);
+    expect(arrivalLook('sunrise', { ...d, veilTint: 'dim' }).veilColor).toBe(VEIL_TINTS.dim);
+    expect(arrivalLook('sunset', { ...d, veilTint: 'dim' }).veilColor).toBe('#000000');
+  });
+
+  it('burn moves each picture toward its own veil: up into white, down into black', () => {
+    const d = { ...D, veilStyle: 'burn' as const };
+    expect(arrivalLook('sunrise', d)).toMatchObject({ veilColor: '#ffffff', lift: 1.6 });
+    expect(arrivalLook('sunset', d)).toMatchObject({ veilColor: '#000000', lift: 0 });
+    // A lift below 1 on the sunrise screen would darken it into a white veil, which is nonsense.
+    expect(arrivalLook('sunrise', { ...d, burnLift: 0.2 }).lift).toBe(1);
+  });
+
+  it('an unknown style falls back to black rather than to no veil at all', () => {
+    expect(arrivalLook('sunrise', { ...D, veilStyle: 'nonsense' as never }).veilColor).toBe('#000000');
+  });
+});
+
+describe('the easing both halves of a dissolve share', () => {
+  it('every curve on offer is point-symmetric, which is what keeps the pair matched', () => {
+    // The guard on PR #160's bug: an eased arrival against a linear departure
+    // lands in a third of the time it left in. A symmetric curve run in
+    // reverse is the same curve, so a pair using one cannot drift apart.
+    for (const [name, css] of Object.entries(ARRIVAL_EASES)) {
+      expect(easingIsSymmetric(css), `${name} (${css}) must be symmetric`).toBe(true);
+    }
+  });
+
+  it('recognises an asymmetric curve, so a future one cannot be added quietly', () => {
+    expect(easingIsSymmetric('cubic-bezier(0.4, 0, 0.2, 1)')).toBe(false); // the standard "ease-out"
+    expect(easingIsSymmetric('ease-in-out')).toBe(false); // a keyword we cannot verify
+    expect(bezierPoints('cubic-bezier(0.4, 0, 0.6, 1)')).toEqual([0.4, 0, 0.6, 1]);
+    expect(bezierPoints('linear')).toBeNull();
+  });
+
+  it('the look carries one timing function for every layer of the change', () => {
+    expect(arrivalLook('sunrise', D).ease).toBe(ARRIVAL_EASES.gentle);
+    expect(arrivalLook('sunset', { ...D, arrivalEase: 'linear' }).ease).toBe('linear');
+    expect(arrivalLook('sunset', { ...D, arrivalEase: 'nonsense' as never }).ease).toBe('linear');
+  });
+});

--- a/app/lib/solo2/veil.ts
+++ b/app/lib/solo2/veil.ts
@@ -1,0 +1,109 @@
+import type { Feed } from '@/app/lib/solo/types';
+import type { Solo2Dials, VeilTint, ArrivalEase, VeilCovers } from './types';
+
+/**
+ * What a camera change dips through, and how it eases (arrival-look spec).
+ *
+ * The four styles are pairs, one look per screen, because the whole point is
+ * the asymmetry: a sunset ending in black is the story, a sunrise ending in
+ * black is a sunrise playing backwards. Reported 2026-09-07: "narratively
+ * this makes sense for sunsets, but sunrise should fade to white or crossfade
+ * because it's becoming light."
+ */
+
+/** The tints the `light` style can dip a sunrise through. */
+export const VEIL_TINTS: Record<VeilTint, string> = {
+  white: '#ffffff',
+  dawn: '#f4e6cf',
+  sky: '#dfe6ee',
+  dim: '#b9a892',
+};
+
+/**
+ * The timing function both halves of a dissolve share.
+ *
+ * Every curve here is point-symmetric about (0.5, 0.5) — the mirror of
+ * (x1, y1) is (1 - x1, 1 - y1) — and that is not decoration. A dissolve is two
+ * animations, one leaving and one arriving, and they only stay matched while
+ * they are the same shape run in opposite directions. An eased arrival against
+ * a linear departure lands in a third of the time it left in (PR #160,
+ * 2026-09-06). Adding a curve that is not symmetric here reintroduces that bug
+ * for every style at once, so `easingIsSymmetric` guards the table.
+ */
+export const ARRIVAL_EASES: Record<ArrivalEase, string> = {
+  linear: 'linear',
+  gentle: 'cubic-bezier(0.4, 0, 0.6, 1)',
+  soft: 'cubic-bezier(0.65, 0, 0.35, 1)',
+};
+
+/** The control points of a cubic-bezier easing, or null for a keyword. */
+export function bezierPoints(css: string): [number, number, number, number] | null {
+  const m = css.match(/^cubic-bezier\(([^)]+)\)$/);
+  if (!m) return null;
+  const n = m[1].split(',').map((v) => Number(v.trim()));
+  return n.length === 4 && n.every((v) => Number.isFinite(v)) ? (n as [number, number, number, number]) : null;
+}
+
+/**
+ * Whether a timing function runs the same shape backwards as forwards, which
+ * is what lets the two halves of a dissolve use it without drifting apart.
+ * `linear` trivially does; a cubic-bezier does when its second control point
+ * is the first one reflected through the centre.
+ */
+export function easingIsSymmetric(css: string): boolean {
+  if (css === 'linear') return true;
+  const p = bezierPoints(css);
+  if (!p) return false;
+  const [x1, y1, x2, y2] = p;
+  return Math.abs(x2 - (1 - x1)) < 1e-9 && Math.abs(y2 - (1 - y1)) < 1e-9;
+}
+
+/** How one screen's camera change looks, resolved from the style and the feed. */
+export interface ArrivalLook {
+  /**
+   * The veil the change dips through, or null to crossfade with no veil at
+   * all. The panel is black, so a black veil and no veil differ only in
+   * whether the outgoing picture is still there underneath.
+   */
+  veilColor: string | null;
+  /**
+   * The brightness the outgoing picture reaches as the veil closes, and the
+   * one the incoming picture comes back from. 1 leaves the picture alone.
+   * Above 1 it blows out toward a white veil; 0 darkens into a black one.
+   *
+   * The picture moves TOWARD the veil rather than merely being covered by it,
+   * which is what separates an exposure from a dip through a coloured card.
+   */
+  lift: number;
+  /** Whether the veil spans the panel or only the picture inside it. */
+  covers: VeilCovers;
+  /** The timing function every layer of this change shares. */
+  ease: string;
+}
+
+/**
+ * The look for one screen. `sunset` keeps black under every style: the
+ * question this answers is what a SUNRISE should do instead.
+ */
+export function arrivalLook(feed: Feed, d: Pick<Solo2Dials,
+  'veilStyle' | 'veilTint' | 'burnLift' | 'veilCovers' | 'arrivalEase'>): ArrivalLook {
+  const ease = ARRIVAL_EASES[d.arrivalEase] ?? ARRIVAL_EASES.linear;
+  const base = { covers: d.veilCovers, ease };
+  const sunrise = feed === 'sunrise';
+  switch (d.veilStyle) {
+    case 'crossfade':
+      return { ...base, veilColor: sunrise ? null : '#000000', lift: 1 };
+    case 'light':
+      return { ...base, veilColor: sunrise ? (VEIL_TINTS[d.veilTint] ?? VEIL_TINTS.dawn) : '#000000', lift: 1 };
+    case 'burn':
+      // The picture moves toward the veil: up into white on the sunrise
+      // screen, down into black on the sunset one. Both screens burn; they
+      // burn toward opposite ends, which is the whole idea.
+      return sunrise
+        ? { ...base, veilColor: '#ffffff', lift: Math.max(1, d.burnLift) }
+        : { ...base, veilColor: '#000000', lift: 0 };
+    case 'black':
+    default:
+      return { ...base, veilColor: '#000000', lift: 1 };
+  }
+}

--- a/app/studio/Rail.test.tsx
+++ b/app/studio/Rail.test.tsx
@@ -1,4 +1,9 @@
 import { describe, it, expect, vi } from 'vitest';
+import { ARRIVAL_SECTION } from './Rail';
+
+/** solo2's dials split across two rail pages; the tests assert each page shows only its own. */
+const ARRIVAL_KNOBS = SOLO2_SETTINGS_SCHEMA.filter((k) => k.section === ARRIVAL_SECTION);
+const PLAY_KNOBS = SOLO2_SETTINGS_SCHEMA.filter((k) => k.section !== ARRIVAL_SECTION);
 import { render, screen, fireEvent } from '@testing-library/react';
 import { Rail } from './Rail';
 import { STUDIO_SURFACES } from './surfaces';
@@ -29,13 +34,31 @@ describe('Rail, solo kind', () => {
   it('play page: every glass and bins knob under its group, bold when it differs; caption knobs wait on the picture tab', () => {
     const a = api({ diffByNamespace: { solo2: ['valleys'] } });
     render(<Rail api={a} surface={STUDIO_SURFACES.solo2} tab="play" onTab={noop}><span>TAKES</span></Rail>);
-    for (const k of SOLO2_SETTINGS_SCHEMA) expect(screen.getByLabelText(k.label)).toBeInTheDocument();
+    for (const k of PLAY_KNOBS) expect(screen.getByLabelText(k.label)).toBeInTheDocument();
     for (const k of CAPTION_SCHEMA) expect(screen.queryByLabelText(k.label)).toBeNull();
+    for (const k of ARRIVAL_KNOBS) expect(screen.queryByLabelText(k.label)).toBeNull();
     expect(screen.getByText('valleys per peak')).toHaveStyle({ fontWeight: 700 });
     expect(screen.getByText('dwell (s)')).toHaveStyle({ fontWeight: 400 });
     expect(screen.getByRole('tab', { name: 'Play' })).toHaveAttribute('aria-selected', 'true');
     expect(screen.getByText('TAKES')).toBeInTheDocument();
     expect(screen.queryByText(/glass .* · dials/)).toBeNull();
+  });
+  it('change page: the arrival dials, and only those; reset clears that section', () => {
+    const a = api({ diffByNamespace: { solo2: ['veilStyle'] } });
+    render(<Rail api={a} surface={STUDIO_SURFACES.solo2} tab="change" onTab={noop} />);
+    for (const k of ARRIVAL_KNOBS) expect(screen.getByLabelText(k.label)).toBeInTheDocument();
+    for (const k of PLAY_KNOBS) expect(screen.queryByLabelText(k.label)).toBeNull();
+    expect(screen.getByText('the change')).toHaveStyle({ fontWeight: 700 });
+    expect(screen.getByRole('tab', { name: /Change/ })).toHaveAttribute('aria-selected', 'true');
+    fireEvent.click(screen.getByText('reset arrival'));
+    expect(a.resetSection).toHaveBeenCalledWith('solo2', 'arrival');
+  });
+  it('a version with no arrival dials has no Change tab, and asking for that page falls back to Play', () => {
+    // solo has no camera change to shape, so the tab would be an empty rail.
+    render(<Rail api={api()} surface={STUDIO_SURFACES.solo} tab="change" onTab={noop} />);
+    expect(screen.queryByRole('tab', { name: /Change/ })).toBeNull();
+    expect(screen.getByRole('tab', { name: 'Play' })).toHaveAttribute('aria-selected', 'true');
+    expect(screen.getByLabelText('dwell (s)')).toBeInTheDocument();
   });
   it('picture page: every caption knob bound to the shared namespace, with the readout; reset clears that section', () => {
     const a = api({ diffByNamespace: { shared: ['titleGray'] } });
@@ -85,7 +108,7 @@ describe('Rail, solo kind', () => {
   });
   it('every play-page knob label carries a hint glyph whose title is its schema description', () => {
     const { container } = render(<Rail api={api()} surface={STUDIO_SURFACES.solo2} tab="play" onTab={noop} />);
-    for (const k of SOLO2_SETTINGS_SCHEMA) {
+    for (const k of PLAY_KNOBS) {
       // The glyph is a sibling of the <label>, not a child of it: nesting it
       // inside the label would make getByLabelText(k.label) see "label?" and
       // stop matching (see the Hint doc comment in Rail.tsx).

--- a/app/studio/Rail.tsx
+++ b/app/studio/Rail.tsx
@@ -13,13 +13,26 @@ import type { Solo2Dials } from '@/app/lib/solo2/types';
 import type { PlanDials } from '@/app/lib/solo2/plan';
 import { DwellBudget } from './solo/DwellBudget';
 
-/** The rail's two pages: what plays and when, and how the picture and its words are drawn. */
-export type RailTab = 'play' | 'picture';
+/**
+ * The rail's pages: what plays and when, how one picture gives way to the
+ * next, and how the picture and its words are drawn. `change` appears only
+ * for a version whose schema has arrival dials, which today is solo2 alone.
+ */
+export type RailTab = 'play' | 'change' | 'picture';
+
+/** The section a version's arrival dials live in; its presence is what shows the Change tab. */
+export const ARRIVAL_SECTION = 'arrival';
 
 const TABS: { id: RailTab; label: string; hint: string }[] = [
   { id: 'play', label: 'Play', hint: 'Timing, overlays and the ordering algorithm: what plays and when.' },
+  { id: 'change', label: 'Change', hint: 'How one picture gives way to the next: what a camera change dips through, and how the dissolves start and stop.' },
   { id: 'picture', label: 'Picture', hint: 'The picture\'s size on black and the words beneath it. The screens above draw them as you move.' },
 ];
+
+const ARRIVAL_GROUP = {
+  title: 'Change · one picture giving way to the next', color: '#8fb8ff',
+  hint: 'The sunset screen ends in black under every style. These dials are about what a SUNRISE does instead — and how gently every dissolve starts and stops.',
+};
 
 /**
  * A solo version's two coloured groups. Every solo schema sorts its knobs
@@ -255,11 +268,16 @@ export function Rail({ api, surface, tab, onTab, runFrames = 1, children }: {
       sameCameraFadeS: (soloDials as Partial<Solo2Dials>).sameCameraFadeS,
     }
     : null;
-  const page: RailTab = surface.hasPicturePage ? tab : 'play';
+  const hasChangePage = surface.schema.some((k) => k.section === ARRIVAL_SECTION);
+  const tabs = TABS.filter((t) => (t.id === 'picture' ? surface.hasPicturePage : t.id === 'change' ? hasChangePage : true));
+  // A tab the current version does not have falls back to Play rather than
+  // rendering an empty rail: the studio keeps one tab across a version switch.
+  const page: RailTab = tabs.some((t) => t.id === tab) ? tab : 'play';
   // A solo schema is expected to sort into glass and bins, but a knob in any
   // other section has to land somewhere: a plain grey group after the two,
   // rather than nowhere at all.
-  const soloExtras = sectionsOf(surface.schema).filter((s) => !(s in SOLO_GROUPS));
+  // Arrival has its own page, so it must not also fall through to Play's grey catch-all group.
+  const soloExtras = sectionsOf(surface.schema).filter((s) => !(s in SOLO_GROUPS) && s !== ARRIVAL_SECTION);
   // Which collapsible groups are open. Unvisited sections fall back to
   // "the first one", so the rail opens the same way it always did.
   const [opened, setOpened] = useState<Record<string, boolean>>({});
@@ -275,9 +293,9 @@ export function Rail({ api, surface, tab, onTab, runFrames = 1, children }: {
 
   return (
     <div style={{ fontSize: 12, display: 'flex', flexDirection: 'column', minHeight: '100%' }}>
-      {surface.hasPicturePage && (
+      {tabs.length > 1 && (
         <div role="tablist" aria-label="Rail pages" style={{ display: 'flex', gap: 4, margin: '0 0 6px' }}>
-          {TABS.map((t) => (
+          {tabs.map((t) => (
             <button key={t.id} type="button" role="tab" aria-selected={page === t.id} title={t.hint}
               onClick={() => onTab(t.id)} style={{
                 flex: 1, padding: '5px 0', fontSize: 11, letterSpacing: '.06em', textTransform: 'uppercase', cursor: 'pointer',
@@ -315,6 +333,13 @@ export function Rail({ api, surface, tab, onTab, runFrames = 1, children }: {
           </details>
         );
       })}
+      {page === 'change' && (
+        <section>
+          <GroupHeader {...ARRIVAL_GROUP} section={ARRIVAL_SECTION}
+            onReset={() => api.resetSection(ns, ARRIVAL_SECTION)} />
+          {surface.schema.filter((k) => k.section === ARRIVAL_SECTION).map((k) => knob(k, { ns, values, diff }))}
+        </section>
+      )}
       {page === 'picture' && (
         <section>
           <GroupHeader {...CAPTION_GROUP} section={CAPTION_SECTION}

--- a/app/studio/solo/GlassPreview.test.tsx
+++ b/app/studio/solo/GlassPreview.test.tsx
@@ -1,4 +1,5 @@
 import { it, expect, beforeAll, vi, afterEach } from 'vitest';
+import { ARRIVAL_EASES } from '@/app/lib/solo2/veil';
 import { render, screen, act } from '@testing-library/react';
 import { GlassPreview } from './GlassPreview';
 import { dialsFrom, SOLO_SETTINGS_SCHEMA } from '@/app/lib/solo/settingsSchema';
@@ -64,7 +65,8 @@ it('solo2 plays the on-glass camera\'s run on the studio dials, looping on a loc
   const s2 = { ...server, entries } as unknown as StateView;
   render(<GlassPreview version={SOLO_VERSIONS.solo2} screens={[{ feed: 'sunset', server: s2, projected: null }]} dials={d2} panel={{ width: 1920, height: 1080 }} />);
   expect(screen.getByTestId('top')).toHaveAttribute('src', 'u5');
-  expect(screen.getByTestId('seq-1')).toHaveStyle({ opacity: '0', transition: 'opacity 1s linear' });
+  expect(screen.getByTestId('seq-1'))
+    .toHaveStyle({ opacity: '0', transition: `opacity 1s ${ARRIVAL_EASES.gentle}` });
   await act(async () => { vi.advanceTimersByTime(3_600); }); // 1.5 s arrival + 2.1 s: the second frame is up
   expect(screen.getByTestId('top')).toHaveAttribute('src', 'u6');
   await act(async () => { vi.advanceTimersByTime(2_000); });

--- a/docs/superpowers/specs/2026-09-07-solo2-arrival-look-design.md
+++ b/docs/superpowers/specs/2026-09-07-solo2-arrival-look-design.md
@@ -1,0 +1,143 @@
+# solo2: what a camera change dips through
+
+**Date:** 2026-09-07
+**Status:** built (PR on `fix/solo2-arrival-segment`)
+**Entry point for the model programme:** unchanged — `2026-08-29-two-scale-model-STATE.md`
+
+## 1. What Jesse saw
+
+> "The way the fades are working now in studio solo2, sunrise AND sunset are
+> fading to black. Narratively this makes sense for sunsets, but sunrise should
+> probably fade to white or crossfade because it's becoming light. It's
+> confusing and disappointing if a sunrise fades to black, especially in the
+> context of the sunsets fading to black — it looks like the sun is setting and
+> it's getting dark."
+
+Two later reports in the same session, both real and both fixed here:
+
+- *"The fade out still seems quicker than the fade in, and this seems more
+  pronounced on the sunrise screen."*
+- *"The transition down into the new camera kind of snaps in suddenly. If we
+  could ease that a little, that would be great."*
+
+## 2. The decision: one dial, four looks, each a PAIR
+
+`veilStyle` says what a camera change dips through. It is a pair — one look per
+screen — because the asymmetry is the entire point. The sunset screen ends in
+black under all four; the dial is about what a **sunrise** does instead.
+
+| style | sunrise | sunset |
+|---|---|---|
+| `black` (default) | dips through black | dips through black |
+| `crossfade` | no veil at all; one dawn dissolves into the next | dips through black |
+| `light` | dips through `veilTint` | dips through black |
+| `burn` | blows out into white | darkens into black |
+
+`black` is today's behaviour exactly, so merging changes nothing until the dial
+moves. Resolution lives in `app/lib/solo2/veil.ts` (`arrivalLook`), pure and
+testable without React.
+
+### 2.1 `veilStyle` only bites on a dip
+
+The existing `transition` dial (cut / crossfade / dip) still says what the
+gesture *is*, for both screens. `veilStyle` says what a **dip** dips through.
+A screen set to cut or crossfade is already not ending in black, so there is
+nothing for the new dial to say and it is ignored.
+
+The one case where the two interact: `veilStyle: crossfade` resolves the
+sunrise screen's veil to `null`, and a dip with no veil is rendered as a
+crossfade over the whole fade. That is how one screen crossfades while the
+other still dips — an asymmetry the single `transition` dial cannot express.
+
+### 2.2 The picture moves toward the veil
+
+`burn` is not "a dip through a white card". The outgoing picture's brightness
+ramps toward the veil as the veil closes, and the arriving picture comes back
+from it: up into white on a sunrise, down into black on a sunset. `burnLift`
+is how far. At 1 there is no ramp and `burn` degrades to a plain dip through
+white, which is a useful comparison rather than a broken state.
+
+The lift travels as a CSS custom property (`--solo2-lift`), never interpolated
+into the keyframes. Two screens render two `Solo2Frame`s into one document and
+a `<style>` rule is global: keyframes carrying a number would have the second
+screen's burn silently overwrite the first's.
+
+### 2.3 Why the burn had to stop carrying the timing
+
+The first build ramped brightness alone and Jesse read the two halves as
+different speeds. They were not — but brightness is not perceptually linear at
+the ends. A picture's highlights clip to white early on the way out and stay
+clipped until late on the way in, so a numerically symmetric ramp reads as a
+quick departure, a long white, and a late arrival. Sunrise pictures are bright
+to begin with, so they clipped soonest, which is why that screen was worse.
+
+The veil's **opacity** carries the timing; the lift only supplies the look.
+Opacity over a flat colour is what the eye reads evenly, and it is the same
+mechanism the black dip has always used.
+
+## 3. The easing, and the constraint on it
+
+`arrivalEase` — `linear` (today), `gentle`, `soft` — is applied to every layer
+of a dissolve: the veil, the outgoing picture, the arriving picture, the
+caption, and the steps inside a camera run. Default `gentle`, which is the
+change Jesse asked for; `linear` remains available.
+
+**Every curve offered is point-symmetric about (0.5, 0.5)**, and that is a
+correctness constraint, not a style preference. A dissolve is two animations,
+one leaving and one arriving, matched only while they are the same shape run
+in opposite directions. An eased arrival against a linear departure lands in a
+third of the time it left in — PR #160, 2026-09-06. `easingIsSymmetric` guards
+the table so a later curve cannot be added quietly, and the frame test asserts
+both halves carry one value *and* that the value is symmetric.
+
+## 4. Sky-sampled is NOT in this change
+
+The fifth look Jesse compared — the veil taking its colour from the pictures
+themselves — needs the browser to read the pixels of a frame. Measured
+2026-09-07:
+
+```
+curl -I https://storage.googleapis.com/sunrisesunset-32a25.firebasestorage.app/snapshots/…
+→ 200, and NO access-control-allow-origin header
+```
+
+Without that header the canvas is tainted and `getImageData` throws. It works
+in the mockup only because those frames are embedded in the page.
+
+Shipping it anyway would mean a dial that silently renders something else —
+precisely the fallback-masquerading-as-real-output failure this project has
+already been burned by. **Unblocked by one bucket setting** (a CORS
+configuration allowing the site's origin), which is Jesse's to run; after that
+it is a small follow-up: sample region, tone toward day/night, and a hold on
+the flat colour, all of which the mockup already demonstrates.
+
+## 5. The rail gains a page
+
+`Change` sits between `Play` and `Picture`, and appears only for a version
+whose schema has an `arrival` section — solo2 alone today. A version without
+one falls back to `Play` rather than rendering an empty rail, so the studio
+keeps its tab across a version switch.
+
+Grouping the arrival dials onto their own page rather than adding five knobs to
+`Glass` also answers the standing note about studio clutter: a new surface
+should replace something or stand apart, not thicken an existing column.
+
+## 6. Dials
+
+| key | kind | default | notes |
+|---|---|---|---|
+| `veilStyle` | enum | `black` | black / crossfade / light / burn |
+| `veilTint` | enum | `dawn` | white / dawn / sky / dim; `light` only |
+| `burnLift` | number 1–3 | 1.6 | `burn` only; 1 is a plain dip through white |
+| `veilCovers` | enum | `picture` | picture / panel; invisible while the veil is black |
+| `arrivalEase` | enum | `gentle` | linear / gentle / soft; symmetric by construction |
+
+## 7. Open
+
+- **Glass check.** The burn adds a brightness animation on one full-screen
+  layer, on a Pi 4 driving two 1440p Chromium windows. Cheap per-pixel work the
+  GPU composites, but unmeasured. Watch the glass after the first reload with
+  `burn` selected before trusting it for the show.
+- **Sky-sampled**, pending the bucket header above.
+- The mockup that produced these decisions:
+  https://claude.ai/code/artifact/6d65f737-8074-4040-b6a8-6a1c12b9b9b6


### PR DESCRIPTION
This is the second half of the work started in #168. #168 merged with only its first commit (the arrival segment); this commit was pushed to that branch afterwards and never reached main. Same code, new branch, merged with current main and re-tested.

Two solo2 changes to how one picture gives way to the next. Both came out of a design session against a mockup built on real frames: https://claude.ai/code/artifact/6d65f737-8074-4040-b6a8-6a1c12b9b9b6

## 1. A sunrise no longer ends in black

A sunrise fading to black plays the day backwards, and beside a sunset screen doing the same thing it reads as the sun going down.

`veilStyle` says what a camera change dips through, as a **pair** — one look per screen. The sunset screen ends in black under all four; the dial is about what a sunrise does instead.

| style | sunrise | sunset |
|---|---|---|
| `black` (default) | dips through black | dips through black |
| `crossfade` | no veil at all | dips through black |
| `light` | dips through `veilTint` | dips through black |
| `burn` | blows out into white | darkens into black |

`black` is today's behaviour exactly, so **merging changes nothing until the dial moves.**

`burn` is not a dip through a coloured card. The picture's brightness moves *toward* the veil and the arriving picture comes back from it, by `burnLift`. The lift travels as a CSS custom property, never interpolated into the keyframes: two screens render into one document and a `<style>` rule is global.

The veil's **opacity** carries the timing, not the brightness. Brightness is not perceptually even at the ends — highlights clip to white early leaving and stay clipped until late arriving — which is why the first version read as two different speeds, and why the sunrise screen was worse.

## 2. Dissolves stop snapping

`arrivalEase` — `linear` (today), `gentle` (new default), `soft` — puts **one** timing function on every layer of every dissolve: the veil, both pictures, the caption, and the steps inside a camera run.

Every curve offered is point-symmetric about (0.5, 0.5), and that is a correctness constraint rather than taste. An eased arrival against a linear departure lands in a third of the time it left in — PR #160. `easingIsSymmetric` guards the table, and the frame test asserts both halves carry one value *and* that the value is symmetric.

## 3. The rail gains a Change page

Between Play and Picture, shown only for a version with `arrival` dials. A version without one falls back to Play rather than rendering an empty rail.

## Deliberately absent: sky-sampled

The fifth look from the mockup — the veil taking its colour from the pictures — needs canvas pixel access. Measured today:

```
curl -I https://storage.googleapis.com/sunrisesunset-32a25.firebasestorage.app/snapshots/…
→ 200, and no access-control-allow-origin header
```

The canvas is tainted, `getImageData` throws. It works in the mockup only because those frames are embedded. Shipping it would mean a dial that silently renders something else. One CORS setting on the bucket unblocks it, then it's a small follow-up.

## Verify

- `/studio` solo2, **Change** tab: switch the styles and watch both preview screens. Try `burn` at 1.6, then 1.0 for comparison.
- Glass after merge: `bash scripts/pi/kiosk-doctor.sh --sync --reload`. No migration.

## Open

The burn adds a brightness animation on one full-screen layer, on a Pi 4 driving two 1440p Chromium windows. Cheap work for the GPU, but unmeasured. Watch the glass with `burn` selected before trusting it for the show.

2439 tests pass on the merge result, not just on the branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013jWANNE6txRkKK7Xkddx4v
