### PR TITLE
fix(studio): the dials go back to the veil study's names

### DIFF
--- a/app/components/solo2/Solo2Frame.test.tsx
+++ b/app/components/solo2/Solo2Frame.test.tsx
@@ -187,27 +187,27 @@ describe('what the change dips through', () => {
     expect(screen.getByTestId('dip')).toHaveStyle({ background: '#000000' });
   });
 
-  it('light dips the sunrise through its tint and leaves the sunset ending in black', () => {
-    dip({ veilStyle: 'light', veilTint: 'dawn' });
+  it('lift dips the sunrise through its tint and leaves the sunset ending in black', () => {
+    dip({ veilStyle: 'lift', veilTint: 'dawn' });
     expect(screen.getByTestId('dip')).toHaveStyle({ background: VEIL_TINTS.dawn });
     cleanup();
-    dip({ veilStyle: 'light', veilTint: 'dawn' }, 'sunset');
+    dip({ veilStyle: 'lift', veilTint: 'dawn' }, 'sunset');
     expect(screen.getByTestId('dip')).toHaveStyle({ background: '#000000' });
   });
 
-  it('a veil of `none` takes it off the sunrise screen entirely; the sunset screen still dips', () => {
-    dip({ veilStyle: 'none' });
+  it('a sunrise change of `crossfade` takes the veil off that screen entirely; the sunset screen still dips', () => {
+    dip({ veilStyle: 'crossfade' });
     expect(screen.queryByTestId('dip')).toBeNull();
     // Not a cut: the outgoing picture stays, and the new one dissolves over the WHOLE fade.
     expect(screen.getByTestId('prev')).toBeInTheDocument();
     expect(screen.getByTestId('stack')).toHaveStyle({ animation: `solo2-fade-in 2s ${E} both` });
     cleanup();
-    dip({ veilStyle: 'none' }, 'sunset');
+    dip({ veilStyle: 'crossfade' }, 'sunset');
     expect(screen.getByTestId('dip')).toHaveStyle({ background: '#000000' });
   });
 
-  it('burn moves the picture toward the veil, each screen toward its own end', () => {
-    dip({ veilStyle: 'burn', burnLift: 1.6 });
+  it('exposure moves the picture toward the veil, each screen toward its own end', () => {
+    dip({ veilStyle: 'exposure', burnLift: 1.6 });
     expect(screen.getByTestId('dip')).toHaveStyle({ background: '#ffffff' });
     expect(screen.getByTestId('prev').style.animation).toBe(`solo2-burn-out 1s ${E} both`);
     expect(screen.getByTestId('stack').style.animation)
@@ -216,23 +216,23 @@ describe('what the change dips through', () => {
     // share one document, and a `<style>` rule is global.
     expect(screen.getByTestId('prev').style.getPropertyValue('--solo2-lift')).toBe('1.6');
     cleanup();
-    dip({ veilStyle: 'burn', burnLift: 1.6 }, 'sunset');
+    dip({ veilStyle: 'exposure', burnLift: 1.6 }, 'sunset');
     expect(screen.getByTestId('dip')).toHaveStyle({ background: '#000000' });
     expect(screen.getByTestId('stack').style.getPropertyValue('--solo2-lift')).toBe('0');
   });
 
   it('no burn animation at all when the lift asks for nothing', () => {
-    dip({ veilStyle: 'burn', burnLift: 1 });
+    dip({ veilStyle: 'exposure', burnLift: 1 });
     expect(screen.getByTestId('prev').style.animation).toBe('');
     expect(screen.getByTestId('stack').style.animation).toBe(`solo2-fade-in 1s ${E} 1s both`);
   });
 
   it('the veil stays inside the picture unless it is told to flood the panel', () => {
-    dip({ veilStyle: 'light', veilCovers: 'panel' });
+    dip({ veilStyle: 'lift', veilCovers: 'panel' });
     expect(screen.getByTestId('dip')).toHaveStyle({ width: '100%', height: '100%' });
     cleanup();
     // Inside the picture: the veil takes the picture box, the same one the stack sits in.
-    dip({ veilStyle: 'light' });
+    dip({ veilStyle: 'lift' });
     const veil = screen.getByTestId('dip').style;
     const stack = screen.getByTestId('stack').style;
     expect(veil.width).toBe(stack.width);

--- a/app/lib/solo2/settingsSchema.ts
+++ b/app/lib/solo2/settingsSchema.ts
@@ -56,24 +56,24 @@ export const SOLO2_SETTINGS_SCHEMA: SettingsSchema = [
   // ---- change: everything about one picture giving way to the next (its own rail page) ----
   {
     key: 'transition', kind: 'enum', options: ['cut', 'crossfade', 'dip'], default: 'dip',
-    label: 'how it changes', section: 'arrival',
+    label: 'camera change', section: 'arrival',
     description: 'The gesture, for both screens. cut: the new picture simply replaces the old. crossfade: the old picture fades out while the new one fades in on top of it. dip: the old picture fades away into a veil, then the new one fades up out of it. Only `dip` reads the veil dial below — the other two are already not ending in darkness.',
   },
-  { ...(solo('fadeS') as NumberKnob), default: 1.5, section: 'arrival', label: 'how long (s)', description: 'How long a crossfade takes, or a dip (down plus up). Ignored by cut. This also sets the arrival segment at the front of every dwell, so a long change makes every dwell longer — watch the dwell line on the Play tab.' },
+  { ...(solo('fadeS') as NumberKnob), default: 1.5, section: 'arrival', label: 'camera change (s)', description: 'How long a crossfade takes, or a dip (down plus up). Ignored by cut. This also sets the arrival segment at the front of every dwell, so a long change makes every dwell longer — watch the dwell line on the Play tab.' },
   {
-    key: 'veilStyle', kind: 'enum', options: ['black', 'none', 'light', 'burn'], default: 'black',
-    label: 'a sunrise dips through', section: 'arrival',
-    description: 'What a camera change dips through, on a `dip`. The SUNSET screen ends in black under all four; this dial is about what a sunrise does instead, because a sunrise fading to black plays the day backwards. black: both screens dip through black, as today. none: the sunrise screen never goes dark, one dawn dissolving straight into the next. light: the sunrise screen dips through the tint below. burn: the picture itself moves toward its veil — the sunrise blows out into white, the sunset darkens into black.',
+    key: 'veilStyle', kind: 'enum', options: ['black', 'crossfade', 'lift', 'exposure'], default: 'black',
+    label: 'sunrise change', section: 'arrival',
+    description: 'What a camera change dips through, on a `dip`. The SUNSET screen ends in black under all four; this dial is about what a sunrise does instead, because a sunrise fading to black plays the day backwards. black: both screens dip through black, as today. crossfade: the sunrise screen never goes dark, one dawn dissolving straight into the next. lift: the sunrise screen dips through the tint below. exposure: the picture itself moves toward its veil — the sunrise blows out into white, the sunset darkens into black.',
   },
   {
     key: 'veilTint', kind: 'enum', options: ['white', 'dawn', 'sky', 'dim'], default: 'dawn',
-    label: 'light tint', section: 'arrival',
-    description: 'Which light a `light` sunrise dips through. Pure white on a 27-inch panel in a dark room reads as a camera flash; dawn and dim are the room-safe ones. Ignored by the other three.',
+    label: 'lift tint', section: 'arrival',
+    description: 'Which light a `lift` sunrise dips through. Pure white on a 27-inch panel in a dark room reads as a camera flash; dawn and dim are the room-safe ones. Ignored by the other three.',
   },
   {
     key: 'burnLift', kind: 'number', min: 1, max: 3, step: 0.1, default: 1.6,
     label: 'burn', section: 'arrival',
-    description: 'How hard an exposure pushes the picture toward its veil. 1 is a plain dip through white — the picture is covered, never brightened. 1.6 blows the sky out first and the dark ground last, which is what reads as overexposure. Past about 2 the picture is white long before the veil is, and the change looks lopsided again. Ignored unless the change is `burn`.',
+    description: 'How hard an exposure pushes the picture toward its veil. 1 is a plain dip through white — the picture is covered, never brightened. 1.6 blows the sky out first and the dark ground last, which is what reads as overexposure. Past about 2 the picture is white long before the veil is, and the change looks lopsided again. Ignored unless the sunrise change is `exposure`.',
   },
   {
     key: 'veilCovers', kind: 'enum', options: ['picture', 'panel'], default: 'picture',

--- a/app/lib/solo2/types.ts
+++ b/app/lib/solo2/types.ts
@@ -7,7 +7,7 @@ export type Transition = 'cut' | 'crossfade' | 'dip';
 export type { TimeStyle } from '@/app/lib/solo/types';
 
 /** What a camera change dips through (arrival-look spec §2). A pair: one look per screen. */
-export type VeilStyle = 'black' | 'none' | 'light' | 'burn';
+export type VeilStyle = 'black' | 'crossfade' | 'lift' | 'exposure';
 
 /** The tint a `light` sunrise dips through (veil.ts `VEIL_TINTS`). */
 export type VeilTint = 'white' | 'dawn' | 'sky' | 'dim';

--- a/app/lib/solo2/veil.test.ts
+++ b/app/lib/solo2/veil.test.ts
@@ -12,21 +12,21 @@ describe('the four looks, per screen', () => {
     expect(arrivalLook('sunset', D)).toMatchObject({ veilColor: '#000000', lift: 1 });
   });
 
-  it('none takes the veil off the sunrise screen and leaves the sunset one ending in black', () => {
-    const d = { ...D, veilStyle: 'none' as const };
+  it('crossfade takes the veil off the sunrise screen and leaves the sunset one ending in black', () => {
+    const d = { ...D, veilStyle: 'crossfade' as const };
     expect(arrivalLook('sunrise', d).veilColor).toBeNull();
     expect(arrivalLook('sunset', d).veilColor).toBe('#000000');
   });
 
-  it('light dips a sunrise through the chosen tint; the sunset screen never changes colour', () => {
-    const d = { ...D, veilStyle: 'light' as const };
+  it('lift dips a sunrise through the chosen tint; the sunset screen never changes colour', () => {
+    const d = { ...D, veilStyle: 'lift' as const };
     expect(arrivalLook('sunrise', d).veilColor).toBe(VEIL_TINTS.dawn);
     expect(arrivalLook('sunrise', { ...d, veilTint: 'dim' }).veilColor).toBe(VEIL_TINTS.dim);
     expect(arrivalLook('sunset', { ...d, veilTint: 'dim' }).veilColor).toBe('#000000');
   });
 
-  it('burn moves each picture toward its own veil: up into white, down into black', () => {
-    const d = { ...D, veilStyle: 'burn' as const };
+  it('exposure moves each picture toward its own veil: up into white, down into black', () => {
+    const d = { ...D, veilStyle: 'exposure' as const };
     expect(arrivalLook('sunrise', d)).toMatchObject({ veilColor: '#ffffff', lift: 1.6 });
     expect(arrivalLook('sunset', d)).toMatchObject({ veilColor: '#000000', lift: 0 });
     // A lift below 1 on the sunrise screen would darken it into a white veil, which is nonsense.

--- a/app/lib/solo2/veil.ts
+++ b/app/lib/solo2/veil.ts
@@ -91,11 +91,11 @@ export function arrivalLook(feed: Feed, d: Pick<Solo2Dials,
   const base = { covers: d.veilCovers, ease };
   const sunrise = feed === 'sunrise';
   switch (d.veilStyle) {
-    case 'none':
+    case 'crossfade':
       return { ...base, veilColor: sunrise ? null : '#000000', lift: 1 };
-    case 'light':
+    case 'lift':
       return { ...base, veilColor: sunrise ? (VEIL_TINTS[d.veilTint] ?? VEIL_TINTS.dawn) : '#000000', lift: 1 };
-    case 'burn':
+    case 'exposure':
       // The picture moves toward the veil: up into white on the sunrise
       // screen, down into black on the sunset one. Both screens burn; they
       // burn toward opposite ends, which is the whole idea.

--- a/app/studio/Rail.test.tsx
+++ b/app/studio/Rail.test.tsx
@@ -48,7 +48,7 @@ describe('Rail, solo kind', () => {
     render(<Rail api={a} surface={STUDIO_SURFACES.solo2} tab="change" onTab={noop} />);
     for (const k of ARRIVAL_KNOBS) expect(screen.getByLabelText(k.label)).toBeInTheDocument();
     for (const k of PLAY_KNOBS) expect(screen.queryByLabelText(k.label)).toBeNull();
-    expect(screen.getByText('a sunrise dips through')).toHaveStyle({ fontWeight: 700 });
+    expect(screen.getByText('sunrise change')).toHaveStyle({ fontWeight: 700 });
     expect(screen.getByRole('tab', { name: /Change/ })).toHaveAttribute('aria-selected', 'true');
     fireEvent.click(screen.getByText('reset arrival'));
     expect(a.resetSection).toHaveBeenCalledWith('solo2', 'arrival');

--- a/docs/superpowers/specs/2026-09-07-solo2-arrival-look-design.md
+++ b/docs/superpowers/specs/2026-09-07-solo2-arrival-look-design.md
@@ -30,8 +30,15 @@ black under all four; the dial is about what a **sunrise** does instead.
 |---|---|---|
 | `black` (default) | dips through black | dips through black |
 | `crossfade` | no veil at all; one dawn dissolves into the next | dips through black |
-| `light` | dips through `veilTint` | dips through black |
-| `burn` | blows out into white | darkens into black |
+| `lift` | dips through `veilTint` | dips through black |
+| `exposure` | blows out into white | darkens into black |
+
+**The names are the mockup's names**, deliberately. Jesse spent an afternoon
+comparing these looks on a page whose tabs read *Today / Crossfade / Lift /
+Exposure / Sky-sampled*, and that is the vocabulary he now thinks in. Shipping
+`light` and `burn` instead cost him a round trip: *"why did we change the names?
+The names used to be very clear in the veil study. Can we keep those?"* When a
+decision is made against a prototype, the prototype's words ship with it.
 
 `black` is today's behaviour exactly, so merging changes nothing until the dial
 moves. Resolution lives in `app/lib/solo2/veil.ts` (`arrivalLook`), pure and
@@ -123,8 +130,14 @@ tabs — the UI taught the wrong thing.
 Everything about one picture giving way to the next now lives on the Change
 page, in the order you reason about it: **how it changes** → **how long** → **a
 sunrise dips through** → its tint / burn / coverage → **same camera** → **ease**.
-`veilStyle`'s `crossfade` option became `none`, because `transition` already owns
-that word and a dropdown should not offer the same value under two meanings.
+The dials keep the mockup's labels too — *camera change*, *camera change (s)*,
+*sunrise change*, *lift tint*, *burn*, *veil covers*, *same camera (s)*, *ease*.
+An earlier pass renamed `veilStyle`'s `crossfade` option to `none`, reasoning
+that `transition` already owned the word. That was solving the wrong problem:
+the confusion was never two identical option values, it was two dials called
+almost the same thing **on different tabs**. One tab owning both, with
+`transition` labelled for the gesture and `veilStyle` for the screen it acts on,
+removes it without spending the mockup's vocabulary.
 
 A schema test now asserts the arrival section's exact membership and that no two
 dials in the schema share a label.


### PR DESCRIPTION
**Reported:** *"Why did we change the names? The names used to be very clear in the veil study. Can we keep those?"*

Fair. The mockup's tabs read **Today / Crossfade / Lift / Exposure / Sky-sampled**. That is the vocabulary the decision was actually made in, and I shipped different words for no good reason.

## The dropdown

| was | now | in the study |
|---|---|---|
| `black` | `black` | Today — both screens dip through black |
| `none` | **`crossfade`** | Crossfade / dip |
| `light` | **`lift`** | Lift / dip |
| `burn` | **`exposure`** | Exposure |

The dial labels go back too: **camera change**, **camera change (s)**, **sunrise change**, **lift tint**, **burn**, **veil covers**, **same camera (s)**, **ease**.

## The `none` rename was solving the wrong problem

I had renamed `crossfade` to `none` on the reasoning that `transition` already owned that word. That misread the original bug. The confusion was never two identical option *values* — it was two dials called almost the same thing **on different tabs**, so you found one and reasonably assumed it was the other.

Now that one tab owns both, with `transition` labelled for the gesture and `veilStyle` labelled for the screen it acts on, the ambiguity is gone without spending the mockup's vocabulary on it.

## Safety

Nothing has ever been stored for `veilStyle` — it has run on its `black` default since it shipped — so no settings row changes meaning and no migration is needed. 2443 tests pass.

## Spec

§2 of the arrival-look design gains the rule: **when a decision is made against a prototype, the prototype's words ship with it.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013jWANNE6txRkKK7Xkddx4v
