### PR TITLE
feat(caption): "13 minutes ago" instead of two clocks

### DIFF
--- a/app/components/solo/Caption.test.tsx
+++ b/app/components/solo/Caption.test.tsx
@@ -4,6 +4,15 @@ import { Caption } from './Caption';
 import { dialsFrom, SOLO_SETTINGS_SCHEMA } from '@/app/lib/solo/settingsSchema';
 import { schemaDefaults } from '@/app/lib/settings/schema';
 
+const D = dialsFrom(schemaDefaults(SOLO_SETTINGS_SCHEMA));
+const MIN = 60_000;
+const AT = Date.UTC(2026, 8, 5, 2, 42);
+const e = {
+  title: 'Split › West', region: 'Split-Dalmatia County', country: 'Croatia',
+  capturedAt: AT, timezone: 'America/Mazatlan', sunAltitudeDeg: null,
+};
+const PICTURE = { left: 0, top: 0, width: 1920, height: 940 };
+
 /**
  * The time line as it is actually drawn. Mid-crossfade the line also carries
  * the reading on its way out, which is aria-hidden and sits on top of the one
@@ -15,55 +24,44 @@ const drawnTime = () => {
   return el.textContent;
 };
 
-
-const D = dialsFrom(schemaDefaults(SOLO_SETTINGS_SCHEMA));
-const AT = Date.UTC(2026, 8, 5, 2, 42); // 7:42 pm in Mazatlán, 10:42 pm in New York
-const e = {
-  title: 'Split › West', region: 'Split-Dalmatia County', country: 'Croatia',
-  capturedAt: AT, timezone: 'America/Mazatlan', sunAltitudeDeg: null,
-};
-const PICTURE = { left: 0, top: 0, width: 1920, height: 940 };
 const draw = (props: Partial<Parameters<typeof Caption>[0]> = {}) =>
-  render(<Caption entry={e} dials={D} picture={PICTURE} width={1920} hereTimezone="America/New_York" {...props} />);
+  render(<Caption entry={e} dials={D} picture={PICTURE} width={1920} now={AT + 13 * MIN} {...props} />);
 
-it('the here dial writes the glass’s own clock beside the camera’s, in the shape it names', () => {
-  draw({ dials: { ...D, hereTime: 'parens' } });
-  expect(screen.getByTestId('caption-time')).toHaveTextContent('7:42 pm there (10:42 pm here)');
-});
-
-it('off leaves the camera’s clock alone', () => {
+it('the default time reading is how long ago the picture was taken', () => {
   draw();
-  expect(screen.getByTestId('caption-time')).toHaveTextContent('7:42 pm there');
+  expect(drawnTime()).toBe('13 minutes ago');
 });
 
-it('a step fades each reading against its own predecessor, so the words that held still do not animate', () => {
-  const from = { ...e, capturedAt: AT - 9 * 60_000 }; // 7:33 pm there, 10:33 pm here
-  draw({ dials: { ...D, hereTime: 'dot' }, step: { from, fadeS: 1 } });
-  expect(drawnTime()).toBe('7:42 pm there · 10:42 pm here');
-  // Two readings moved, so two stretches fade in and two fade out — and each
-  // reading holds its own ends rather than sharing one tail with the other.
-  // 7:33 → 7:42 and 10:33 → 10:42: the hour and the colon held, so only the
-  // minutes are on the move.
-  expect(screen.getAllByTestId('caption-time-head').map((n) => n.textContent)).toEqual(['42', '42']);
-  expect(screen.getAllByTestId('caption-time-out').map((n) => n.textContent)).toEqual(['33', '33']);
-  for (const n of screen.getAllByTestId('caption-time-head')) {
-    expect(n).toHaveStyle({ animation: 'solo-time-in 1s ease both' });
-  }
+it('past an hour it reads hours and minutes', () => {
+  draw({ now: AT + 65 * MIN });
+  expect(drawnTime()).toBe('1 hour 5 minutes ago');
 });
 
-it('the separator between them is never asked to fade', () => {
-  const from = { ...e, capturedAt: AT - 9 * 60_000 };
-  draw({ dials: { ...D, hereTime: 'dot' }, step: { from, fadeS: 1 } });
-  const dots = screen.getAllByTestId('caption-time-out').map((n) => n.textContent);
-  expect(dots.join('')).not.toContain('·');
+it('it needs no timezone, so a camera that has none still says when', () => {
+  draw({ entry: { ...e, timezone: null } });
+  expect(drawnTime()).toBe('13 minutes ago');
 });
 
-it('two frames of the same minute say the same thing, so nothing animates', () => {
-  draw({ dials: { ...D, hereTime: 'dot' }, step: { from: { ...e, capturedAt: AT + 5_000 }, fadeS: 1 } });
+it('a run counts down, and only the digit that moved fades', () => {
+  // The frame arriving was taken ten minutes later than the one it replaces,
+  // so at one wall clock the reading goes 38 minutes ago → 28 minutes ago.
+  const now = AT + 38 * MIN;
+  draw({ entry: { ...e, capturedAt: AT + 10 * MIN }, now, step: { from: e, fadeS: 1 } });
+  expect(drawnTime()).toBe('28 minutes ago');
+  expect(screen.getByTestId('caption-time-head')).toHaveTextContent('2');
+  expect(screen.getByTestId('caption-time-head')).toHaveStyle({ animation: 'solo-time-in 1s ease both' });
+  expect(screen.getByTestId('caption-time-out')).toHaveTextContent('3');
+  expect(screen.getByTestId('caption-time-out')).toHaveStyle({ animation: 'solo-time-out 1s ease both' });
+});
+
+it('one wall clock for both readings, so a step shows the age gap and not a tick of the clock', () => {
+  // Same frame twice: the two readings are identical and nothing animates,
+  // which could only be true if both were measured against the same `now`.
+  draw({ step: { from: e, fadeS: 1 } });
   expect(screen.queryByTestId('caption-time-out')).toBeNull();
 });
 
-it('a camera in the glass’s own zone does not say the time twice', () => {
-  draw({ dials: { ...D, hereTime: 'dot' }, hereTimezone: 'America/Los_Angeles' });
-  expect(screen.getByTestId('caption-time')).toHaveTextContent('7:42 pm there');
+it('the clock styles still read the camera’s own time', () => {
+  draw({ dials: { ...D, timeStyle: '12h-there' } });
+  expect(drawnTime()).toBe('7:42 pm there');
 });

--- a/app/components/solo/Caption.tsx
+++ b/app/components/solo/Caption.tsx
@@ -3,7 +3,7 @@
 import type { CSSProperties } from 'react';
 import type { Feed, SoloDials } from '@/app/lib/solo/types';
 import {
-  FONT_STACKS, LINE_HEIGHT, captionBox, captionLines, captionScale, gray, lineGaps, localTimezone,
+  FONT_STACKS, LINE_HEIGHT, captionBox, captionLines, captionScale, gray, lineGaps,
   pairTimeSegments, splitTime, timeSegments,
   type CaptionEntry, type Rect,
 } from '@/app/lib/solo/caption';
@@ -19,7 +19,7 @@ const TIME_KEYFRAMES = `
  * the frame. Null when the place dial is off. Everything positional comes
  * from lib/solo/caption.ts, so this is layout only.
  */
-export function Caption({ entry, dials, picture, width, feed, step, hereTimezone }: {
+export function Caption({ entry, dials, picture, width, feed, step, now = Date.now() }: {
   entry: CaptionEntry;
   dials: SoloDials;
   /** Where the picture sits on the panel, from pictureRect. */
@@ -32,22 +32,23 @@ export function Caption({ entry, dials, picture, width, feed, step, hereTimezone
   /**
    * The frame the time is stepping from, inside a camera run. Every frame of
    * a run is the same camera, so the title and the place hold still and only
-   * the clock moves — and inside the clock, only the words that actually
-   * change. Those crossfade over `fadeS`, out and in together, the way the
-   * picture underneath dissolves; "pm there" and the rest of the shared tail
-   * never animate. Absent on a dwell's first frame, where the whole caption
-   * arrives with the picture instead.
+   * the time moves — and inside it, only the characters that actually change.
+   * Those crossfade over `fadeS`, out and in together, the way the picture
+   * underneath dissolves; the characters the two readings share at either end
+   * never animate, so a run counts down "38 minutes ago" to "28 minutes ago"
+   * by moving one digit. Absent on a dwell's first frame, where the whole
+   * caption arrives with the picture instead.
    */
   step?: { from: CaptionEntry; fadeS: number } | null;
   /**
-   * The zone the "my time" dial reads as here. Defaults to the zone this
-   * glass is set to, which is why a Pi on the wrong timezone writes the wrong
-   * here-clock; tests and the studio pass it explicitly.
+   * The wall clock the 'ago' style measures against. One value for the frame
+   * arriving and the frame it replaces, so the only thing between the two
+   * readings is how much older one picture is than the other — never a tick
+   * of the clock that would make the difference look larger than it is.
    */
-  hereTimezone?: string | null;
+  now?: number;
 }) {
-  const here = { style: dials.hereTime, timezone: hereTimezone === undefined ? localTimezone() : hereTimezone };
-  const lines = captionLines(entry, dials, feed, here.timezone);
+  const lines = captionLines(entry, dials, feed, now);
   if (!lines) return null;
   const s = captionScale(width);
   const box = captionBox(dials, picture, width);
@@ -75,7 +76,7 @@ export function Caption({ entry, dials, picture, width, feed, step, hereTimezone
   // the two ends of the fade are always the same format, then matched piece
   // for piece against the reading arriving.
   const leaving = step && step.fadeS > 0
-    ? timeSegments(dials.timeStyle, step.from.capturedAt, step.from.timezone, step.from.sunAltitudeDeg, here)
+    ? timeSegments(dials.timeStyle, step.from.capturedAt, step.from.timezone, step.from.sunAltitudeDeg, now)
     : null;
   const pairs = pairTimeSegments(leaving, lines.timeParts);
   // Two frames of the same minute say the same thing; nothing to fade.

--- a/app/components/solo/SoloFrame.test.tsx
+++ b/app/components/solo/SoloFrame.test.tsx
@@ -4,7 +4,9 @@ import { SoloFrame } from './SoloFrame';
 import { dialsFrom, SOLO_SETTINGS_SCHEMA } from '@/app/lib/solo/settingsSchema';
 import { schemaDefaults } from '@/app/lib/settings/schema';
 
-const D = dialsFrom(schemaDefaults(SOLO_SETTINGS_SCHEMA));
+// The caption's default time reading is now "13 minutes ago", which moves
+// with the wall clock; these tests are about layout, so they pin the clock.
+const D = { ...dialsFrom(schemaDefaults(SOLO_SETTINGS_SCHEMA)), timeStyle: '12h-there' as const };
 const AT = Date.UTC(2026, 8, 5, 2, 42); // 7:42 pm in Mazatlán
 const e = {
   snapshotId: 1, webcamId: 1, bin: 'sunset' as const, quality: 0.91, detection: 0.88, isNew: false, tally: 2, enteredAt: 0,

--- a/app/components/solo2/Solo2Frame.test.tsx
+++ b/app/components/solo2/Solo2Frame.test.tsx
@@ -21,7 +21,9 @@ const drawnTime = () => {
 /** The curve the default dials put on every layer of a dissolve. */
 const E = ARRIVAL_EASES.gentle;
 
-const D = dialsFrom2(schemaDefaults(SOLO2_SETTINGS_SCHEMA));
+// The caption's default time reading is now "13 minutes ago", which moves
+// with the wall clock; these tests are about the run, so they pin the clock.
+const D = { ...dialsFrom2(schemaDefaults(SOLO2_SETTINGS_SCHEMA)), timeStyle: '12h-there' as const };
 const AT = Date.UTC(2026, 8, 5, 2, 42); // 7:42 pm in Mazatlán
 const e = {
   snapshotId: 3, webcamId: 1, bin: 'sunset' as const, quality: 0.91, detection: 0.88, isNew: false, tally: 2, enteredAt: 0,

--- a/app/lib/solo/caption.test.ts
+++ b/app/lib/solo/caption.test.ts
@@ -1,13 +1,10 @@
 import { describe, it, expect } from 'vitest';
-import { captionBox, captionHeight, captionLines, displayTitle, drawFactor, formatTime, gray, lineGaps, pairTimeSegments, pictureRect, splitTime, timeSegments } from './caption';
+import { captionBox, captionHeight, captionLines, displayTitle, drawFactor, formatAgo, formatTime, gray, lineGaps, pairTimeSegments, pictureRect, splitTime, timeSegments, timeText } from './caption';
 
 // 02:42 UTC on 2026-09-05 is 7:42 pm the evening before in Mazatlán (UTC−7).
 const AT = Date.UTC(2026, 8, 5, 2, 42);
 const TZ = 'America/Mazatlan';
-// The glass, three hours east of the camera: the same instant reads 10:42 pm.
-const HERE = 'America/New_York';
-// Los Angeles keeps the same offset as Mazatl\u00e1n, so it reads the same clock.
-const SAME = 'America/Los_Angeles';
+const MIN = 60_000;
 
 describe('formatTime', () => {
   it('renders each style', () => {
@@ -32,47 +29,49 @@ describe('formatTime', () => {
   });
 });
 
-describe('the glass\u2019s own clock beside the camera\u2019s', () => {
-  const here = (style: 'off' | 'dot' | 'parens' | 'parens-bare' | 'dash' | 'comma', timezone: string | null = HERE) =>
-    ({ style, timezone });
-
-  it('each shape attaches the here reading its own way', () => {
-    expect(formatTime('12h-there', AT, TZ, 1.23, here('dot'))).toBe('7:42 pm there \u00b7 10:42 pm here');
-    expect(formatTime('12h-there', AT, TZ, 1.23, here('parens'))).toBe('7:42 pm there (10:42 pm here)');
-    expect(formatTime('12h-there', AT, TZ, 1.23, here('parens-bare'))).toBe('7:42 pm there (10:42 pm)');
-    expect(formatTime('12h-there', AT, TZ, 1.23, here('dash'))).toBe('7:42 pm there \u2014 10:42 pm here');
-    expect(formatTime('12h-there', AT, TZ, 1.23, here('comma'))).toBe('7:42 pm there, 10:42 pm here');
+describe('formatAgo', () => {
+  it('counts minutes up to an hour', () => {
+    expect(formatAgo(13 * MIN)).toBe('13 minutes ago');
+    expect(formatAgo(1 * MIN)).toBe('1 minute ago');
+    expect(formatAgo(59 * MIN)).toBe('59 minutes ago');
   });
-
-  it('off, an unknown zone, and a time that says nothing all leave the line alone', () => {
-    expect(formatTime('12h-there', AT, TZ, 1.23, here('off'))).toBe('7:42 pm there');
-    expect(formatTime('12h-there', AT, TZ, 1.23, here('dot', null))).toBe('7:42 pm there');
-    expect(formatTime('12h-there', AT, TZ, 1.23, here('dot', 'Mars/Olympus'))).toBe('7:42 pm there');
-    expect(formatTime('off', AT, TZ, 1.23, here('dot'))).toBeNull();
-    // The camera has no zone, so its half said nothing; there is nothing to sit beside.
-    expect(formatTime('12h', AT, null, 1.23, here('dot'))).toBeNull();
+  it('then hours and minutes, dropping a round remainder', () => {
+    expect(formatAgo(65 * MIN)).toBe('1 hour 5 minutes ago');
+    expect(formatAgo(60 * MIN)).toBe('1 hour ago');
+    expect(formatAgo(120 * MIN)).toBe('2 hours ago');
+    expect(formatAgo(181 * MIN)).toBe('3 hours 1 minute ago');
   });
-
-  it('a camera in this glass\u2019s own zone does not say the time twice', () => {
-    expect(formatTime('12h-there', AT, TZ, 1.23, here('dot', SAME))).toBe('7:42 pm there');
+  it('then days and hours, for a camera that has gone quiet', () => {
+    expect(formatAgo(25 * 60 * MIN)).toBe('1 day 1 hour ago');
+    expect(formatAgo(48 * 60 * MIN)).toBe('2 days ago');
   });
-
-  it('it attaches to whatever the style said, the sun included', () => {
-    expect(formatTime('sun', AT, TZ, 1.23, here('parens'))).toBe('sun 1.2\u00b0 above the horizon (10:42 pm here)');
+  it('under a minute, and a capture that reads as being in the future, are both just now', () => {
+    expect(formatAgo(59_000)).toBe('just now');
+    expect(formatAgo(0)).toBe('just now');
+    expect(formatAgo(-5 * MIN)).toBe('just now');
   });
+});
 
-  it('the punctuation is its own piece, so only the readings can fade', () => {
-    expect(timeSegments('12h-there', AT, TZ, null, here('parens'))).toEqual([
-      { text: '7:42 pm there', fade: true },
-      { text: ' (', fade: false },
-      { text: '10:42 pm here', fade: true },
-      { text: ')', fade: false },
-    ]);
-    expect(timeSegments('12h-sun', AT, TZ, -2.15)).toEqual([
-      { text: '7:42 pm', fade: true },
-      { text: ' \u00b7 ', fade: false },
-      { text: 'sun 2.1\u00b0 below the horizon', fade: true },
-    ]);
+describe('the ago style', () => {
+  it('measures the picture against the wall clock it is given', () => {
+    expect(formatTime('ago', AT, TZ, 1.23, AT + 13 * MIN)).toBe('13 minutes ago');
+    expect(formatTime('ago', AT, null, null, AT + 65 * MIN)).toBe('1 hour 5 minutes ago');
+  });
+  it('needs neither a zone nor a sun angle, so it always says something', () => {
+    expect(timeSegments('ago', AT, null, null, AT + MIN)).toEqual([{ text: '1 minute ago', fade: true }]);
+  });
+  it('a run counts down, and only the digit that moved is asked to fade', () => {
+    const now = AT + 38 * MIN;
+    const from = timeSegments('ago', AT, TZ, null, now);
+    const to = timeSegments('ago', AT + 10 * MIN, TZ, null, now);
+    expect(timeText(from)).toBe('38 minutes ago');
+    expect(timeText(to)).toBe('28 minutes ago');
+    const [pair] = pairTimeSegments(from, to);
+    expect(splitTime(pair.from, pair.to)).toEqual({ lead: '', fromMid: '3', toMid: '2', tail: '8 minutes ago' });
+  });
+  it('an hour reading holds the hour still and moves the minute', () => {
+    expect(splitTime('1 hour 5 minutes ago', '1 hour 4 minutes ago'))
+      .toEqual({ lead: '1 hour ', fromMid: '5', toMid: '4', tail: ' minutes ago' });
   });
 });
 
@@ -135,7 +134,7 @@ describe('displayTitle', () => {
 
 describe('captionLines', () => {
   const e = { title: 'Porjus › North-west: Northern Lights webcam', region: 'Norrbotten County', country: 'Sweden', capturedAt: AT, timezone: TZ, sunAltitudeDeg: 1.2 };
-  const d = { showPlace: true, timeStyle: '12h-there' as const, hereTime: 'off' as const, titleClean: 'compass' as const };
+  const d = { showPlace: true, timeStyle: '12h-there' as const, titleClean: 'compass' as const };
   it('gives the cleaned title, the place, the time, and the two joined', () => {
     expect(captionLines(e, d)).toEqual({
       title: 'Porjus: Northern Lights webcam', place: 'Norrbotten County, Sweden', time: '7:42 pm there',
@@ -143,11 +142,10 @@ describe('captionLines', () => {
       sub: 'Norrbotten County, Sweden · 7:42 pm there',
     });
   });
-  it('writes the glass\u2019s own clock beside the camera\u2019s when the here dial asks, and passes the pieces on', () => {
-    const lines = captionLines(e, { ...d, hereTime: 'parens' }, undefined, HERE)!;
-    expect(lines.time).toBe('7:42 pm there (10:42 pm here)');
-    expect(lines.timeParts.map((p) => p.text)).toEqual(['7:42 pm there', ' (', '10:42 pm here', ')']);
-    expect(lines.sub).toBe('Norrbotten County, Sweden \u00b7 7:42 pm there (10:42 pm here)');
+  it('the ago style reads against the wall clock the caller passes', () => {
+    const lines = captionLines(e, { ...d, timeStyle: 'ago' }, undefined, AT + 13 * MIN)!;
+    expect(lines.time).toBe('13 minutes ago');
+    expect(lines.sub).toBe('Norrbotten County, Sweden · 13 minutes ago');
   });
   it('names the screen before the title when the prefix dial is on and a feed is given', () => {
     expect(captionLines(e, { ...d, feedPrefix: true }, 'sunset')!.title).toBe('Sunset: Porjus: Northern Lights webcam');

--- a/app/lib/solo/caption.ts
+++ b/app/lib/solo/caption.ts
@@ -1,4 +1,4 @@
-import type { Feed, HereTime, SoloDials, TimeStyle, TitleClean, CaptionFont } from './types';
+import type { Feed, SoloDials, TimeStyle, TitleClean, CaptionFont } from './types';
 
 /**
  * The caption under (or over) a solo frame: what it says and where it sits.
@@ -51,48 +51,44 @@ export interface TimeSegment {
   fade: boolean;
 }
 
-/** Where the glass is, and how it wants its own clock written. */
-export interface HereClock {
-  style: HereTime;
-  /** IANA name of the glass's own zone; null when it cannot be resolved. */
-  timezone: string | null;
-}
-
-/** The glass's own zone, or null where Intl cannot say (a test, an odd runtime). */
-export function localTimezone(): string | null {
-  try {
-    return Intl.DateTimeFormat().resolvedOptions().timeZone || null;
-  } catch {
-    return null;
-  }
+/**
+ * How long ago the picture was taken, in words. The point of it is that the
+ * sunset is happening somewhere else right now: a clock in a zone you do not
+ * live in has to be converted before it says anything, where "13 minutes ago"
+ * says it outright.
+ *
+ * Minutes up to an hour, then hours and minutes, then days and hours. Round
+ * amounts drop the smaller unit — "2 hours ago", not "2 hours 0 minutes ago".
+ * Anything under a minute, and any capture that reads as being in the future
+ * because two clocks disagree, is "just now".
+ */
+export function formatAgo(elapsedMs: number): string {
+  const minutes = Math.floor(elapsedMs / 60_000);
+  if (!Number.isFinite(minutes) || minutes < 1) return 'just now';
+  const unit = (n: number, word: string) => `${n} ${word}${n === 1 ? '' : 's'}`;
+  const pair = (big: number, bigWord: string, small: number, smallWord: string) =>
+    `${unit(big, bigWord)}${small ? ` ${unit(small, smallWord)}` : ''} ago`;
+  if (minutes < 60) return `${unit(minutes, 'minute')} ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return pair(hours, 'hour', minutes % 60, 'minute');
+  return pair(Math.floor(hours / 24), 'day', hours % 24, 'hour');
 }
 
 /**
- * How each shape attaches the here reading: what goes before it, whether it
- * says the word, and what closes it. Kept as data so the studio's dial and
- * the glass cannot drift apart about what a shape looks like.
+ * The time line for one style (solo2 spec §4.5), as segments, or empty when
+ * there is nothing to say (style off, or the data the style needs is missing).
+ * `now` is the wall clock the 'ago' style measures against.
  */
-const HERE_SHAPES: Record<Exclude<HereTime, 'off'>, { open: string; word: boolean; close: string }> = {
-  dot: { open: ' · ', word: true, close: '' },
-  parens: { open: ' (', word: true, close: ')' },
-  'parens-bare': { open: ' (', word: false, close: ')' },
-  dash: { open: ' — ', word: true, close: '' },
-  comma: { open: ', ', word: true, close: '' },
-};
-
-/**
- * The camera's half of the time line for one style (solo2 spec §4.5), as
- * segments, or empty when there is nothing to say (style off, or the data
- * the style needs is missing).
- */
-function thereSegments(
+export function timeSegments(
   style: TimeStyle, capturedAt: number, timezone: string | null, sunAltitudeDeg: number | null,
+  now: number = Date.now(),
 ): TimeSegment[] {
   const twelve = timezone ? clock(capturedAt, timezone, true) : null;
   const sunPart = sunAltitudeDeg == null || !Number.isFinite(sunAltitudeDeg) ? null : sun(sunAltitudeDeg);
   const one = (text: string | null): TimeSegment[] => (text ? [{ text, fade: true }] : []);
   switch (style) {
     case 'off': return [];
+    case 'ago': return one(formatAgo(now - capturedAt));
     case '12h': return one(twelve);
     case '12h-there': return one(twelve ? `${twelve} there` : null);
     case '24h': return one(timezone ? clock(capturedAt, timezone, false) : null);
@@ -102,32 +98,6 @@ function thereSegments(
       return parts.flatMap((text, i) => (i === 0 ? [{ text, fade: true }] : [{ text: ' · ', fade: false }, { text, fade: true }]));
     }
   }
-}
-
-/**
- * The whole time line as segments: the camera's reading, then the glass's own
- * clock on the same instant when the here dial asks for it.
- *
- * The here half is dropped when the two zones read the same clock — a camera
- * in your own zone would otherwise say the time twice — and when the there
- * half said nothing at all, since there is nothing for it to sit beside.
- */
-export function timeSegments(
-  style: TimeStyle, capturedAt: number, timezone: string | null, sunAltitudeDeg: number | null,
-  here?: HereClock,
-): TimeSegment[] {
-  const there = thereSegments(style, capturedAt, timezone, sunAltitudeDeg);
-  if (!here || here.style === 'off' || !here.timezone || there.length === 0) return there;
-  const mine = clock(capturedAt, here.timezone, true);
-  if (!mine) return there;
-  if (timezone && mine === clock(capturedAt, timezone, true)) return there; // same zone; it is one clock
-  const shape = HERE_SHAPES[here.style];
-  return [
-    ...there,
-    { text: shape.open, fade: false },
-    { text: shape.word ? `${mine} here` : mine, fade: true },
-    ...(shape.close ? [{ text: shape.close, fade: false }] : []),
-  ];
 }
 
 /** The segments written out, or '' when there are none. */
@@ -140,9 +110,9 @@ export const timeText = (segments: TimeSegment[]): string => segments.map((s) =>
  */
 export function formatTime(
   style: TimeStyle, capturedAt: number, timezone: string | null, sunAltitudeDeg: number | null,
-  here?: HereClock,
+  now?: number,
 ): string | null {
-  return timeText(timeSegments(style, capturedAt, timezone, sunAltitudeDeg, here)) || null;
+  return timeText(timeSegments(style, capturedAt, timezone, sunAltitudeDeg, now)) || null;
 }
 
 const norm = (s: string) => s.toLowerCase().replace(/[^a-z0-9]+/g, '');
@@ -191,16 +161,14 @@ export const FEED_PREFIX: Record<Feed, string> = { sunrise: 'Sunrise: ', sunset:
  * begins with its name (camera-run spec §6.2).
  */
 export function captionLines(
-  e: CaptionEntry, d: Pick<SoloDials, 'showPlace' | 'timeStyle' | 'hereTime' | 'titleClean' | 'feedPrefix'>,
-  feed?: Feed, hereTimezone?: string | null,
+  e: CaptionEntry, d: Pick<SoloDials, 'showPlace' | 'timeStyle' | 'titleClean' | 'feedPrefix'>,
+  feed?: Feed, now?: number,
 ): CaptionLines | null {
   if (!d.showPlace) return null;
   const t = displayTitle(e.title, d.titleClean);
   const prefix = d.feedPrefix && feed ? FEED_PREFIX[feed] : '';
   const place = [t.city, e.region, e.country].filter(Boolean).join(', ');
-  const timeParts = timeSegments(d.timeStyle, e.capturedAt, e.timezone, e.sunAltitudeDeg, {
-    style: d.hereTime, timezone: hereTimezone === undefined ? localTimezone() : hereTimezone,
-  });
+  const timeParts = timeSegments(d.timeStyle, e.capturedAt, e.timezone, e.sunAltitudeDeg, now);
   const time = timeText(timeParts);
   return { title: prefix + t.title, place, time, timeParts, sub: [place, time].filter(Boolean).join(' · ') };
 }

--- a/app/lib/solo/captionSchema.test.ts
+++ b/app/lib/solo/captionSchema.test.ts
@@ -11,7 +11,7 @@ describe('CAPTION_SCHEMA', () => {
       font: 'system', feedPrefix: true, titleClean: 'compass',
       titleSize: 21, titleWeight: '300', titleGray: 71,
       placeSize: 17, placeGray: 57, lineGap: 0,
-      timeStyle: '12h-there', hereTime: 'off', timeLine: 'own', timeGap: 0, timeSize: 12, timeGray: 46,
+      timeStyle: 'ago', timeLine: 'own', timeGap: 0, timeSize: 12, timeGray: 46,
     });
   });
 

--- a/app/lib/solo/captionSchema.ts
+++ b/app/lib/solo/captionSchema.ts
@@ -1,7 +1,7 @@
 import { mergeSettings } from '@/app/lib/settings/schema';
 import type { SettingsSchema, SettingsValues } from '@/app/lib/settings/schema';
 import type {
-  CaptionAlign, CaptionDials, CaptionFont, CaptionLayout, HereTime, TimeLine, TimeStyle, TitleClean, TitleWeight,
+  CaptionAlign, CaptionDials, CaptionFont, CaptionLayout, TimeLine, TimeStyle, TitleClean, TitleWeight,
 } from './types';
 
 /** The rail section every caption knob sits in. */
@@ -93,14 +93,9 @@ export const CAPTION_SCHEMA: SettingsSchema = [
     description: 'Extra space above every caption line after the first.',
   },
   {
-    key: 'timeStyle', kind: 'enum', options: ['off', '12h', '12h-there', '24h', 'sun', '12h-sun'], default: '12h-there',
+    key: 'timeStyle', kind: 'enum', options: ['off', 'ago', '12h', '12h-there', '24h', 'sun', '12h-sun'], default: 'ago',
     label: 'time', section: CAPTION_SECTION,
-    description: 'The local clock at the camera when the picture was taken (12h → "7:42 pm", 12h-there → "7:42 pm there", 24h → "19:42"), the sun\'s height ("sun 1.2° above the horizon"), or both.',
-  },
-  {
-    key: 'hereTime', kind: 'enum', options: ['off', 'dot', 'parens', 'parens-bare', 'dash', 'comma'], default: 'off',
-    label: 'my time too', section: CAPTION_SECTION,
-    description: 'Write the glass\u2019s own clock beside the camera\u2019s, on the same instant, so the pair says one moment read on two clocks. Against a camera reading "7:42 pm there": dot \u2192 "\u00b7 10:42 am here", parens \u2192 "(10:42 am here)", parens-bare \u2192 "(10:42 am)", dash \u2192 "\u2014 10:42 am here", comma \u2192 ", 10:42 am here". Nothing when the time is off, or when the camera is in this glass\u2019s own zone and the two clocks would read the same.',
+    description: 'ago → how long since the picture was taken ("13 minutes ago", "1 hour 5 minutes ago"). It says the sunset is happening somewhere else right now without asking anyone to convert a clock, and inside a camera run it counts down. The rest read the camera\'s own clock at the moment of the picture (12h → "7:42 pm", 12h-there → "7:42 pm there", 24h → "19:42"), the sun\'s height ("sun 1.2° above the horizon"), or both.',
   },
   {
     key: 'timeLine', kind: 'enum', options: ['own', 'inline'], default: 'own',
@@ -192,7 +187,6 @@ export function captionDialsFrom(values: SettingsValues): CaptionDials {
     placeGray: values.placeGray as number,
     lineGap: values.lineGap as number,
     timeStyle: values.timeStyle as TimeStyle,
-    hereTime: values.hereTime as HereTime,
     timeLine: values.timeLine as TimeLine,
     timeGap: values.timeGap as number,
     timeSize: values.timeSize as number,

--- a/app/lib/solo/settingsSchema.test.ts
+++ b/app/lib/solo/settingsSchema.test.ts
@@ -20,7 +20,7 @@ describe('SOLO_SETTINGS_SCHEMA', () => {
       font: 'system', feedPrefix: true, titleClean: 'compass',
       titleSize: 21, titleWeight: '300', titleGray: 71,
       placeSize: 17, placeGray: 57, lineGap: 0,
-      timeStyle: '12h-there', hereTime: 'off', timeLine: 'own', timeGap: 0, timeSize: 12, timeGray: 46,
+      timeStyle: 'ago', timeLine: 'own', timeGap: 0, timeSize: 12, timeGray: 46,
     });
   });
 

--- a/app/lib/solo/types.ts
+++ b/app/lib/solo/types.ts
@@ -38,15 +38,9 @@ export interface BinEntry {
 export type CaptionLayout = 'overlay' | 'inset';
 export type CaptionAlign = 'picture' | 'center' | 'panel';
 /** The time part of the caption (solo2 spec §4.5). */
-export type TimeStyle = 'off' | '12h' | '12h-there' | '24h' | 'sun' | '12h-sun';
+export type TimeStyle = 'off' | '12h' | '12h-there' | '24h' | 'sun' | '12h-sun' | 'ago';
 /** The time on its own line, or after the place with a middle dot. */
 export type TimeLine = 'own' | 'inline';
-/**
- * Whether the glass's own clock is written beside the camera's, and what
- * shape it takes: "7:42 pm there · 10:42 am here" against "7:42 pm there
- * (10:42 am)". One instant read on two clocks, which is the point of it.
- */
-export type HereTime = 'off' | 'dot' | 'parens' | 'parens-bare' | 'dash' | 'comma';
 /** What to do with Windy's "City › Compass: Spot" titles. */
 export type TitleClean = 'raw' | 'comma' | 'dot' | 'compass' | 'spot';
 export type TitleWeight = '300' | '400' | '500' | '600';
@@ -77,8 +71,6 @@ export interface CaptionDials {
   placeGray: number;
   lineGap: number;
   timeStyle: TimeStyle;
-  /** The glass's own clock beside the camera's, and its shape; 'off' for neither. */
-  hereTime: HereTime;
   timeLine: TimeLine;
   /** Extra space above the time line, on top of lineGap; own-line time only. */
   timeGap: number;

--- a/app/lib/solo2/settingsSchema.test.ts
+++ b/app/lib/solo2/settingsSchema.test.ts
@@ -34,7 +34,7 @@ describe('solo2 settings schema', () => {
     const d = dialsFrom2(schemaDefaults(SOLO2_SETTINGS_SCHEMA));
     expect(d).toMatchObject({
       leadS: 0, leadScale: 1.03, cameraRun: true,
-      timeStyle: '12h-there', valleys: 0, screens: 'together',
+      timeStyle: 'ago', valleys: 0, screens: 'together',
     });
     expect('prelude' in d).toBe(false);
     // Decided 2026-09-05: a camera change dips through black, the same camera dissolves.

--- a/app/studio/solo/GlassPreview.test.tsx
+++ b/app/studio/solo/GlassPreview.test.tsx
@@ -30,7 +30,7 @@ beforeAll(() => {
 
 it('draws each screen\'s current frame at the panel\'s true pixels with the studio dials, and says when a screen has nothing', () => {
   render(<GlassPreview screens={[{ feed: 'sunrise', server, projected: null }, { feed: 'sunset', server: null, projected: null }]}
-    dials={{ ...D, titleClean: 'spot' }} panel={{ width: 1920, height: 1080 }} />);
+    dials={{ ...D, titleClean: 'spot', timeStyle: '12h-there' }} panel={{ width: 1920, height: 1080 }} />);
   expect(screen.getByTestId('caption-title')).toHaveTextContent('Northern Lights webcam');
   expect(screen.getByTestId('caption-place')).toHaveTextContent('Porjus, Norrbotten County, Sweden');
   expect(screen.getByTestId('caption-time')).toHaveTextContent('8:46 pm there');


### PR DESCRIPTION
## What

The caption's time reading becomes how long ago the picture was taken.

```
Sunset: Split
Split-Dalmatia County, Croatia
13 minutes ago
```

Two clocks said the same thing the long way: the reader had to hold a foreign time against their own and do the subtraction. The subtraction is the message, so the caption does it.

`ago` joins the existing time dial and is the new default. `just now` under a minute, then `13 minutes ago`, `1 hour 5 minutes ago`, and `2 hours ago` on a round hour. Past a day it reads `1 day 1 hour ago`, for a camera that has gone quiet.

It needs neither a timezone nor a sun angle, so unlike every other style it always says something.

## The countdown

Inside a camera run the frames step forward in capture time, so the reading counts down. Against the live pool:

```
2 hours 2 minutes ago
1 hour 50 minutes ago
1 hour 39 minutes ago
```

Both readings are measured against one wall clock, so the only difference between them is how much older one picture is than the other. A tick of the clock between the two would make the gap look larger than it is.

## Removed

The "my time too" dial and its five shapes, along with the here-clock machinery behind them. The Picture tab ends up with one row fewer than before that dial existed. Its stored value is unknown to the schema now and is dropped on merge.

## What the numbers will actually say

I measured the live pool before building this, since the whole idea rests on frames being recent.

| newest frame per camera | minutes |
|---|---|
| median | 13.7 |
| 25th percentile | 8.1 |
| 75th percentile | 50.2 |

Half the cameras have something under 15 minutes old. The pool as a whole is older, median 65 minutes, because it holds each camera's history, which is what gives a run something to count down from. Capture timestamps check out against the wall clock, no timezone skew.

## One thing deliberately not built

The number is computed when the frame is drawn, so a frame sitting alone on screen freezes its count until the next frame arrives. Inside a run that is every few seconds, so it never shows. On a lone frame it could sit up to the dwell. A once-a-minute tick is the fix if it reads wrong on the glass; better to see it first than add a timer nobody needs.

## Testing

Full suite green (2464 tests), build clean. New coverage for every wording boundary, the future-capture and no-timezone cases, the countdown, and the single-clock guarantee. Tests that were asserting the old default clock now pin it explicitly, since the new default moves with the wall clock.

No migration. After merge, pick `ago` on the time dial in /studio, because the live row has an explicit style stored. Then `bash scripts/pi/kiosk-doctor.sh --sync --reload`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BHS436fcGJfTLCPfQmrSnp
