### PR TITLE
feat(caption): the glass writes its own clock beside the camera's

### DIFF
--- a/app/components/solo/Caption.test.tsx
+++ b/app/components/solo/Caption.test.tsx
@@ -1,0 +1,56 @@
+import { it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { Caption } from './Caption';
+import { dialsFrom, SOLO_SETTINGS_SCHEMA } from '@/app/lib/solo/settingsSchema';
+import { schemaDefaults } from '@/app/lib/settings/schema';
+
+const D = dialsFrom(schemaDefaults(SOLO_SETTINGS_SCHEMA));
+const AT = Date.UTC(2026, 8, 5, 2, 42); // 7:42 pm in Mazatlán, 10:42 pm in New York
+const e = {
+  title: 'Split › West', region: 'Split-Dalmatia County', country: 'Croatia',
+  capturedAt: AT, timezone: 'America/Mazatlan', sunAltitudeDeg: null,
+};
+const PICTURE = { left: 0, top: 0, width: 1920, height: 940 };
+const draw = (props: Partial<Parameters<typeof Caption>[0]> = {}) =>
+  render(<Caption entry={e} dials={D} picture={PICTURE} width={1920} hereTimezone="America/New_York" {...props} />);
+
+it('the here dial writes the glass’s own clock beside the camera’s, in the shape it names', () => {
+  draw({ dials: { ...D, hereTime: 'parens' } });
+  expect(screen.getByTestId('caption-time')).toHaveTextContent('7:42 pm there (10:42 pm here)');
+});
+
+it('off leaves the camera’s clock alone', () => {
+  draw();
+  expect(screen.getByTestId('caption-time')).toHaveTextContent('7:42 pm there');
+});
+
+it('a step fades each reading against its own predecessor, so the words that held still do not animate', () => {
+  const from = { ...e, capturedAt: AT - 9 * 60_000 }; // 7:33 pm there, 10:33 pm here
+  draw({ dials: { ...D, hereTime: 'dot' }, step: { from, fadeS: 1 } });
+  // Two readings moved, so two heads fade in and two fade out — and "pm there"
+  // and "pm here" are tails on their own reading rather than one shared tail.
+  // (The line also carries the readings on their way out, so it is the heads
+  // and the tails that say what is being drawn, not the line's text content.)
+  expect(screen.getAllByTestId('caption-time-head').map((n) => n.textContent)).toEqual(['7:42', '10:42']);
+  expect(screen.getAllByTestId('caption-time-out').map((n) => n.textContent)).toEqual(['7:33', '10:33']);
+  for (const n of screen.getAllByTestId('caption-time-head')) {
+    expect(n).toHaveStyle({ animation: 'solo-time-in 1s ease both' });
+  }
+});
+
+it('the separator between them is never asked to fade', () => {
+  const from = { ...e, capturedAt: AT - 9 * 60_000 };
+  draw({ dials: { ...D, hereTime: 'dot' }, step: { from, fadeS: 1 } });
+  const dots = screen.getAllByTestId('caption-time-out').map((n) => n.textContent);
+  expect(dots.join('')).not.toContain('·');
+});
+
+it('two frames of the same minute say the same thing, so nothing animates', () => {
+  draw({ dials: { ...D, hereTime: 'dot' }, step: { from: { ...e, capturedAt: AT + 5_000 }, fadeS: 1 } });
+  expect(screen.queryByTestId('caption-time-out')).toBeNull();
+});
+
+it('a camera in the glass’s own zone does not say the time twice', () => {
+  draw({ dials: { ...D, hereTime: 'dot' }, hereTimezone: 'America/Los_Angeles' });
+  expect(screen.getByTestId('caption-time')).toHaveTextContent('7:42 pm there');
+});

--- a/app/components/solo/Caption.test.tsx
+++ b/app/components/solo/Caption.test.tsx
@@ -4,6 +4,18 @@ import { Caption } from './Caption';
 import { dialsFrom, SOLO_SETTINGS_SCHEMA } from '@/app/lib/solo/settingsSchema';
 import { schemaDefaults } from '@/app/lib/settings/schema';
 
+/**
+ * The time line as it is actually drawn. Mid-crossfade the line also carries
+ * the reading on its way out, which is aria-hidden and sits on top of the one
+ * that replaced it, so it has to come out before reading the text.
+ */
+const drawnTime = () => {
+  const el = screen.getByTestId('caption-time').cloneNode(true) as HTMLElement;
+  el.querySelectorAll('[aria-hidden="true"]').forEach((n) => n.remove());
+  return el.textContent;
+};
+
+
 const D = dialsFrom(schemaDefaults(SOLO_SETTINGS_SCHEMA));
 const AT = Date.UTC(2026, 8, 5, 2, 42); // 7:42 pm in Mazatlán, 10:42 pm in New York
 const e = {
@@ -27,12 +39,13 @@ it('off leaves the camera’s clock alone', () => {
 it('a step fades each reading against its own predecessor, so the words that held still do not animate', () => {
   const from = { ...e, capturedAt: AT - 9 * 60_000 }; // 7:33 pm there, 10:33 pm here
   draw({ dials: { ...D, hereTime: 'dot' }, step: { from, fadeS: 1 } });
-  // Two readings moved, so two heads fade in and two fade out — and "pm there"
-  // and "pm here" are tails on their own reading rather than one shared tail.
-  // (The line also carries the readings on their way out, so it is the heads
-  // and the tails that say what is being drawn, not the line's text content.)
-  expect(screen.getAllByTestId('caption-time-head').map((n) => n.textContent)).toEqual(['7:42', '10:42']);
-  expect(screen.getAllByTestId('caption-time-out').map((n) => n.textContent)).toEqual(['7:33', '10:33']);
+  expect(drawnTime()).toBe('7:42 pm there · 10:42 pm here');
+  // Two readings moved, so two stretches fade in and two fade out — and each
+  // reading holds its own ends rather than sharing one tail with the other.
+  // 7:33 → 7:42 and 10:33 → 10:42: the hour and the colon held, so only the
+  // minutes are on the move.
+  expect(screen.getAllByTestId('caption-time-head').map((n) => n.textContent)).toEqual(['42', '42']);
+  expect(screen.getAllByTestId('caption-time-out').map((n) => n.textContent)).toEqual(['33', '33']);
   for (const n of screen.getAllByTestId('caption-time-head')) {
     expect(n).toHaveStyle({ animation: 'solo-time-in 1s ease both' });
   }

--- a/app/components/solo/Caption.tsx
+++ b/app/components/solo/Caption.tsx
@@ -3,7 +3,8 @@
 import type { CSSProperties } from 'react';
 import type { Feed, SoloDials } from '@/app/lib/solo/types';
 import {
-  FONT_STACKS, LINE_HEIGHT, captionBox, captionLines, captionScale, formatTime, gray, lineGaps, splitTime,
+  FONT_STACKS, LINE_HEIGHT, captionBox, captionLines, captionScale, gray, lineGaps, localTimezone,
+  pairTimeSegments, splitTime, timeSegments,
   type CaptionEntry, type Rect,
 } from '@/app/lib/solo/caption';
 
@@ -18,7 +19,7 @@ const TIME_KEYFRAMES = `
  * the frame. Null when the place dial is off. Everything positional comes
  * from lib/solo/caption.ts, so this is layout only.
  */
-export function Caption({ entry, dials, picture, width, feed, step }: {
+export function Caption({ entry, dials, picture, width, feed, step, hereTimezone }: {
   entry: CaptionEntry;
   dials: SoloDials;
   /** Where the picture sits on the panel, from pictureRect. */
@@ -38,8 +39,15 @@ export function Caption({ entry, dials, picture, width, feed, step }: {
    * arrives with the picture instead.
    */
   step?: { from: CaptionEntry; fadeS: number } | null;
+  /**
+   * The zone the "my time" dial reads as here. Defaults to the zone this
+   * glass is set to, which is why a Pi on the wrong timezone writes the wrong
+   * here-clock; tests and the studio pass it explicitly.
+   */
+  hereTimezone?: string | null;
 }) {
-  const lines = captionLines(entry, dials, feed);
+  const here = { style: dials.hereTime, timezone: hereTimezone === undefined ? localTimezone() : hereTimezone };
+  const lines = captionLines(entry, dials, feed, here.timezone);
   if (!lines) return null;
   const s = captionScale(width);
   const box = captionBox(dials, picture, width);
@@ -56,43 +64,54 @@ export function Caption({ entry, dials, picture, width, feed, step }: {
     textShadow: overlay ? '0 1px 4px #000' : undefined,
   };
   const line: CSSProperties = { overflow: 'hidden', textOverflow: 'ellipsis' };
+  // `caption-time` wraps the whole line, the readings on their way out
+  // included: a ghost rides on top of the reading that replaced it until the
+  // crossfade ends, so read the heads and tails, not the line's text.
   const timeFace: CSSProperties = {
     fontSize: dials.timeSize * s, color: gray(dials.timeGray), fontVariantNumeric: 'tabular-nums',
   };
 
-  // The clock the step is leaving, read with this caption's own dials so the
-  // two ends of the fade are always the same format.
-  const from = step && step.fadeS > 0
-    ? formatTime(dials.timeStyle, step.from.capturedAt, step.from.timezone, step.from.sunAltitudeDeg)
+  // The reading the step is leaving, built with this caption's own dials so
+  // the two ends of the fade are always the same format, then matched piece
+  // for piece against the reading arriving.
+  const leaving = step && step.fadeS > 0
+    ? timeSegments(dials.timeStyle, step.from.capturedAt, step.from.timezone, step.from.sunAltitudeDeg, here)
     : null;
+  const pairs = pairTimeSegments(leaving, lines.timeParts);
   // Two frames of the same minute say the same thing; nothing to fade.
-  const stepping = !!from && !!lines.time && from !== lines.time;
-  // What the two readings share, and the head that differs.
-  const split = stepping && from ? splitTime(from, lines.time) : null;
-  const fade = split && step ? step.fadeS : 0;
+  const stepping = pairs.some((p) => p.fade && p.from !== p.to);
+  const fade = stepping && step ? step.fadeS : 0;
 
-  const time = !lines.time ? null : split ? (
-    // The head crossfades in place: the outgoing reading rides on top of the
-    // incoming one, which holds the width so the tail beside it never moves.
-    // Each head is keyed by its own text, so a step restarts the two
-    // animations without remounting the line they sit in.
-    <span style={{ ...timeFace, position: 'relative', display: 'inline-block' }}>
-      <span data-testid="caption-time" style={{ display: 'inline-block' }}>
-        <span data-testid="caption-time-head" key={split.toHead} style={{
-          display: 'inline-block', animation: `solo-time-in ${fade}s ease both`,
-        }}>
-          {split.toHead}
-        </span>
-        {split.tail ? ` ${split.tail}` : null}
-      </span>
-      <span data-testid="caption-time-out" key={split.fromHead} aria-hidden style={{
-        position: 'absolute', left: 0, top: 0, animation: `solo-time-out ${fade}s ease both`,
-      }}>
-        {split.fromHead}
-      </span>
+  const time = !lines.time ? null : (
+    <span data-testid="caption-time" style={{ ...timeFace, whiteSpace: 'pre' }}>
+      {pairs.map((p, i) => {
+        // A piece that did not change, and every piece of punctuation, is
+        // written as it is: only what actually moved animates.
+        if (!p.fade || p.from === p.to) return <span key={i}>{p.to}</span>;
+        // The head crossfades in place: the outgoing reading rides on top of
+        // the incoming one, which holds the width so the tail beside it never
+        // moves. Each head is keyed by its own text, so a step restarts the
+        // two animations without remounting the line they sit in.
+        const split = splitTime(p.from, p.to);
+        return (
+          <span key={i} style={{ position: 'relative', display: 'inline-block' }}>
+            <span style={{ display: 'inline-block' }}>
+              <span data-testid="caption-time-head" key={split.toHead} style={{
+                display: 'inline-block', animation: `solo-time-in ${fade}s ease both`,
+              }}>
+                {split.toHead}
+              </span>
+              {split.tail ? ` ${split.tail}` : null}
+            </span>
+            <span data-testid="caption-time-out" key={split.fromHead} aria-hidden style={{
+              position: 'absolute', left: 0, top: 0, animation: `solo-time-out ${fade}s ease both`,
+            }}>
+              {split.fromHead}
+            </span>
+          </span>
+        );
+      })}
     </span>
-  ) : (
-    <span data-testid="caption-time" style={timeFace}>{lines.time}</span>
   );
 
   return (

--- a/app/components/solo/Caption.tsx
+++ b/app/components/solo/Caption.tsx
@@ -94,20 +94,21 @@ export function Caption({ entry, dials, picture, width, feed, step, hereTimezone
         // two animations without remounting the line they sit in.
         const split = splitTime(p.from, p.to);
         return (
-          <span key={i} style={{ position: 'relative', display: 'inline-block' }}>
-            <span style={{ display: 'inline-block' }}>
-              <span data-testid="caption-time-head" key={split.toHead} style={{
+          <span key={i}>
+            {split.lead}
+            <span style={{ position: 'relative', display: 'inline-block' }}>
+              <span data-testid="caption-time-head" key={split.toMid} style={{
                 display: 'inline-block', animation: `solo-time-in ${fade}s ease both`,
               }}>
-                {split.toHead}
+                {split.toMid}
               </span>
-              {split.tail ? ` ${split.tail}` : null}
+              <span data-testid="caption-time-out" key={split.fromMid} aria-hidden style={{
+                position: 'absolute', left: 0, top: 0, animation: `solo-time-out ${fade}s ease both`,
+              }}>
+                {split.fromMid}
+              </span>
             </span>
-            <span data-testid="caption-time-out" key={split.fromHead} aria-hidden style={{
-              position: 'absolute', left: 0, top: 0, animation: `solo-time-out ${fade}s ease both`,
-            }}>
-              {split.fromHead}
-            </span>
+            {split.tail}
           </span>
         );
       })}

--- a/app/components/solo2/Solo2Frame.test.tsx
+++ b/app/components/solo2/Solo2Frame.test.tsx
@@ -6,6 +6,18 @@ import { schemaDefaults } from '@/app/lib/settings/schema';
 import { fitPlan } from '@/app/lib/solo2/plan';
 import { ARRIVAL_EASES, VEIL_TINTS, easingIsSymmetric } from '@/app/lib/solo2/veil';
 
+/**
+ * The time line as it is actually drawn. Mid-crossfade the line also carries
+ * the reading on its way out, which is aria-hidden and sits on top of the one
+ * that replaced it, so it has to come out before reading the text.
+ */
+const drawnTime = () => {
+  const el = screen.getByTestId('caption-time').cloneNode(true) as HTMLElement;
+  el.querySelectorAll('[aria-hidden="true"]').forEach((n) => n.remove());
+  return el.textContent;
+};
+
+
 /** The curve the default dials put on every layer of a dissolve. */
 const E = ARRIVAL_EASES.gentle;
 
@@ -31,7 +43,7 @@ it('the last frame: inset on black, centred, with place and local time, no score
   expect(screen.getByTestId('stack')).toHaveStyle({ left: '125px', top: '70px', width: '1671px', height: '940px' });
   expect(screen.getByText('Pier')).toBeInTheDocument();
   expect(screen.getByText('Baja California Sur, Mexico')).toBeInTheDocument();
-  expect(screen.getByTestId('caption-time')).toHaveTextContent('7:42 pm there');
+  expect(drawnTime()).toBe('7:42 pm there');
   expect(screen.queryByText(/rating 4\.6/)).toBeNull();
 });
 
@@ -41,7 +53,7 @@ it('an earlier frame of the run carries its own caption, time and scores', () =>
   expect(screen.getByTestId('top')).toHaveAttribute('src', 'u2');
   expect(screen.getByText('Pier mid')).toBeInTheDocument();
   expect(screen.queryByText('Pier')).toBeNull();
-  expect(screen.getByTestId('caption-time')).toHaveTextContent('7:32 pm there');
+  expect(drawnTime()).toBe('7:32 pm there');
   expect(screen.getByText(/rating 3\.8/)).toBeInTheDocument(); // 1 + 4 × 0.7
   expect(screen.getByText(/×1/)).toBeInTheDocument();
   expect(screen.getByText(/sunset bin #3/)).toBeInTheDocument(); // the drawn frame's rank stands in for a run frame without one
@@ -282,11 +294,11 @@ it('inside a run only the clock moves, and inside the clock only the part that c
   const sameCam = run.map((f) => ({ ...f, title: 'Pier' }));
   const { rerender } = render(<Solo2Frame entry={e} run={sameCam} previous={null} stage={{ index: 1, leadProgress: 0 }} plan={plan}
     dials={{ ...D, sameCameraFadeS: 1 }} width={1920} height={1080} />);
-  expect(screen.getByTestId('caption-time')).toHaveTextContent('7:32 pm there');
-  // Only "7:22" → "7:32" animates; "pm there" is one static text node beside it.
-  expect(screen.getByTestId('caption-time-head')).toHaveTextContent('7:32');
+  expect(drawnTime()).toBe('7:32 pm there');
+  // Only the minute's first digit animates: "7:" holds and so does "2 pm there".
+  expect(screen.getByTestId('caption-time-head')).toHaveTextContent('3');
   expect(screen.getByTestId('caption-time-head')).toHaveStyle({ animation: 'solo-time-in 1s ease both' });
-  expect(screen.getByTestId('caption-time-out')).toHaveTextContent('7:22');
+  expect(screen.getByTestId('caption-time-out')).toHaveTextContent('2');
   // No delay on either: out and in run together, the way the picture dissolves.
   expect(screen.getByTestId('caption-time-out')).toHaveStyle({ animation: 'solo-time-out 1s ease both' });
 
@@ -298,9 +310,9 @@ it('inside a run only the clock moves, and inside the clock only the part that c
     dials={{ ...D, sameCameraFadeS: 1 }} width={1920} height={1080} />);
   expect(screen.getByTestId('caption-layer')).toBe(held);
   expect(screen.getByTestId('caption-time')).toBe(tail);
-  expect(screen.getByTestId('caption-time')).toHaveTextContent('7:42 pm there');
-  expect(screen.getByTestId('caption-time-head')).toHaveTextContent('7:42');
-  expect(screen.getByTestId('caption-time-out')).toHaveTextContent('7:32');
+  expect(drawnTime()).toBe('7:42 pm there');
+  expect(screen.getByTestId('caption-time-head')).toHaveTextContent('4');
+  expect(screen.getByTestId('caption-time-out')).toHaveTextContent('3');
 });
 
 it('a run’s first frame has no clock to leave', () => {

--- a/app/lib/solo/caption.test.ts
+++ b/app/lib/solo/caption.test.ts
@@ -205,18 +205,26 @@ describe('pictureRect', () => {
 });
 
 describe('splitTime', () => {
-  it('keeps the words the two readings share and hands back only what changed', () => {
-    expect(splitTime('7:42 pm there', '7:52 pm there')).toEqual({ fromHead: '7:42', toHead: '7:52', tail: 'pm there' });
-    // "pm" is shared until it isn't.
-    expect(splitTime('11:52 am there', '12:02 pm there')).toEqual({ fromHead: '11:52 am', toHead: '12:02 pm', tail: 'there' });
-    expect(splitTime('sun 1.2° above the horizon', 'sun 0.4° above the horizon'))
-      .toEqual({ fromHead: 'sun 1.2°', toHead: 'sun 0.4°', tail: 'above the horizon' });
+  it('holds every character the two readings share at both ends and fades only the stretch between', () => {
+    // The hour and the colon did not move, so they do not animate.
+    expect(splitTime('7:22 pm there', '7:32 pm there'))
+      .toEqual({ lead: '7:', fromMid: '2', toMid: '3', tail: '2 pm there' });
+    expect(splitTime('7:42 pm there', '7:52 pm there'))
+      .toEqual({ lead: '7:', fromMid: '4', toMid: '5', tail: '2 pm there' });
+    // One digit of the sun's angle, with "sun 1." and the words after it still.
+    expect(splitTime('sun 1.2° above the horizon', 'sun 1.4° above the horizon'))
+      .toEqual({ lead: 'sun 1.', fromMid: '2', toMid: '4', tail: '° above the horizon' });
   });
-  it('compares whole words, so a shared digit never splits a number', () => {
-    expect(splitTime('7:42', '7:52')).toEqual({ fromHead: '7:42', toHead: '7:52', tail: '' });
+  it('an hour rolling over past noon moves the middle and keeps both ends', () => {
+    expect(splitTime('11:52 am there', '12:02 pm there'))
+      .toEqual({ lead: '1', fromMid: '1:52 a', toMid: '2:02 p', tail: 'm there' });
   });
-  it('leaves a word in the head even when every word matches, so there is always something to fade', () => {
-    expect(splitTime('7:42 pm there', '7:42 pm there')).toEqual({ fromHead: '7:42', toHead: '7:42', tail: 'pm there' });
+  it('a reading with no shared ends fades whole', () => {
+    expect(splitTime('7:59', '8:00')).toEqual({ lead: '', fromMid: '7:59', toMid: '8:00', tail: '' });
+  });
+  it('leaves a character in the middle even when the two readings match, so there is always something to fade', () => {
+    expect(splitTime('7:42 pm there', '7:42 pm there'))
+      .toEqual({ lead: '7:42 pm ther', fromMid: 'e', toMid: 'e', tail: '' });
   });
 });
 

--- a/app/lib/solo/caption.test.ts
+++ b/app/lib/solo/caption.test.ts
@@ -1,9 +1,13 @@
 import { describe, it, expect } from 'vitest';
-import { captionBox, captionHeight, captionLines, displayTitle, drawFactor, formatTime, gray, lineGaps, pictureRect, splitTime } from './caption';
+import { captionBox, captionHeight, captionLines, displayTitle, drawFactor, formatTime, gray, lineGaps, pairTimeSegments, pictureRect, splitTime, timeSegments } from './caption';
 
 // 02:42 UTC on 2026-09-05 is 7:42 pm the evening before in Mazatlán (UTC−7).
 const AT = Date.UTC(2026, 8, 5, 2, 42);
 const TZ = 'America/Mazatlan';
+// The glass, three hours east of the camera: the same instant reads 10:42 pm.
+const HERE = 'America/New_York';
+// Los Angeles keeps the same offset as Mazatl\u00e1n, so it reads the same clock.
+const SAME = 'America/Los_Angeles';
 
 describe('formatTime', () => {
   it('renders each style', () => {
@@ -25,6 +29,77 @@ describe('formatTime', () => {
   });
   it('an unknown zone name is treated as no zone', () => {
     expect(formatTime('12h', AT, 'Mars/Olympus', 1)).toBeNull();
+  });
+});
+
+describe('the glass\u2019s own clock beside the camera\u2019s', () => {
+  const here = (style: 'off' | 'dot' | 'parens' | 'parens-bare' | 'dash' | 'comma', timezone: string | null = HERE) =>
+    ({ style, timezone });
+
+  it('each shape attaches the here reading its own way', () => {
+    expect(formatTime('12h-there', AT, TZ, 1.23, here('dot'))).toBe('7:42 pm there \u00b7 10:42 pm here');
+    expect(formatTime('12h-there', AT, TZ, 1.23, here('parens'))).toBe('7:42 pm there (10:42 pm here)');
+    expect(formatTime('12h-there', AT, TZ, 1.23, here('parens-bare'))).toBe('7:42 pm there (10:42 pm)');
+    expect(formatTime('12h-there', AT, TZ, 1.23, here('dash'))).toBe('7:42 pm there \u2014 10:42 pm here');
+    expect(formatTime('12h-there', AT, TZ, 1.23, here('comma'))).toBe('7:42 pm there, 10:42 pm here');
+  });
+
+  it('off, an unknown zone, and a time that says nothing all leave the line alone', () => {
+    expect(formatTime('12h-there', AT, TZ, 1.23, here('off'))).toBe('7:42 pm there');
+    expect(formatTime('12h-there', AT, TZ, 1.23, here('dot', null))).toBe('7:42 pm there');
+    expect(formatTime('12h-there', AT, TZ, 1.23, here('dot', 'Mars/Olympus'))).toBe('7:42 pm there');
+    expect(formatTime('off', AT, TZ, 1.23, here('dot'))).toBeNull();
+    // The camera has no zone, so its half said nothing; there is nothing to sit beside.
+    expect(formatTime('12h', AT, null, 1.23, here('dot'))).toBeNull();
+  });
+
+  it('a camera in this glass\u2019s own zone does not say the time twice', () => {
+    expect(formatTime('12h-there', AT, TZ, 1.23, here('dot', SAME))).toBe('7:42 pm there');
+  });
+
+  it('it attaches to whatever the style said, the sun included', () => {
+    expect(formatTime('sun', AT, TZ, 1.23, here('parens'))).toBe('sun 1.2\u00b0 above the horizon (10:42 pm here)');
+  });
+
+  it('the punctuation is its own piece, so only the readings can fade', () => {
+    expect(timeSegments('12h-there', AT, TZ, null, here('parens'))).toEqual([
+      { text: '7:42 pm there', fade: true },
+      { text: ' (', fade: false },
+      { text: '10:42 pm here', fade: true },
+      { text: ')', fade: false },
+    ]);
+    expect(timeSegments('12h-sun', AT, TZ, -2.15)).toEqual([
+      { text: '7:42 pm', fade: true },
+      { text: ' \u00b7 ', fade: false },
+      { text: 'sun 2.1\u00b0 below the horizon', fade: true },
+    ]);
+  });
+});
+
+describe('pairTimeSegments', () => {
+  const seg = (text: string, fade = true) => ({ text, fade });
+
+  it('nothing to fade from means nothing animates', () => {
+    expect(pairTimeSegments(null, [seg('7:42 pm')])).toEqual([{ from: '7:42 pm', to: '7:42 pm', fade: false }]);
+  });
+
+  it('matches piece for piece, so the reading that held still is not asked to fade', () => {
+    const from = [seg('7:42 pm there'), seg(' (', false), seg('10:42 pm here'), seg(')', false)];
+    const to = [seg('7:51 pm there'), seg(' (', false), seg('10:51 pm here'), seg(')', false)];
+    expect(pairTimeSegments(from, to)).toEqual([
+      { from: '7:42 pm there', to: '7:51 pm there', fade: true },
+      { from: ' (', to: ' (', fade: false },
+      { from: '10:42 pm here', to: '10:51 pm here', fade: true },
+      { from: ')', to: ')', fade: false },
+    ]);
+  });
+
+  it('two readings of different shapes crossfade as one line, the way they did before there were pieces', () => {
+    const from = [seg('7:42 pm'), seg(' \u00b7 ', false), seg('sun 1.2\u00b0 above the horizon')];
+    const to = [seg('7:51 pm')];
+    expect(pairTimeSegments(from, to)).toEqual([
+      { from: '7:42 pm \u00b7 sun 1.2\u00b0 above the horizon', to: '7:51 pm', fade: true },
+    ]);
   });
 });
 
@@ -60,12 +135,19 @@ describe('displayTitle', () => {
 
 describe('captionLines', () => {
   const e = { title: 'Porjus › North-west: Northern Lights webcam', region: 'Norrbotten County', country: 'Sweden', capturedAt: AT, timezone: TZ, sunAltitudeDeg: 1.2 };
-  const d = { showPlace: true, timeStyle: '12h-there' as const, titleClean: 'compass' as const };
+  const d = { showPlace: true, timeStyle: '12h-there' as const, hereTime: 'off' as const, titleClean: 'compass' as const };
   it('gives the cleaned title, the place, the time, and the two joined', () => {
     expect(captionLines(e, d)).toEqual({
       title: 'Porjus: Northern Lights webcam', place: 'Norrbotten County, Sweden', time: '7:42 pm there',
+      timeParts: [{ text: '7:42 pm there', fade: true }],
       sub: 'Norrbotten County, Sweden · 7:42 pm there',
     });
+  });
+  it('writes the glass\u2019s own clock beside the camera\u2019s when the here dial asks, and passes the pieces on', () => {
+    const lines = captionLines(e, { ...d, hereTime: 'parens' }, undefined, HERE)!;
+    expect(lines.time).toBe('7:42 pm there (10:42 pm here)');
+    expect(lines.timeParts.map((p) => p.text)).toEqual(['7:42 pm there', ' (', '10:42 pm here', ')']);
+    expect(lines.sub).toBe('Norrbotten County, Sweden \u00b7 7:42 pm there (10:42 pm here)');
   });
   it('names the screen before the title when the prefix dial is on and a feed is given', () => {
     expect(captionLines(e, { ...d, feedPrefix: true }, 'sunset')!.title).toBe('Sunset: Porjus: Northern Lights webcam');

--- a/app/lib/solo/caption.ts
+++ b/app/lib/solo/caption.ts
@@ -233,21 +233,40 @@ export function pictureRect(
 }
 
 /**
- * The two readings of the clock, split into the words that change and the
- * tail they share. "7:42 pm there" → "7:52 pm there" changes only "7:42", so
- * only that crossfades and "pm there" holds still; "sun 1.2° above the
- * horizon" keeps "above the horizon". Compared word by word from the end, so
- * a shared digit never splits a number, and the head keeps at least one word.
+ * One reading and the reading it replaces, split into the characters they
+ * share at each end and the stretch between that actually moved.
+ *
+ * Character by character, not word by word: "7:22 pm there" → "7:32 pm there"
+ * moves one digit, so `lead` holds "7:", `tail` holds "2 pm there", and only
+ * "2" → "3" crossfades. Comparing words would have faded the whole "7:22",
+ * carrying the hour and the colon along with the minute that changed. The
+ * time is drawn in tabular figures, so a digit swapped mid-number lands in
+ * exactly the same place and nothing beside it shifts.
+ *
+ * Both ends stop one character short of consuming a reading, so there is
+ * always something in the middle to fade even when the two are the same.
  */
-export function splitTime(from: string, to: string): { fromHead: string; toHead: string; tail: string } {
-  const a = from.split(' ');
-  const b = to.split(' ');
-  let shared = 0;
-  while (shared < a.length - 1 && shared < b.length - 1 && a[a.length - 1 - shared] === b[b.length - 1 - shared]) shared++;
+export interface TimeSplit {
+  /** What both readings begin with; never animates. */
+  lead: string;
+  /** The stretch that moved, on its way out and on its way in. */
+  fromMid: string;
+  toMid: string;
+  /** What both readings end with; never animates. */
+  tail: string;
+}
+
+export function splitTime(from: string, to: string): TimeSplit {
+  const room = Math.min(from.length, to.length) - 1;
+  let lead = 0;
+  while (lead < room && from[lead] === to[lead]) lead++;
+  let tail = 0;
+  while (lead + tail < room && from[from.length - 1 - tail] === to[to.length - 1 - tail]) tail++;
   return {
-    fromHead: a.slice(0, a.length - shared).join(' '),
-    toHead: b.slice(0, b.length - shared).join(' '),
-    tail: b.slice(b.length - shared).join(' '),
+    lead: to.slice(0, lead),
+    fromMid: from.slice(lead, from.length - tail),
+    toMid: to.slice(lead, to.length - tail),
+    tail: tail ? to.slice(to.length - tail) : '',
   };
 }
 

--- a/app/lib/solo/caption.ts
+++ b/app/lib/solo/caption.ts
@@ -1,4 +1,4 @@
-import type { Feed, SoloDials, TimeStyle, TitleClean, CaptionFont } from './types';
+import type { Feed, HereTime, SoloDials, TimeStyle, TitleClean, CaptionFont } from './types';
 
 /**
  * The caption under (or over) a solo frame: what it says and where it sits.
@@ -36,23 +36,113 @@ function sun(deg: number): string {
 }
 
 /**
- * The time part of the caption for one time style (solo2 spec §4.5), or
- * null when there is nothing to say (style off, or the data the style needs
- * is missing).
+ * One piece of the time line. The line is drawn piece by piece rather than as
+ * one string so that a step inside a camera run crossfades only the pieces
+ * that actually changed: with the glass's own clock written beside the
+ * camera's, the reading that moves sits in the middle of the line, and a
+ * single split from the end would re-fade every word around it.
+ *
+ * `fade` is false for the punctuation between the readings, which never
+ * animates. Segments carry no separator of their own: `text` is written
+ * verbatim, in order, and the fixed segments are the spacing.
+ */
+export interface TimeSegment {
+  text: string;
+  fade: boolean;
+}
+
+/** Where the glass is, and how it wants its own clock written. */
+export interface HereClock {
+  style: HereTime;
+  /** IANA name of the glass's own zone; null when it cannot be resolved. */
+  timezone: string | null;
+}
+
+/** The glass's own zone, or null where Intl cannot say (a test, an odd runtime). */
+export function localTimezone(): string | null {
+  try {
+    return Intl.DateTimeFormat().resolvedOptions().timeZone || null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * How each shape attaches the here reading: what goes before it, whether it
+ * says the word, and what closes it. Kept as data so the studio's dial and
+ * the glass cannot drift apart about what a shape looks like.
+ */
+const HERE_SHAPES: Record<Exclude<HereTime, 'off'>, { open: string; word: boolean; close: string }> = {
+  dot: { open: ' · ', word: true, close: '' },
+  parens: { open: ' (', word: true, close: ')' },
+  'parens-bare': { open: ' (', word: false, close: ')' },
+  dash: { open: ' — ', word: true, close: '' },
+  comma: { open: ', ', word: true, close: '' },
+};
+
+/**
+ * The camera's half of the time line for one style (solo2 spec §4.5), as
+ * segments, or empty when there is nothing to say (style off, or the data
+ * the style needs is missing).
+ */
+function thereSegments(
+  style: TimeStyle, capturedAt: number, timezone: string | null, sunAltitudeDeg: number | null,
+): TimeSegment[] {
+  const twelve = timezone ? clock(capturedAt, timezone, true) : null;
+  const sunPart = sunAltitudeDeg == null || !Number.isFinite(sunAltitudeDeg) ? null : sun(sunAltitudeDeg);
+  const one = (text: string | null): TimeSegment[] => (text ? [{ text, fade: true }] : []);
+  switch (style) {
+    case 'off': return [];
+    case '12h': return one(twelve);
+    case '12h-there': return one(twelve ? `${twelve} there` : null);
+    case '24h': return one(timezone ? clock(capturedAt, timezone, false) : null);
+    case 'sun': return one(sunPart);
+    case '12h-sun': {
+      const parts = [twelve, sunPart].filter(Boolean) as string[];
+      return parts.flatMap((text, i) => (i === 0 ? [{ text, fade: true }] : [{ text: ' · ', fade: false }, { text, fade: true }]));
+    }
+  }
+}
+
+/**
+ * The whole time line as segments: the camera's reading, then the glass's own
+ * clock on the same instant when the here dial asks for it.
+ *
+ * The here half is dropped when the two zones read the same clock — a camera
+ * in your own zone would otherwise say the time twice — and when the there
+ * half said nothing at all, since there is nothing for it to sit beside.
+ */
+export function timeSegments(
+  style: TimeStyle, capturedAt: number, timezone: string | null, sunAltitudeDeg: number | null,
+  here?: HereClock,
+): TimeSegment[] {
+  const there = thereSegments(style, capturedAt, timezone, sunAltitudeDeg);
+  if (!here || here.style === 'off' || !here.timezone || there.length === 0) return there;
+  const mine = clock(capturedAt, here.timezone, true);
+  if (!mine) return there;
+  if (timezone && mine === clock(capturedAt, timezone, true)) return there; // same zone; it is one clock
+  const shape = HERE_SHAPES[here.style];
+  return [
+    ...there,
+    { text: shape.open, fade: false },
+    { text: shape.word ? `${mine} here` : mine, fade: true },
+    ...(shape.close ? [{ text: shape.close, fade: false }] : []),
+  ];
+}
+
+/** The segments written out, or '' when there are none. */
+export const timeText = (segments: TimeSegment[]): string => segments.map((s) => s.text).join('');
+
+/**
+ * The time part of the caption as one string, or null when there is nothing
+ * to say. The glass draws segments; this is for the readouts that want a
+ * plain line.
  */
 export function formatTime(
   style: TimeStyle, capturedAt: number, timezone: string | null, sunAltitudeDeg: number | null,
+  here?: HereClock,
 ): string | null {
-  const twelve = timezone ? clock(capturedAt, timezone, true) : null;
-  const sunPart = sunAltitudeDeg == null || !Number.isFinite(sunAltitudeDeg) ? null : sun(sunAltitudeDeg);
-  switch (style) {
-    case 'off': return null;
-    case '12h': return twelve;
-    case '12h-there': return twelve ? `${twelve} there` : null;
-    case '24h': return timezone ? clock(capturedAt, timezone, false) : null;
-    case 'sun': return sunPart;
-    case '12h-sun': return [twelve, sunPart].filter(Boolean).join(' · ') || null;
-  }
+  return timeText(timeSegments(style, capturedAt, timezone, sunAltitudeDeg, here)) || null;
 }
 
 const norm = (s: string) => s.toLowerCase().replace(/[^a-z0-9]+/g, '');
@@ -86,6 +176,8 @@ export interface CaptionLines {
   place: string;
   /** The formatted time, or '' when the style or the data says nothing. */
   time: string;
+  /** The same time, piece by piece, so the glass can crossfade each piece on its own. */
+  timeParts: TimeSegment[];
   /** place · time on one line, for the studio's compact readouts. */
   sub: string;
 }
@@ -99,14 +191,18 @@ export const FEED_PREFIX: Record<Feed, string> = { sunrise: 'Sunrise: ', sunset:
  * begins with its name (camera-run spec §6.2).
  */
 export function captionLines(
-  e: CaptionEntry, d: Pick<SoloDials, 'showPlace' | 'timeStyle' | 'titleClean' | 'feedPrefix'>, feed?: Feed,
+  e: CaptionEntry, d: Pick<SoloDials, 'showPlace' | 'timeStyle' | 'hereTime' | 'titleClean' | 'feedPrefix'>,
+  feed?: Feed, hereTimezone?: string | null,
 ): CaptionLines | null {
   if (!d.showPlace) return null;
   const t = displayTitle(e.title, d.titleClean);
   const prefix = d.feedPrefix && feed ? FEED_PREFIX[feed] : '';
   const place = [t.city, e.region, e.country].filter(Boolean).join(', ');
-  const time = formatTime(d.timeStyle, e.capturedAt, e.timezone, e.sunAltitudeDeg) ?? '';
-  return { title: prefix + t.title, place, time, sub: [place, time].filter(Boolean).join(' · ') };
+  const timeParts = timeSegments(d.timeStyle, e.capturedAt, e.timezone, e.sunAltitudeDeg, {
+    style: d.hereTime, timezone: hereTimezone === undefined ? localTimezone() : hereTimezone,
+  });
+  const time = timeText(timeParts);
+  return { title: prefix + t.title, place, time, timeParts, sub: [place, time].filter(Boolean).join(' · ') };
 }
 
 export interface Rect { left: number; top: number; width: number; height: number }
@@ -153,6 +249,25 @@ export function splitTime(from: string, to: string): { fromHead: string; toHead:
     toHead: b.slice(0, b.length - shared).join(' '),
     tail: b.slice(b.length - shared).join(' '),
   };
+}
+
+/**
+ * The two readings of one time line, matched piece for piece, so the glass
+ * can fade each piece against the one it replaces. Pieces line up when the
+ * two readings have the same shape, which is the normal case inside a camera
+ * run; when they do not — a frame that knows the sun's height beside one that
+ * does not — the whole line is treated as a single piece and crossfades as
+ * one, which is what it did before there were pieces.
+ *
+ * `from` null means there is nothing to fade from, so nothing animates.
+ */
+export interface TimePair { from: string; to: string; fade: boolean }
+
+export function pairTimeSegments(from: TimeSegment[] | null, to: TimeSegment[]): TimePair[] {
+  if (!from) return to.map((s) => ({ from: s.text, to: s.text, fade: false }));
+  const aligned = from.length === to.length && to.every((s, i) => s.fade === from[i].fade);
+  if (aligned) return to.map((s, i) => ({ from: from[i].text, to: s.text, fade: s.fade }));
+  return [{ from: timeText(from), to: timeText(to), fade: true }];
 }
 
 export interface CaptionBox {

--- a/app/lib/solo/captionSchema.test.ts
+++ b/app/lib/solo/captionSchema.test.ts
@@ -11,7 +11,7 @@ describe('CAPTION_SCHEMA', () => {
       font: 'system', feedPrefix: true, titleClean: 'compass',
       titleSize: 21, titleWeight: '300', titleGray: 71,
       placeSize: 17, placeGray: 57, lineGap: 0,
-      timeStyle: '12h-there', timeLine: 'own', timeGap: 0, timeSize: 12, timeGray: 46,
+      timeStyle: '12h-there', hereTime: 'off', timeLine: 'own', timeGap: 0, timeSize: 12, timeGray: 46,
     });
   });
 

--- a/app/lib/solo/captionSchema.ts
+++ b/app/lib/solo/captionSchema.ts
@@ -1,7 +1,7 @@
 import { mergeSettings } from '@/app/lib/settings/schema';
 import type { SettingsSchema, SettingsValues } from '@/app/lib/settings/schema';
 import type {
-  CaptionAlign, CaptionDials, CaptionFont, CaptionLayout, TimeLine, TimeStyle, TitleClean, TitleWeight,
+  CaptionAlign, CaptionDials, CaptionFont, CaptionLayout, HereTime, TimeLine, TimeStyle, TitleClean, TitleWeight,
 } from './types';
 
 /** The rail section every caption knob sits in. */
@@ -98,6 +98,11 @@ export const CAPTION_SCHEMA: SettingsSchema = [
     description: 'The local clock at the camera when the picture was taken (12h → "7:42 pm", 12h-there → "7:42 pm there", 24h → "19:42"), the sun\'s height ("sun 1.2° above the horizon"), or both.',
   },
   {
+    key: 'hereTime', kind: 'enum', options: ['off', 'dot', 'parens', 'parens-bare', 'dash', 'comma'], default: 'off',
+    label: 'my time too', section: CAPTION_SECTION,
+    description: 'Write the glass\u2019s own clock beside the camera\u2019s, on the same instant, so the pair says one moment read on two clocks. Against a camera reading "7:42 pm there": dot \u2192 "\u00b7 10:42 am here", parens \u2192 "(10:42 am here)", parens-bare \u2192 "(10:42 am)", dash \u2192 "\u2014 10:42 am here", comma \u2192 ", 10:42 am here". Nothing when the time is off, or when the camera is in this glass\u2019s own zone and the two clocks would read the same.',
+  },
+  {
     key: 'timeLine', kind: 'enum', options: ['own', 'inline'], default: 'own',
     label: 'time placement', section: CAPTION_SECTION,
     description: 'own: the time on its own line under the place. inline: after the place with a middle dot.',
@@ -187,6 +192,7 @@ export function captionDialsFrom(values: SettingsValues): CaptionDials {
     placeGray: values.placeGray as number,
     lineGap: values.lineGap as number,
     timeStyle: values.timeStyle as TimeStyle,
+    hereTime: values.hereTime as HereTime,
     timeLine: values.timeLine as TimeLine,
     timeGap: values.timeGap as number,
     timeSize: values.timeSize as number,

--- a/app/lib/solo/settingsSchema.test.ts
+++ b/app/lib/solo/settingsSchema.test.ts
@@ -20,7 +20,7 @@ describe('SOLO_SETTINGS_SCHEMA', () => {
       font: 'system', feedPrefix: true, titleClean: 'compass',
       titleSize: 21, titleWeight: '300', titleGray: 71,
       placeSize: 17, placeGray: 57, lineGap: 0,
-      timeStyle: '12h-there', timeLine: 'own', timeGap: 0, timeSize: 12, timeGray: 46,
+      timeStyle: '12h-there', hereTime: 'off', timeLine: 'own', timeGap: 0, timeSize: 12, timeGray: 46,
     });
   });
 

--- a/app/lib/solo/types.ts
+++ b/app/lib/solo/types.ts
@@ -41,6 +41,12 @@ export type CaptionAlign = 'picture' | 'center' | 'panel';
 export type TimeStyle = 'off' | '12h' | '12h-there' | '24h' | 'sun' | '12h-sun';
 /** The time on its own line, or after the place with a middle dot. */
 export type TimeLine = 'own' | 'inline';
+/**
+ * Whether the glass's own clock is written beside the camera's, and what
+ * shape it takes: "7:42 pm there · 10:42 am here" against "7:42 pm there
+ * (10:42 am)". One instant read on two clocks, which is the point of it.
+ */
+export type HereTime = 'off' | 'dot' | 'parens' | 'parens-bare' | 'dash' | 'comma';
 /** What to do with Windy's "City › Compass: Spot" titles. */
 export type TitleClean = 'raw' | 'comma' | 'dot' | 'compass' | 'spot';
 export type TitleWeight = '300' | '400' | '500' | '600';
@@ -71,6 +77,8 @@ export interface CaptionDials {
   placeGray: number;
   lineGap: number;
   timeStyle: TimeStyle;
+  /** The glass's own clock beside the camera's, and its shape; 'off' for neither. */
+  hereTime: HereTime;
   timeLine: TimeLine;
   /** Extra space above the time line, on top of lineGap; own-line time only. */
   timeGap: number;


### PR DESCRIPTION
## What

The caption can now write the glass's own clock beside the camera's, on the same instant:

```
Sunset: Split
Split-Dalmatia County, Croatia
7:42 pm there (10:42 pm here)
```

One moment read on two clocks. The picture starts reading as something happening now rather than as a picture of somewhere.

## The dial

One new shared caption dial, **my time too** (`hereTime`), in the Picture tab. Default `off`, so nothing changes until you turn it on. It attaches the here reading to whatever the time style already said, so it composes with the sun style too (`sun 1.2° above the horizon (10:42 pm here)`).

| value | renders |
|---|---|
| `off` | `7:42 pm there` |
| `dot` | `7:42 pm there · 10:42 pm here` |
| `parens` | `7:42 pm there (10:42 pm here)` |
| `parens-bare` | `7:42 pm there (10:42 pm)` |
| `dash` | `7:42 pm there — 10:42 pm here` |
| `comma` | `7:42 pm there, 10:42 pm here` |

Five shapes rather than one, because the right separator is a thing to see on the glass, not to argue about in a diff.

It drops itself when the camera sits in the glass's own zone, so a Seattle camera on a Seattle screen does not say the time twice. It says nothing when the time style is off, since there is nothing for it to sit beside.

"Here" is the glass's own timezone, from `Intl`. A Pi set to the wrong zone writes the wrong here-clock; that is a `timedatectl` fix on the glass, not a code change.

## Why the time line was rebuilt as segments

The crossfade compares the two readings word by word from the end and holds the shared tail still, so only the digits that moved animate. With the moving there-clock now sitting in the *middle* of the line, that single split would have found almost nothing shared and re-faded every word — undoing the only-changed-words work from #158.

The line is now drawn piece by piece. Each reading fades against its own predecessor, and the punctuation between them never animates. That also fixes the sun style, where a moving sun angle used to re-fade a clock that had not changed.


## Second commit: the fade now moves characters, not words

The split only ever looked for a shared *ending*, so the one word that moved crossfaded whole — `7:33` → `7:42` faded the hour and the colon along with the minute. It now finds the shared characters at both ends:

```
HOLDS "7:"      FADES "33" -> "42"   HOLDS " pm there"
HOLDS " · "
HOLDS "10:"     FADES "33" -> "42"   HOLDS " pm here"
HOLDS "sun 1."  FADES "2"  -> "4"    HOLDS "° above the horizon"
```

Tabular figures mean a digit swapped mid-number lands in the same place, so nothing beside it shifts. Both ends stop one character short of consuming a reading, so there is always something in the middle to fade.

## Not in this one

The here reading on its own third line. That is not a string change — it moves through `captionHeight`, the line gaps, the studio readout and the panel overflow check. Worth trying the five inline shapes on the glass first.

## Testing

Full suite green (2460 tests), build clean. New coverage for each shape, the same-zone drop, the unknown-zone and time-off cases, segment pairing, and a component test that two readings fade against their own predecessors with the separator held still.

No migration. After merge: `bash scripts/pi/kiosk-doctor.sh --sync --reload`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BHS436fcGJfTLCPfQmrSnp
