### PR TITLE
fix(studio): one tab owns the camera change, and no two dials share a name

### DIFF
--- a/app/components/solo2/Solo2Frame.test.tsx
+++ b/app/components/solo2/Solo2Frame.test.tsx
@@ -195,14 +195,14 @@ describe('what the change dips through', () => {
     expect(screen.getByTestId('dip')).toHaveStyle({ background: '#000000' });
   });
 
-  it('crossfade takes the veil off the sunrise screen entirely; the sunset screen still dips', () => {
-    dip({ veilStyle: 'crossfade' });
+  it('a veil of `none` takes it off the sunrise screen entirely; the sunset screen still dips', () => {
+    dip({ veilStyle: 'none' });
     expect(screen.queryByTestId('dip')).toBeNull();
     // Not a cut: the outgoing picture stays, and the new one dissolves over the WHOLE fade.
     expect(screen.getByTestId('prev')).toBeInTheDocument();
     expect(screen.getByTestId('stack')).toHaveStyle({ animation: `solo2-fade-in 2s ${E} both` });
     cleanup();
-    dip({ veilStyle: 'crossfade' }, 'sunset');
+    dip({ veilStyle: 'none' }, 'sunset');
     expect(screen.getByTestId('dip')).toHaveStyle({ background: '#000000' });
   });
 

--- a/app/lib/solo2/settingsSchema.test.ts
+++ b/app/lib/solo2/settingsSchema.test.ts
@@ -7,13 +7,28 @@ describe('solo2 settings schema', () => {
   it('is its own namespace', () => {
     expect(SOLO2_NAMESPACE).toBe('solo2');
   });
-  it('carries every solo dial with the same section, and the same default except the fade', () => {
+  it('carries every solo dial, same default except the fade, same section except the change dials', () => {
+    // solo has no camera change to shape, so its `fadeS` sits under glass.
+    // solo2 gathers everything about one picture giving way to the next onto
+    // the rail's Change page, so those move sections deliberately.
+    const MOVED = new Set(['fadeS']);
     for (const k of SOLO_SETTINGS_SCHEMA) {
       const mine = SOLO2_SETTINGS_SCHEMA.find((x) => x.key === k.key);
       expect(mine, k.key).toBeDefined();
       if (k.key !== 'fadeS') expect(mine!.default, k.key).toBe(k.default);
-      expect(mine!.section).toBe(k.section);
+      expect(mine!.section, k.key).toBe(MOVED.has(k.key) ? 'arrival' : k.section);
     }
+  });
+  it('every dial about the change is on the Change page, and none of them is left on glass', () => {
+    // The reported confusion, 2026-09-07: two dials named "camera change", one
+    // on Play and one on Change, and the one on Play was the one you found.
+    const arrival = SOLO2_SETTINGS_SCHEMA.filter((k) => k.section === 'arrival').map((k) => k.key);
+    expect(arrival).toEqual([
+      'transition', 'fadeS', 'veilStyle', 'veilTint', 'burnLift', 'veilCovers', 'sameCameraFadeS', 'arrivalEase',
+    ]);
+    // No two dials may share a label; that is what sent Jesse to the wrong tab.
+    const labels = SOLO2_SETTINGS_SCHEMA.map((k) => k.label);
+    expect(new Set(labels).size).toBe(labels.length);
   });
   it('the additions default to solo\'s behaviour, except the dissolves and the camera run; the time dial is solo\'s', () => {
     const d = dialsFrom2(schemaDefaults(SOLO2_SETTINGS_SCHEMA));

--- a/app/lib/solo2/settingsSchema.ts
+++ b/app/lib/solo2/settingsSchema.ts
@@ -29,17 +29,6 @@ export const SOLO2_SETTINGS_SCHEMA: SettingsSchema = [
     description: 'A camera\'s frames are one item in the bin. A dwell plays them oldest to newest, each for an even share of the dwell, dissolving from one to the next. Off: every frame is its own item, as solo does.',
   },
   {
-    key: 'transition', kind: 'enum', options: ['cut', 'crossfade', 'dip'], default: 'dip',
-    label: 'camera change', section: 'glass',
-    description: 'How the screen goes from one camera to another. cut: the new picture simply replaces the old. crossfade: the old picture fades out while the new one fades in on top of it. dip: the old picture fades to black, then the new one fades up from black.',
-  },
-  { ...(solo('fadeS') as NumberKnob), default: 1.5, label: 'camera change (s)', description: 'How long a crossfade takes, or a dip (down plus up). Ignored by cut.' },
-  {
-    key: 'sameCameraFadeS', kind: 'number', min: 0, max: 5, step: 0.5, default: 1.5,
-    label: 'same camera (s)', section: 'glass',
-    description: 'How long one frame of a camera takes to dissolve into the next inside the run, and on a change to a later frame of the camera on glass. Never through black. 0 is a cut.',
-  },
-  {
     key: 'minStepS', kind: 'number', min: 1, max: 20, step: 0.5, default: 4,
     label: 'shortest frame (s)', section: 'glass',
     description: 'The floor under a run\u2019s frames. A dwell is a budget its frames share: with few enough frames they simply divide it and the dwell stays the dwell. Once the share would fall below this, frames hold here instead and the dwell stretches. At a 20 s dwell that threshold is 5 frames.',
@@ -64,11 +53,17 @@ export const SOLO2_SETTINGS_SCHEMA: SettingsSchema = [
     label: 'lead scale', section: 'glass',
     description: 'How far the push goes by the moment of the change. 1.03 is barely felt; 1.10 is a visible zoom.',
   },
-  // ---- arrival: what a camera change dips through (its own rail page) ----
+  // ---- change: everything about one picture giving way to the next (its own rail page) ----
   {
-    key: 'veilStyle', kind: 'enum', options: ['black', 'crossfade', 'light', 'burn'], default: 'black',
-    label: 'the change', section: 'arrival',
-    description: 'What a camera change dips through. The sunset screen ends in black under all four; this dial is about what a SUNRISE does instead, because a sunrise fading to black plays the day backwards. black: both screens dip through black, as today. crossfade: the sunrise screen never goes dark, one dawn dissolving into the next. light: the sunrise screen dips through the tint below. burn: the picture itself moves toward its veil — the sunrise blows out into white, the sunset darkens into black.',
+    key: 'transition', kind: 'enum', options: ['cut', 'crossfade', 'dip'], default: 'dip',
+    label: 'how it changes', section: 'arrival',
+    description: 'The gesture, for both screens. cut: the new picture simply replaces the old. crossfade: the old picture fades out while the new one fades in on top of it. dip: the old picture fades away into a veil, then the new one fades up out of it. Only `dip` reads the veil dial below — the other two are already not ending in darkness.',
+  },
+  { ...(solo('fadeS') as NumberKnob), default: 1.5, section: 'arrival', label: 'how long (s)', description: 'How long a crossfade takes, or a dip (down plus up). Ignored by cut. This also sets the arrival segment at the front of every dwell, so a long change makes every dwell longer — watch the dwell line on the Play tab.' },
+  {
+    key: 'veilStyle', kind: 'enum', options: ['black', 'none', 'light', 'burn'], default: 'black',
+    label: 'a sunrise dips through', section: 'arrival',
+    description: 'What a camera change dips through, on a `dip`. The SUNSET screen ends in black under all four; this dial is about what a sunrise does instead, because a sunrise fading to black plays the day backwards. black: both screens dip through black, as today. none: the sunrise screen never goes dark, one dawn dissolving straight into the next. light: the sunrise screen dips through the tint below. burn: the picture itself moves toward its veil — the sunrise blows out into white, the sunset darkens into black.',
   },
   {
     key: 'veilTint', kind: 'enum', options: ['white', 'dawn', 'sky', 'dim'], default: 'dawn',
@@ -84,6 +79,11 @@ export const SOLO2_SETTINGS_SCHEMA: SettingsSchema = [
     key: 'veilCovers', kind: 'enum', options: ['picture', 'panel'], default: 'picture',
     label: 'veil covers', section: 'arrival',
     description: 'Whether the veil stays inside the picture or floods the black surround with it too. Invisible while the veil is black; it is the light and burn styles that make it a choice.',
+  },
+  {
+    key: 'sameCameraFadeS', kind: 'number', min: 0, max: 5, step: 0.5, default: 1.5,
+    label: 'same camera (s)', section: 'arrival',
+    description: 'How long one frame of a camera takes to dissolve into the next inside the run, and on a change to a later frame of the camera on glass. Never through black. 0 is a cut.',
   },
   {
     key: 'arrivalEase', kind: 'enum', options: ['linear', 'gentle', 'soft'], default: 'gentle',

--- a/app/lib/solo2/types.ts
+++ b/app/lib/solo2/types.ts
@@ -7,7 +7,7 @@ export type Transition = 'cut' | 'crossfade' | 'dip';
 export type { TimeStyle } from '@/app/lib/solo/types';
 
 /** What a camera change dips through (arrival-look spec §2). A pair: one look per screen. */
-export type VeilStyle = 'black' | 'crossfade' | 'light' | 'burn';
+export type VeilStyle = 'black' | 'none' | 'light' | 'burn';
 
 /** The tint a `light` sunrise dips through (veil.ts `VEIL_TINTS`). */
 export type VeilTint = 'white' | 'dawn' | 'sky' | 'dim';

--- a/app/lib/solo2/veil.test.ts
+++ b/app/lib/solo2/veil.test.ts
@@ -12,8 +12,8 @@ describe('the four looks, per screen', () => {
     expect(arrivalLook('sunset', D)).toMatchObject({ veilColor: '#000000', lift: 1 });
   });
 
-  it('crossfade takes the veil off the sunrise screen and leaves the sunset one ending in black', () => {
-    const d = { ...D, veilStyle: 'crossfade' as const };
+  it('none takes the veil off the sunrise screen and leaves the sunset one ending in black', () => {
+    const d = { ...D, veilStyle: 'none' as const };
     expect(arrivalLook('sunrise', d).veilColor).toBeNull();
     expect(arrivalLook('sunset', d).veilColor).toBe('#000000');
   });

--- a/app/lib/solo2/veil.ts
+++ b/app/lib/solo2/veil.ts
@@ -91,7 +91,7 @@ export function arrivalLook(feed: Feed, d: Pick<Solo2Dials,
   const base = { covers: d.veilCovers, ease };
   const sunrise = feed === 'sunrise';
   switch (d.veilStyle) {
-    case 'crossfade':
+    case 'none':
       return { ...base, veilColor: sunrise ? null : '#000000', lift: 1 };
     case 'light':
       return { ...base, veilColor: sunrise ? (VEIL_TINTS[d.veilTint] ?? VEIL_TINTS.dawn) : '#000000', lift: 1 };

--- a/app/studio/Rail.test.tsx
+++ b/app/studio/Rail.test.tsx
@@ -48,7 +48,7 @@ describe('Rail, solo kind', () => {
     render(<Rail api={a} surface={STUDIO_SURFACES.solo2} tab="change" onTab={noop} />);
     for (const k of ARRIVAL_KNOBS) expect(screen.getByLabelText(k.label)).toBeInTheDocument();
     for (const k of PLAY_KNOBS) expect(screen.queryByLabelText(k.label)).toBeNull();
-    expect(screen.getByText('the change')).toHaveStyle({ fontWeight: 700 });
+    expect(screen.getByText('a sunrise dips through')).toHaveStyle({ fontWeight: 700 });
     expect(screen.getByRole('tab', { name: /Change/ })).toHaveAttribute('aria-selected', 'true');
     fireEvent.click(screen.getByText('reset arrival'));
     expect(a.resetSection).toHaveBeenCalledWith('solo2', 'arrival');

--- a/docs/superpowers/specs/2026-09-07-solo2-arrival-look-design.md
+++ b/docs/superpowers/specs/2026-09-07-solo2-arrival-look-design.md
@@ -111,6 +111,24 @@ configuration allowing the site's origin), which is Jesse's to run; after that
 it is a small follow-up: sample region, tone toward day/night, and a hold on
 the flat colour, all of which the mockup already demonstrates.
 
+### 3.1 One tab owns the change (revised 2026-09-07, after the first look)
+
+Shipped, the dials were split: `transition` (cut / crossfade / dip) stayed on
+**Play** labelled *"camera change"*, while the new veil dial sat on **Change**
+labelled *"the change"*. Jesse went looking for the exposure settings, found the
+Play dial, and reported: *"Camera change tab just shows dip, cut, and crossfade.
+It doesn't show the other things."* Two controls, near-identical names, different
+tabs — the UI taught the wrong thing.
+
+Everything about one picture giving way to the next now lives on the Change
+page, in the order you reason about it: **how it changes** → **how long** → **a
+sunrise dips through** → its tint / burn / coverage → **same camera** → **ease**.
+`veilStyle`'s `crossfade` option became `none`, because `transition` already owns
+that word and a dropdown should not offer the same value under two meanings.
+
+A schema test now asserts the arrival section's exact membership and that no two
+dials in the schema share a label.
+
 ## 5. The rail gains a page
 
 `Change` sits between `Play` and `Picture`, and appears only for a version


### PR DESCRIPTION
**Reported:** *"Camera change tab just shows dip, cut, and crossfade. It doesn't show the other things."*

Two dials had near-identical names on different pages. `transition` sat on **Play** labelled *"camera change"*; the new `veilStyle` sat on **Change** labelled *"the change"*. Going looking for the exposure settings, you find the Play one, and it is the wrong one. The UI taught the wrong thing.

## Everything about the change now lives on the Change page

In the order you actually reason about it:

| dial | options | was |
|---|---|---|
| **how it changes** | cut / crossfade / dip | Play, "camera change" |
| **how long (s)** | | Play, "camera change (s)" |
| **a sunrise dips through** | black / none / light / burn | Change, "the change" |
| light tint · burn · veil covers | | unchanged |
| **same camera (s)** | | Play |
| **ease** | linear / gentle / soft | unchanged |

`veilStyle`'s `crossfade` option is renamed **`none`**. `transition` already owns the word "crossfade", and one dropdown offering the same value under two meanings is the same confusion one level down. Nothing has ever been stored for `veilStyle`, so no existing settings row changes meaning.

## Also

The **how long** description now states that this fade sizes the arrival segment at the front of every dwell, so a long change lengthens every dwell. That was invisible, and it matters at the live settings: `fadeS` is 6, which adds 6 s to a 15 s dwell. A 40% slower rotation that nobody asked for and nothing announced.

## Regression guards

Two schema tests, because this class of mistake is invisible in review:

- the arrival section's exact membership **and order**
- **no two dials in the schema share a label** — that is precisely what sent the reader to the wrong tab

2443 tests pass.

## Verify

`/studio` → solo2 → **Change**. The tab should now hold the whole story, top to bottom, and the Play tab should have nothing about transitions left on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013jWANNE6txRkKK7Xkddx4v
