### PR TITLE
fix(caption): the outgoing words dissolve, instead of waiting for a veil

### DIFF
--- a/app/components/solo/SoloFrame.test.tsx
+++ b/app/components/solo/SoloFrame.test.tsx
@@ -64,6 +64,22 @@ it('on a half-size panel everything halves', () => {
   expect(screen.getByTestId('caption')).toHaveStyle({ top: '514px' });
 });
 
+it('with a fade dial the outgoing caption dissolves away rather than sitting under the new words', () => {
+  const prev = { ...e, snapshotId: 9, imageUrl: 'u0', title: 'Old pier' };
+  // A picture needs no fade-out: the arriving frame is opaque and covers it.
+  // A caption is transparent between its letters, so words left at full
+  // opacity stay legible under the new ones for the whole dwell. The two
+  // halves share one timing function, which makes them complementary at every
+  // instant (PR #160's lesson, from the other direction).
+  const { rerender } = render(<SoloFrame entry={e} previous={prev} fadeS={2} dials={D} width={1920} height={1080} />);
+  expect(screen.getByTestId('caption-prev')).toHaveStyle({ animation: 'solo-fade-out 2s ease both' });
+  expect(screen.getByTestId('caption-layer')).toHaveStyle({ animation: 'solo-fade-in 2s ease' });
+
+  // At a cut there is nothing to dissolve and no outgoing caption at all.
+  rerender(<SoloFrame entry={e} previous={prev} fadeS={0} dials={D} width={1920} height={1080} />);
+  expect(screen.queryByTestId('caption-prev')).toBeNull();
+});
+
 it('overlay layout: the picture fills the panel and the caption floats over it with a shadow', () => {
   render(<SoloFrame entry={e} previous={null} fadeS={0} dials={{ ...D, captionLayout: 'overlay' }} width={1920} height={1080} />);
   expect(screen.getByRole('presentation')).toHaveStyle({ left: '0px', top: '0px', width: '1920px', height: '1080px' });

--- a/app/components/solo/SoloFrame.tsx
+++ b/app/components/solo/SoloFrame.tsx
@@ -52,11 +52,17 @@ export function SoloFrame({ entry, previous, fadeS, dials, width, height, feed }
           transition: `opacity ${fadeS}s ease`,
         }}
       />
-      <style>{'@keyframes solo-fade-in { from { opacity: 0 } to { opacity: 1 } }'}</style>
+      <style>{'@keyframes solo-fade-in { from { opacity: 0 } to { opacity: 1 } }\n@keyframes solo-fade-out { from { opacity: 1 } to { opacity: 0 } }'}</style>
       {previous && fadeS > 0 && (
-        // The words being left behind, under the arriving caption. Only while
-        // the dial fades: at a cut they would sit under identical text.
-        <div key={`caption-prev-${previous.snapshotId}`} data-testid="caption-prev" style={captionLayer}>
+        // The words being left behind. They have to dissolve, not merely be
+        // covered: the arriving picture is opaque, but a caption is
+        // transparent between its letters, so words left at full opacity stay
+        // legible under the new ones for the whole dwell. Both halves name the
+        // same timing function, which makes their opacities sum to 1 at every
+        // instant — the mismatch PR #160 fixed, avoided here by construction.
+        // Only while the dial fades: at a cut they would sit under identical text.
+        <div key={`caption-prev-${previous.snapshotId}`} data-testid="caption-prev"
+          style={{ ...captionLayer, animation: `solo-fade-out ${fadeS}s ease both` }}>
           <Caption entry={previous} dials={dials} picture={picture} width={width} height={height} feed={feed} />
         </div>
       )}

--- a/app/components/solo2/Solo2Frame.test.tsx
+++ b/app/components/solo2/Solo2Frame.test.tsx
@@ -141,6 +141,35 @@ it('the caption arrives on the picture’s transition: the same animation, and t
   expect(screen.queryByTestId('caption-prev')).toBeNull();
 });
 
+it('the outgoing caption dissolves away, so a veil-less change never leaves two readings stacked', () => {
+  // Words are not a picture: an arriving picture is opaque and covers the one
+  // under it, an arriving caption is transparent between its letters. Left at
+  // full opacity the old title, place and clock stay legible under the new
+  // ones for the whole dwell. Only the dip's veil ever hid them, so every
+  // change without a veil — a crossfade, a same-camera arrival, or a dip whose
+  // veil colour is null — showed both at once (reported 2026-09-07).
+  const prev = { ...e, snapshotId: 0, webcamId: 99, imageUrl: 'u0', title: 'Old pier' };
+  const one = { index: 0, leadProgress: 0 };
+  const { rerender } = render(<Solo2Frame entry={e} run={[e]} previous={prev} stage={one} plan={plan}
+    dials={{ ...D, transition: 'crossfade', fadeS: 2 }} width={1920} height={1080} />);
+  // It leaves on exactly the ramp the new caption arrives on, held at the end.
+  expect(screen.getByTestId('caption-prev')).toHaveStyle({ animation: `solo2-fade-out 2s ${E} both` });
+
+  // A dip: the words leave while the veil closes, over the veil's own half.
+  rerender(<Solo2Frame entry={e} run={[e]} previous={prev} stage={one} plan={plan}
+    dials={{ ...D, transition: 'dip', fadeS: 2 }} width={1920} height={1080} />);
+  expect(screen.getByTestId('caption-prev')).toHaveStyle({ animation: `solo2-fade-out 1s ${E} both` });
+  expect(screen.getByTestId('caption-prev').style.animation.split(' ').slice(1, 2))
+    .toEqual(screen.getByTestId('dip').style.animation.split(' ').slice(1, 2));
+
+  // A sunrise set to `none` has no veil, so its dip becomes a crossfade — the
+  // case #172 opened up, and the one that must not strand the old words.
+  rerender(<Solo2Frame entry={e} run={[e]} previous={prev} stage={one} plan={plan} feed="sunrise"
+    dials={{ ...D, transition: 'dip', fadeS: 2, veilStyle: 'none' }} width={1920} height={1080} />);
+  expect(screen.queryByTestId('dip')).toBeNull();
+  expect(screen.getByTestId('caption-prev')).toHaveStyle({ animation: `solo2-fade-out 2s ${E} both` });
+});
+
 it('on a dip the veil covers the outgoing caption, and the new words fade in after it', () => {
   const prev = { ...e, snapshotId: 0, webcamId: 99, imageUrl: 'u0' };
   render(<Solo2Frame entry={e} run={[e]} previous={prev} stage={{ index: 0, leadProgress: 0 }} plan={plan}

--- a/app/components/solo2/Solo2Frame.tsx
+++ b/app/components/solo2/Solo2Frame.tsx
@@ -22,6 +22,7 @@ export type RunFrame = ViewEntry & { rank?: number };
  */
 const KEYFRAMES = `
 @keyframes solo2-fade-in { from { opacity: 0 } to { opacity: 1 } }
+@keyframes solo2-fade-out { from { opacity: 1 } to { opacity: 0 } }
 @keyframes solo2-dip { from { opacity: 0 } to { opacity: 1 } }
 @keyframes solo2-burn-out { from { filter: brightness(1) } to { filter: brightness(var(--solo2-lift, 1)) } }
 @keyframes solo2-burn-in { from { filter: brightness(var(--solo2-lift, 1)) } to { filter: brightness(1) } }
@@ -119,6 +120,18 @@ export function Solo2Frame({ entry, run, previous, stage, plan, dials, width, he
     arrive.kind === 'crossfade' ? `solo2-fade-in ${arrive.fadeS}s ${ease} both`
     : arrive.kind === 'dip' ? `solo2-fade-in ${arrive.fadeS / 2}s ${ease} ${arrive.fadeS / 2}s both`
     : undefined;
+  // The outgoing caption's half of that dissolve. A picture needs none — the
+  // arriving frame is opaque and covers the one beneath it — but a caption is
+  // transparent between its letters, so words left at full opacity stay
+  // legible under the new words for the whole dwell. Only the dip's veil ever
+  // hid them, which is why a crossfade, a same-camera arrival, or a dip with
+  // no veil colour showed two clocks at once. It leaves over the same span the
+  // picture takes to cover it: the whole fade on a crossfade, the closing half
+  // on a dip, held at the end by `both`.
+  const outAnimation =
+    arrive.kind === 'crossfade' ? `solo2-fade-out ${arrive.fadeS}s ${ease} both`
+    : arrive.kind === 'dip' ? `solo2-fade-out ${arrive.fadeS / 2}s ${ease} both`
+    : undefined;
   // The picture moves toward the veil rather than merely being covered by it:
   // up into white on a sunrise, down into black on a sunset. That is what
   // separates an exposure from a dip through a coloured card. Only on a dip,
@@ -150,7 +163,8 @@ export function Solo2Frame({ entry, run, previous, stage, plan, dials, width, he
       {showPrevious && (
         // The words being left behind, under the veil and under the arriving
         // caption, so the caption dissolves exactly as the picture does.
-        <div key={`caption-prev-${previous.snapshotId}`} data-testid="caption-prev" style={captionLayer}>
+        <div key={`caption-prev-${previous.snapshotId}`} data-testid="caption-prev"
+          style={{ ...captionLayer, animation: outAnimation }}>
           <Caption entry={previous} dials={dials} picture={picture} width={width} height={height} feed={feed} />
         </div>
       )}


### PR DESCRIPTION
## The symptom

Two captions legible at once for a whole dwell: the old title, place and clock sitting under the new ones. It looked like a run problem, because a camera change showed only one.

## Root cause

A picture needs no fade-out. The arriving frame is opaque and covers the one beneath it, so the layer stack alone does the dissolve. A caption is transparent between its letters, so the same stack leaves **both** readings visible.

The outgoing caption had no animation at all. The only thing that ever hid it was the dip's black veil, which holds at opacity 1 for the rest of the dwell.

So every arrival **without** a veil showed both:

- a same-camera arrival, which resolves to `crossfade` whenever `sameCameraFadeS > 0`
- `transition: crossfade`
- since #172, a dip whose `veilColor` is null, which is a sunrise screen set to `veilStyle: none`

And a real camera change dipping through black showed one. That inversion is why the fault read as belonging to the run rather than to the change.

## The fix

The outgoing caption leaves over the span the picture takes to cover it: the whole fade on a crossfade, the closing half on a dip, held at the end by `both`.

Both halves name one timing function, so their opacities sum to 1 at every instant. That is the mismatch PR #160 fixed, avoided here by construction rather than by a rule.

Same defect and same fix in `SoloFrame`, where it sits behind a fade dial that is currently 0 and so was not biting yet. Left unfixed it returns the moment that dial moves.

## Verification

A failing test was written first for each renderer, covering the crossfade arrival, the dip's half-span, and the veil-less sunrise dip that #172 opened up. `npm run test` 2445 passing, lint and build green. No migration.

Not yet seen on glass. After merge: `bash scripts/pi/kiosk-doctor.sh --sync --reload`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019dqJA4E1zc1qM9WEnxN7Mg
