### PR TITLE
The panel edge was clipped away, so nothing was drawn

### DIFF
--- a/app/studio/StudioPanelFrame.test.tsx
+++ b/app/studio/StudioPanelFrame.test.tsx
@@ -56,7 +56,7 @@ describe('StudioPanelFrame', () => {
     expect(stage.style.background).toBe('rgb(0, 0, 0)');
   });
 
-  it('outlines the panel box when given an edge colour, and nothing without one', () => {
+  it('draws the edge inside the panel box, where the wrapper cannot clip it', () => {
     stubResizeObserver({ width: 700, height: 900 });
 
     const { rerender } = render(
@@ -65,18 +65,25 @@ describe('StudioPanelFrame', () => {
       </StudioPanelFrame>
     );
 
-    // On the box, not the stage: the stage is unscaled panel pixels, so a line
-    // there would be drawn at the scale factor and read as a hairline of a
-    // different weight on every panel preset.
-    expect(screen.getByTestId('studio-panel-box').style.outline).toBe('1px solid #f5a344');
-    expect(screen.getByTestId('studio-panel-stage').style.outline).toBe('');
+    // Not `outline`, which paints outside the border box: fitScale sizes the
+    // box to meet the measuring wrapper on its limiting axis, and that
+    // wrapper is `overflow: hidden`, so an outline is clipped away — all four
+    // sides of it when the panel and its column are the same shape. An inset
+    // shadow is painted inside the box and survives.
+    const box = screen.getByTestId('studio-panel-box');
+    expect(box.style.outline).toBe('');
+    expect(box.style.position).toBe('relative');
+    const line = screen.getByTestId('studio-panel-edge');
+    expect(line.style.boxShadow).toBe('inset 0 0 0 1px #f5a344');
+    // Over the stage, whose own black background would cover a line behind it.
+    expect(box.lastElementChild).toBe(line);
 
     rerender(
       <StudioPanelFrame panel={{ width: 1440, height: 2560 }}>
         <div>content</div>
       </StudioPanelFrame>
     );
-    expect(screen.getByTestId('studio-panel-box').style.outline).toBe('');
+    expect(screen.queryByTestId('studio-panel-edge')).toBeNull();
   });
 
   it('caps the scale at 1 when the measured box is larger than the panel', () => {

--- a/app/studio/StudioPanelFrame.tsx
+++ b/app/studio/StudioPanelFrame.tsx
@@ -14,8 +14,16 @@ import { fitScale, type PanelSize } from '@/app/kiosk/panelPreview';
  * bezel makes. Without it the only rectangle in the preview column is the
  * column's own border, and the panel inside it is black on black, so a
  * caption falling off the panel still looks comfortably inside the frame the
- * eye is using. It is an outline, not a border: outlines take no layout
- * space, so the box the line marks is exactly the box that was measured.
+ * eye is using.
+ *
+ * It is an inset shadow on a layer over the stage, not an outline on the box.
+ * An outline is painted *outside* the border box, and `fitScale` sizes the
+ * box to meet the measuring wrapper on its limiting axis — so the wrapper's
+ * `overflow: hidden` clipped the line away on that axis, and clipped all four
+ * sides whenever the panel and the column were the same shape, which in the
+ * solo studio they nearly are. Measured headless: nothing drawn at all.
+ * An inset shadow is painted inside, so it cannot be clipped; the layer puts
+ * it over the stage, whose own black background would otherwise cover it.
  */
 export function StudioPanelFrame({
   panel,
@@ -64,7 +72,7 @@ export function StudioPanelFrame({
           width: panel.width * scale,
           height: panel.height * scale,
           overflow: 'hidden',
-          outline: edge ? `1px solid ${edge}` : undefined,
+          position: 'relative',
         }}
       >
         <div
@@ -79,6 +87,18 @@ export function StudioPanelFrame({
         >
           {children}
         </div>
+        {edge && (
+          <div
+            data-testid="studio-panel-edge"
+            aria-hidden
+            style={{
+              position: 'absolute',
+              inset: 0,
+              boxShadow: `inset 0 0 0 1px ${edge}`,
+              pointerEvents: 'none',
+            }}
+          />
+        )}
       </div>
     </div>
   );

--- a/app/studio/solo/GlassPreview.test.tsx
+++ b/app/studio/solo/GlassPreview.test.tsx
@@ -50,7 +50,7 @@ it('draws the panel edge on the panel and leaves the preview column unbordered',
   // only because they happen to share an aspect. A portrait panel in this
   // column would leave black margins, and a border on the column would sit
   // where the glass has nothing.
-  expect(screen.getByTestId('studio-panel-box')).toHaveStyle({ outline: '1px solid #f5a344' });
+  expect(screen.getByTestId('studio-panel-edge').style.boxShadow).toBe('inset 0 0 0 1px #f5a344');
   expect(screen.getByTestId('preview-sunrise').style.border).toBe('');
 });
 


### PR DESCRIPTION
You were right that the amber edge from #170 was not there. It was being drawn and then clipped.

`outline` is painted **outside** the border box. `fitScale` sizes the panel box to meet the measuring wrapper on its limiting axis, and that wrapper is `overflow: hidden` — so the line was clipped on that axis always, and on all four sides whenever the panel and its column are the same shape. In the solo studio they nearly are: a 16:9 panel in a 16:9 column.

Reproduced headless with a 1920×1080 panel in a 720×405 column:

| | amber pixels drawn |
|---|---|
| outline, wrapper clipping (shipped in #170) | 0 |
| outline, clip removed (control) | 1126 |
| inset shadow on a layer (this PR) | 2246, corner to corner |

The line is now an inset shadow on a layer over the stage. Inset shadows are painted inside the box, where the clip cannot reach, and the layer sits above the stage, whose own black background would otherwise cover a line drawn behind it.

After this deploys, hard-reload /studio.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0143asXDZBv7ZKuH8NedZdLA
