### PR TITLE
fix(leaderboard): say sunrise or sunset from the sun, not from a judge

### DIFF
--- a/app/api/leaderboards/route.test.ts
+++ b/app/api/leaderboards/route.test.ts
@@ -106,4 +106,57 @@ describe('GET /api/leaderboards', () => {
     expect(text).not.toMatch(/s\.webcam_id = /i);
     expect(params).toEqual([60]);
   });
+
+  // Kasane: Chobe Savanna Lodge, the camera whose board entry announced itself
+  // as a sunrise. Coordinates and capture times are the real archive rows.
+  const kasane = (over: Record<string, unknown>) => ({
+    id: 82891,
+    llmQuality: '0.820',
+    llmIsSunset: true,
+    llmIsSunrise: true,
+    firebaseUrl: 'https://storage.googleapis.com/f.jpg',
+    webcamId: 2926965,
+    webcamTitle: 'Kasane: Chobe Savanna Lodge - Chobe National Park',
+    country: 'Botswana',
+    lat: -17.8306,
+    lng: 25.05327,
+    ...over,
+  });
+
+  it('reads captured_at as UTC — a naive column read raw is hours off', async () => {
+    await GET(req());
+    const [text] = sqlQueryMock.mock.calls[0];
+    expect(text).toMatch(/\(s\.captured_at AT TIME ZONE 'UTC'\) AS "capturedAt"/i);
+  });
+
+  it('selects the coordinates the phase is computed from, as numbers', async () => {
+    await GET(req());
+    const [text] = sqlQueryMock.mock.calls[0];
+    expect(text).toMatch(/w\.lat::float8 AS "lat"/i);
+    expect(text).toMatch(/w\.lng::float8 AS "lng"/i);
+  });
+
+  it('stamps phase from the sun, not from Claude — a climbing sun is a sunrise', async () => {
+    // Claude says sunrise AND sunset here, which is why the frame is on a
+    // sunset board at all. The sun was on the horizon and climbing.
+    sqlQueryMock.mockResolvedValue([kasane({ capturedAt: '2026-03-14T04:27:24.354Z' })]);
+    const body = await (await GET(req())).json();
+    expect(body.entries[0].phase).toBe('sunrise');
+  });
+
+  it('calls a falling sun a sunset even when Claude called it a sunrise', async () => {
+    sqlQueryMock.mockResolvedValue([
+      kasane({ capturedAt: '2026-03-14T15:44:35.470Z', llmIsSunrise: true }),
+    ]);
+    const body = await (await GET(req())).json();
+    expect(body.entries[0].phase).toBe('sunset');
+  });
+
+  it('leaves phase null when the row has no coordinate to compute from', async () => {
+    sqlQueryMock.mockResolvedValue([
+      kasane({ capturedAt: '2026-03-14T04:27:24.354Z', lat: null, lng: null }),
+    ]);
+    const body = await (await GET(req())).json();
+    expect(body.entries[0].phase).toBeNull();
+  });
 });

--- a/app/api/leaderboards/route.ts
+++ b/app/api/leaderboards/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server';
 import { sql } from '@/app/lib/db';
+import { solarPhaseOf, type SolarPhase } from '@/app/lib/solarPhase';
 
 export const dynamic = 'force-dynamic';
 
@@ -76,10 +77,25 @@ export interface LeaderboardEntry {
   aiModelVersionRegression: string | null;
   sortScore: number | string | null; // COALESCE(llm_quality, ai_regression_score) — the rank key
   firebaseUrl: string | null;
+  /** UTC. The column is naive, so the query converts it; see solarPhase.ts. */
   capturedAt: string;
   webcamId: number;
   webcamTitle: string | null;
   country: string;
+  lat: number | null;
+  lng: number | null;
+  /**
+   * Sunrise or sunset, computed from the sun's own position at this camera at
+   * this moment — the one label on this row that is not somebody's opinion.
+   * Null only when the camera has no usable coordinate or time.
+   *
+   * It is NOT the frame's admission ticket: a frame is on this board because
+   * Claude called it a sunset, and Claude answers yes to both questions on a
+   * sky that could be either. 6,590 of the 21,061 eligible frames are
+   * geometrically sunrises (2026-09-08). Labeling them honestly is this
+   * field's job; whether the board should carry them is a separate decision.
+   */
+  phase: SolarPhase | null;
 }
 
 function pick<T>(value: string | null, allowed: readonly T[], fallback: T): T {
@@ -122,10 +138,17 @@ export async function GET(request: Request) {
       s.ai_model_version_regression AS "aiModelVersionRegression",
       COALESCE(s.llm_quality, s.ai_regression_score) AS "sortScore",
       s.firebase_url AS "firebaseUrl",
-      s.captured_at AS "capturedAt",
+      -- captured_at is timestamp WITHOUT time zone holding UTC digits. Read
+      -- raw, the driver reinterprets those digits in the server's local zone
+      -- and every solar angle computed from them is hours off.
+      (s.captured_at AT TIME ZONE 'UTC') AS "capturedAt",
       s.webcam_id AS "webcamId",
       w.title AS "webcamTitle",
-      COALESCE(w.country, 'Unknown') AS country
+      COALESCE(w.country, 'Unknown') AS country,
+      -- NUMERIC through this driver is a string; cast so the solar math gets
+      -- numbers rather than silently comparing "47.606200" to a float.
+      w.lat::float8 AS "lat",
+      w.lng::float8 AS "lng"
     `;
     // Claude-primary with a real-model fallback. The fallback clause is inert
     // until ai_regression_score is backfilled (U3). Never reads junk ai_rating.
@@ -160,7 +183,14 @@ export async function GET(request: Request) {
       `;
     }
 
-    const rows = (await sql.query(queryText, params)) as LeaderboardEntry[];
+    const raw = (await sql.query(queryText, params)) as LeaderboardEntry[];
+    // The sun says which it is. Computed here, once, so every surface that
+    // renders a board entry reads the same answer instead of each deciding
+    // from whichever flag it happens to have.
+    const rows: LeaderboardEntry[] = raw.map((row) => ({
+      ...row,
+      phase: solarPhaseOf(row.capturedAt, row.lat, row.lng),
+    }));
 
     return NextResponse.json(
       { grouping, window, count: rows.length, entries: rows },

--- a/app/components/Leaderboard/LeaderboardTab.tsx
+++ b/app/components/Leaderboard/LeaderboardTab.tsx
@@ -36,6 +36,8 @@ interface Entry {
   webcamId: number;
   webcamTitle: string | null;
   country: string;
+  /** Sunrise or sunset from the sun's position, computed by the route. */
+  phase: 'sunrise' | 'sunset' | null;
 }
 
 const fetcher = (url: string) =>
@@ -86,7 +88,12 @@ function entryToWebcam(e: Entry): WindyWebcam {
     images: { current: { preview: e.firebaseUrl ?? '' } },
     location: { country: e.country, longitude: 0, latitude: 0 },
     categories: [],
-    phase: e.llmIsSunrise ? 'sunrise' : 'sunset',
+    // The sun's position at this camera at this moment, from the route — not
+    // Claude's llm_is_sunrise flag, which used to decide this word. That flag
+    // is a judgment about the picture and it says yes to both questions on a
+    // sky that could be either, so a genuine sunrise on this board announced
+    // itself as one only by accident and a genuine sunset could too.
+    phase: e.phase,
     // Claude (third judge) — real fields, no longer faked into model slots.
     llmQuality,
     llmIsSunset: e.llmIsSunset,

--- a/app/lib/solarPhase.test.ts
+++ b/app/lib/solarPhase.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest';
+import { solarPhaseAt, solarPhaseOf, sunAltitudeDeg } from './solarPhase';
+
+// Kasane, Botswana — the camera that started this: "Kasane: Chobe Savanna
+// Lodge". Both frames below are real archive rows, and the two labels we used
+// to trust disagree about them, which is the point of computing it instead.
+const KASANE = { lat: -17.8306, lng: 25.05327 };
+const utc = (iso: string) => new Date(iso);
+
+describe('solarPhaseAt', () => {
+  it('calls a climbing sun a sunrise', () => {
+    // Snapshot 82891, 06:27 local, sun on the horizon. Claude scored it 0.82
+    // and it ranks 8th on a board titled Best Sunsets.
+    const at = utc('2026-03-14T04:27:24Z');
+    expect(sunAltitudeDeg(at, KASANE.lat, KASANE.lng)).toBeCloseTo(0.3, 0);
+    expect(solarPhaseAt(at, KASANE.lat, KASANE.lng)).toBe('sunrise');
+  });
+
+  it('calls a falling sun a sunset', () => {
+    const at = utc('2026-03-14T15:44:35Z'); // snapshot 85701, sun at +11°
+    expect(solarPhaseAt(at, KASANE.lat, KASANE.lng)).toBe('sunset');
+  });
+
+  it('disagrees with the stored phase column when the column is wrong', () => {
+    // Snapshot 119355 is stored as phase 'sunset'; the sun was below the
+    // horizon and climbing, so it is a pre-dawn frame.
+    const at = utc('2026-07-31T04:15:56Z');
+    expect(sunAltitudeDeg(at, KASANE.lat, KASANE.lng)).toBeLessThan(0);
+    expect(solarPhaseAt(at, KASANE.lat, KASANE.lng)).toBe('sunrise');
+  });
+
+  it('holds inside the polar circle, where the sun can climb without rising', () => {
+    // Longyearbyen in midsummer: the sun never sets, so an azimuth-crossing
+    // test has nothing to cross. Local midnight is still the sunrise half.
+    const svalbard = { lat: 78.22, lng: 15.65 };
+    // Solar midnight there is ~22:52 UTC; half an hour past it the sun is
+    // climbing again, 11.8° up and never having touched the horizon.
+    const midnight = utc('2026-06-21T23:30:00Z');
+    const afternoon = utc('2026-06-21T13:00:00Z');
+    expect(sunAltitudeDeg(midnight, svalbard.lat, svalbard.lng)).toBeGreaterThan(0);
+    expect(solarPhaseAt(midnight, svalbard.lat, svalbard.lng)).toBe('sunrise');
+    expect(solarPhaseAt(afternoon, svalbard.lat, svalbard.lng)).toBe('sunset');
+  });
+});
+
+describe('solarPhaseOf', () => {
+  it('accepts the shapes a database row arrives in', () => {
+    expect(solarPhaseOf('2026-03-14T04:27:24Z', KASANE.lat, KASANE.lng)).toBe('sunrise');
+    expect(solarPhaseOf(utc('2026-03-14T15:44:35Z'), KASANE.lat, KASANE.lng)).toBe('sunset');
+    expect(solarPhaseOf(Date.parse('2026-03-14T15:44:35Z'), KASANE.lat, KASANE.lng)).toBe('sunset');
+  });
+
+  it('says nothing rather than guessing when the row cannot answer', () => {
+    expect(solarPhaseOf(null, KASANE.lat, KASANE.lng)).toBeNull();
+    expect(solarPhaseOf('2026-03-14T04:27:24Z', null, KASANE.lng)).toBeNull();
+    expect(solarPhaseOf('2026-03-14T04:27:24Z', KASANE.lat, undefined)).toBeNull();
+    expect(solarPhaseOf('not a date', KASANE.lat, KASANE.lng)).toBeNull();
+    expect(solarPhaseOf('2026-03-14T04:27:24Z', Number.NaN, KASANE.lng)).toBeNull();
+  });
+});

--- a/app/lib/solarPhase.ts
+++ b/app/lib/solarPhase.ts
@@ -1,0 +1,57 @@
+import SunCalc from 'suncalc';
+
+/**
+ * Sunrise or sunset, decided by where the sun actually was — not by what a
+ * judge said about the picture and not by which sweep bucket a camera sat in
+ * when the frame was captured.
+ *
+ * A place and a moment are enough. The sun is either climbing or falling, and
+ * that is the whole distinction, so this is ground truth wherever we have a
+ * latitude, a longitude and a capture time. Measured against the 21,061
+ * leaderboard-eligible frames on 2026-09-08, the two labels we had been using
+ * instead disagree with it often: the stored `webcam_snapshots.phase` on
+ * 3,658 frames (17%), and Claude's `llm_is_sunrise` flag on 6,493 (31%).
+ *
+ * ⚠️ `webcam_snapshots.captured_at` is `timestamp WITHOUT time zone` holding
+ * UTC digits, and the Neon driver hands it back as a Date shifted by the
+ * server's local offset. Read it as `captured_at AT TIME ZONE 'UTC'` (or
+ * `::text` plus a `Z`) before passing it here, or every altitude is hours off.
+ */
+export type SolarPhase = 'sunrise' | 'sunset';
+
+const DEG_PER_RAD = 180 / Math.PI;
+const TEN_MINUTES_MS = 10 * 60 * 1000;
+
+/** Solar altitude above the horizon at a place and moment, degrees. Negative below. */
+export function sunAltitudeDeg(at: Date, lat: number, lng: number): number {
+  return SunCalc.getPosition(at, lat, lng).altitude * DEG_PER_RAD;
+}
+
+/**
+ * Which half of the day a moment belongs to: a climbing sun is a sunrise, a
+ * falling sun is a sunset. Compared over ten minutes rather than read off the
+ * azimuth, which keeps it correct at every latitude including inside the
+ * polar circles, where the sun can circle the sky without setting.
+ */
+export function solarPhaseAt(at: Date, lat: number, lng: number): SolarPhase {
+  const now = sunAltitudeDeg(at, lat, lng);
+  const later = sunAltitudeDeg(new Date(at.getTime() + TEN_MINUTES_MS), lat, lng);
+  return later > now ? 'sunrise' : 'sunset';
+}
+
+/**
+ * The same call for a row that may be missing a coordinate or a time. Null,
+ * never a guess: a surface that cannot say which it is should say neither
+ * rather than pick one.
+ */
+export function solarPhaseOf(
+  at: Date | string | number | null | undefined,
+  lat: number | null | undefined,
+  lng: number | null | undefined,
+): SolarPhase | null {
+  if (lat == null || lng == null || at == null) return null;
+  if (!Number.isFinite(lat) || !Number.isFinite(lng)) return null;
+  const moment = at instanceof Date ? at : new Date(at);
+  if (Number.isNaN(moment.getTime())) return null;
+  return solarPhaseAt(moment, lat, lng);
+}

--- a/app/lib/solo/zone.ts
+++ b/app/lib/solo/zone.ts
@@ -1,19 +1,16 @@
-import SunCalc from 'suncalc';
+import { solarPhaseAt, sunAltitudeDeg } from '@/app/lib/solarPhase';
 import type { Feed } from './types';
 
-const DEG_PER_RAD = 180 / Math.PI;
-const TEN_MINUTES_MS = 10 * 60 * 1000;
+export { sunAltitudeDeg };
 
-/** Solar altitude above the horizon at a place and moment, degrees. Negative below. */
-export function sunAltitudeDeg(at: Date, lat: number, lng: number): number {
-  return SunCalc.getPosition(at, lat, lng).altitude * DEG_PER_RAD;
-}
-
-/** Which feed a place belongs to right now: rising sun is sunrise, falling is sunset. */
+/**
+ * Which feed a place belongs to right now: rising sun is sunrise, falling is
+ * sunset. The test itself lives in `app/lib/solarPhase.ts`, because the same
+ * question is asked of an archived frame on the leaderboard. A `Feed` and a
+ * `SolarPhase` are the same two words, so this is a name, not a conversion.
+ */
 export function feedAt(at: Date, lat: number, lng: number): Feed {
-  const now = sunAltitudeDeg(at, lat, lng);
-  const later = sunAltitudeDeg(new Date(at.getTime() + TEN_MINUTES_MS), lat, lng);
-  return later > now ? 'sunrise' : 'sunset';
+  return solarPhaseAt(at, lat, lng);
 }
 
 /** The swept altitude band, from sweepGeometry's coverage span. */


### PR DESCRIPTION
Jesse spotted "Kasane: Chobe Savanna Lodge" on the Best Sunsets board announcing itself as a sunrise, and asked the right question: don't we know from time and geography which one it is?

We do. Nothing was ever asking the sun.

## What the card was reading

`LeaderboardTab` took the word from Claude's `llm_is_sunrise` flag. That is a judgment about the picture, and Claude answers yes to **both** questions on a sky that reads as either, so on 4,873 eligible frames sunrise simply won a ternary. Frames Claude never scored fall to the other side of the same ternary and are called sunsets by default.

The camera data was never wrong. That camera is on the sunset side of the terminator right now, correctly. The frame that put it on the board is a genuine sunrise from March, captured with the sun 0.3° above the horizon and climbing.

## What it reads now

`app/lib/solarPhase.ts` holds one test: the sun is climbing or it is falling. That is the whole distinction, and a latitude, a longitude and a moment settle it. `app/lib/solo/zone.ts` had this test already for the kiosk feeds; it now names the shared one instead of repeating it. The route stamps `phase` on every entry, and the card reads that.

Measured over the 21,061 frames the board is eligible to show (2026-09-08), against the labels we had been trusting:

| label | disagrees with the sun on |
| --- | --- |
| stored `webcam_snapshots.phase` | 3,658 (17%) |
| Claude's `llm_is_sunrise` | 6,493 (31%) |

Also fixes `captured_at` on this route. The column is `timestamp WITHOUT time zone` holding UTC digits, so read raw the driver reinterprets them in the server's local zone and every angle derived from them is hours off. Neither consumer read the field yet. The solar math does.

## Two things this makes visible and does not fix

**The board is half sunrises.** The all-time top 100 came back 51 sunrises to 49 sunsets. Admission is Claude's `llm_is_sunset`, which asks whether the sky looks like a sunset, not which half of the day it was. Every one of those cards will now say so out loud. Whether Best Sunsets should carry them is a product decision, so it is Jesse's to make, not mine to smuggle into a bug fix.

**The stored phase column is written from the wrong source.** The capture cron stamps whichever sweep bucket the camera sat in, not the sun at that moment. That is the 17% above, and fixing it means changing ingest plus backfilling the archive. Separate change.

## Verification

- 2,475 tests pass, `npm run lint` clean of new warnings, `npm run build` green.
- New tests cover the two real Kasane frames, a stored-phase disagreement, and a Svalbard midsummer case where the sun circles without ever setting and an azimuth test would have nothing to cross.
- Checked live against production data through the running route, not only through mocks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DMBNGcwjKJUxWxGUu9AbK3
