### PR TITLE
docs: merged is a claim about a branch, not about main

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,6 +36,14 @@ Still true in every worktree:
 - **Push as soon as a commit exists** and land small increments the same day.
   Long-lived branches orphan fixes:
   `docs/solutions/best-practices/integrate-frequently-dont-let-branches-sprawl.md`.
+- **"Merged" is a claim about a branch, not about `main`.** Before pushing a
+  follow-up to a branch that already has a PR, check `gh pr view <n> --json
+  state` — MERGED means that branch is closed and the work needs a new one.
+  Before saying anything shipped, run `git merge-base --is-ancestor <sha>
+  origin/main`; it is the only check that answers the question. Merging parallel
+  PRs, build the merge RESULT (`git merge --no-commit`, then `npm run build`),
+  never each branch alone — a zero-file-overlap merge broke `main` twice.
+  `docs/solutions/workflow-issues/merged-is-a-claim-about-a-branch.md`.
 - **Remove the worktree when the PR merges.** `git worktree list` should read
   like the list of open PRs.
 

--- a/docs/solutions/best-practices/integrate-frequently-dont-let-branches-sprawl.md
+++ b/docs/solutions/best-practices/integrate-frequently-dont-let-branches-sprawl.md
@@ -39,3 +39,15 @@ already fix/build this?" a one-line `git log main` away.
 - Prefer a few short integration checkpoints over a heroic end-of-arc tidy.
 - When you *do* spin up parallel worktrees, set a reminder to reconcile them back soon — a
   worktree is a loan against `main`, not a parking lot.
+
+## Necessary, but not sufficient (added 2026-09-07)
+
+Landing fast is not the same as landing. This doc treats orphaning as a function
+of *time*, and that reading is incomplete: on 2026-09-06 a stacked PR orphaned
+five files in **21 seconds**, and on 2026-09-07 a commit was orphaned within the
+hour, both on branches doing exactly what this doc asks. Speed narrows the window
+for drift; it does nothing about work that never reached `main` at all.
+
+The complement is to verify rather than infer — `git merge-base --is-ancestor
+<sha> origin/main` is the only signal that means "on main". See
+`docs/solutions/workflow-issues/merged-is-a-claim-about-a-branch.md`.

--- a/docs/solutions/integration-issues/stacked-branch-missing-merged-dependency.md
+++ b/docs/solutions/integration-issues/stacked-branch-missing-merged-dependency.md
@@ -59,4 +59,10 @@ Stacked branches snapshot their base at cut time; later merges to that base don'
 - A **walking-skeleton run** (deploy + run the real entrypoint early) catches this class of bug structurally — see [[walking-skeleton-over-horizontal-buildout]].
 
 ## Related Issues
+
+- `docs/solutions/workflow-issues/merged-is-a-claim-about-a-branch.md` — this
+  incident is one of five sharing a root cause: every cheap git signal describes
+  a branch, never `main`. That doc also carries the other reading of the ancestry
+  check (`--is-ancestor <sha> origin/main`, "did my work reach main"), which is
+  the general rule; the direction used here is the special case.
 - `../integration-issues/mpu6050-reads-fake-zeros-when-asleep.md` — the gyro `wake()`/`make_orientation_reader` fix (PR #4) that was the missing dependency here.

--- a/docs/solutions/workflow-issues/merged-is-a-claim-about-a-branch.md
+++ b/docs/solutions/workflow-issues/merged-is-a-claim-about-a-branch.md
@@ -1,0 +1,246 @@
+---
+title: Merged is a claim about a branch, not about main
+date: 2026-09-07
+category: docs/solutions/workflow-issues
+module: dev-workflow
+problem_type: workflow_issue
+component: development_workflow
+severity: high
+root_cause: missing_workflow_step
+resolution_type: workflow_improvement
+applies_when:
+  - "About to report work as shipped, merged, live, or landed"
+  - "About to push a follow-up commit to a branch that already has a PR"
+  - "Merging a stacked PR whose base branch may itself have merged already"
+  - "Two branches are ready at once and each is green on its own"
+  - "Cutting a branch that depends on a symbol another in-flight PR adds"
+symptoms:
+  - "A pull request reads MERGED while a later commit on the same head branch has never reached main"
+  - "Two branches with zero overlapping files break main on merge"
+  - "A stacked pull request reads MERGED but its files are absent from main"
+  - "Green tests on a branch hide a break that only the build or an untested entrypoint reveals"
+  - "Someone asks where work went after it was reported as shipped"
+related_components:
+  - tooling
+  - testing_framework
+tags: [git, github, pull-requests, merge-verification, stacked-prs, worktrees, ancestry]
+---
+
+# Merged is a claim about a branch, not about main
+
+## Context
+
+Five incidents across three months, in two repos, all from one mistake: treating
+a cheap git or GitHub signal as evidence that code reached `main`.
+
+**Shape 1 — a branch cut before its dependency landed** (2026-06-08, firmware).
+A branch referenced `make_orientation_reader`, which only reached `main` in a
+later PR. The suite was green because the broken import lived in a launcher
+script no test imports. Deep dive:
+`docs/solutions/integration-issues/stacked-branch-missing-merged-dependency.md`.
+
+**Shape 2 — the merge result was never built** (2026-09-06). PR #147 made
+`kiosk_deploys.deployed_at` nullable, changing `DeployRow.deployedAt` to
+`string | null`. PR #149 added a script passing that value to `Date.parse`. The
+two shared **no files**, so the merge-desk audit — "empty file intersection,
+merge order does not matter" — was true and useless. `main` stopped compiling
+the moment both landed, and every deploy failed until #150. **Tests all passed;
+only `npm run build` caught it.**
+
+**Shape 3 — a stacked PR merged into a corpse** (2026-09-06). PR #148 was based
+on `feat/one-studio-takes`. That base merged to `main` at 23:50:24Z; #148 merged
+into the base 21 seconds later, at 23:50:45Z. GitHub showed #148 as merged, its
+branch looked finished, and its five files never reached `main`.
+
+**Shape 4 — a PR merged out from under an in-flight branch** (2026-09-06
+evening, and again 2026-09-07). PR #155 was merged while commits were still
+being pushed to its branch, so only its first commit reached `main` and the
+commit that fixed the reported bug was left behind; recovered as #159. The
+identical thing happened the next day: PR #168 merged at 21:10:59Z carrying only
+its first commit, and a second commit was pushed to that same branch at
+21:42:50Z, thirty-two minutes after the branch had closed. GitHub still read
+MERGED and warned about nothing. The work was reported as shipped while it sat
+orphaned. Jesse caught it: *"I already merged that PR an hour ago, where did
+this go?"* Recovered as #169.
+
+**The unifying root cause.** Every cheap signal — the PR's state, "the branch
+exists", "the push succeeded", "tests are green on the branch" — is a statement
+about a **branch**. None is a statement about `main`. They are not merely
+unreliable; they answer a different question, so reading them more carefully
+does not help. A merged PR is a *snapshot of a branch at merge time*, not a live
+channel: push to that branch afterwards and no UI anywhere says a word.
+
+This repo's conventions make the collision routine rather than exceptional. Work
+happens in one sibling worktree per feature while the main checkout serves as the
+merge desk, and Jesse merges PRs from parallel sessions while agent sessions are
+still working on those same branches. A PR merging mid-task is a normal Tuesday.
+
+## Guidance
+
+**1. The only signal that means "this is on main" is an ancestry check.**
+
+```bash
+git fetch origin main --quiet
+git merge-base --is-ancestor <sha> origin/main && echo "ON MAIN" || echo "NOT ON MAIN"
+```
+
+Takes a commit SHA, a local branch name, or `origin/<branch>`. The fetch is not
+optional: a stale `origin/main` answers confidently and wrongly.
+
+Note this command reads in both directions, and the two readings are different
+questions. `--is-ancestor origin/main <branch>` asks *does my branch contain
+main* (shape 1). `--is-ancestor <sha> origin/main` asks *did my work reach main*
+(shapes 2 through 4). The second is the general rule.
+
+**2. Before pushing a follow-up to a branch that already has a PR, check the PR
+is still open.**
+
+```bash
+gh pr view <n> --json state,baseRefName,headRefOid,mergeCommit
+```
+
+- `state` is `MERGED` — that branch is **closed for business**. New work needs a
+  new branch and a new PR. Pushing to it succeeds and accomplishes nothing.
+- `baseRefName` is not `main` — this was stacked. MERGED means it merged into its
+  *base*, which may itself never have reached `main`. Ancestry-check
+  `mergeCommit.oid` before believing it.
+- `headRefOid` should equal your local tip. If the PR merged before your last
+  commit, it will not, and that difference is the orphaned work.
+
+**3. Build the merge RESULT, not the branch.** Green tests on a branch say
+nothing about that branch merged into current `main`. Type coupling, changed
+signatures, and renamed exports break across branches with no file overlap at
+all.
+
+```bash
+git fetch origin main --quiet
+git switch -c merge-check/<branch> origin/main
+git merge --no-commit --no-ff <branch>     # a REAL merge
+npm run test && npm run build              # BUILD, not just test
+git merge --abort; git switch -; git branch -D merge-check/<branch>
+```
+
+`npm run build` is not optional here. In shape 2 the whole suite passed and only
+the type-check in the build caught it.
+
+**Do not** substitute `git merge-tree ... | grep '^<<<<<<<'`. Old-style
+`merge-tree` output is diff-prefixed, so conflict markers arrive as `+<<<<<<<`
+and the anchored grep reports zero conflicts while a real conflict exists.
+Likewise `git diff A...B` between two tips is not a merge preview and shows
+phantom deletions when the merge base is old.
+
+**4. Recovering orphaned work.**
+
+```bash
+git fetch origin --quiet
+git switch -c <fresh-branch> <orphaned-sha>
+git merge --no-edit origin/main
+npm run test && npm run build              # against the MERGE RESULT
+git push -u origin <fresh-branch>
+gh pr create --base main --title "..." --body "..."
+git push origin --delete <stale-branch>    # so nobody pushes into a dead branch again
+```
+
+**5. Verify the claim, not just the action.** This is as much a reporting failure
+as a git one. Any sentence containing *merged*, *shipped*, *live*, *on main*, or
+*deployed* must be backed by an ancestry check run **after** the last relevant
+push — never by a status field read earlier in the session.
+
+## Why This Matters
+
+**The failure is silent by construction.** All five incidents produced zero
+errors, zero warnings, and a green-looking UI. Nothing notifies you when you push
+to a merged branch, nothing flags a stacked PR whose base is already gone,
+nothing signals that two conflict-free branches are type-incompatible. The
+failure surfaces later — in `main`, in a failed deploy, or when someone asks
+where the work went.
+
+**A broken `main` is not an inconvenience here.** The kiosk renders whatever
+`main` built, and the show has a fixed date. On 2026-09-06 `main` broke twice in
+one day and every deploy failed until a follow-up PR landed.
+
+**It costs trust, which is worse than it costs time.** Reporting work as shipped
+when it is orphaned means every future report has to be independently checked,
+which erases the value of reporting at all.
+
+**Landing fast is not the same as landing.** The existing advice to integrate
+frequently
+(`docs/solutions/best-practices/integrate-frequently-dont-let-branches-sprawl.md`)
+treats orphaning as a function of *time*. It is not sufficient: shape 3 orphaned
+five files in 21 seconds, and shape 4 in under an hour, on branches doing
+everything that doc asks. Short-lived branches orphan work just as silently.
+
+## When to Apply
+
+These are deliberate checks at specific moments. Run reflexively at every git
+command they become noise, and noise gets skipped.
+
+**Ancestry check** — before *saying* work is merged, shipped, live, or on main,
+every time without exception; when a session resumed or minutes of other work
+passed and you are about to act on a PR state you read earlier; when a PR reads
+MERGED but its base was another branch; before removing a worktree, since
+`scripts/wt.sh rm` refuses on unpushed work but not on unmerged-to-main work.
+
+**PR-state check** — before pushing to a branch that already has a PR, unless
+you opened that PR seconds ago. Any elapsed time is enough in this repo.
+
+**Merge-result build** — when anything landed on `main` after your branch was
+cut and your branch touches shared types, exported signatures, or shared helpers.
+File overlap is *not* the trigger; shape 2 had none. Also when merging a stacked
+PR whose base has already merged.
+
+**You may skip all three** only when you merged the PR yourself, watched the
+merge commit land, and nothing has been pushed since.
+
+## Examples
+
+**The misleading signal against the authoritative one** (shape 4, 2026-09-07):
+
+```
+$ git push origin fix/solo2-arrival-segment      # succeeds
+$ gh pr view 168 --json state
+{"state":"MERGED"}
+```
+
+Both facts true, both irrelevant. #168 merged 32 minutes earlier at head
+`c1ce49bfd`; the new commit `cc7af753c` was on nobody's path to `main`.
+
+```
+$ git fetch origin main --quiet
+$ git merge-base --is-ancestor cc7af753c origin/main && echo "ON MAIN" || echo "NOT ON MAIN"
+NOT ON MAIN
+```
+
+One command, run before speaking, catches it.
+
+**Same word, two different situations** (shape 3): `gh pr view 148 --json state`
+returns `MERGED`. Adding one field returns
+`{"state":"MERGED","baseRefName":"feat/one-studio-takes"}` — it merged into a
+branch that had itself already merged, so its commits went nowhere reachable.
+The word MERGED is identical in both cases; only the ancestry check separates
+them.
+
+**Conflict-free is a fact about text** (shape 2): `git diff --name-only A...B`
+showed no shared files, both branches were green, and the merge raised no
+conflict. `git switch -c check origin/main && git merge --no-commit --no-ff B &&
+npm run build` fails immediately on a type error. Conflict-freedom is a statement
+about text; the build is a statement about meaning.
+
+**Coverage is a floor, not a proof** (shape 1): the suite passed because the
+missing import lived in a launcher script no test file imports.
+
+## Related
+
+- `docs/solutions/integration-issues/stacked-branch-missing-merged-dependency.md`
+  — shape 1 in depth, and the other reading of the ancestry check.
+- `docs/solutions/best-practices/integrate-frequently-dont-let-branches-sprawl.md`
+  — why work must land quickly. Necessary but not sufficient; see above.
+- `docs/solutions/workflow-issues/migrations-need-a-ledger.md` — the same move
+  applied to migrations: a rule in a spec that kept being missed became a command
+  that exits non-zero. The ancestry check wants the same promotion.
+- `docs/solutions/developer-experience/git-worktrees-for-js-and-python-repos.md`
+  — the worktree layout these incidents happen inside.
+- `CONCEPTS.md`, the **Glass** entry, states the same epistemology one step
+  downstream: *"On the Glass always means verified at the surface, never inferred
+  from an upstream step succeeding."* Merged-versus-on-main is its upstream
+  sibling — deployed is not on the glass, and merged is not on main.


### PR DESCRIPTION
Documents a failure mode that has now bitten five times in three months, across two repos. Written via the compound-engineering workflow, so it lands in `docs/solutions/` where the frontmatter grep will find it.

## The pattern

| | date | what happened |
|---|---|---|
| 1 | 2026-06-08 | Branch cut before its dependency landed. Green tests hid it, because the broken import lived in a launcher script no test imports. |
| 2 | 2026-09-06 | #147 and #149 shared **zero files** and still broke `main`, via type coupling. Every test passed; only `npm run build` caught it. |
| 3 | 2026-09-06 | #148 merged into a base that had merged **21 seconds** earlier. GitHub said merged. Five files never reached `main`. |
| 4 | 2026-09-06 | #155 merged mid-push, dropping the commit that fixed the reported bug. Recovered as #159. |
| 5 | 2026-09-07 | #168 merged at 21:10:59Z. A commit was pushed to that branch at 21:42:50Z and reported as shipped. Orphaned, with no warning anywhere. Recovered as #169. |

**The unifying cause.** The PR's state, "the branch exists", "the push succeeded", "tests are green on the branch" — every one of those is a statement about a **branch**. None is a statement about `main`. They do not answer the question less reliably; they answer a *different question*, which is why reading them more carefully never helped. A merged PR is a snapshot of a branch at merge time, not a live channel: push to it afterwards and nothing anywhere says a word.

## What the doc adds

Three checks, with explicit guidance on *when* each is worth running so they don't become a ritual that gets skipped:

- `git merge-base --is-ancestor <sha> origin/main` — the only signal that means "on main". Before saying anything shipped, every time.
- `gh pr view <n> --json state,baseRefName,headRefOid` — before pushing a follow-up to a branch that already has a PR.
- A real `git merge --no-commit` plus **`npm run build`** — the merge result, not the branch. File overlap is not the trigger; case 2 had none.

Plus the recovery recipe, and why `git merge-tree | grep '^<<<<<<<'` and `git diff A...B` both lie here.

## Also in this PR

- **CLAUDE.md gains the rule.** Worth flagging: every git bullet in there was branch-level, and *"push as soon as a commit exists"* is precisely what produced case 5. The rule as written was followed faithfully and produced the bug.
- **`integrate-frequently-dont-let-branches-sprawl.md` gains a correction.** It attributes orphaning to branch *duration*. Case 3 orphaned five files in 21 seconds while obeying it. Landing fast is necessary, not sufficient.
- **`stacked-branch-missing-merged-dependency.md` gains a back-link**, and a note that the ancestry check reads in both directions — that doc uses the special case, the new one carries the general rule.

## Notes

Overlap with the existing 2026-06-08 doc was assessed as moderate (2.5 of 5 dimensions), so this is a new doc rather than an edit — updating it would have meant rewriting its title, frontmatter, symptoms and solution, and burying a general merge-hygiene rule inside a story about a Python import error on a Pi.

Vocabulary: `CONCEPTS.md` scanned, no qualifying terms. Its **Glass** entry already states this epistemology one step downstream — *"never inferred from an upstream step succeeding"* — and the new doc cites it, since merged-versus-on-main is its upstream sibling.

Docs only. No code, no migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013jWANNE6txRkKK7Xkddx4v
