### PR TITLE
fix(test): main is red — a caption test names a veil option that was renamed

### DIFF
--- a/app/components/solo2/Solo2Frame.test.tsx
+++ b/app/components/solo2/Solo2Frame.test.tsx
@@ -162,10 +162,11 @@ it('the outgoing caption dissolves away, so a veil-less change never leaves two 
   expect(screen.getByTestId('caption-prev').style.animation.split(' ').slice(1, 2))
     .toEqual(screen.getByTestId('dip').style.animation.split(' ').slice(1, 2));
 
-  // A sunrise set to `none` has no veil, so its dip becomes a crossfade — the
-  // case #172 opened up, and the one that must not strand the old words.
+  // A sunrise change of `crossfade` has no veil, so its dip becomes a crossfade
+  // — the case #172 opened up, and the one that must not strand the old words.
+  // (This option was briefly named `none`; #175 restored the veil study's word.)
   rerender(<Solo2Frame entry={e} run={[e]} previous={prev} stage={one} plan={plan} feed="sunrise"
-    dials={{ ...D, transition: 'dip', fadeS: 2, veilStyle: 'none' }} width={1920} height={1080} />);
+    dials={{ ...D, transition: 'dip', fadeS: 2, veilStyle: 'crossfade' }} width={1920} height={1080} />);
   expect(screen.queryByTestId('dip')).toBeNull();
   expect(screen.getByTestId('caption-prev')).toHaveStyle({ animation: `solo2-fade-out 2s ${E} both` });
 });


### PR DESCRIPTION
**`main` is currently red.** One word.

Two PRs, each green on its own branch, red together:

- **#174** fixed the outgoing caption and wrote its regression test against the veil option `none`.
- **#175** renamed that option to `crossfade`, restoring the veil study's vocabulary.

Neither branch could see the other, and the option name is the only thing they share. The stale name falls through `arrivalLook`'s `default:` to a black veil, so a `dip` element renders where the test asserts none.

```
× the outgoing caption dissolves away, so a veil-less change never leaves two readings stacked
  → expected <div data-testid="dip" …/> to be null
```

2445 pass with the fix.

## My fault, and worth naming

The rename was mine. Renaming a shipped enum value while other sessions are writing against it is the hazard, and I did not check who else was touching that surface.

This is also the third instance of the class I documented an hour ago in `docs/solutions/workflow-issues/merged-is-a-claim-about-a-branch.md` — building each branch proves nothing about the merge. One honest difference from the cases in that doc: these two branches **did** overlap in a file, so even the weaker file-intersection check would have caught it. That makes this a skipped check rather than a missing one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013jWANNE6txRkKK7Xkddx4v