### PR TITLE
fix(caption): the words after the clock glide instead of jumping

### DIFF
--- a/app/components/solo/Caption.test.tsx
+++ b/app/components/solo/Caption.test.tsx
@@ -54,6 +54,26 @@ it('a run counts down, and only the digit that moved fades', () => {
   expect(screen.getByTestId('caption-time-out')).toHaveStyle({ animation: 'solo-time-out 1s ease both' });
 });
 
+it('the words after the digit are one element, so they can travel together', () => {
+  // 10 minutes ago → 9 minutes ago loses a digit, so " minutes ago" has to end
+  // up further left. It glides there over the fade, which needs it in a box of
+  // its own to move; before this it was loose text that took its new place the
+  // instant the step landed, and that is what read as the line sliding.
+  const now = AT + 10 * MIN;
+  draw({ entry: { ...e, capturedAt: AT + 1 * MIN }, now, step: { from: e, fadeS: 1 } });
+  expect(drawnTime()).toBe('9 minutes ago');
+  expect(screen.getByTestId('caption-time-tail')).toHaveTextContent('minutes ago');
+});
+
+it('the step runs on the curve the dissolve it belongs to is running on', () => {
+  // One timing function for every layer of a change, the picture's included.
+  const now = AT + 38 * MIN;
+  const ease = 'cubic-bezier(0.4, 0, 0.6, 1)';
+  draw({ entry: { ...e, capturedAt: AT + 10 * MIN }, now, step: { from: e, fadeS: 1, ease } });
+  expect(screen.getByTestId('caption-time-head')).toHaveStyle({ animation: `solo-time-in 1s ${ease} both` });
+  expect(screen.getByTestId('caption-time-out')).toHaveStyle({ animation: `solo-time-out 1s ${ease} both` });
+});
+
 it('one wall clock for both readings, so a step shows the age gap and not a tick of the clock', () => {
   // Same frame twice: the two readings are identical and nothing animates,
   // which could only be true if both were measured against the same `now`.

--- a/app/components/solo/Caption.tsx
+++ b/app/components/solo/Caption.tsx
@@ -1,10 +1,10 @@
 'use client';
 
-import type { CSSProperties } from 'react';
+import { Fragment, useLayoutEffect, useRef, type CSSProperties, type ReactNode } from 'react';
 import type { Feed, SoloDials } from '@/app/lib/solo/types';
 import {
   FONT_STACKS, LINE_HEIGHT, captionBox, captionLines, captionScale, gray, lineGaps,
-  pairTimeSegments, splitTime, timeSegments,
+  pairTimeSegments, splitTime, tailTravel, timeSegments,
   type CaptionEntry, type Rect,
 } from '@/app/lib/solo/caption';
 
@@ -12,6 +12,16 @@ const TIME_KEYFRAMES = `
 @keyframes solo-time-out { from { opacity: 1 } to { opacity: 0 } }
 @keyframes solo-time-in { from { opacity: 0 } to { opacity: 1 } }
 `;
+
+/** The three elements of one crossfading stretch, kept so the glide can measure it. */
+interface StretchNodes {
+  /** The slot the stretch swaps inside; its width is the arriving reading's. */
+  slot: HTMLElement | null;
+  /** The reading on its way out, absolutely placed, so its width is the leaving one's. */
+  out: HTMLElement | null;
+  /** Everything after the stretch, which travels when the two widths differ. */
+  tail: HTMLElement | null;
+}
 
 /**
  * The words under (or over) a solo frame, drawn from the caption dials. Shared
@@ -36,10 +46,20 @@ export function Caption({ entry, dials, picture, width, feed, step, now = Date.n
    * Those crossfade over `fadeS`, out and in together, the way the picture
    * underneath dissolves; the characters the two readings share at either end
    * never animate, so a run counts down "38 minutes ago" to "28 minutes ago"
-   * by moving one digit. Absent on a dwell's first frame, where the whole
+   * by moving one digit.
+   *
+   * When the two readings are not the same width — "10 minutes ago" losing a
+   * digit to "9 minutes ago" — the words after the digit glide to their new
+   * place across the same fade instead of arriving there at once, which is
+   * what used to read as the line sliding sideways.
+   *
+   * `ease` is the timing function of the dissolve this step belongs to. It is
+   * one value for every layer of a change, the picture's included: an eased
+   * arrival against a departure on another curve lands in a third of the time
+   * it left in (PR #160). Absent on a dwell's first frame, where the whole
    * caption arrives with the picture instead.
    */
-  step?: { from: CaptionEntry; fadeS: number } | null;
+  step?: { from: CaptionEntry; fadeS: number; ease?: string } | null;
   /**
    * The wall clock the 'ago' style measures against. One value for the frame
    * arriving and the frame it replaces, so the only thing between the two
@@ -48,8 +68,8 @@ export function Caption({ entry, dials, picture, width, feed, step, now = Date.n
    */
   now?: number;
 }) {
+  const stretches = useRef(new Map<number, StretchNodes>());
   const lines = captionLines(entry, dials, feed, now);
-  if (!lines) return null;
   const s = captionScale(width);
   const box = captionBox(dials, picture, width);
   const overlay = dials.captionLayout === 'overlay';
@@ -57,6 +77,43 @@ export function Caption({ entry, dials, picture, width, feed, step, now = Date.n
   // Margins, not a flex gap: the time line can be pushed further down than
   // the place line is, and captionHeight adds up the same two numbers.
   const gaps = lineGaps(dials);
+
+  // The reading the step is leaving, built with this caption's own dials so
+  // the two ends of the fade are always the same format, then matched piece
+  // for piece against the reading arriving.
+  const leaving = step && step.fadeS > 0 && lines
+    ? timeSegments(dials.timeStyle, step.from.capturedAt, step.from.timezone, step.from.sunAltitudeDeg, now)
+    : null;
+  const pairs = pairTimeSegments(leaving, lines?.timeParts ?? []);
+  // Two frames of the same minute say the same thing; nothing to fade.
+  const stepping = pairs.some((p) => p.fade && p.from !== p.to);
+  const fade = stepping && step ? step.fadeS : 0;
+  const ease = step?.ease ?? 'ease';
+
+  // Measured once the step is laid out, so the words that have to move start
+  // where they were and travel to where they now are. One width read and one
+  // transform written per changed stretch, and the transform is composited:
+  // animating the slot's width instead lays the whole line out again on every
+  // frame, which lands the words on whole pixels and steps rather than glides.
+  const stepKey = `${fade}|${ease}|${pairs.map((p) => `${p.from}›${p.to}`).join('|')}`;
+  useLayoutEffect(() => {
+    if (fade <= 0) return;
+    for (const { slot, out, tail } of stretches.current.values()) {
+      if (!slot || !out || !tail || typeof tail.animate !== 'function') continue;
+      const travel = tailTravel(out.getBoundingClientRect().width, slot.getBoundingClientRect().width);
+      if (!travel) continue;
+      // The glass steps every few seconds for days at a time, so each step
+      // clears the one before it rather than stacking finished animations on
+      // an element that never unmounts.
+      tail.getAnimations?.().forEach((a) => a.cancel());
+      tail.animate(
+        [{ transform: `translateX(${travel}px)` }, { transform: 'translateX(0px)' }],
+        { duration: fade * 1000, easing: ease, fill: 'backwards' },
+      );
+    }
+  }, [stepKey, fade, ease]);
+
+  if (!lines) return null;
 
   const block: CSSProperties = {
     position: 'absolute', left: box.left, top: box.top, bottom: box.bottom, width: box.width, maxWidth: box.maxWidth,
@@ -72,47 +129,58 @@ export function Caption({ entry, dials, picture, width, feed, step, now = Date.n
     fontSize: dials.timeSize * s, color: gray(dials.timeGray), fontVariantNumeric: 'tabular-nums',
   };
 
-  // The reading the step is leaving, built with this caption's own dials so
-  // the two ends of the fade are always the same format, then matched piece
-  // for piece against the reading arriving.
-  const leaving = step && step.fadeS > 0
-    ? timeSegments(dials.timeStyle, step.from.capturedAt, step.from.timezone, step.from.sunAltitudeDeg, now)
-    : null;
-  const pairs = pairTimeSegments(leaving, lines.timeParts);
-  // Two frames of the same minute say the same thing; nothing to fade.
-  const stepping = pairs.some((p) => p.fade && p.from !== p.to);
-  const fade = stepping && step ? step.fadeS : 0;
+  const keep = (i: number, part: keyof StretchNodes) => (node: HTMLElement | null) => {
+    const held = stretches.current.get(i) ?? { slot: null, out: null, tail: null };
+    held[part] = node;
+    if (held.slot || held.out || held.tail) stretches.current.set(i, held);
+    else stretches.current.delete(i);
+  };
+
+  /**
+   * The time line from piece `i` on. Each changed stretch nests everything
+   * after it inside its own tail, so a second stretch that also changes width
+   * travels its own distance on top of the first one's rather than having to
+   * know about it.
+   */
+  const piece = (i: number): ReactNode => {
+    if (i >= pairs.length) return null;
+    const p = pairs[i];
+    const rest = piece(i + 1);
+    // A piece that did not change, and every piece of punctuation, is written
+    // as it is: only what actually moved animates.
+    if (!p.fade || p.from === p.to) return <Fragment key={i}>{p.to}{rest}</Fragment>;
+    const split = splitTime(p.from, p.to);
+    return (
+      <Fragment key={i}>
+        {split.lead}
+        {/* The stretch crossfades in place: the outgoing reading rides on top
+            of the incoming one, which holds the slot's width. Each half is
+            keyed by its own text, so a step restarts the two animations
+            without remounting the line they sit in. */}
+        <span ref={keep(i, 'slot')} style={{ position: 'relative', display: 'inline-block' }}>
+          <span data-testid="caption-time-head" key={split.toMid} style={{
+            display: 'inline-block', animation: `solo-time-in ${fade}s ${ease} both`,
+          }}>
+            {split.toMid}
+          </span>
+          <span data-testid="caption-time-out" key={split.fromMid} aria-hidden ref={keep(i, 'out')} style={{
+            position: 'absolute', left: 0, top: 0, animation: `solo-time-out ${fade}s ${ease} both`,
+          }}>
+            {split.fromMid}
+          </span>
+        </span>
+        {split.tail || rest ? (
+          <span data-testid="caption-time-tail" ref={keep(i, 'tail')} style={{ display: 'inline-block' }}>
+            {split.tail}{rest}
+          </span>
+        ) : null}
+      </Fragment>
+    );
+  };
 
   const time = !lines.time ? null : (
     <span data-testid="caption-time" style={{ ...timeFace, whiteSpace: 'pre' }}>
-      {pairs.map((p, i) => {
-        // A piece that did not change, and every piece of punctuation, is
-        // written as it is: only what actually moved animates.
-        if (!p.fade || p.from === p.to) return <span key={i}>{p.to}</span>;
-        // The head crossfades in place: the outgoing reading rides on top of
-        // the incoming one, which holds the width so the tail beside it never
-        // moves. Each head is keyed by its own text, so a step restarts the
-        // two animations without remounting the line they sit in.
-        const split = splitTime(p.from, p.to);
-        return (
-          <span key={i}>
-            {split.lead}
-            <span style={{ position: 'relative', display: 'inline-block' }}>
-              <span data-testid="caption-time-head" key={split.toMid} style={{
-                display: 'inline-block', animation: `solo-time-in ${fade}s ease both`,
-              }}>
-                {split.toMid}
-              </span>
-              <span data-testid="caption-time-out" key={split.fromMid} aria-hidden style={{
-                position: 'absolute', left: 0, top: 0, animation: `solo-time-out ${fade}s ease both`,
-              }}>
-                {split.fromMid}
-              </span>
-            </span>
-            {split.tail}
-          </span>
-        );
-      })}
+      {piece(0)}
     </span>
   );
 

--- a/app/components/solo2/Solo2Frame.test.tsx
+++ b/app/components/solo2/Solo2Frame.test.tsx
@@ -298,11 +298,14 @@ it('inside a run only the clock moves, and inside the clock only the part that c
     dials={{ ...D, sameCameraFadeS: 1 }} width={1920} height={1080} />);
   expect(drawnTime()).toBe('7:32 pm there');
   // Only the minute's first digit animates: "7:" holds and so does "2 pm there".
+  // Both halves run on the same curve the picture beneath them is dissolving
+  // on — arrivalEase, not a hardcoded one — so no layer of the change arrives
+  // ahead of another.
   expect(screen.getByTestId('caption-time-head')).toHaveTextContent('3');
-  expect(screen.getByTestId('caption-time-head')).toHaveStyle({ animation: 'solo-time-in 1s ease both' });
+  expect(screen.getByTestId('caption-time-head')).toHaveStyle({ animation: `solo-time-in 1s ${ARRIVAL_EASES.gentle} both` });
   expect(screen.getByTestId('caption-time-out')).toHaveTextContent('2');
   // No delay on either: out and in run together, the way the picture dissolves.
-  expect(screen.getByTestId('caption-time-out')).toHaveStyle({ animation: 'solo-time-out 1s ease both' });
+  expect(screen.getByTestId('caption-time-out')).toHaveStyle({ animation: `solo-time-out 1s ${ARRIVAL_EASES.gentle} both` });
 
   // Stepping again keeps the very same caption element, and the tail with it:
   // the title, the place and "pm there" hold still while the clock swaps.

--- a/app/components/solo2/Solo2Frame.tsx
+++ b/app/components/solo2/Solo2Frame.tsx
@@ -197,7 +197,7 @@ export function Solo2Frame({ entry, run, previous, stage, plan, dials, width, he
           per dwell; inside the dwell only the clock moves. */}
       <div key={`caption-${dwellId}`} data-testid="caption-layer" style={{ ...captionLayer, animation: inAnimation }}>
         <Caption entry={up} dials={dials} picture={picture} width={width} height={height} feed={feed}
-          step={shown > 0 ? { from: sequence[shown - 1], fadeS: stepFade } : null} />
+          step={shown > 0 ? { from: sequence[shown - 1], fadeS: stepFade, ease } : null} />
       </div>
       {(dials.showScores || dials.showRank || dials.showTally) && (
         <div style={{

--- a/app/lib/solo/caption.test.ts
+++ b/app/lib/solo/caption.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { captionBox, captionHeight, captionLines, displayTitle, drawFactor, formatAgo, formatTime, gray, lineGaps, pairTimeSegments, pictureRect, splitTime, timeSegments, timeText } from './caption';
+import { captionBox, captionHeight, captionLines, displayTitle, drawFactor, formatAgo, formatTime, gray, lineGaps, pairTimeSegments, pictureRect, splitTime, tailTravel, timeSegments, timeText } from './caption';
 
 // 02:42 UTC on 2026-09-05 is 7:42 pm the evening before in Mazatlán (UTC−7).
 const AT = Date.UTC(2026, 8, 5, 2, 42);
@@ -302,5 +302,27 @@ describe('drawFactor', () => {
     expect(drawFactor(pictureRect(d, 1920, 1080))).toBeCloseTo(4.18, 2);
     expect(drawFactor(pictureRect({ ...d, captionLayout: 'overlay' }, 2560, 1440))).toBeCloseTo(6.4, 2);
     expect(drawFactor({ width: 1000 }, { width: 500 })).toBe(2);
+  });
+});
+
+describe('tailTravel', () => {
+  it('moves the words left by what the number lost', () => {
+    // "10 minutes ago" → "9 minutes ago": the digits are 20px, then 11px, so
+    // the twelve characters after them end up 9px further left.
+    expect(tailTravel(20, 11)).toBe(9);
+  });
+
+  it('moves them right when the reading grows', () => {
+    expect(tailTravel(11, 20)).toBe(-9);
+  });
+
+  it('is nothing when the number keeps its width', () => {
+    // 38 → 28 in tabular figures: one digit swapped, same advance, so there is
+    // nothing for the words beside it to do.
+    expect(tailTravel(20, 20)).toBe(0);
+  });
+
+  it('ignores a sub-pixel difference rather than promoting a layer for it', () => {
+    expect(tailTravel(20.2, 20)).toBe(0);
   });
 });

--- a/app/lib/solo/caption.ts
+++ b/app/lib/solo/caption.ts
@@ -358,3 +358,23 @@ export const SOURCE_FRAME = { width: 400, height: 224 } as const;
 export function drawFactor(picture: Pick<Rect, 'width'>, source: { width: number } = SOURCE_FRAME): number {
   return picture.width / source.width;
 }
+
+/**
+ * How far the words after a changed stretch have to travel when the stretch
+ * changes width, in CSS pixels: positive when the reading shrinks and the
+ * words come back to the left.
+ *
+ * "10 minutes ago" → "9 minutes ago" moves one digit, and the twelve
+ * characters after it have to end up one digit further left. Landing them
+ * there the instant the step begins is the thing that read as a snap while
+ * the digit beside them was still crossfading: the fade was fine, the words
+ * beside it teleported. They glide instead, over the same duration and the
+ * same curve as the dissolve they belong to.
+ *
+ * Under half a pixel is nothing to move, and moving it would promote the
+ * words to their own layer for a distance no one can see.
+ */
+export function tailTravel(fromWidth: number, toWidth: number): number {
+  const travel = fromWidth - toWidth;
+  return Math.abs(travel) < 0.5 ? 0 : travel;
+}


### PR DESCRIPTION
## The bug

A step inside a camera run crossfades only the characters that changed and leaves the ones both readings share alone. That is right while the reading keeps its width. It is wrong the moment it loses one.

"10 minutes ago" becoming "9 minutes ago" faded the digit in place and put " minutes ago" in its new spot at once, so twelve characters teleported sideways while the digit beside them was still dissolving. Jesse: *"it fades to the left or right and looks bizarre."*

Longer would not have fixed it. A snap is instant at any duration.

## The fix

The words after a changed stretch travel that distance across the same fade. Measured once the step is laid out — the leaving stretch's width against the arriving one's — and moved with a **transform**, so the browser shifts a finished layer.

Animating the slot's width looks identical on paper and is the choppy one: it lays the whole line out again on every frame, which lands the words on whole pixels and steps rather than glides. That was visible in the prototype and is why the diff reads a width and writes a transform rather than animating the width directly.

Each changed stretch nests everything after it inside its own tail, so a line with two of them (`12h-sun`) composes: the second travels its own distance on top of the first's without knowing about it.

## One curve for every layer

The step also stops running on a hardcoded `ease`. It now takes the timing function of the dissolve it belongs to, which is `arrivalEase` — the same one the picture underneath is stepping on, and the one every other layer of a change already shared (#160). Its default is `gentle`, which is what Jesse picked.

## Prototyped first

Five treatments stepping in unison against the real hard cases, with a frame meter: https://claude.ai/code/artifact/8957366f-0723-4120-a8fd-30cf6882592d

Glide won, at 1 second on the gentle curve.

## Not in this PR

**The 1 second is a dial, not a default change.** It is `sameCameraFadeS`, currently 1.5, and it drives the picture's step dissolve as well as the words. Set it in /studio; say the word and I will move the default instead.

## Verification

- `npx vitest run` — 2491 passed, 293 files
- `npm run build` — exit 0
- No migration.
- Unverified on the glass and in a signed-in /studio. After merge: `bash scripts/pi/kiosk-doctor.sh --sync --reload`, then `scripts/wt.sh rm fix/caption-glide`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FchUpY3ndm2H2UTLBtx95v
