### PR TITLE
The preview's rectangle is the panel, and the time gap reaches

### DIFF
--- a/app/lib/solo/captionSchema.test.ts
+++ b/app/lib/solo/captionSchema.test.ts
@@ -15,6 +15,15 @@ describe('CAPTION_SCHEMA', () => {
     });
   });
 
+  it('the time gap reaches far enough to drop the time clear of the pair above it', () => {
+    const timeGap = CAPTION_SCHEMA.find((k) => k.key === 'timeGap');
+    // A gap that tops out below the two lines it is separating the time from
+    // cannot separate them: at the mockup sizes title + place stand about 47
+    // glass px tall, and 60 px of gap left the time reading as the third line
+    // of one block rather than as its own thing.
+    expect(timeGap?.kind === 'number' && timeGap.max).toBeGreaterThanOrEqual(200);
+  });
+
   it('every knob is in the caption section, keys are unique, and every default is legal', () => {
     const keys = CAPTION_SCHEMA.map((k) => k.key);
     expect(new Set(keys).size).toBe(keys.length);

--- a/app/lib/solo/captionSchema.ts
+++ b/app/lib/solo/captionSchema.ts
@@ -103,9 +103,9 @@ export const CAPTION_SCHEMA: SettingsSchema = [
     description: 'own: the time on its own line under the place. inline: after the place with a middle dot.',
   },
   {
-    key: 'timeGap', kind: 'number', min: 0, max: 60, step: 1, default: 0,
+    key: 'timeGap', kind: 'number', min: 0, max: 240, step: 1, default: 0,
     label: 'time gap (px)', section: CAPTION_SECTION,
-    description: 'Extra space above the time line only, on top of the line gap, so the time can sit apart from the title and the place instead of evenly under them. Nothing when the time is inline.',
+    description: 'Extra space above the time line only, on top of the line gap, so the time can sit apart from the title and the place instead of evenly under them. It reaches a quarter of the panel, far enough to drop the time clear of the pair above it; past what the panel can hold the time leaves the panel, and the preview\u2019s amber edge shows where that is. Nothing when the time is inline.',
   },
   {
     key: 'timeSize', kind: 'number', min: 8, max: 32, step: 1, default: 12,

--- a/app/studio/StudioPanelFrame.test.tsx
+++ b/app/studio/StudioPanelFrame.test.tsx
@@ -56,6 +56,29 @@ describe('StudioPanelFrame', () => {
     expect(stage.style.background).toBe('rgb(0, 0, 0)');
   });
 
+  it('outlines the panel box when given an edge colour, and nothing without one', () => {
+    stubResizeObserver({ width: 700, height: 900 });
+
+    const { rerender } = render(
+      <StudioPanelFrame panel={{ width: 1440, height: 2560 }} edge="#f5a344">
+        <div>content</div>
+      </StudioPanelFrame>
+    );
+
+    // On the box, not the stage: the stage is unscaled panel pixels, so a line
+    // there would be drawn at the scale factor and read as a hairline of a
+    // different weight on every panel preset.
+    expect(screen.getByTestId('studio-panel-box').style.outline).toBe('1px solid #f5a344');
+    expect(screen.getByTestId('studio-panel-stage').style.outline).toBe('');
+
+    rerender(
+      <StudioPanelFrame panel={{ width: 1440, height: 2560 }}>
+        <div>content</div>
+      </StudioPanelFrame>
+    );
+    expect(screen.getByTestId('studio-panel-box').style.outline).toBe('');
+  });
+
   it('caps the scale at 1 when the measured box is larger than the panel', () => {
     stubResizeObserver({ width: 5000, height: 8000 });
 

--- a/app/studio/StudioPanelFrame.tsx
+++ b/app/studio/StudioPanelFrame.tsx
@@ -9,12 +9,22 @@ import { fitScale, type PanelSize } from '@/app/kiosk/panelPreview';
  * studio's preview column, sized by the rest of the grid). Same stage
  * markup — true panel px, scaled down, `top left` origin — just measured
  * with a ResizeObserver on the wrapping element instead of `window.innerWidth`.
+ *
+ * `edge` draws a hairline on the scaled panel box — the line the glass's own
+ * bezel makes. Without it the only rectangle in the preview column is the
+ * column's own border, and the panel inside it is black on black, so a
+ * caption falling off the panel still looks comfortably inside the frame the
+ * eye is using. It is an outline, not a border: outlines take no layout
+ * space, so the box the line marks is exactly the box that was measured.
  */
 export function StudioPanelFrame({
   panel,
+  edge,
   children,
 }: {
   panel: PanelSize;
+  /** Colour of the panel-edge hairline. No line without one. */
+  edge?: string;
   children: React.ReactNode;
 }) {
   const measureRef = useRef<HTMLDivElement | null>(null);
@@ -54,6 +64,7 @@ export function StudioPanelFrame({
           width: panel.width * scale,
           height: panel.height * scale,
           overflow: 'hidden',
+          outline: edge ? `1px solid ${edge}` : undefined,
         }}
       >
         <div

--- a/app/studio/solo/GlassPreview.test.tsx
+++ b/app/studio/solo/GlassPreview.test.tsx
@@ -42,6 +42,17 @@ it('draws each screen\'s current frame at the panel\'s true pixels with the stud
   expect(stage).toHaveStyle({ width: '1920px', height: '1080px', transform: 'scale(0.25)' });
 });
 
+it('draws the panel edge on the panel and leaves the preview column unbordered', () => {
+  render(<GlassPreview screens={[{ feed: 'sunrise', server, projected: null }]} dials={D} panel={{ width: 1920, height: 1080 }} />);
+  // The line the eye judges the caption against must be the panel's, not the
+  // column's: the column is 480 x 270 here and the panel scales to 480 x 270
+  // only because they happen to share an aspect. A portrait panel in this
+  // column would leave black margins, and a border on the column would sit
+  // where the glass has nothing.
+  expect(screen.getByTestId('studio-panel-box')).toHaveStyle({ outline: '1px solid #f5a344' });
+  expect(screen.getByTestId('preview-sunrise').style.border).toBe('');
+});
+
 it('names the screen before the title on each preview', () => {
   render(<GlassPreview screens={[{ feed: 'sunrise', server, projected: null }, { feed: 'sunset', server, projected: null }]} dials={D} panel={{ width: 1920, height: 1080 }} />);
   const titles = screen.getAllByTestId('caption-title').map((t) => t.textContent);

--- a/app/studio/solo/GlassPreview.tsx
+++ b/app/studio/solo/GlassPreview.tsx
@@ -15,6 +15,14 @@ import { useSoloPreview } from './useSoloPreview';
 
 const mono = 'ui-monospace, SFMono-Regular, Menlo, monospace';
 const SIDE: Record<Feed, string> = { sunrise: 'left screen', sunset: 'right screen' };
+/**
+ * The panel's own edge, drawn on the scaled panel and nowhere else. Amber
+ * because it must not be mistaken for the chrome around it: the preview column
+ * used to carry the only visible rectangle, so the eye read the column's
+ * border as the glass and judged the caption against a line the glass does
+ * not have. This one is the glass.
+ */
+const PANEL_EDGE = '#f5a344';
 
 /** One screen's inputs: what the glass holds, and the queue re-projected on the studio dials. */
 export interface PreviewScreen {
@@ -114,9 +122,10 @@ function PlayingScreen({ feed, server, projected, error, dials, panel, version }
         <span>{status}</span>
         <span style={{ marginLeft: 'auto' }}>{panel.width} × {panel.height}</span>
       </div>
-      <div data-testid={`preview-${feed}`} style={{ flex: 1, minHeight: 0, background: '#000', border: '1px solid #1d2432' }}>
+      {/* No border here: this box is the column, not the panel. The panel draws its own edge. */}
+      <div data-testid={`preview-${feed}`} style={{ flex: 1, minHeight: 0, background: '#000' }}>
         {dwell.entry ? (
-          <StudioPanelFrame panel={panel}>
+          <StudioPanelFrame panel={panel} edge={PANEL_EDGE}>
             {solo2 ? (
               <Solo2Frame entry={dwell.entry} run={run} previous={dwell.previous} stage={stage} plan={plan} dials={d2} dwellKey={dwell.startMs}
                 width={panel.width} height={panel.height} feed={feed} />


### PR DESCRIPTION
The solo studio preview drew a border around the preview **column**, not the panel. The column is `flex: 1` and fills whatever the studio grid gives it; `StudioPanelFrame` centres the true panel inside it, black on black. So the only visible rectangle was one the glass does not have, and a caption dialled to sit just inside that line was actually sitting past the panel's foot, where the glass cuts it.

The geometry was never wrong. Measured off the Pi's framebuffer with the live dials, the picture lands on exactly the pixels `pictureRect` computes:

| | on glass | computed |
|---|---|---|
| picture left | 164 | 164 |
| picture width | 1593 | 1593 |
| picture top | 49 | 49 |

## What changed

- The preview column loses its border. `StudioPanelFrame` takes an `edge` colour and draws it as an outline on the scaled panel box. An outline takes no layout space, so the box the line marks is exactly the box that was measured. Amber, so it does not read as more studio chrome.
- The time gap reaches 240 px instead of 60. At the mockup sizes the title and place stand about 47 px tall, so a 60 px ceiling could not drop the time clear of them and it still read as the third line of one block. Past what the panel can hold the time leaves the panel, which the preview now shows for what it is.

## Checking it

On /studio with a solo version selected, the amber hairline is the glass edge. Drag the time gap up until the time crosses it — that is the point the glass will cut.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0143asXDZBv7ZKuH8NedZdLA
