### PR TITLE
feat(solo2): the dwell spread becomes a boost and a trim, set apart

### DIFF
--- a/app/lib/solo/replay.test.ts
+++ b/app/lib/solo/replay.test.ts
@@ -118,7 +118,7 @@ describe('replay', () => {
   });
 
   it('solo2 stretches the clock by each draw\u2019s own budget, not by the dial', () => {
-    const d2 = { ...dialsFrom2(schemaDefaults(SOLO2_SETTINGS_SCHEMA)), dwellS: 20, offsetS: 10, cameraRun: true, dwellSpread: 0 };
+    const d2 = { ...dialsFrom2(schemaDefaults(SOLO2_SETTINGS_SCHEMA)), dwellS: 20, offsetS: 10, cameraRun: true, dwellBoost: 0, dwellTrim: 0 };
     // One camera with eight frames: past n* the budget floor stretches the dwell.
     const many = [1, 2, 3, 4, 5, 6, 7, 8].map((i) => sun(i, 0.9 - i * 0.01, { webcamId: 7, capturedAt: i }));
     const strip = replay({ feed: FEED, version: SOLO_VERSIONS.solo2, dials: d2, entries: many, priorDraws: [], fromMs: at(SLOT0), toMs: at(SLOT0) + 1 });
@@ -163,7 +163,7 @@ describe('replay', () => {
   });
 
   it('solo2 marks every frame of the camera run shown, and the strip carries them', () => {
-    const d2 = { ...dialsFrom2(schemaDefaults(SOLO2_SETTINGS_SCHEMA)), dwellS: 20, offsetS: 10, cameraRun: true, dwellSpread: 0 };
+    const d2 = { ...dialsFrom2(schemaDefaults(SOLO2_SETTINGS_SCHEMA)), dwellS: 20, offsetS: 10, cameraRun: true, dwellBoost: 0, dwellTrim: 0 };
     const rows = [
       sun(1, 0.9, { webcamId: 7, capturedAt: 100 }), sun(3, 0.7, { webcamId: 7, capturedAt: 300 }),
       sun(2, 0.8, { webcamId: 8, capturedAt: 150 }),

--- a/app/lib/solo/versions.test.ts
+++ b/app/lib/solo/versions.test.ts
@@ -37,7 +37,7 @@ describe('descriptors', () => {
     // renders toward a dwell end follows without knowing about versions.
     for (const v of Object.values(SOLO_VERSIONS)) {
       // solo2's spread swings the budget by rank; pinned so the dwell is the dial here.
-      const d = { ...v.dialsFrom(schemaDefaults(v.schema)), dwellSpread: 0 };
+      const d = { ...v.dialsFrom(schemaDefaults(v.schema)), dwellBoost: 0, dwellTrim: 0 };
       // solo2's dwell opens with the camera change's own segment (dwell-budget
       // spec §3.3); solo's dials have no fades, so its arrival is 0.
       const expected = (d.dwellS + arrivalS(d)) * 1000;

--- a/app/lib/solo2/engine.test.ts
+++ b/app/lib/solo2/engine.test.ts
@@ -16,7 +16,7 @@ import type { Solo2Dials } from './types';
 
 // The spread swings each draw's budget by rank; these tests are about the
 // budget rule itself, so they pin it to the dial.
-const D: Solo2Dials = { ...dialsFrom2(schemaDefaults(SOLO2_SETTINGS_SCHEMA)), dwellSpread: 0 };
+const D: Solo2Dials = { ...dialsFrom2(schemaDefaults(SOLO2_SETTINGS_SCHEMA)), dwellBoost: 0, dwellTrim: 0 };
 const S0: ScreenState = { lastSnapshotId: null, sunsetStreak: 0 };
 
 function sun(id: number, q: number, extra: Partial<BinEntry> = {}): BinEntry {
@@ -162,7 +162,7 @@ describe('the camera run', () => {
 
 describe('dwellMs2: the budget rule over the frames actually played', () => {
   // The spread swings the budget by rank; this suite is about the rule, so it pins the dial.
-  const D2 = { ...dialsFrom2(schemaDefaults(SOLO2_SETTINGS_SCHEMA)), cameraRun: true, dwellSpread: 0 };
+  const D2 = { ...dialsFrom2(schemaDefaults(SOLO2_SETTINGS_SCHEMA)), cameraRun: true, dwellBoost: 0, dwellTrim: 0 };
   // The camera change's own segment at the default fades (dwell-budget spec
   // §3.3): every dwell is this much longer than the frames' budget.
   const ARRIVAL = 1_500;

--- a/app/lib/solo2/run.test.ts
+++ b/app/lib/solo2/run.test.ts
@@ -131,8 +131,8 @@ describe('the run by rank: the peak buys screen time, a grey sunset gives it bac
   });
 });
 
-describe('the dwell spread: a grey frame gives back a little time, the best sunset takes a little more', () => {
-  const d = { dwellS: 13, dwellSpread: 25, runFramesSunset: 16, runFramesOther: 5, runShape: 'rank' as const };
+describe('the dwell boost and trim: a grey frame gives back a little time, the best sunset takes a little more', () => {
+  const d = { dwellS: 13, dwellBoost: 25, dwellTrim: 25, runFramesSunset: 16, runFramesOther: 5, runShape: 'rank' as const };
   const pool = [
     f(1, 1, 1000, { quality: 0.2 }),
     f(2, 2, 1000, { quality: 0.6 }),
@@ -145,9 +145,15 @@ describe('the dwell spread: a grey frame gives back a little time, the best suns
     expect(budgetS(pool[1], d, pool)).toBeCloseTo(13);
     expect(budgetS(pool[2], d, pool)).toBeCloseTo(16.25);
   });
-  it('0 spread is the dial for everyone', () => {
-    expect(budgetS(pool[3], { ...d, dwellSpread: 0 }, pool)).toBe(13);
-    expect(budgetS(pool[2], { ...d, dwellSpread: 0 }, pool)).toBe(13);
+  it('both at 0 is the dial for everyone', () => {
+    expect(budgetS(pool[3], { ...d, dwellBoost: 0, dwellTrim: 0 }, pool)).toBe(13);
+    expect(budgetS(pool[2], { ...d, dwellBoost: 0, dwellTrim: 0 }, pool)).toBe(13);
+  });
+  it('the two ends are set apart: a big boost does not shorten grey frames, and no trim leaves them at the dial', () => {
+    expect(budgetS(pool[2], { ...d, dwellBoost: 100, dwellTrim: 0 }, pool)).toBeCloseTo(26);
+    expect(budgetS(pool[3], { ...d, dwellBoost: 100, dwellTrim: 0 }, pool)).toBe(13);
+    expect(budgetS(pool[0], { ...d, dwellBoost: 100, dwellTrim: 0 }, pool)).toBe(13);
+    expect(budgetS(pool[1], { ...d, dwellBoost: 100, dwellTrim: 0 }, pool)).toBeCloseTo(19.5);
   });
   it('flat shape: every sunset is the strongest, non-sunsets still below', () => {
     expect(budgetS(pool[0], { ...d, runShape: 'flat' }, pool)).toBeCloseTo(16.25);

--- a/app/lib/solo2/run.ts
+++ b/app/lib/solo2/run.ts
@@ -95,28 +95,32 @@ function standing<T extends RunEntry>(e: Pick<BinEntry, 'bin'> & Partial<T>, d: 
   return qualityRank(e as T, entries, cameraRun);
 }
 
+/** The two ends the budget swings between, as dial fields; both optional so older callers read as the dial. */
+export interface BudgetDials { dwellS: number; dwellBoost?: number; dwellTrim?: number }
+
 /**
  * The dwell budget for a draw of `e`, seconds (the `dwellS` the budget rule
- * of the dwell-budget spec §3 then shares among the run's frames). The dial
- * is the middle: a non-sunset and the weakest sunset present get the dial
- * less the spread, the strongest sunset present gets the dial plus it, and
- * sunsets between sit by rank. So a grey frame gives back a little screen
- * time and the best sunset on offer takes a little more — the same shape as
- * the frame cap, applied to the clock, so a lone frame with no run to
- * lengthen still feels the difference.
+ * of the dwell-budget spec §3 then shares among the run's frames). A
+ * non-sunset, and the weakest sunset present, hold the dial less the trim;
+ * the strongest sunset present holds the dial plus the boost; sunsets
+ * between sit by rank. Two dials rather than one spread so the top and the
+ * bottom can be set apart: how long the best may run and how short a grey
+ * frame may get are different worries. The same shape as the frame cap,
+ * applied to the clock, so a lone frame with no run to lengthen still
+ * feels the difference.
  */
 export function budgetS<T extends RunEntry>(
-  e: Pick<BinEntry, 'bin'> & Partial<T>, d: CapDials & { dwellS: number; dwellSpread?: number },
-  entries?: T[], cameraRun = true,
+  e: Pick<BinEntry, 'bin'> & Partial<T>, d: CapDials & BudgetDials, entries?: T[], cameraRun = true,
 ): number {
-  const spread = (d.dwellSpread ?? 0) / 100;
-  if (spread === 0) return d.dwellS;
+  const boost = (d.dwellBoost ?? 0) / 100;
+  const trim = (d.dwellTrim ?? 0) / 100;
+  if (boost === 0 && trim === 0) return d.dwellS;
   const rank = e.bin === 'sunset' ? standing(e, d, entries, cameraRun) : 0;
-  return d.dwellS * (1 - spread + 2 * spread * rank);
+  return d.dwellS * (1 - trim + (trim + boost) * rank);
 }
 
 /** `d` with its dwell replaced by the draw's budget, ready for fitPlan. */
-export function planDialsFor<T extends RunEntry, D extends CapDials & { dwellS: number; dwellSpread?: number }>(
+export function planDialsFor<T extends RunEntry, D extends CapDials & BudgetDials>(
   e: Pick<BinEntry, 'bin'> & Partial<T>, d: D, entries?: T[], cameraRun = true,
 ): D {
   return { ...d, dwellS: budgetS(e, d, entries, cameraRun) };

--- a/app/lib/solo2/settingsSchema.ts
+++ b/app/lib/solo2/settingsSchema.ts
@@ -49,9 +49,14 @@ export const SOLO2_SETTINGS_SCHEMA: SettingsSchema = [
     description: 'rank: a sunset\u2019s run is measured against the other sunsets on offer. The best one present plays the whole sunset cap, the weakest plays no longer than a non-sunset, and the rest sit between, so a strong sunset buys screen time and a grey one gives it back. flat: every sunset may play the whole cap, whatever else is present.',
   },
   {
-    key: 'dwellSpread', kind: 'number', min: 0, max: 50, step: 5, default: 25,
-    label: 'dwell spread (%)', section: 'glass',
-    description: 'How far a draw\u2019s dwell swings from the dial. A non-sunset, and the weakest sunset present, hold for the dial less this; the strongest sunset present holds for the dial plus it; the rest sit between by rank. At 13 s and 25% that is 9.75 s for a grey frame and 16.25 s for the best sunset on offer. A camera run\u2019s frames share the swung budget, so a strong sunset\u2019s timelapse is longer twice over. 0 gives every draw the dial.',
+    key: 'dwellBoost', kind: 'number', min: 0, max: 100, step: 5, default: 25,
+    label: 'best sunset holds longer (%)', section: 'glass',
+    description: 'How much more than the dwell the strongest sunset present holds; sunsets below it get a share of this by rank, down to the trim at the bottom. At 13 s and 25% the best sunset on offer holds 16.25 s. A camera run\u2019s frames share the longer budget, so a strong sunset\u2019s timelapse is longer twice over; the most-frames dial still caps how long that can run. 0 = the dwell.',
+  },
+  {
+    key: 'dwellTrim', kind: 'number', min: 0, max: 50, step: 5, default: 25,
+    label: 'grey frame holds shorter (%)', section: 'glass',
+    description: 'How much less than the dwell a non-sunset holds, and the weakest sunset present with it. At 13 s and 25% that is 9.75 s. 0 = the dwell; a non-sunset can never hold longer than the dwell whatever the boost says.',
   },
   {
     key: 'leadS', kind: 'number', min: 0, max: 10, step: 0.5, default: 0,
@@ -137,7 +142,8 @@ export function dialsFrom2(values: SettingsValues): Solo2Dials {
     runFramesSunset: values.runFramesSunset as number,
     runFramesOther: values.runFramesOther as number,
     runShape: values.runShape as RunShape,
-    dwellSpread: values.dwellSpread as number,
+    dwellBoost: values.dwellBoost as number,
+    dwellTrim: values.dwellTrim as number,
     veilStyle: values.veilStyle as VeilStyle,
     veilTint: values.veilTint as VeilTint,
     burnLift: values.burnLift as number,

--- a/app/lib/solo2/types.ts
+++ b/app/lib/solo2/types.ts
@@ -58,12 +58,10 @@ export interface Solo2Dials extends SoloDials {
   runFramesOther: number;
   /** Flat: every sunset may play the sunset cap. Rank: a sunset's run sits between the two caps by its rank among the sunsets present. */
   runShape: RunShape;
-  /**
-   * How far a draw's dwell budget swings from the dial, percent. A non-sunset
-   * and the weakest sunset present get the dial less this; the strongest
-   * sunset present gets the dial plus it. 0 gives every draw the dial.
-   */
-  dwellSpread: number;
+  /** How much more than the dial the strongest sunset present holds, percent. Sunsets below it get a share by rank. 0 = the dial. */
+  dwellBoost: number;
+  /** How much less than the dial a non-sunset, and the weakest sunset present, hold, percent. 0 = the dial. */
+  dwellTrim: number;
   /** What a camera change dips through; the sunset screen stays black under all of them. */
   veilStyle: VeilStyle;
   /** The tint a `light` sunrise dips through. Ignored by every other style. */

--- a/app/studio/solo/GlassPreview.test.tsx
+++ b/app/studio/solo/GlassPreview.test.tsx
@@ -70,7 +70,7 @@ it('solo2 plays the on-glass camera\'s run on the studio dials, looping on a loc
   vi.useFakeTimers();
   // 3 frames → 2 s each, after the 1.5 s arrival segment the default dip adds
   // at the front of every solo2 dwell (dwell-budget spec §3.3): 7.5 s a dwell.
-  const d2 = { ...dialsFrom2(schemaDefaults(SOLO2_SETTINGS_SCHEMA)), dwellS: 6, sameCameraFadeS: 1, minStepS: 1, dwellSpread: 0 };
+  const d2 = { ...dialsFrom2(schemaDefaults(SOLO2_SETTINGS_SCHEMA)), dwellS: 6, sameCameraFadeS: 1, minStepS: 1, dwellBoost: 0, dwellTrim: 0 };
   const older = (id: number, capturedAt: number) => ({ ...entry, snapshotId: id, imageUrl: `u${id}`, capturedAt });
   const entries = [older(5, entry.capturedAt - 20 * 60_000), older(6, entry.capturedAt - 10 * 60_000), entry];
   const s2 = { ...server, entries } as unknown as StateView;
@@ -115,7 +115,7 @@ it('solo2 plays the queued dwell\'s own camera run once the preview advances', a
   const { SOLO_VERSIONS } = await import('@/app/lib/solo/versions');
   const { SOLO2_SETTINGS_SCHEMA, dialsFrom2 } = await import('@/app/lib/solo2/settingsSchema');
   vi.useFakeTimers();
-  const d2 = { ...dialsFrom2(schemaDefaults(SOLO2_SETTINGS_SCHEMA)), dwellS: 6, sameCameraFadeS: 1, minStepS: 1, dwellSpread: 0 };
+  const d2 = { ...dialsFrom2(schemaDefaults(SOLO2_SETTINGS_SCHEMA)), dwellS: 6, sameCameraFadeS: 1, minStepS: 1, dwellBoost: 0, dwellTrim: 0 };
   const cam2a = at(11, 2, entry.capturedAt - 30 * 60_000);
   const cam2b = at(12, 2, entry.capturedAt - 20 * 60_000);
   const s2 = { ...server, entries: [entry, cam2a, cam2b] } as unknown as StateView;
@@ -151,7 +151,7 @@ it('restarts the run\'s stage clock when the server advances a different camera 
   const { SOLO_VERSIONS } = await import('@/app/lib/solo/versions');
   const { SOLO2_SETTINGS_SCHEMA, dialsFrom2 } = await import('@/app/lib/solo2/settingsSchema');
   vi.useFakeTimers();
-  const d2 = { ...dialsFrom2(schemaDefaults(SOLO2_SETTINGS_SCHEMA)), dwellS: 6, sameCameraFadeS: 1, minStepS: 1, dwellSpread: 0 }; // 2 frames → 3 s each, after a 1.5 s arrival
+  const d2 = { ...dialsFrom2(schemaDefaults(SOLO2_SETTINGS_SCHEMA)), dwellS: 6, sameCameraFadeS: 1, minStepS: 1, dwellBoost: 0, dwellTrim: 0 }; // 2 frames → 3 s each, after a 1.5 s arrival
   const panel = { width: 1920, height: 1080 };
   const camAOlder = at(5, 1, entry.capturedAt - 20 * 60_000);
   const s2a = { current: { entry, shownSince: 0, slot: 1 }, entries: [camAOlder, entry] } as unknown as StateView;
@@ -188,7 +188,7 @@ it('a run restarts by rebuilding its stack, never by fading back down to an earl
   vi.useFakeTimers();
   // minStepS 2 keeps the 6 s dwell divided evenly by 3 rather than stretched,
   // so this test is about the stack and not about the budget.
-  const d2 = { ...dialsFrom2(schemaDefaults(SOLO2_SETTINGS_SCHEMA)), dwellS: 6, minStepS: 2, sameCameraFadeS: 1, dwellSpread: 0 }; // 3 frames → 2 s each, after a 1.5 s arrival
+  const d2 = { ...dialsFrom2(schemaDefaults(SOLO2_SETTINGS_SCHEMA)), dwellS: 6, minStepS: 2, sameCameraFadeS: 1, dwellBoost: 0, dwellTrim: 0 }; // 3 frames → 2 s each, after a 1.5 s arrival
   const older = (id: number, capturedAt: number) => ({ ...entry, snapshotId: id, imageUrl: `u${id}`, capturedAt });
   const entries = [older(5, entry.capturedAt - 20 * 60_000), older(6, entry.capturedAt - 10 * 60_000), entry];
   const s2 = { ...server, entries } as unknown as StateView;


### PR DESCRIPTION
## What

The symmetric dwell spread from #179 becomes two dials, so the top and the bottom can be set apart:

- **best sunset holds longer (%)** (`dwellBoost`, default 25). The strongest sunset present holds the dwell plus this; sunsets below it get a share by rank.
- **grey frame holds shorter (%)** (`dwellTrim`, default 25). A non-sunset, and the weakest sunset present, hold the dwell less this. At 0 a grey frame holds the full dwell whatever the boost says.

How long the best may run and how short a grey frame may get are different worries; one spread could not answer them separately. The most-frames dial still caps how long a run can go.

## Why this is its own PR

This commit was pushed to the #179 branch thirteen minutes after #179 merged, so it never reached main. Same change, new branch.

`dwellSpread` is dropped; a stored value for it is unknown to the schema and falls away on merge. Both new dials default to the old spread's 25, so the glass does not move on merge.

## Testing

Full suite green (2475), build clean. New test: a big boost never shortens a grey frame, and no trim leaves it at the dial.

No migration. After merge: `bash scripts/pi/kiosk-doctor.sh --sync --reload`, then the two dials appear in the studio's solo2 section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BHS436fcGJfTLCPfQmrSnp
