### PR TITLE
[HOLD until 2026-09-12] Run collection phase 1: whole-evening capture for a camera panel

### DIFF
--- a/app/api/cron/update-cameras/lib/dbOperations.test.ts
+++ b/app/api/cron/update-cameras/lib/dbOperations.test.ts
@@ -149,6 +149,27 @@ describe('insertWindyDisagreementSnapshot', () => {
     // Three explicit nulls: score, is_sunset, model version.
     expect(values.filter((v) => v === null).length).toBeGreaterThanOrEqual(3);
   });
+
+  it('accepts the run intake reason for whole-evening panel capture', async () => {
+    sqlMock.mockResolvedValue([{ id: 4242 }]);
+
+    const id = await insertWindyDisagreementSnapshot({
+      webcamId: 700,
+      phase: 'sunset',
+      firebaseUrl: 'https://storage.googleapis.com/x.jpg',
+      firebasePath: 'x.jpg',
+      aiRating: 2.5,
+      aiRegressionScore: 0.375,
+      aiModelVersionRegression: 'v5',
+      scoringPath: 'onnx',
+      disagreementKind: null,
+      intakeReason: 'run',
+    });
+
+    expect(id).toBe(4242);
+    const values = sqlMock.mock.calls[0].slice(1);
+    expect(values).toContain('run');
+  });
 });
 
 describe('upsertTerminatorState', () => {

--- a/app/api/cron/update-cameras/lib/dbOperations.test.ts
+++ b/app/api/cron/update-cameras/lib/dbOperations.test.ts
@@ -170,6 +170,28 @@ describe('insertWindyDisagreementSnapshot', () => {
     const values = sqlMock.mock.calls[0].slice(1);
     expect(values).toContain('run');
   });
+
+  it('accepts a sunrise-phase frame for the same panel capture', async () => {
+    // The panel is not sunset-only. This test exists so that a later change
+    // adding a phase gate to the persist path fails loudly here.
+    sqlMock.mockResolvedValue([{ id: 4243 }]);
+
+    const id = await insertWindyDisagreementSnapshot({
+      webcamId: 700,
+      phase: 'sunrise',
+      firebaseUrl: 'https://storage.googleapis.com/y.jpg',
+      firebasePath: 'y.jpg',
+      aiRating: 2.5,
+      aiRegressionScore: 0.375,
+      aiModelVersionRegression: 'v5',
+      scoringPath: 'onnx',
+      disagreementKind: null,
+      intakeReason: 'run',
+    });
+
+    expect(id).toBe(4243);
+    expect(sqlMock.mock.calls[0].slice(1)).toContain('run');
+  });
 });
 
 describe('upsertTerminatorState', () => {

--- a/app/api/cron/update-cameras/lib/dbOperations.ts
+++ b/app/api/cron/update-cameras/lib/dbOperations.ts
@@ -336,8 +336,17 @@ export async function insertWindyDisagreementSnapshot(opts: {
   aiModelVersionBinary?: string;
   // Why this row entered the archive. 'trickle' is the unbiased control arm
   // (masterConfig SAVE_RANDOM_TRICKLE_RATE) and must stay separable from the
-  // model-gated reasons, or the arm is unrecoverable after the fact.
-  intakeReason?: 'disagreement' | 'high_rated' | 'trickle' | 'all_rated' | 'kiosk_bin';
+  // model-gated reasons, or the arm is unrecoverable after the fact. 'run' is
+  // whole-evening panel capture and outranks every other reason, because a
+  // panel frame was kept regardless of score and attributing it to a gated
+  // reason would misrepresent it as model-selected.
+  intakeReason?:
+    | 'disagreement'
+    | 'high_rated'
+    | 'trickle'
+    | 'all_rated'
+    | 'kiosk_bin'
+    | 'run';
 }): Promise<number> {
   const [row] = (await sql`
     insert into webcam_snapshots (

--- a/app/api/cron/update-cameras/lib/runPanel.test.ts
+++ b/app/api/cron/update-cameras/lib/runPanel.test.ts
@@ -52,4 +52,10 @@ describe('loadRunPanel', () => {
 
     expect(panel.has(700)).toBe(true);
   });
+
+  it('fails closed (empty set, no throw) when the query rejects', async () => {
+    sqlMock.mockRejectedValueOnce(new Error('connection refused'));
+
+    await expect(loadRunPanel()).resolves.toEqual(new Set());
+  });
 });

--- a/app/api/cron/update-cameras/lib/runPanel.test.ts
+++ b/app/api/cron/update-cameras/lib/runPanel.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const sqlMock = vi.fn();
+
+vi.mock('@/app/lib/db', () => ({
+  sql: (strings: TemplateStringsArray, ...values: unknown[]) =>
+    sqlMock(strings, ...values),
+}));
+
+import { loadRunPanel } from './runPanel';
+
+describe('loadRunPanel', () => {
+  beforeEach(() => {
+    sqlMock.mockReset();
+  });
+
+  it('returns the panel ids when the flag is on', async () => {
+    sqlMock
+      .mockResolvedValueOnce([{ enabled: true }])
+      .mockResolvedValueOnce([{ webcam_id: 700 }, { webcam_id: 800 }]);
+
+    const panel = await loadRunPanel();
+
+    expect(panel.has(700)).toBe(true);
+    expect(panel.has(800)).toBe(true);
+    expect(panel.size).toBe(2);
+  });
+
+  it('returns an empty set and never queries the panel when the flag is off', async () => {
+    sqlMock.mockResolvedValueOnce([{ enabled: false }]);
+
+    const panel = await loadRunPanel();
+
+    expect(panel.size).toBe(0);
+    expect(sqlMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns an empty set when the flag row does not exist', async () => {
+    sqlMock.mockResolvedValueOnce([]);
+
+    const panel = await loadRunPanel();
+
+    expect(panel.size).toBe(0);
+  });
+
+  it('coerces ids that the driver serializes as strings', async () => {
+    sqlMock
+      .mockResolvedValueOnce([{ enabled: true }])
+      .mockResolvedValueOnce([{ webcam_id: '700' }]);
+
+    const panel = await loadRunPanel();
+
+    expect(panel.has(700)).toBe(true);
+  });
+});

--- a/app/api/cron/update-cameras/lib/runPanel.ts
+++ b/app/api/cron/update-cameras/lib/runPanel.ts
@@ -6,17 +6,29 @@ import { sql } from '@/app/lib/db';
  * Read once per tick, not per frame. The BIGINT id comes back from the Neon
  * driver as a string on some paths, so it is coerced here rather than at every
  * call site.
+ *
+ * Fails CLOSED, same contract as runtimeFlags.isFlagEnabled: an unreachable
+ * database gives today's behaviour (no panel capture), never a thrown error.
+ * This call sits above the per-webcam scoring loop with no surrounding
+ * try/catch in the caller, so an unguarded throw here would abort the whole
+ * tick -- no scoring, no snapshots, no bin admission -- every 10 minutes
+ * until the fault clears.
  */
 export async function loadRunPanel(): Promise<Set<number>> {
-  const flag = (await sql`
-    SELECT enabled FROM runtime_flags WHERE key = 'run_panel_capture'
-  `) as { enabled: boolean }[];
+  try {
+    const flag = (await sql`
+      SELECT enabled FROM runtime_flags WHERE key = 'run_panel_capture'
+    `) as { enabled: boolean }[];
 
-  if (flag[0]?.enabled !== true) return new Set();
+    if (flag[0]?.enabled !== true) return new Set();
 
-  const rows = (await sql`
-    SELECT webcam_id FROM run_panel
-  `) as { webcam_id: number | string }[];
+    const rows = (await sql`
+      SELECT webcam_id FROM run_panel
+    `) as { webcam_id: number | string }[];
 
-  return new Set(rows.map((r) => Number(r.webcam_id)));
+    return new Set(rows.map((r) => Number(r.webcam_id)));
+  } catch (error) {
+    console.warn('[runPanel] read failed, treating as no panel this tick:', error);
+    return new Set();
+  }
 }

--- a/app/api/cron/update-cameras/lib/runPanel.ts
+++ b/app/api/cron/update-cameras/lib/runPanel.ts
@@ -1,0 +1,22 @@
+import { sql } from '@/app/lib/db';
+
+/**
+ * The cameras whose whole evening is kept, or an empty set when capture is off.
+ *
+ * Read once per tick, not per frame. The BIGINT id comes back from the Neon
+ * driver as a string on some paths, so it is coerced here rather than at every
+ * call site.
+ */
+export async function loadRunPanel(): Promise<Set<number>> {
+  const flag = (await sql`
+    SELECT enabled FROM runtime_flags WHERE key = 'run_panel_capture'
+  `) as { enabled: boolean }[];
+
+  if (flag[0]?.enabled !== true) return new Set();
+
+  const rows = (await sql`
+    SELECT webcam_id FROM run_panel
+  `) as { webcam_id: number | string }[];
+
+  return new Set(rows.map((r) => Number(r.webcam_id)));
+}

--- a/app/api/cron/update-cameras/route.test.ts
+++ b/app/api/cron/update-cameras/route.test.ts
@@ -113,7 +113,8 @@ vi.mock('./lib/providerUsage', () => ({
 vi.mock('@/app/lib/db', () => ({ sql: vi.fn() }));
 vi.mock('@/app/lib/runtimeFlags', () => ({
   SWEEP_FORCE_DAY_RING: 'sweep_force_day_ring',
-  isFlagEnabled: () => isFlagEnabledMock(),
+  DISAGREEMENT_INTAKE: 'disagreement_intake',
+  isFlagEnabled: (key: string) => isFlagEnabledMock(key),
 }));
 
 const upsertSweepStatsMock = vi.fn();
@@ -257,6 +258,16 @@ beforeEach(() => {
 
 function makeReq(): Request {
   return new Request('http://test/api/cron/update-cameras');
+}
+
+// Seeded OFF in production (2026-09-08): tests that exercise the
+// disagreement-persist path must opt in explicitly, matching the flag's
+// real default rather than a blanket isFlagEnabledMock.mockResolvedValue(true)
+// that would also flip the unrelated SWEEP_FORCE_DAY_RING switch.
+function enableDisagreementIntake(): void {
+  isFlagEnabledMock.mockImplementation(async (key: string) =>
+    key === 'disagreement_intake',
+  );
 }
 
 describe('GET /api/cron/update-cameras', () => {
@@ -472,6 +483,8 @@ describe('GET /api/cron/update-cameras', () => {
 
   it('persists a Windy snapshot when computeDisagreementKind flags the score', async () => {
     // Mock the disagreement helper to return a non-null kind for this tick.
+    // The disagreement_intake flag must be on for this arm to persist.
+    enableDisagreementIntake();
     computeDisagreementKindMock.mockReturnValueOnce(
       'binary_negative_regression_high',
     );
@@ -487,6 +500,7 @@ describe('GET /api/cron/update-cameras', () => {
   });
 
   it('passes the binary head evidence through to the persisted snapshot', async () => {
+    enableDisagreementIntake();
     computeDisagreementKindMock.mockReturnValueOnce(
       'binary_negative_regression_high',
     );
@@ -588,6 +602,36 @@ describe('GET /api/cron/update-cameras', () => {
       intakeReason: 'run',
       disagreementKind: 'binary_negative_regression_high',
     });
+  });
+
+  it('does not persist a frame for disagreement alone when the intake flag is off', async () => {
+    // Default beforeEach already resolves isFlagEnabledMock to false for
+    // every key, matching the flag's real seeded-off default, but this is
+    // asserted explicitly so a future default flip fails loudly here.
+    computeDisagreementKindMock.mockReturnValueOnce(
+      'binary_negative_regression_high',
+    );
+    await GET(makeReq());
+    expect(insertWindyDisagreementSnapshotMock).not.toHaveBeenCalled();
+  });
+
+  it('still records the disagreement kind, under a different intake reason, when a frame disagrees but the intake flag is off', async () => {
+    // The precise failure this invariant guards against: a frame that enters
+    // via trickle and happens to disagree must NOT be stamped 'disagreement'
+    // when disagreement_intake is off, or the unbiased control arm stops
+    // being separable. model_disagreement_kind is still written regardless,
+    // because the Hard Examples queue filters on that column.
+    toggles.trickleRate = 1; // draw always hits
+    computeDisagreementKindMock.mockReturnValueOnce(
+      'binary_negative_regression_high',
+    );
+    await GET(makeReq());
+    expect(insertWindyDisagreementSnapshotMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        intakeReason: 'trickle',
+        disagreementKind: 'binary_negative_regression_high',
+      }),
+    );
   });
 
   it('samples at roughly the configured rate, independent of score', async () => {

--- a/app/api/cron/update-cameras/route.test.ts
+++ b/app/api/cron/update-cameras/route.test.ts
@@ -248,6 +248,7 @@ beforeEach(() => {
   });
   insertWindyDisagreementSnapshotMock.mockReset().mockReturnValue(999);
   isFlagEnabledMock.mockReset().mockResolvedValue(false);
+  loadRunPanelMock.mockReset().mockResolvedValue(new Set<number>());
   sweepHoldMock.mockReset();
   toggles.high = false;
   toggles.all = false;
@@ -568,6 +569,24 @@ describe('GET /api/cron/update-cameras', () => {
     await GET(makeReq());
     expect(insertWindyDisagreementSnapshotMock.mock.calls[0][0]).toMatchObject({
       intakeReason: 'high_rated',
+    });
+  });
+
+  it('stamps run FIRST even when the same frame also disagrees, without losing the disagreement', async () => {
+    // The most counter-intuitive rule in the precedence chain: a panel camera's
+    // frame is kept regardless of score, so it must never read as model-selected.
+    // But the disagreement itself must still land — model_disagreement_kind is
+    // what the Hard Examples queue actually filters on, independent of
+    // intake_reason. Both assertions below defend that invariant together.
+    loadRunPanelMock.mockResolvedValue(new Set([700]));
+    computeDisagreementKindMock.mockReturnValueOnce(
+      'binary_negative_regression_high',
+    );
+    await GET(makeReq());
+    expect(insertWindyDisagreementSnapshotMock).toHaveBeenCalledTimes(1);
+    expect(insertWindyDisagreementSnapshotMock.mock.calls[0][0]).toMatchObject({
+      intakeReason: 'run',
+      disagreementKind: 'binary_negative_regression_high',
     });
   });
 

--- a/app/api/cron/update-cameras/route.test.ts
+++ b/app/api/cron/update-cameras/route.test.ts
@@ -73,6 +73,12 @@ vi.mock('./lib/dbOperations', () => ({
   insertWindyDisagreementSnapshot: (...a: unknown[]) =>
     insertWindyDisagreementSnapshotMock(...a),
 }));
+// Empty set matches loadRunPanel's real "capture off" behavior, so this file
+// exercises the same isRunPanel === false path production takes by default.
+const loadRunPanelMock = vi.fn(async () => new Set<number>());
+vi.mock('./lib/runPanel', () => ({
+  loadRunPanel: (...a: unknown[]) => loadRunPanelMock(...a),
+}));
 const maintainBinsMock = vi.fn(async () => ({ leftZone: 0, expired: 0 }));
 vi.mock('./lib/binAdmission', () => ({
   decideBin: () => null,

--- a/app/api/cron/update-cameras/route.ts
+++ b/app/api/cron/update-cameras/route.ts
@@ -34,7 +34,11 @@ import {
   TERMINATOR_RETENTION_GRACE_MS,
   TERMINATOR_SWEEP_FAILED_HOLD_RATIO,
 } from '@/app/lib/masterConfig';
-import { isFlagEnabled, SWEEP_FORCE_DAY_RING } from '@/app/lib/runtimeFlags';
+import {
+  isFlagEnabled,
+  SWEEP_FORCE_DAY_RING,
+  DISAGREEMENT_INTAKE,
+} from '@/app/lib/runtimeFlags';
 import { classifyCustomCamerasForTick } from './lib/customClassification';
 import { verifyCronAuth } from './lib/auth';
 import { dedupeCoords, fetchCoordsCounted } from './lib/windyApi';
@@ -192,6 +196,11 @@ export async function GET(req: Request) {
   // One query per tick, not per frame. Empty when the flag is off.
   const runPanel = await loadRunPanel();
 
+  // Hard-example mining, switchable without a redeploy. Off since 2026-09-08:
+  // 32,013 banked frames, none labeled. isFlagEnabled fails closed, and closed
+  // means "do not collect", so a database blip costs nothing.
+  const disagreementIntake = await isFlagEnabled(DISAGREEMENT_INTAKE);
+
   // Get mapping of external IDs to internal IDs
   const externalIds = windyAll.map((w) => String(w.webcamId));
   const idByExternal = await getWebcamIdMap(externalIds);
@@ -317,10 +326,17 @@ export async function GET(req: Request) {
       // score, which is the entire point — the model-gated reasons drop the
       // N-to-1 crossing, and that crossing is what run labeling needs.
       const isRunPanel = runPanel.has(webcamId);
+      // The disagreement is always COMPUTED and always recorded on the row via
+      // model_disagreement_kind, which is what the Hard Examples queue reads.
+      // Only whether it is a reason to KEEP the frame is switchable. Gated by
+      // the SAME boolean the precedence chain below uses, so a frame that
+      // enters via some other arm (e.g. trickle) and happens to disagree never
+      // gets mislabeled 'disagreement' just because the mining arm is on.
+      const disagreementPersisted = disagreementKind !== null && disagreementIntake;
       const binKind = decideBin(scored);
       const binFeed = feedByExternalId.get(externalId) ?? null;
       const shouldPersist =
-        disagreementKind !== null ||
+        disagreementPersisted ||
         isHighRated ||
         isTrickle ||
         isRunPanel ||
@@ -340,7 +356,7 @@ export async function GET(req: Request) {
         | 'disagreement' | 'high_rated' | 'trickle' | 'all_rated' | 'kiosk_bin' | 'run' =
         isRunPanel
           ? 'run'
-          : disagreementKind !== null
+          : disagreementPersisted
             ? 'disagreement'
             : isHighRated
               ? 'high_rated'

--- a/app/api/cron/update-cameras/route.ts
+++ b/app/api/cron/update-cameras/route.ts
@@ -57,6 +57,7 @@ import {
   updateWebcamAiFields,
   insertWindyDisagreementSnapshot,
 } from './lib/dbOperations';
+import { loadRunPanel } from './lib/runPanel';
 import { computeDisagreementKind, scoreImage } from './lib/aiScoring';
 import { decideBin, enterBins, maintainBins, type Admission } from './lib/binAdmission';
 import { getLiveSettingsCached } from '@/app/lib/settings/liveSettings';
@@ -188,6 +189,9 @@ export async function GET(req: Request) {
   for (const w of sunsetList) feedByExternalId.set(String(w.webcamId), 'sunset');
   const admissions: Admission[] = [];
 
+  // One query per tick, not per frame. Empty when the flag is off.
+  const runPanel = await loadRunPanel();
+
   // Get mapping of external IDs to internal IDs
   const externalIds = windyAll.map((w) => String(w.webcamId));
   const idByExternal = await getWebcamIdMap(externalIds);
@@ -309,28 +313,39 @@ export async function GET(req: Request) {
       // Drawn independently per frame — no seed, because the point is that
       // nothing about the frame influences whether it is kept.
       const isTrickle = Math.random() < SAVE_RANDOM_TRICKLE_RATE;
+      // Whole-evening capture: this camera's frames are kept regardless of
+      // score, which is the entire point — the model-gated reasons drop the
+      // N-to-1 crossing, and that crossing is what run labeling needs.
+      const isRunPanel = runPanel.has(webcamId);
       const binKind = decideBin(scored);
       const binFeed = feedByExternalId.get(externalId) ?? null;
       const shouldPersist =
         disagreementKind !== null ||
         isHighRated ||
         isTrickle ||
+        isRunPanel ||
         SAVE_ALL_RATED_SNAPSHOTS ||
         (binKind !== null && binFeed !== null);
-      // Precedence matters for the analysis, not for the write: a frame that
-      // would have been saved anyway is NOT part of the unbiased arm, so the
-      // gated reasons win and 'trickle' marks only frames nothing else caught.
-      // 'kiosk_bin' likewise marks only frames the bins alone brought in.
-      const intakeReason: 'disagreement' | 'high_rated' | 'trickle' | 'all_rated' | 'kiosk_bin' =
-        disagreementKind !== null
-          ? 'disagreement'
-          : isHighRated
-            ? 'high_rated'
-            : isTrickle
-              ? 'trickle'
-              : SAVE_ALL_RATED_SNAPSHOTS
-                ? 'all_rated'
-                : 'kiosk_bin';
+      // Precedence matters for the analysis, not for the write. 'run' is FIRST:
+      // a panel frame would have been kept whatever it scored, so stamping it
+      // 'disagreement' would make a uniformly sampled frame look model-selected
+      // and silently poison the corpus this panel exists to produce. The
+      // disagreement itself is not lost — model_disagreement_kind is written
+      // independently, and the Hard Examples queue filters on that column, not
+      // on intake_reason.
+      const intakeReason:
+        | 'disagreement' | 'high_rated' | 'trickle' | 'all_rated' | 'kiosk_bin' | 'run' =
+        isRunPanel
+          ? 'run'
+          : disagreementKind !== null
+            ? 'disagreement'
+            : isHighRated
+              ? 'high_rated'
+              : isTrickle
+                ? 'trickle'
+                : SAVE_ALL_RATED_SNAPSHOTS
+                  ? 'all_rated'
+                  : 'kiosk_bin';
       if (shouldPersist) {
         try {
           const capturedAt = new Date();

--- a/app/api/cron/update-cameras/route.ts
+++ b/app/api/cron/update-cameras/route.ts
@@ -332,7 +332,10 @@ export async function GET(req: Request) {
       // and silently poison the corpus this panel exists to produce. The
       // disagreement itself is not lost — model_disagreement_kind is written
       // independently, and the Hard Examples queue filters on that column, not
-      // on intake_reason.
+      // on intake_reason. Below 'run', a frame that would have been saved
+      // anyway is NOT part of the unbiased arm, so the gated reasons win and
+      // 'trickle' marks only frames nothing else caught. 'kiosk_bin' likewise
+      // marks only frames the bins alone brought in.
       const intakeReason:
         | 'disagreement' | 'high_rated' | 'trickle' | 'all_rated' | 'kiosk_bin' | 'run' =
         isRunPanel

--- a/app/api/snapshots/cleanup/route.test.ts
+++ b/app/api/snapshots/cleanup/route.test.ts
@@ -98,4 +98,13 @@ describe('GET /api/snapshots/cleanup', () => {
     const q = strings.join('?').toLowerCase();
     expect(q).toMatch(/llm_quality\s+is\s+null/i);
   });
+
+  it("excludes run-panel frames (intake_reason = 'run') — the unbiased corpus this panel exists to collect", async () => {
+    cleanupEnabledMock.value = true;
+    sqlMock.mockResolvedValueOnce([]); // SELECT returns nothing
+    await GET(makeReq());
+    const [strings] = sqlMock.mock.calls[0];
+    const q = strings.join('?');
+    expect(q).toMatch(/intake_reason\s+is\s+distinct\s+from\s+'run'/i);
+  });
 });

--- a/app/api/snapshots/cleanup/route.ts
+++ b/app/api/snapshots/cleanup/route.ts
@@ -76,7 +76,12 @@ async function cleanup(request: Request) {
     //      guts old scenes. It is precisely the ORDINARY frames — no
     //      disagreement, no Claude score, no high model score — that make a
     //      scene worth replaying, and every other rule here would drop them.
-    //   6. It carries a GOLD label. manual_labels is the table the two-scale
+    //   6. It arrived as a run-panel frame (intake_reason = 'run'). These are
+    //      whole-evening captures kept specifically because they are
+    //      ordinary — no disagreement, no Claude score, no high model score —
+    //      so every other rule here would otherwise select exactly the
+    //      unbiased frames the run panel exists to collect.
+    //   7. It carries a GOLD label. manual_labels is the table the two-scale
     //      model program actually trains on, and a label names a frame by id.
     //      Rule 2 covers the public star table only, so a low-scoring frame
     //      the operator labeled by hand — a trickle frame out of the random
@@ -88,6 +93,7 @@ async function cleanup(request: Request) {
       WHERE captured_at < NOW() - INTERVAL '7 days'
         AND model_disagreement_kind IS NULL
         AND intake_reason IS DISTINCT FROM 'scene_capture'
+        AND intake_reason IS DISTINCT FROM 'run'
         AND llm_quality IS NULL
         AND (ai_rating IS NULL OR ai_rating < ${AI_SNAPSHOT_MIN_RATING_THRESHOLD})
         AND id NOT IN (

--- a/app/lib/runKey.test.ts
+++ b/app/lib/runKey.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest';
+import { runKey } from './runKey';
+
+describe('runKey', () => {
+  it('groups an evening that straddles UTC midnight into one run', () => {
+    // Seattle, lng -122. Both frames are the same local evening, but they sit
+    // on opposite sides of UTC midnight, so a naive UTC date splits them.
+    const before = new Date('2026-09-07T23:30:00Z');
+    const after = new Date('2026-09-08T01:00:00Z');
+
+    expect(runKey(700, 'sunset', before, -122)).toBe('700:sunset:2026-09-07');
+    expect(runKey(700, 'sunset', after, -122)).toBe('700:sunset:2026-09-07');
+  });
+
+  it('separates two different evenings on the same camera', () => {
+    const monday = new Date('2026-09-08T02:00:00Z');
+    const tuesday = new Date('2026-09-09T02:00:00Z');
+
+    expect(runKey(700, 'sunset', monday, -122)).not.toBe(
+      runKey(700, 'sunset', tuesday, -122),
+    );
+  });
+
+  it('keeps sunrise and sunset on the same camera and day apart', () => {
+    const at = new Date('2026-09-08T02:00:00Z');
+
+    expect(runKey(700, 'sunset', at, -122)).not.toBe(
+      runKey(700, 'sunrise', at, -122),
+    );
+  });
+
+  it('handles an eastern longitude', () => {
+    // Tokyo, lng +139. 2026-09-08T09:30Z is the evening of 09-08 local.
+    const at = new Date('2026-09-08T09:30:00Z');
+    expect(runKey(42, 'sunset', at, 139)).toBe('42:sunset:2026-09-08');
+  });
+});

--- a/app/lib/runKey.ts
+++ b/app/lib/runKey.ts
@@ -1,0 +1,31 @@
+import type { SolarPhase } from './solarPhase';
+
+const MS_PER_HOUR = 3_600_000;
+
+/**
+ * The identity of one camera's one evening.
+ *
+ * Keyed on LOCAL SOLAR date, not a fixed UTC offset. Longitude gives local
+ * solar time directly at 15 degrees per hour, and both solar events sit far
+ * from local midnight, so a sunset never straddles a local-solar-day boundary.
+ * A fixed offset does not have that property: at lng -122 an evening lands on
+ * both sides of UTC midnight and would split into two runs, which is exactly
+ * the bug that would cut a run in half at its most interesting end.
+ *
+ * KNOWN DUPLICATION: scripts/run-inventory.mjs mirrors this in SQL, because a
+ * .mjs script cannot import a .ts module. This function is the definition of
+ * record. Phase 2 collapses the two when the queue needs run identity in
+ * TypeScript; until then, a change here must be made in that query too.
+ */
+export function runKey(
+  webcamId: number,
+  phase: SolarPhase,
+  capturedAt: Date,
+  lngDeg: number,
+): string {
+  const solarLocal = new Date(
+    capturedAt.getTime() + (lngDeg / 15) * MS_PER_HOUR,
+  );
+  const date = solarLocal.toISOString().slice(0, 10);
+  return `${webcamId}:${phase}:${date}`;
+}

--- a/app/lib/runtimeFlags.ts
+++ b/app/lib/runtimeFlags.ts
@@ -19,6 +19,16 @@ import { sql } from '@/app/lib/db';
 export const SWEEP_FORCE_DAY_RING = 'sweep_force_day_ring';
 
 /**
+ * Persist a Windy frame because the two model heads disagree (the Hard
+ * Examples mining arm). Off by default: 32,013 frames were already banked
+ * with zero labeled, and hard examples are model-relative, so flip this on
+ * only in the week before a labeling sitting. model_disagreement_kind is
+ * still computed and written on every persisted row regardless of this flag
+ * -- the Hard Examples queue filters on that column, not on intake_reason.
+ */
+export const DISAGREEMENT_INTAKE = 'disagreement_intake';
+
+/**
  * Read one flag. Fails CLOSED: any error, missing row, or non-boolean value
  * reads as off.
  *

--- a/database/migrations/20260908_run_panel.sql
+++ b/database/migrations/20260908_run_panel.sql
@@ -1,0 +1,40 @@
+-- Whole-evening run capture: a bounded panel of cameras whose frames are kept
+-- regardless of model score.
+--
+-- Why: the archive's other intake reasons are model-gated. Measured 2026-09-08,
+-- inside 6+ frame sunset runs from the last 45 days, 4,864 frames entered as
+-- 'disagreement' against 66 as 'trickle'. The N-to-1 crossing is exactly where
+-- both heads agree nothing is there, so the boundary that carries 21 of the 35
+-- ceiling disagreements is the one intake systematically drops. Crossing labels
+-- derived from those gaps would be interpolations across non-random holes.
+-- Spec: docs/superpowers/specs/2026-09-08-run-crossing-labeling-design.md
+--
+-- Forward-only, idempotent. Apply via:
+--   node scripts/apply-migration.mjs database/migrations/20260908_run_panel.sql --apply
+
+CREATE TABLE IF NOT EXISTS run_panel (
+  webcam_id  BIGINT PRIMARY KEY,
+  added_at   TIMESTAMPTZ NOT NULL DEFAULT now(),
+  note       TEXT
+);
+
+-- 'run' joins the existing reasons. The full list is restated because the
+-- constraint is replaced wholesale, not extended.
+ALTER TABLE webcam_snapshots
+  DROP CONSTRAINT IF EXISTS webcam_snapshots_intake_reason_check;
+
+ALTER TABLE webcam_snapshots
+  ADD CONSTRAINT webcam_snapshots_intake_reason_check
+  CHECK (intake_reason IN (
+    'disagreement', 'high_rated', 'trickle', 'all_rated', 'scene_capture',
+    'operator_label', 'kiosk_bin', 'run'
+  ));
+
+-- Seeded OFF. Flip with scripts/set-runtime-flag.mjs once the panel is seeded.
+INSERT INTO runtime_flags (key, enabled, note)
+VALUES (
+  'run_panel_capture',
+  false,
+  'Keep every scored frame for cameras in run_panel, stamped intake_reason=run. ~9 frames per camera-evening.'
+)
+ON CONFLICT (key) DO NOTHING;

--- a/database/migrations/20260908_run_panel.sql
+++ b/database/migrations/20260908_run_panel.sql
@@ -38,3 +38,16 @@ VALUES (
   'Keep every scored frame for cameras in run_panel, stamped intake_reason=run. ~9 frames per camera-evening.'
 )
 ON CONFLICT (key) DO NOTHING;
+
+-- The disagreement arm has banked 32,013 frames, zero of them ever labeled,
+-- at ~5,000/day. Labeling stopped 2026-08-30 with the ceiling verdict, and the
+-- backlog is ~11 sittings deep. Seeded OFF: flip it on a week before a sitting
+-- so hard examples are re-mined against the then-current model, since a hard
+-- example is model-relative and goes stale when the model changes.
+INSERT INTO runtime_flags (key, enabled, note)
+VALUES (
+  'disagreement_intake',
+  false,
+  'Persist a Windy frame because the two heads disagree. OFF: 32,013 unlabeled frames already banked. model_disagreement_kind is still written on rows that persist for other reasons, so the Hard Examples queue is unaffected.'
+)
+ON CONFLICT (key) DO NOTHING;

--- a/docs/superpowers/plans/2026-09-08-run-collection-phase1.md
+++ b/docs/superpowers/plans/2026-09-08-run-collection-phase1.md
@@ -1,0 +1,702 @@
+# Run Collection (Phase 1) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+> ## ⛔ DO NOT MERGE BEFORE 2026-09-12
+> Task 4 edits the `update-cameras` cron, which is the tick the opening-night
+> show depends on. The show is Friday 2026-09-12 and the freeze is Wednesday
+> 09-10. **Build and review this now, merge it after the show.** Four lost
+> evenings of run data is cheap; a broken cron during show week is not.
+> Runbook: `docs/superpowers/plans/2026-09-03-opening-night-runbook.md`.
+
+**Goal:** Start collecting uniform, whole-evening frame runs from a bounded panel of cameras, so that run-crossing labeling has an unbiased corpus to work on.
+
+**Architecture:** A `run_panel` table names the cameras. A `runtime_flags` row switches collection on without a redeploy. The `update-cameras` cron persists every scored frame for a panel camera and stamps it `intake_reason = 'run'`, which takes highest precedence so a panel frame is never misattributed to a model-gated reason. A pure `runKey` function gives a run its identity from local solar time rather than a fixed UTC offset.
+
+**Tech Stack:** Next.js App Router, TypeScript, Vitest, Neon serverless Postgres, forward-only SQL migrations.
+
+**Spec:** `docs/superpowers/specs/2026-09-08-run-crossing-labeling-design.md`
+
+## Global Constraints
+
+- **Migrations apply BEFORE the code that reads the column merges.** `node scripts/apply-migration.mjs <file> --apply`. Dry by default. There is no dev database — every `--apply` is production.
+- **Stage explicit paths.** Never `git add -A`. Parallel sessions exist.
+- **Verify the branch in the same command as any commit**, per `CLAUDE.md`.
+- Run tests with `npm run test`. Lint with `npm run lint`. Build with `npm run build`.
+- **Never write derived labels into `manual_labels`.** Out of scope here, but it governs Phase 2 and is repeated so it is not lost.
+- `beforeEach` bodies use braces, never a concise arrow returning `mockReset()` — a returned mock value is called as Vitest teardown.
+- Panel size is **60 cameras** unless the operator says otherwise.
+
+## Scope
+
+This plan is Phase 1 of two. **Phase 1 is collection only.** The marking queue, the `run_crossings` table and the reproducibility experiment are Phase 2 and get their own plan, written after this lands and after real runs have accumulated. Phase 1 is useful on its own: it starts banking the corpus, which is the only part that loses value every day it is delayed.
+
+---
+
+### Task 1: Migration — the `run` intake reason, the panel table, the flag
+
+**Files:**
+- Create: `database/migrations/20260908_run_panel.sql`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: table `run_panel (webcam_id BIGINT PRIMARY KEY, added_at TIMESTAMPTZ, note TEXT)`; `runtime_flags` row with key `run_panel_capture`; `webcam_snapshots.intake_reason` accepts `'run'`.
+
+- [ ] **Step 1: Write the migration**
+
+```sql
+-- Whole-evening run capture: a bounded panel of cameras whose frames are kept
+-- regardless of model score.
+--
+-- Why: the archive's other intake reasons are model-gated. Measured 2026-09-08,
+-- inside 6+ frame sunset runs from the last 45 days, 4,864 frames entered as
+-- 'disagreement' against 66 as 'trickle'. The N-to-1 crossing is exactly where
+-- both heads agree nothing is there, so the boundary that carries 21 of the 35
+-- ceiling disagreements is the one intake systematically drops. Crossing labels
+-- derived from those gaps would be interpolations across non-random holes.
+-- Spec: docs/superpowers/specs/2026-09-08-run-crossing-labeling-design.md
+--
+-- Forward-only, idempotent. Apply via:
+--   node scripts/apply-migration.mjs database/migrations/20260908_run_panel.sql --apply
+
+CREATE TABLE IF NOT EXISTS run_panel (
+  webcam_id  BIGINT PRIMARY KEY,
+  added_at   TIMESTAMPTZ NOT NULL DEFAULT now(),
+  note       TEXT
+);
+
+-- 'run' joins the existing reasons. The full list is restated because the
+-- constraint is replaced wholesale, not extended.
+ALTER TABLE webcam_snapshots
+  DROP CONSTRAINT IF EXISTS webcam_snapshots_intake_reason_check;
+
+ALTER TABLE webcam_snapshots
+  ADD CONSTRAINT webcam_snapshots_intake_reason_check
+  CHECK (intake_reason IN (
+    'disagreement', 'high_rated', 'trickle', 'all_rated', 'scene_capture',
+    'operator_label', 'kiosk_bin', 'run'
+  ));
+
+-- Seeded OFF. Flip with scripts/set-runtime-flag.mjs once the panel is seeded.
+INSERT INTO runtime_flags (key, enabled, note)
+VALUES (
+  'run_panel_capture',
+  false,
+  'Keep every scored frame for cameras in run_panel, stamped intake_reason=run. ~9 frames per camera-evening.'
+)
+ON CONFLICT (key) DO NOTHING;
+```
+
+- [ ] **Step 2: Dry-run the migration**
+
+Run: `node scripts/apply-migration.mjs database/migrations/20260908_run_panel.sql`
+Expected: prints the statements and exits without writing, saying it is a dry run.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add database/migrations/20260908_run_panel.sql
+git commit -m "feat(run-capture): migration for run_panel, run intake reason, capture flag"
+```
+
+> **Operator step, not the implementer's:** apply this migration with `--apply` before Task 4's code merges. A missing constraint value would make every panel insert throw inside a cron that swallows its own errors.
+
+---
+
+### Task 2: `runKey` — run identity from local solar time
+
+**Files:**
+- Create: `app/lib/runKey.ts`
+- Test: `app/lib/runKey.test.ts`
+
+**Interfaces:**
+- Consumes: `SolarPhase` from `@/app/lib/solarPhase`.
+- Produces: `runKey(webcamId: number, phase: SolarPhase, capturedAt: Date, lngDeg: number): string` returning `"<webcamId>:<phase>:<YYYY-MM-DD>"`.
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+import { describe, it, expect } from 'vitest';
+import { runKey } from './runKey';
+
+describe('runKey', () => {
+  it('groups an evening that straddles UTC midnight into one run', () => {
+    // Seattle, lng -122. Both frames are the same local evening, but they sit
+    // on opposite sides of UTC midnight, so a naive UTC date splits them.
+    const before = new Date('2026-09-07T23:30:00Z');
+    const after = new Date('2026-09-08T01:00:00Z');
+
+    expect(runKey(700, 'sunset', before, -122)).toBe('700:sunset:2026-09-07');
+    expect(runKey(700, 'sunset', after, -122)).toBe('700:sunset:2026-09-07');
+  });
+
+  it('separates two different evenings on the same camera', () => {
+    const monday = new Date('2026-09-08T02:00:00Z');
+    const tuesday = new Date('2026-09-09T02:00:00Z');
+
+    expect(runKey(700, 'sunset', monday, -122)).not.toBe(
+      runKey(700, 'sunset', tuesday, -122),
+    );
+  });
+
+  it('keeps sunrise and sunset on the same camera and day apart', () => {
+    const at = new Date('2026-09-08T02:00:00Z');
+
+    expect(runKey(700, 'sunset', at, -122)).not.toBe(
+      runKey(700, 'sunrise', at, -122),
+    );
+  });
+
+  it('handles an eastern longitude', () => {
+    // Tokyo, lng +139. 2026-09-08T09:30Z is the evening of 09-08 local.
+    const at = new Date('2026-09-08T09:30:00Z');
+    expect(runKey(42, 'sunset', at, 139)).toBe('42:sunset:2026-09-08');
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `npx vitest run app/lib/runKey.test.ts`
+Expected: FAIL, cannot resolve `./runKey`.
+
+- [ ] **Step 3: Write the implementation**
+
+```typescript
+import type { SolarPhase } from './solarPhase';
+
+const MS_PER_HOUR = 3_600_000;
+
+/**
+ * The identity of one camera's one evening.
+ *
+ * Keyed on LOCAL SOLAR date, not a fixed UTC offset. Longitude gives local
+ * solar time directly at 15 degrees per hour, and both solar events sit far
+ * from local midnight, so a sunset never straddles a local-solar-day boundary.
+ * A fixed offset does not have that property: at lng -122 an evening lands on
+ * both sides of UTC midnight and would split into two runs, which is exactly
+ * the bug that would cut a run in half at its most interesting end.
+ *
+ * KNOWN DUPLICATION: scripts/run-inventory.mjs mirrors this in SQL, because a
+ * .mjs script cannot import a .ts module. This function is the definition of
+ * record. Phase 2 collapses the two when the queue needs run identity in
+ * TypeScript; until then, a change here must be made in that query too.
+ */
+export function runKey(
+  webcamId: number,
+  phase: SolarPhase,
+  capturedAt: Date,
+  lngDeg: number,
+): string {
+  const solarLocal = new Date(
+    capturedAt.getTime() + (lngDeg / 15) * MS_PER_HOUR,
+  );
+  const date = solarLocal.toISOString().slice(0, 10);
+  return `${webcamId}:${phase}:${date}`;
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `npx vitest run app/lib/runKey.test.ts`
+Expected: PASS, 4 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/lib/runKey.ts app/lib/runKey.test.ts
+git commit -m "feat(run-capture): runKey identifies a camera-evening by local solar date"
+```
+
+---
+
+### Task 3: The panel loader
+
+**Files:**
+- Create: `app/api/cron/update-cameras/lib/runPanel.ts`
+- Test: `app/api/cron/update-cameras/lib/runPanel.test.ts`
+
+**Interfaces:**
+- Consumes: `sql` from `@/app/lib/db`.
+- Produces: `loadRunPanel(): Promise<Set<number>>`. Returns an empty set when the flag is off or the panel is empty, so callers need no null check.
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const sqlMock = vi.fn();
+
+vi.mock('@/app/lib/db', () => ({
+  sql: (strings: TemplateStringsArray, ...values: unknown[]) =>
+    sqlMock(strings, ...values),
+}));
+
+import { loadRunPanel } from './runPanel';
+
+describe('loadRunPanel', () => {
+  beforeEach(() => {
+    sqlMock.mockReset();
+  });
+
+  it('returns the panel ids when the flag is on', async () => {
+    sqlMock
+      .mockResolvedValueOnce([{ enabled: true }])
+      .mockResolvedValueOnce([{ webcam_id: 700 }, { webcam_id: 800 }]);
+
+    const panel = await loadRunPanel();
+
+    expect(panel.has(700)).toBe(true);
+    expect(panel.has(800)).toBe(true);
+    expect(panel.size).toBe(2);
+  });
+
+  it('returns an empty set and never queries the panel when the flag is off', async () => {
+    sqlMock.mockResolvedValueOnce([{ enabled: false }]);
+
+    const panel = await loadRunPanel();
+
+    expect(panel.size).toBe(0);
+    expect(sqlMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns an empty set when the flag row does not exist', async () => {
+    sqlMock.mockResolvedValueOnce([]);
+
+    const panel = await loadRunPanel();
+
+    expect(panel.size).toBe(0);
+  });
+
+  it('coerces ids that the driver serializes as strings', async () => {
+    sqlMock
+      .mockResolvedValueOnce([{ enabled: true }])
+      .mockResolvedValueOnce([{ webcam_id: '700' }]);
+
+    const panel = await loadRunPanel();
+
+    expect(panel.has(700)).toBe(true);
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `npx vitest run app/api/cron/update-cameras/lib/runPanel.test.ts`
+Expected: FAIL, cannot resolve `./runPanel`.
+
+- [ ] **Step 3: Write the implementation**
+
+```typescript
+import { sql } from '@/app/lib/db';
+
+/**
+ * The cameras whose whole evening is kept, or an empty set when capture is off.
+ *
+ * Read once per tick, not per frame. The BIGINT id comes back from the Neon
+ * driver as a string on some paths, so it is coerced here rather than at every
+ * call site.
+ */
+export async function loadRunPanel(): Promise<Set<number>> {
+  const flag = (await sql`
+    SELECT enabled FROM runtime_flags WHERE key = 'run_panel_capture'
+  `) as { enabled: boolean }[];
+
+  if (flag[0]?.enabled !== true) return new Set();
+
+  const rows = (await sql`
+    SELECT webcam_id FROM run_panel
+  `) as { webcam_id: number | string }[];
+
+  return new Set(rows.map((r) => Number(r.webcam_id)));
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `npx vitest run app/api/cron/update-cameras/lib/runPanel.test.ts`
+Expected: PASS, 4 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/api/cron/update-cameras/lib/runPanel.ts app/api/cron/update-cameras/lib/runPanel.test.ts
+git commit -m "feat(run-capture): loadRunPanel reads the flag and the camera panel"
+```
+
+---
+
+### Task 4: Wire run capture into the cron tick
+
+**Files:**
+- Modify: `app/api/cron/update-cameras/lib/dbOperations.ts:340` — add `'run'` to the `intakeReason` union
+- Modify: `app/api/cron/update-cameras/route.ts:311-333` — panel membership, persistence, precedence
+- Test: `app/api/cron/update-cameras/lib/dbOperations.test.ts`
+
+**Interfaces:**
+- Consumes: `loadRunPanel` from Task 3.
+- Produces: rows in `webcam_snapshots` with `intake_reason = 'run'`.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `app/api/cron/update-cameras/lib/dbOperations.test.ts`, inside the existing `insertWindyDisagreementSnapshot` describe block:
+
+```typescript
+  it('accepts the run intake reason for whole-evening panel capture', async () => {
+    sqlMock.mockResolvedValue([{ id: 4242 }]);
+
+    const id = await insertWindyDisagreementSnapshot({
+      webcamId: 700,
+      phase: 'sunset',
+      firebaseUrl: 'https://storage.googleapis.com/x.jpg',
+      firebasePath: 'x.jpg',
+      aiRating: 2.5,
+      aiRegressionScore: 0.375,
+      aiModelVersionRegression: 'v5',
+      scoringPath: 'onnx',
+      disagreementKind: null,
+      intakeReason: 'run',
+    });
+
+    expect(id).toBe(4242);
+    const values = sqlMock.mock.calls[0].slice(1);
+    expect(values).toContain('run');
+  });
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `npx vitest run app/api/cron/update-cameras/lib/dbOperations.test.ts`
+Expected: FAIL at type-check or assertion, because `'run'` is not in the `intakeReason` union.
+
+- [ ] **Step 3: Widen the union in `dbOperations.ts`**
+
+Replace the `intakeReason` field declaration at `app/api/cron/update-cameras/lib/dbOperations.ts:340`:
+
+```typescript
+  // Why this row entered the archive. 'trickle' is the unbiased control arm
+  // (masterConfig SAVE_RANDOM_TRICKLE_RATE) and must stay separable from the
+  // model-gated reasons, or the arm is unrecoverable after the fact. 'run' is
+  // whole-evening panel capture and outranks every other reason, because a
+  // panel frame was kept regardless of score and attributing it to a gated
+  // reason would misrepresent it as model-selected.
+  intakeReason?:
+    | 'disagreement'
+    | 'high_rated'
+    | 'trickle'
+    | 'all_rated'
+    | 'kiosk_bin'
+    | 'run';
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `npx vitest run app/api/cron/update-cameras/lib/dbOperations.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Load the panel once per tick**
+
+In `app/api/cron/update-cameras/route.ts`, add the import beside the other lib imports:
+
+```typescript
+import { loadRunPanel } from './lib/runPanel';
+```
+
+Then, immediately before the loop that iterates webcams (the same place `feedByExternalId` is prepared), add:
+
+```typescript
+  // One query per tick, not per frame. Empty when the flag is off.
+  const runPanel = await loadRunPanel();
+```
+
+- [ ] **Step 6: Add panel membership to persistence and precedence**
+
+In `app/api/cron/update-cameras/route.ts`, after the `const isTrickle = ...` line at :311, add:
+
+```typescript
+      // Whole-evening capture: this camera's frames are kept regardless of
+      // score, which is the entire point — the model-gated reasons drop the
+      // N-to-1 crossing, and that crossing is what run labeling needs.
+      const isRunPanel = runPanel.has(webcamId);
+```
+
+Extend `shouldPersist` to include it:
+
+```typescript
+      const shouldPersist =
+        disagreementKind !== null ||
+        isHighRated ||
+        isTrickle ||
+        isRunPanel ||
+        SAVE_ALL_RATED_SNAPSHOTS ||
+        (binKind !== null && binFeed !== null);
+```
+
+Put `'run'` at the top of the precedence chain:
+
+```typescript
+      // Precedence matters for the analysis, not for the write. 'run' is FIRST:
+      // a panel frame would have been kept whatever it scored, so stamping it
+      // 'disagreement' would make a uniformly sampled frame look model-selected
+      // and silently poison the corpus this panel exists to produce. The
+      // disagreement itself is not lost — model_disagreement_kind is written
+      // independently, and the Hard Examples queue filters on that column, not
+      // on intake_reason.
+      const intakeReason:
+        | 'disagreement' | 'high_rated' | 'trickle' | 'all_rated' | 'kiosk_bin' | 'run' =
+        isRunPanel
+          ? 'run'
+          : disagreementKind !== null
+            ? 'disagreement'
+            : isHighRated
+              ? 'high_rated'
+              : isTrickle
+                ? 'trickle'
+                : SAVE_ALL_RATED_SNAPSHOTS
+                  ? 'all_rated'
+                  : 'kiosk_bin';
+```
+
+- [ ] **Step 7: Run the full suite and the build**
+
+Run: `npm run test`
+Expected: PASS, no regressions in the cron suites.
+
+Run: `npm run build`
+Expected: build completes.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add app/api/cron/update-cameras/route.ts app/api/cron/update-cameras/lib/dbOperations.ts app/api/cron/update-cameras/lib/dbOperations.test.ts
+git commit -m "feat(run-capture): keep whole evenings for panel cameras as intake_reason=run"
+```
+
+---
+
+### Task 5: Seed the panel
+
+**Files:**
+- Create: `scripts/seed-run-panel.mjs`
+
+**Interfaces:**
+- Consumes: table `run_panel` from Task 1.
+- Produces: 60 rows in `run_panel`. Dry by default, `--apply` to write, matching `set-runtime-flag.mjs` and `apply-migration.mjs`.
+
+- [ ] **Step 1: Write the script**
+
+```javascript
+// scripts/seed-run-panel.mjs
+//
+// Chooses the whole-evening capture panel. Cameras that have actually produced
+// operator-confirmed sunsets, spread across longitude so runs land at different
+// UTC hours rather than all in one part of the world.
+//
+// Dry by default. Every env file here points at the SAME Neon endpoint, so
+// every --apply run is a production change.
+//
+//   node scripts/seed-run-panel.mjs
+//   node scripts/seed-run-panel.mjs --apply
+//   node scripts/seed-run-panel.mjs --size 40 --apply
+import { neon } from '@neondatabase/serverless';
+import { readFileSync } from 'node:fs';
+
+function loadDatabaseUrl() {
+  if (process.env.DATABASE_URL) return process.env.DATABASE_URL;
+  const env = readFileSync('.env.local', 'utf8');
+  const line = env.split('\n').find((l) => l.startsWith('DATABASE_URL='));
+  if (!line) throw new Error('DATABASE_URL not found in env or .env.local');
+  return line.slice('DATABASE_URL='.length).replace(/^"|"$/g, '');
+}
+
+const sql = neon(loadDatabaseUrl());
+const apply = process.argv.includes('--apply');
+const sizeArg = process.argv.indexOf('--size');
+const SIZE = sizeArg === -1 ? 60 : Number(process.argv[sizeArg + 1]);
+// 24 buckets of 15 degrees: one per hour of local solar time.
+const BUCKETS = 24;
+
+const candidates = await sql`
+  SELECT w.id, w.longitude, count(*)::int AS confirmed_sunsets
+  FROM manual_labels m
+  JOIN webcam_snapshots s ON s.id = m.image_id AND m.source = 'webcam'
+  JOIN webcams w ON w.id = s.webcam_id
+  WHERE m.is_sunset AND w.longitude IS NOT NULL
+  GROUP BY w.id, w.longitude
+  HAVING count(*) >= 3
+  ORDER BY count(*) DESC
+`;
+
+// Round-robin across longitude buckets so the panel is not all one meridian.
+const byBucket = new Map();
+for (const c of candidates) {
+  const b = Math.floor(((Number(c.longitude) + 180) % 360) / (360 / BUCKETS));
+  if (!byBucket.has(b)) byBucket.set(b, []);
+  byBucket.get(b).push(c);
+}
+
+const picked = [];
+let exhausted = false;
+while (picked.length < SIZE && !exhausted) {
+  exhausted = true;
+  for (const list of byBucket.values()) {
+    if (picked.length >= SIZE) break;
+    const next = list.shift();
+    if (next) {
+      picked.push(next);
+      exhausted = false;
+    }
+  }
+}
+
+console.log(`candidates: ${candidates.length}, buckets used: ${byBucket.size}`);
+console.log(`picked ${picked.length} of a requested ${SIZE}:`);
+for (const p of picked) {
+  console.log(`  webcam ${p.id}  lng ${Number(p.longitude).toFixed(1)}  ${p.confirmed_sunsets} confirmed sunsets`);
+}
+
+if (!apply) {
+  console.log('\nDRY RUN. Re-run with --apply to write run_panel.');
+  process.exit(0);
+}
+
+for (const p of picked) {
+  await sql`
+    INSERT INTO run_panel (webcam_id, note)
+    VALUES (${Number(p.id)}, ${`seeded 2026-09-08: ${p.confirmed_sunsets} confirmed sunsets, lng ${Number(p.longitude).toFixed(1)}`})
+    ON CONFLICT (webcam_id) DO NOTHING
+  `;
+}
+console.log(`\nwrote ${picked.length} rows to run_panel.`);
+console.log('Now enable capture: node scripts/set-runtime-flag.mjs run_panel_capture on --apply');
+```
+
+- [ ] **Step 2: Dry-run it**
+
+Run: `node scripts/seed-run-panel.mjs`
+Expected: prints candidate count, bucket count, and 60 chosen cameras with longitudes spread across buckets. Writes nothing.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add scripts/seed-run-panel.mjs
+git commit -m "feat(run-capture): seed the capture panel across longitude buckets"
+```
+
+---
+
+### Task 6: Run inventory report
+
+**Files:**
+- Create: `scripts/run-inventory.mjs`
+
+**Interfaces:**
+- Consumes: `webcam_snapshots.intake_reason`, `webcams.longitude`, and the run definition from Task 2 expressed in SQL.
+- Produces: a console report. This is how the corpus is watched as it accumulates, and how Phase 2 decides it has enough runs to start.
+
+- [ ] **Step 1: Write the script**
+
+```javascript
+// scripts/run-inventory.mjs
+//
+// What run corpus exists, and how much of it is uniform rather than
+// model-selected. Read this before starting a labeling sitting.
+//
+// A run is one camera's one evening, keyed on LOCAL SOLAR date (longitude / 15
+// hours). A fixed UTC offset splits western-hemisphere evenings in half.
+//
+// This query MIRRORS app/lib/runKey.ts, which is the definition of record. The
+// duplication exists because a .mjs script cannot import a .ts module; change
+// both or neither.
+//
+//   node scripts/run-inventory.mjs
+//   node scripts/run-inventory.mjs --days 30
+import { neon } from '@neondatabase/serverless';
+import { readFileSync } from 'node:fs';
+
+function loadDatabaseUrl() {
+  if (process.env.DATABASE_URL) return process.env.DATABASE_URL;
+  const env = readFileSync('.env.local', 'utf8');
+  const line = env.split('\n').find((l) => l.startsWith('DATABASE_URL='));
+  if (!line) throw new Error('DATABASE_URL not found in env or .env.local');
+  return line.slice('DATABASE_URL='.length).replace(/^"|"$/g, '');
+}
+
+const sql = neon(loadDatabaseUrl());
+const daysArg = process.argv.indexOf('--days');
+const DAYS = daysArg === -1 ? 45 : Number(process.argv[daysArg + 1]);
+
+const runs = await sql`
+  WITH framed AS (
+    SELECT s.id, s.webcam_id, s.phase, s.intake_reason,
+           s.captured_at,
+           ((s.captured_at AT TIME ZONE 'UTC'
+             + make_interval(mins => (w.longitude / 15.0 * 60)::int)))::date AS solar_day
+    FROM webcam_snapshots s
+    JOIN webcams w ON w.id = s.webcam_id
+    WHERE s.captured_at > now() - make_interval(days => ${DAYS}::int)
+      AND s.phase = 'sunset'
+      AND w.longitude IS NOT NULL
+  ),
+  grouped AS (
+    SELECT webcam_id, solar_day,
+           count(*)::int AS frames,
+           count(*) FILTER (WHERE intake_reason = 'run')::int AS run_frames,
+           extract(epoch FROM (max(captured_at) - min(captured_at))) / 60 AS span_min
+    FROM framed GROUP BY webcam_id, solar_day
+  )
+  SELECT
+    count(*) FILTER (WHERE frames >= 6 AND span_min BETWEEN 30 AND 150)::int AS labelable_runs,
+    count(*) FILTER (WHERE frames >= 6 AND span_min BETWEEN 30 AND 150
+                       AND run_frames = frames)::int AS uniform_runs,
+    count(DISTINCT webcam_id) FILTER (WHERE run_frames > 0)::int AS panel_cameras_seen,
+    round(avg(frames) FILTER (WHERE run_frames = frames)::numeric, 1) AS avg_frames_uniform
+  FROM grouped
+`;
+console.log(`window: last ${DAYS} days, sunset phase`);
+console.table(runs);
+
+const mix = await sql`
+  SELECT coalesce(intake_reason, '(null)') AS reason, count(*)::int AS frames
+  FROM webcam_snapshots
+  WHERE captured_at > now() - make_interval(days => ${DAYS}::int)
+  GROUP BY 1 ORDER BY 2 DESC
+`;
+console.log('intake mix over the same window:');
+console.table(mix);
+```
+
+- [ ] **Step 2: Run it against production**
+
+Run: `node scripts/run-inventory.mjs`
+Expected: `uniform_runs` is 0 before the flag is switched on. That zero is the baseline, and it is the number that should start climbing the evening after capture is enabled.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add scripts/run-inventory.mjs
+git commit -m "feat(run-capture): run inventory report separates uniform runs from model-selected ones"
+```
+
+---
+
+## Operator checklist — after 2026-09-12, in this order
+
+Do not reorder. The migration must land before the code that writes `'run'`, because the cron swallows its own write errors and a constraint violation would lose frames silently rather than loudly.
+
+- [ ] Apply the migration: `node scripts/apply-migration.mjs database/migrations/20260908_run_panel.sql --apply`
+- [ ] Confirm: `npm run migrate:status` exits 0
+- [ ] Merge the PR, let the Vercel build go Ready
+- [ ] Seed the panel: `node scripts/seed-run-panel.mjs` then re-run with `--apply`
+- [ ] Enable capture: `node scripts/set-runtime-flag.mjs run_panel_capture on --apply`
+- [ ] Next morning, confirm the corpus is growing: `node scripts/run-inventory.mjs`, `uniform_runs` above 0
+- [ ] Watch cost for a week against the ~$0.44/day baseline in `scripts/usage-report.mjs`. The panel adds roughly 540 frames per evening, well under the ~32k per week `disagreement` already takes, so a visible jump means something is wrong with panel size, not with the estimate.
+
+## Phase 2, not in this plan
+
+Written once runs have accumulated:
+
+- `run_crossings` table, keyed by run, pass number and rater
+- The filmstrip marking mode, boundaries first and peak last, blind
+- The pre-registered reproducibility experiment against the `is_sunset` 13.6% and `rating ≥ 4` 12.6% baselines
+- Export-time derivation of per-frame labels, with their own label source, never written into `manual_labels`

--- a/docs/superpowers/plans/2026-09-08-run-collection-phase1.md
+++ b/docs/superpowers/plans/2026-09-08-run-collection-phase1.md
@@ -685,9 +685,11 @@ git commit -m "feat(run-capture): run inventory report separates uniform runs fr
 
 Do not reorder. The migration must land before the code that writes `'run'`, because the cron swallows its own write errors and a constraint violation would lose frames silently rather than loudly.
 
+- [ ] Pre-flight the constraint swap: `scripts/apply-migration.mjs` sends one statement per request, so if the ADD CONSTRAINT fails after the DROP succeeds, `webcam_snapshots` is left with no `intake_reason` check at all. Run `SELECT DISTINCT intake_reason FROM webcam_snapshots;` and confirm every value returned appears in the migration's new CHECK list before running with `--apply`.
 - [ ] Apply the migration: `node scripts/apply-migration.mjs database/migrations/20260908_run_panel.sql --apply`
 - [ ] Confirm: `npm run migrate:status` exits 0
 - [ ] Merge the PR, let the Vercel build go Ready
+- [ ] Confirm the inventory script's phase-splitting fix is in place (`scripts/run-inventory.mjs` derives morning/evening from local solar hour, not the stored `phase` column). Without it, the report reads 0 uniform runs regardless of whether capture is working and looks like a failure.
 - [ ] Seed the panel: `node scripts/seed-run-panel.mjs` then re-run with `--apply`
 - [ ] Enable capture: `node scripts/set-runtime-flag.mjs run_panel_capture on --apply`
 - [ ] Next morning, confirm the corpus is growing: `node scripts/run-inventory.mjs`, `uniform_runs` above 0

--- a/docs/superpowers/plans/2026-09-08-run-collection-phase1.md
+++ b/docs/superpowers/plans/2026-09-08-run-collection-phase1.md
@@ -26,6 +26,7 @@
 - **Never write derived labels into `manual_labels`.** Out of scope here, but it governs Phase 2 and is repeated so it is not lost.
 - `beforeEach` bodies use braces, never a concise arrow returning `mockReset()` — a returned mock value is called as Vitest teardown.
 - Panel size is **60 cameras** unless the operator says otherwise.
+- Camera coordinates on `webcams` are **`lat` and `lng`, both `double precision`** — verified 2026-09-08. There is no `longitude` column.
 
 ## Scope
 
@@ -517,12 +518,12 @@ const SIZE = sizeArg === -1 ? 60 : Number(process.argv[sizeArg + 1]);
 const BUCKETS = 24;
 
 const candidates = await sql`
-  SELECT w.id, w.longitude, count(*)::int AS confirmed_sunsets
+  SELECT w.id, w.lng, count(*)::int AS confirmed_sunsets
   FROM manual_labels m
   JOIN webcam_snapshots s ON s.id = m.image_id AND m.source = 'webcam'
   JOIN webcams w ON w.id = s.webcam_id
-  WHERE m.is_sunset AND w.longitude IS NOT NULL
-  GROUP BY w.id, w.longitude
+  WHERE m.is_sunset AND w.lng IS NOT NULL
+  GROUP BY w.id, w.lng
   HAVING count(*) >= 3
   ORDER BY count(*) DESC
 `;
@@ -530,7 +531,7 @@ const candidates = await sql`
 // Round-robin across longitude buckets so the panel is not all one meridian.
 const byBucket = new Map();
 for (const c of candidates) {
-  const b = Math.floor(((Number(c.longitude) + 180) % 360) / (360 / BUCKETS));
+  const b = Math.floor(((Number(c.lng) + 180) % 360) / (360 / BUCKETS));
   if (!byBucket.has(b)) byBucket.set(b, []);
   byBucket.get(b).push(c);
 }
@@ -552,7 +553,7 @@ while (picked.length < SIZE && !exhausted) {
 console.log(`candidates: ${candidates.length}, buckets used: ${byBucket.size}`);
 console.log(`picked ${picked.length} of a requested ${SIZE}:`);
 for (const p of picked) {
-  console.log(`  webcam ${p.id}  lng ${Number(p.longitude).toFixed(1)}  ${p.confirmed_sunsets} confirmed sunsets`);
+  console.log(`  webcam ${p.id}  lng ${Number(p.lng).toFixed(1)}  ${p.confirmed_sunsets} confirmed sunsets`);
 }
 
 if (!apply) {
@@ -563,7 +564,7 @@ if (!apply) {
 for (const p of picked) {
   await sql`
     INSERT INTO run_panel (webcam_id, note)
-    VALUES (${Number(p.id)}, ${`seeded 2026-09-08: ${p.confirmed_sunsets} confirmed sunsets, lng ${Number(p.longitude).toFixed(1)}`})
+    VALUES (${Number(p.id)}, ${`seeded 2026-09-08: ${p.confirmed_sunsets} confirmed sunsets, lng ${Number(p.lng).toFixed(1)}`})
     ON CONFLICT (webcam_id) DO NOTHING
   `;
 }
@@ -631,12 +632,12 @@ const runs = await sql`
     SELECT s.id, s.webcam_id, s.phase, s.intake_reason,
            s.captured_at,
            ((s.captured_at AT TIME ZONE 'UTC'
-             + make_interval(mins => (w.longitude / 15.0 * 60)::int)))::date AS solar_day
+             + make_interval(mins => (w.lng / 15.0 * 60)::int)))::date AS solar_day
     FROM webcam_snapshots s
     JOIN webcams w ON w.id = s.webcam_id
     WHERE s.captured_at > now() - make_interval(days => ${DAYS}::int)
       AND s.phase = 'sunset'
-      AND w.longitude IS NOT NULL
+      AND w.lng IS NOT NULL
   ),
   grouped AS (
     SELECT webcam_id, solar_day,

--- a/docs/superpowers/plans/2026-09-08-run-collection-phase1.md
+++ b/docs/superpowers/plans/2026-09-08-run-collection-phase1.md
@@ -831,13 +831,16 @@ Do not reorder. The migration must land before the code that writes `'run'`, bec
 - [ ] Pre-flight the constraint swap: `scripts/apply-migration.mjs` sends one statement per request, so if the ADD CONSTRAINT fails after the DROP succeeds, `webcam_snapshots` is left with no `intake_reason` check at all. Run `SELECT DISTINCT intake_reason FROM webcam_snapshots;` and confirm every value returned appears in the migration's new CHECK list before running with `--apply`.
 - [ ] Apply the migration: `node scripts/apply-migration.mjs database/migrations/20260908_run_panel.sql --apply`
 - [ ] Confirm: `npm run migrate:status` exits 0
+- [ ] **Build the MERGE RESULT before merging, not this branch alone.** `main` will have moved during show week. `git merge --no-commit origin/main`, then `npm run build` and `npm run test` on the combined tree, then merge. A zero-file-overlap merge has broken `main` twice on this repo via type coupling; the branch passing on its own proves nothing about the result. See `docs/solutions/workflow-issues/merged-is-a-claim-about-a-branch.md`.
 - [ ] Merge the PR, let the Vercel build go Ready
+- [ ] Confirm it actually reached `main`: `git merge-base --is-ancestor <merge sha> origin/main`. "Merged" is a claim about a branch.
 - [ ] Confirm the inventory script's phase-splitting fix is in place (`scripts/run-inventory.mjs` derives morning/evening from local solar hour, not the stored `phase` column). Without it, the report reads 0 uniform runs regardless of whether capture is working and looks like a failure.
 - [ ] Seed the panel: `node scripts/seed-run-panel.mjs` then re-run with `--apply`
 - [ ] Enable capture: `node scripts/set-runtime-flag.mjs run_panel_capture on --apply`
 - [ ] Confirm the disagreement arm is off: `node scripts/set-runtime-flag.mjs` lists `disagreement_intake = false`. Flip it on only in the week before a planned labeling sitting, and off again after.
 - [ ] Next morning, confirm the corpus is growing: `node scripts/run-inventory.mjs`, `uniform_runs` above 0
-- [ ] Watch cost for a week against the ~$0.44/day baseline in `scripts/usage-report.mjs`. The panel adds roughly 540 frames per evening, well under the ~32k per week `disagreement` already takes, so a visible jump means something is wrong with panel size, not with the estimate.
+- [ ] Watch cost for a week against the ~$0.44/day baseline in `scripts/usage-report.mjs`. Net intake should go DOWN, not up: the panel adds ~1,080 frames/day across both solar events, while switching the disagreement arm off removes ~5,000/day. A rise means the disagreement flag did not actually take effect — check it with `node scripts/set-runtime-flag.mjs` before touching panel size.
+- [ ] Remove the worktree once the PR is merged: `scripts/wt.sh rm feat/run-crossings` from the main checkout. **Check first that no other session is working in it** — a second Claude session was committing to this worktree on 2026-09-08.
 
 ## Phase 2, not in this plan
 

--- a/docs/superpowers/plans/2026-09-08-run-collection-phase1.md
+++ b/docs/superpowers/plans/2026-09-08-run-collection-phase1.md
@@ -9,7 +9,7 @@
 > evenings of run data is cheap; a broken cron during show week is not.
 > Runbook: `docs/superpowers/plans/2026-09-03-opening-night-runbook.md`.
 
-**Goal:** Start collecting uniform, whole-evening frame runs from a bounded panel of cameras, so that run-crossing labeling has an unbiased corpus to work on.
+**Goal:** Start collecting uniform, whole-event frame runs from a bounded panel of cameras, so that run-crossing labeling has an unbiased corpus to work on. A run is one camera and one solar event, so a panel camera yields two runs a day, a sunrise and a sunset. "Evening" below is shorthand for either. Both phases are retained; the spec's Leg 0 says why.
 
 **Architecture:** A `run_panel` table names the cameras. A `runtime_flags` row switches collection on without a redeploy. The `update-cameras` cron persists every scored frame for a panel camera and stamps it `intake_reason = 'run'`, which takes highest precedence so a panel frame is never misattributed to a model-gated reason. A pure `runKey` function gives a run its identity from local solar time rather than a fixed UTC offset.
 
@@ -83,7 +83,7 @@ INSERT INTO runtime_flags (key, enabled, note)
 VALUES (
   'run_panel_capture',
   false,
-  'Keep every scored frame for cameras in run_panel, stamped intake_reason=run. ~9 frames per camera-evening.'
+  'Keep every scored frame for cameras in run_panel, stamped intake_reason=run. Both phases: ~9 frames per camera-event, two events a day.'
 )
 ON CONFLICT (key) DO NOTHING;
 ```
@@ -363,6 +363,28 @@ Append to `app/api/cron/update-cameras/lib/dbOperations.test.ts`, inside the exi
     const values = sqlMock.mock.calls[0].slice(1);
     expect(values).toContain('run');
   });
+
+  it('accepts a sunrise-phase frame for the same panel capture', async () => {
+    // The panel is not sunset-only. This test exists so that a later change
+    // adding a phase gate to the persist path fails loudly here.
+    sqlMock.mockResolvedValue([{ id: 4243 }]);
+
+    const id = await insertWindyDisagreementSnapshot({
+      webcamId: 700,
+      phase: 'sunrise',
+      firebaseUrl: 'https://storage.googleapis.com/y.jpg',
+      firebasePath: 'y.jpg',
+      aiRating: 2.5,
+      aiRegressionScore: 0.375,
+      aiModelVersionRegression: 'v5',
+      scoringPath: 'onnx',
+      disagreementKind: null,
+      intakeReason: 'run',
+    });
+
+    expect(id).toBe(4243);
+    expect(sqlMock.mock.calls[0].slice(1)).toContain('run');
+  });
 ```
 
 - [ ] **Step 2: Run the test to verify it fails**
@@ -415,9 +437,14 @@ Then, immediately before the loop that iterates webcams (the same place `feedByE
 In `app/api/cron/update-cameras/route.ts`, after the `const isTrickle = ...` line at :311, add:
 
 ```typescript
-      // Whole-evening capture: this camera's frames are kept regardless of
+      // Whole-event capture: this camera's frames are kept regardless of
       // score, which is the entire point — the model-gated reasons drop the
       // N-to-1 crossing, and that crossing is what run labeling needs.
+      //
+      // Deliberately NOT gated on phase. Sunrise runs teach the same two
+      // boundaries, the corpus is short of them, and the gate is one Set
+      // lookup either way. Do not add a phase condition here without reading
+      // Leg 0 of the spec first.
       const isRunPanel = runPanel.has(webcamId);
 ```
 

--- a/docs/superpowers/plans/2026-09-08-run-collection-phase1.md
+++ b/docs/superpowers/plans/2026-09-08-run-collection-phase1.md
@@ -708,6 +708,122 @@ git commit -m "feat(run-capture): run inventory report separates uniform runs fr
 
 ---
 
+### Task 7: Flag off the disagreement intake
+
+**Files:**
+- Modify: `database/migrations/20260908_run_panel.sql` — seed a second flag
+- Modify: `app/api/cron/update-cameras/route.ts` — gate the persist trigger and the attribution
+- Test: `app/api/cron/update-cameras/route.test.ts`
+
+**Why.** The disagreement arm has banked **32,013 frames and zero of them have ever been labeled.** It runs at roughly 5,000 frames a day and more than doubled the archive in a month. Labeling effectively stopped on 2026-08-30, when the ceiling verdict cancelled the labeling push, and the existing backlog is about eleven full sittings deep at the historic peak rate. The arm is mining fuel for a program that measurement declared finished.
+
+It is worth keeping the *capability*, because hard examples are model-relative: the banked ones were mined by the currently shipping pair and go stale the moment the model changes. So this is a flag, not a deletion. Flip it on a week before a labeling sitting and it refills against whatever model is current then.
+
+**Two things that must NOT change.** Both are easy to break and neither is optional.
+
+1. **`model_disagreement_kind` is still computed and still written** on every row that persists for some other reason. The Hard Examples queue filters on that column, not on `intake_reason`, so the queue keeps working on the backlog *and* keeps receiving genuinely fresh hard examples for free from the unbiased arms.
+2. **The `'disagreement'` arm of the precedence chain must be gated by the same boolean as the persist trigger.** Otherwise a frame that enters via `trickle` and happens to disagree gets stamped `'disagreement'`, which destroys the separability of the unbiased control arm — the exact property `intake_reason` exists to protect.
+
+**Interfaces:**
+- Consumes: `isFlagEnabled` from `@/app/lib/runtimeFlags`, already imported in `route.ts:37`.
+- Produces: no new exports.
+
+- [ ] **Step 1: Seed the flag in the existing migration**
+
+Append to `database/migrations/20260908_run_panel.sql`:
+
+```sql
+-- The disagreement arm has banked 32,013 frames, zero of them ever labeled,
+-- at ~5,000/day. Labeling stopped 2026-08-30 with the ceiling verdict, and the
+-- backlog is ~11 sittings deep. Seeded OFF: flip it on a week before a sitting
+-- so hard examples are re-mined against the then-current model, since a hard
+-- example is model-relative and goes stale when the model changes.
+INSERT INTO runtime_flags (key, enabled, note)
+VALUES (
+  'disagreement_intake',
+  false,
+  'Persist a Windy frame because the two heads disagree. OFF: 32,013 unlabeled frames already banked. model_disagreement_kind is still written on rows that persist for other reasons, so the Hard Examples queue is unaffected.'
+)
+ON CONFLICT (key) DO NOTHING;
+```
+
+- [ ] **Step 2: Write the failing tests**
+
+Add to `app/api/cron/update-cameras/route.test.ts`, alongside the existing panel-precedence test:
+
+```typescript
+  it('does not persist a frame for disagreement alone when the intake flag is off', async () => {
+    isFlagEnabledMock.mockImplementation(async (key: string) =>
+      key === 'disagreement_intake' ? false : false,
+    );
+    computeDisagreementKindMock.mockReturnValue('binary_negative_regression_high');
+    loadRunPanelMock.mockResolvedValue(new Set<number>());
+
+    await GET(authedRequest());
+
+    expect(insertWindyDisagreementSnapshotMock).not.toHaveBeenCalled();
+  });
+
+  it('still records the disagreement kind on a frame the panel brought in', async () => {
+    isFlagEnabledMock.mockImplementation(async () => false);
+    computeDisagreementKindMock.mockReturnValue('binary_negative_regression_high');
+    loadRunPanelMock.mockResolvedValue(new Set<number>([700]));
+
+    await GET(authedRequest());
+
+    expect(insertWindyDisagreementSnapshotMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        intakeReason: 'run',
+        disagreementKind: 'binary_negative_regression_high',
+      }),
+    );
+  });
+```
+
+Match the file's existing helpers for building an authorized request and for the mock names; the names above are indicative, the existing file is authoritative.
+
+- [ ] **Step 3: Run the tests to verify they fail**
+
+Run: `npx vitest run app/api/cron/update-cameras/route.test.ts`
+Expected: FAIL — the frame is still persisted, because nothing gates the trigger yet.
+
+- [ ] **Step 4: Read the flag once per tick**
+
+In `route.ts`, beside the existing `const runPanel = await loadRunPanel();`:
+
+```typescript
+  // Hard-example mining, switchable without a redeploy. Off since 2026-09-08:
+  // 32,013 banked frames, none labeled. isFlagEnabled fails closed, and closed
+  // means "do not collect", so a database blip costs nothing.
+  const disagreementIntake = await isFlagEnabled('disagreement_intake');
+```
+
+- [ ] **Step 5: Gate the trigger and the attribution together**
+
+Replace the persist decision and the first two arms of the precedence chain:
+
+```typescript
+      // The disagreement is always COMPUTED and always recorded on the row via
+      // model_disagreement_kind, which is what the Hard Examples queue reads.
+      // Only whether it is a reason to KEEP the frame is switchable.
+      const disagreementPersisted = disagreementKind !== null && disagreementIntake;
+```
+
+Use `disagreementPersisted` — not `disagreementKind !== null` — in both `shouldPersist` and the `'disagreement'` arm of the `intakeReason` ternary. Leave `'run'` first. Leave `disagreementKind` itself passed to `insertWindyDisagreementSnapshot` exactly as it is now.
+
+- [ ] **Step 6: Run the tests to verify they pass, then the full suite**
+
+Run: `npx vitest run app/api/cron/update-cameras/`, then `npm run test`, then `npm run build`.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add database/migrations/20260908_run_panel.sql app/api/cron/update-cameras/route.ts app/api/cron/update-cameras/route.test.ts
+git commit -m "feat(intake): make the disagreement arm switchable, seeded off"
+```
+
+---
+
 ## Operator checklist — after 2026-09-12, in this order
 
 Do not reorder. The migration must land before the code that writes `'run'`, because the cron swallows its own write errors and a constraint violation would lose frames silently rather than loudly.
@@ -719,6 +835,7 @@ Do not reorder. The migration must land before the code that writes `'run'`, bec
 - [ ] Confirm the inventory script's phase-splitting fix is in place (`scripts/run-inventory.mjs` derives morning/evening from local solar hour, not the stored `phase` column). Without it, the report reads 0 uniform runs regardless of whether capture is working and looks like a failure.
 - [ ] Seed the panel: `node scripts/seed-run-panel.mjs` then re-run with `--apply`
 - [ ] Enable capture: `node scripts/set-runtime-flag.mjs run_panel_capture on --apply`
+- [ ] Confirm the disagreement arm is off: `node scripts/set-runtime-flag.mjs` lists `disagreement_intake = false`. Flip it on only in the week before a planned labeling sitting, and off again after.
 - [ ] Next morning, confirm the corpus is growing: `node scripts/run-inventory.mjs`, `uniform_runs` above 0
 - [ ] Watch cost for a week against the ~$0.44/day baseline in `scripts/usage-report.mjs`. The panel adds roughly 540 frames per evening, well under the ~32k per week `disagreement` already takes, so a visible jump means something is wrong with panel size, not with the estimate.
 

--- a/docs/superpowers/specs/2026-09-08-run-crossing-labeling-design.md
+++ b/docs/superpowers/specs/2026-09-08-run-crossing-labeling-design.md
@@ -99,15 +99,34 @@ So the archive funds the experiment, and new collection funds the labels.
 ## Leg 0 — collect uniform runs
 
 Add an intake reason `run`. A bounded panel of cameras retains **every scored
-frame in the sunset window** on every evening, regardless of model score.
+frame in both solar windows** on every day, regardless of model score.
+
+**Both phases, not sunset only.** A run is one camera and one solar event, so a
+panel camera produces two runs a day: a sunrise and a sunset. Three reasons,
+and the first is the one that decides it.
+
+- The two boundaries this whole design exists to sharpen, `is_sunset` and
+  `rating >= 4`, are not sunset-specific. A sunrise crossing teaches them the
+  same thing, and the corpus is measurably short of sunrise: the leaderboard
+  fix of 2026-09-08 found the Best Sunsets top hundred was half sunrises, which
+  is what a phase-blind archive looks like from the outside.
+- The panel runs in reverse through a sunrise, so the same camera under the
+  same framing supplies a rising arc and a falling one. That is a stronger
+  anchor pair than two sunsets, and it costs one boolean.
+- The Instagram prelude bank wants alternating sunrise and sunset carousels and
+  has no other source of whole, unclipped runs. Sunset-only capture funds half
+  a feed.
 
 - **Panel size: 60 cameras.** At the 10-minute cron cadence and a ~90 minute
-  window that is roughly 9 frames per camera-evening, so ~540 frames/evening
-  and ~16k/month. Current `disagreement` intake alone ran ~32k frames in seven
-  days, so the panel is under 10% of what the archive already takes.
-- **Panel selection:** cameras with the most operator-confirmed sunsets and
+  window that is roughly 9 frames per camera-event. Two events a day is ~1,080
+  frames/day and ~32k/month. Current `disagreement` intake alone ran ~32k
+  frames in seven days, so the panel is still under a quarter of what the
+  archive already takes, and the flag turns it off without a deploy.
+- **Panel selection:** cameras with the most operator-confirmed events and
   stable framing, spread across longitude so runs land at different UTC hours.
   Seeded once from `manual_labels`, stored explicitly, not recomputed per tick.
+  The seed reads `manual_labels.is_sunset`, which is the operator saying a sky
+  event happened, not a phase. Sunrise-good cameras are already in it.
 - **Fixed panel, slow rotation.** The anchor-pair value comes from the *same*
   camera under different skies. Camera diversity is already abundant elsewhere
   in the corpus.
@@ -116,6 +135,24 @@ frame in the sunset window** on every evening, regardless of model score.
 
 `intake_reason = 'run'` keeps these frames separable forever, which is the
 whole point of that column.
+
+**The capture gate is camera membership, never phase.** Nothing in the persist
+path asks which event this is, so retaining both phases is the absence of a
+filter rather than a second code path. Two things follow, and both are easy to
+get wrong later:
+
+- `webcam_snapshots.phase` is stamped `'sunset'` unconditionally at
+  `app/api/cron/update-cameras/route.ts:340`, and the reason is structural, not
+  laziness: Windy scoring runs earlier in the tick than the sunrise/sunset
+  classification step, so at write time the phase is genuinely not known yet.
+  That column is therefore wrong on roughly half the panel's rows. Nothing here
+  reads it and nothing here should — run identity comes from geometry via
+  `solarPhaseAt`, which is also the standing finding that the stored phase is
+  17% wrong anyway. Left alone deliberately. Fixing it means reordering the
+  cron, which is a separate decision with its own blast radius.
+- "Evening" throughout the plan is shorthand for one solar event. `runKey` is
+  already keyed on camera, phase and local solar date, and already has a test
+  keeping a camera's sunrise and sunset apart on the same day.
 
 ### Timing
 

--- a/docs/superpowers/specs/2026-09-08-run-crossing-labeling-design.md
+++ b/docs/superpowers/specs/2026-09-08-run-crossing-labeling-design.md
@@ -1,0 +1,240 @@
+---
+title: "Run-crossing labeling — rating a sunset by where it changes, not what it scores"
+date: 2026-09-08
+status: design, not approved
+---
+
+# Run-crossing labeling
+
+Label a camera's evening by marking the few frames where it **crosses** a
+boundary, instead of assigning an absolute rating to every frame. Five marks
+per run replace forty ratings, and each mark is a comparison between adjacent
+frames under fixed framing rather than a recall of a scale.
+
+This document is a design. Nothing here is built.
+
+---
+
+## Why this and not anything else
+
+Every measurement in the model program points at the same binding constraint.
+`2026-08-29-two-scale-model-STATE.md` records it: both heads sit at or above
+the operator's own reproducibility, so the limit on rating quality is not the
+model, not the volume of labels, and not any covariate.
+
+| operator test–retest, `retest_v1` | value |
+|---|---|
+| quality self-Pearson | 0.673 |
+| detection self-F1 | 0.807 |
+
+And the noise decomposes. Only two label boundaries ever reach a model, because
+only two cross a training threshold:
+
+| corpus-weighted label noise | value |
+|---|---|
+| `is_sunset` flips | 13.6% |
+| `rating ≥ 4` flips | 12.6% |
+
+A 2↔3 or 4↔5 wobble costs nothing. So the only work that can improve rating is
+work that makes those two boundaries more reproducible.
+
+**Crossing marks attack exactly that.** Within a run the framing is fixed and
+the frames are minutes apart, so the operator compares two adjacent images
+rather than recalling where a 4 begins. Comparison is the standard remedy for
+rater inconsistency on an absolute scale.
+
+**And it is the only proposal that can move the ceiling rather than measure
+against it.** The 0.673 / 0.807 figures are test–retest on *absolute ratings*.
+If crossing marks reproduce better than absolute ratings do, the ceiling itself
+rises and there is headroom again. Every other thread is permanently capped by
+those two numbers.
+
+---
+
+## The finding that changes collection
+
+The archive already holds runs. Measured 2026-09-08, sunset phase, last 150
+days:
+
+| sunset runs | count |
+|---|---|
+| 4+ frames within a 30–150 minute window | 1,876 |
+| of those, 6+ frames | 1,071 |
+| distinct cameras | 1,045 |
+| completely unlabeled | 1,729 |
+
+**But those runs are model-selected subsequences, not evenings.** Intake
+composition inside the 6+ frame runs, last 45 days:
+
+| intake reason | frames |
+|---|---|
+| `disagreement` | 4,864 |
+| `kiosk_bin` | 2,209 |
+| null (pre-column) | 1,842 |
+| `high_rated` | 94 |
+| `scene_capture` | 81 |
+| `trickle` | 66 |
+
+A frame enters the archive mainly because the two heads disagreed about it. The
+N-to-1 crossing is precisely where both heads agree that nothing is there, so
+those frames are the **least** likely to have been retained. The boundary
+carrying 21 of the 35 ceiling disagreements is the one the intake filter drops.
+
+This is the archive-drift failure the `SAVE_RANDOM_TRICKLE_RATE` control arm
+exists to counter, and at 2% that arm is far too sparse to rebuild runs from —
+886 trickle frames over 45 days across a thousand cameras.
+
+**Consequence, and it splits the work cleanly:**
+
+- Derived labels from archive runs are **not trustworthy training data**. The
+  gaps between retained frames are non-random and unbounded.
+- The **reproducibility experiment is still valid on them**, because it
+  compares the same operator against himself on the same frames. Sampling bias
+  does not confound a self-agreement measurement.
+
+So the archive funds the experiment, and new collection funds the labels.
+
+---
+
+## Leg 0 — collect uniform runs
+
+Add an intake reason `run`. A bounded panel of cameras retains **every scored
+frame in the sunset window** on every evening, regardless of model score.
+
+- **Panel size: 60 cameras.** At the 10-minute cron cadence and a ~90 minute
+  window that is roughly 9 frames per camera-evening, so ~540 frames/evening
+  and ~16k/month. Current `disagreement` intake alone ran ~32k frames in seven
+  days, so the panel is under 10% of what the archive already takes.
+- **Panel selection:** cameras with the most operator-confirmed sunsets and
+  stable framing, spread across longitude so runs land at different UTC hours.
+  Seeded once from `manual_labels`, stored explicitly, not recomputed per tick.
+- **Fixed panel, slow rotation.** The anchor-pair value comes from the *same*
+  camera under different skies. Camera diversity is already abundant elsewhere
+  in the corpus.
+- **Behind a runtime flag** (`scripts/set-runtime-flag.mjs`) so it can be
+  turned off without a deploy.
+
+`intake_reason = 'run'` keeps these frames separable forever, which is the
+whole point of that column.
+
+### Timing
+
+Leg 0 touches the `update-cameras` cron. The show is Friday 2026-09-12 and the
+freeze is Wednesday 09-10. **Build it now, merge it after the show.** Four lost
+evenings of clean runs is cheap; a broken cron during show week is not.
+
+---
+
+## Leg 1 — the crossing queue
+
+A new mode in the Hard Examples surface that serves a **whole run** as a
+filmstrip and captures five marks.
+
+### The five marks
+
+| mark | question |
+|---|---|
+| `sky_in` | first frame with usable sky |
+| `sky_out` | last frame with usable sky |
+| `carry_in` | first frame where the warm light carries the frame |
+| `carry_out` | last such frame |
+| `peak` | the best frame in the run |
+
+Every mark is nullable, and null is a real answer: an evening that never
+develops usable sky has no `sky_in`, and an evening that never reaches a 4 has
+no `carry_in`. A queue that cannot record "it never crossed" would silently
+invent crossings.
+
+### Order and blinding
+
+Marks are captured in the order above, boundaries first and `peak` last, so the
+spectacular frame does not anchor the boundary judgments. No model scores, no
+Claude scores, and no prior-pass marks are visible while marking. Blind is the
+default everywhere else in this project and there is no reason to break it here.
+
+### What the marks derive
+
+| region | derived label |
+|---|---|
+| before `sky_in`, after `sky_out` | `is_sunset = false` |
+| `sky_in` → `carry_in`, `carry_out` → `sky_out` | `is_sunset = true`, `rating < 4` |
+| `carry_in` → `carry_out` | `is_sunset = true`, `rating ≥ 4` |
+
+That is exactly the two labels that reach a model, and nothing else. The
+derivation deliberately produces **no** 1/2/3 distinction, because that
+distinction has been measured to cost the model nothing.
+
+### Storage
+
+- New table `run_crossings`, keyed by run, pass number and rater.
+- **Never written to `manual_labels`.** Derived labels are correlated within a
+  run; `manual_labels` rows are treated as independent everywhere downstream.
+  Pooling them would repeat the mistake `docs/ml/label-provenance.md` exists to
+  prevent.
+- Derived per-frame labels are computed at **export** time from crossings and
+  carry their own label source, so a training run includes or excludes them by
+  flag rather than by archaeology.
+
+### Run identity
+
+A run needs a real identity, materialized once.
+
+- A run is **camera + phase + solar window**, not camera + a fixed UTC offset.
+  The `captured_at - interval '6 hours'` grouping used in the probe above is
+  wrong for any camera whose sunset straddles UTC midnight, and would split one
+  evening into two runs.
+- Splits already group by `webcam_id`, and a run lives inside one camera, so
+  runs cannot straddle train and test. Nothing about the existing split logic
+  needs to change.
+
+---
+
+## The pre-registered question
+
+**Do crossing marks reproduce better than absolute ratings?** Registered before
+any second pass exists, in the style the model program already uses.
+
+- Second pass over the same runs, blind, at least 14 days after the first.
+- For each crossing, measure the displacement in frames between passes, and
+  convert it to the implied `is_sunset` and `rating ≥ 4` flip rate over the
+  frames of the run.
+- **Bar:** the flip rates must beat the absolute-rating baselines of
+  `is_sunset` 13.6% and `rating ≥ 4` 12.6%. Gains under 2 percentage points
+  count as a wash, consistent with every other bar in this program.
+- **If the bar fails:** the method does not help, the ceiling stands, and no
+  derived label ever enters training. That outcome is a real result and closes
+  the question cheaply.
+
+The second-pass mechanism must exist in the schema from day one. It is the
+whole experiment, and `manual_label_retests` is the precedent for keeping a
+second pass physically separate from the first.
+
+---
+
+## Non-goals
+
+- **No model training in this work.** No retrain is proposed or justified until
+  the bar above is cleared.
+- **No weather join.** Cloud cover is retrievable retroactively from ERA5 for
+  any coordinate and hour, so it is not time-sensitive. It is demoted to a
+  sampling aid, used only if the run panel needs stratifying so that 200 runs
+  are not all one weather regime.
+- **Runs never enter eval draws.** Evaluation stays a random frame draw from
+  the ordinary distribution. Correlated frames would collapse the effective
+  sample size and make a confirmation set lie.
+- **Custom-camera capture with locked exposure is a later leg.** Windy cameras
+  auto-expose, so brightness is normalized across a run and the "sky is the
+  brightest thing in the frame" test is not photometrically pure. This does not
+  block anything, because the operator and the model both judge the rendered
+  frame. It does mean the *tightest* anchor pairs still want own hardware, at
+  seconds apart under locked exposure rather than ten minutes apart under auto.
+
+---
+
+## Open decisions
+
+1. **Panel size.** Recommending 60 cameras on the cost arithmetic above.
+2. **Whether derived labels ever train anything.** Recommending this stays
+   undecided until the reproducibility bar is settled. If crossings turn out to
+   be a better *measuring* instrument than a labeling one, that is still a win,
+   because it would give a cheaper ceiling test than a full retest sitting.

--- a/scripts/run-inventory.mjs
+++ b/scripts/run-inventory.mjs
@@ -10,6 +10,18 @@
 // duplication exists because a .mjs script cannot import a .ts module; change
 // both or neither.
 //
+// Phase is derived from geometry (local solar hour before/after noon), NOT
+// read from the stored `webcam_snapshots.phase` column. That column is
+// hardcoded to 'sunset' at the cron's write site
+// (app/api/cron/update-cameras/route.ts) even though the scoring loop covers
+// cameras on both terminator arcs, so a panel camera's morning frames are
+// also stamped 'sunset'. Filtering on the column would merge a camera's
+// morning and evening frames into one ~13-hour group and the span_min filter
+// below would then drop it, reporting 0 uniform runs while capture works
+// fine. This mirrors app/lib/solarPhase.ts's rule (see PR #180: the stored
+// phase disagrees with geometry on ~17% of frames) in SQL, since the script
+// cannot import that TypeScript module.
+//
 //   node scripts/run-inventory.mjs
 //   node scripts/run-inventory.mjs --days 30
 import { neon } from '@neondatabase/serverless';
@@ -29,32 +41,33 @@ const DAYS = daysArg === -1 ? 45 : Number(process.argv[daysArg + 1]);
 
 const runs = await sql`
   WITH framed AS (
-    SELECT s.id, s.webcam_id, s.phase, s.intake_reason,
+    SELECT s.id, s.webcam_id, s.intake_reason,
            s.captured_at,
-           ((s.captured_at AT TIME ZONE 'UTC'
-             + make_interval(mins => (w.lng / 15.0 * 60)::int)))::date AS solar_day
+           (s.captured_at AT TIME ZONE 'UTC'
+             + make_interval(mins => (w.lng / 15.0 * 60)::int)) AS local_solar_at
     FROM webcam_snapshots s
     JOIN webcams w ON w.id = s.webcam_id
     WHERE s.captured_at > now() - make_interval(days => ${DAYS}::int)
-      AND s.phase = 'sunset'
       AND w.lng IS NOT NULL
   ),
   grouped AS (
-    SELECT webcam_id, solar_day,
+    SELECT webcam_id,
+           local_solar_at::date AS solar_day,
+           extract(hour FROM local_solar_at) < 12 AS is_morning,
            count(*)::int AS frames,
            count(*) FILTER (WHERE intake_reason = 'run')::int AS run_frames,
            extract(epoch FROM (max(captured_at) - min(captured_at))) / 60 AS span_min
-    FROM framed GROUP BY webcam_id, solar_day
+    FROM framed GROUP BY webcam_id, solar_day, is_morning
   )
   SELECT
-    count(*) FILTER (WHERE frames >= 6 AND span_min BETWEEN 30 AND 150)::int AS labelable_runs,
-    count(*) FILTER (WHERE frames >= 6 AND span_min BETWEEN 30 AND 150
+    count(*) FILTER (WHERE NOT is_morning AND frames >= 6 AND span_min BETWEEN 30 AND 150)::int AS labelable_runs,
+    count(*) FILTER (WHERE NOT is_morning AND frames >= 6 AND span_min BETWEEN 30 AND 150
                        AND run_frames = frames)::int AS uniform_runs,
     count(DISTINCT webcam_id) FILTER (WHERE run_frames > 0)::int AS panel_cameras_seen,
-    round(avg(frames) FILTER (WHERE run_frames = frames)::numeric, 1) AS avg_frames_uniform
+    round(avg(frames) FILTER (WHERE NOT is_morning AND run_frames = frames)::numeric, 1) AS avg_frames_uniform
   FROM grouped
 `;
-console.log(`window: last ${DAYS} days, sunset phase`);
+console.log(`window: last ${DAYS} days, evening groups only (phase derived from local solar hour, not the stored column)`);
 console.table(runs);
 
 const mix = await sql`

--- a/scripts/run-inventory.mjs
+++ b/scripts/run-inventory.mjs
@@ -1,0 +1,67 @@
+// scripts/run-inventory.mjs
+//
+// What run corpus exists, and how much of it is uniform rather than
+// model-selected. Read this before starting a labeling sitting.
+//
+// A run is one camera's one evening, keyed on LOCAL SOLAR date (longitude / 15
+// hours). A fixed UTC offset splits western-hemisphere evenings in half.
+//
+// This query MIRRORS app/lib/runKey.ts, which is the definition of record. The
+// duplication exists because a .mjs script cannot import a .ts module; change
+// both or neither.
+//
+//   node scripts/run-inventory.mjs
+//   node scripts/run-inventory.mjs --days 30
+import { neon } from '@neondatabase/serverless';
+import { readFileSync } from 'node:fs';
+
+function loadDatabaseUrl() {
+  if (process.env.DATABASE_URL) return process.env.DATABASE_URL;
+  const env = readFileSync('.env.local', 'utf8');
+  const line = env.split('\n').find((l) => l.startsWith('DATABASE_URL='));
+  if (!line) throw new Error('DATABASE_URL not found in env or .env.local');
+  return line.slice('DATABASE_URL='.length).replace(/^"|"$/g, '');
+}
+
+const sql = neon(loadDatabaseUrl());
+const daysArg = process.argv.indexOf('--days');
+const DAYS = daysArg === -1 ? 45 : Number(process.argv[daysArg + 1]);
+
+const runs = await sql`
+  WITH framed AS (
+    SELECT s.id, s.webcam_id, s.phase, s.intake_reason,
+           s.captured_at,
+           ((s.captured_at AT TIME ZONE 'UTC'
+             + make_interval(mins => (w.lng / 15.0 * 60)::int)))::date AS solar_day
+    FROM webcam_snapshots s
+    JOIN webcams w ON w.id = s.webcam_id
+    WHERE s.captured_at > now() - make_interval(days => ${DAYS}::int)
+      AND s.phase = 'sunset'
+      AND w.lng IS NOT NULL
+  ),
+  grouped AS (
+    SELECT webcam_id, solar_day,
+           count(*)::int AS frames,
+           count(*) FILTER (WHERE intake_reason = 'run')::int AS run_frames,
+           extract(epoch FROM (max(captured_at) - min(captured_at))) / 60 AS span_min
+    FROM framed GROUP BY webcam_id, solar_day
+  )
+  SELECT
+    count(*) FILTER (WHERE frames >= 6 AND span_min BETWEEN 30 AND 150)::int AS labelable_runs,
+    count(*) FILTER (WHERE frames >= 6 AND span_min BETWEEN 30 AND 150
+                       AND run_frames = frames)::int AS uniform_runs,
+    count(DISTINCT webcam_id) FILTER (WHERE run_frames > 0)::int AS panel_cameras_seen,
+    round(avg(frames) FILTER (WHERE run_frames = frames)::numeric, 1) AS avg_frames_uniform
+  FROM grouped
+`;
+console.log(`window: last ${DAYS} days, sunset phase`);
+console.table(runs);
+
+const mix = await sql`
+  SELECT coalesce(intake_reason, '(null)') AS reason, count(*)::int AS frames
+  FROM webcam_snapshots
+  WHERE captured_at > now() - make_interval(days => ${DAYS}::int)
+  GROUP BY 1 ORDER BY 2 DESC
+`;
+console.log('intake mix over the same window:');
+console.table(mix);

--- a/scripts/seed-run-panel.mjs
+++ b/scripts/seed-run-panel.mjs
@@ -25,6 +25,12 @@ const sql = neon(loadDatabaseUrl());
 const apply = process.argv.includes('--apply');
 const sizeArg = process.argv.indexOf('--size');
 const SIZE = sizeArg === -1 ? 60 : Number(process.argv[sizeArg + 1]);
+if (!Number.isInteger(SIZE) || SIZE <= 0) {
+  console.error(
+    `--size must be a positive integer, got ${JSON.stringify(process.argv[sizeArg + 1])}`,
+  );
+  process.exit(1);
+}
 // 24 buckets of 15 degrees: one per hour of local solar time.
 const BUCKETS = 24;
 

--- a/scripts/seed-run-panel.mjs
+++ b/scripts/seed-run-panel.mjs
@@ -1,0 +1,83 @@
+// scripts/seed-run-panel.mjs
+//
+// Chooses the whole-evening capture panel. Cameras that have actually produced
+// operator-confirmed sunsets, spread across longitude so runs land at different
+// UTC hours rather than all in one part of the world.
+//
+// Dry by default. Every env file here points at the SAME Neon endpoint, so
+// every --apply run is a production change.
+//
+//   node scripts/seed-run-panel.mjs
+//   node scripts/seed-run-panel.mjs --apply
+//   node scripts/seed-run-panel.mjs --size 40 --apply
+import { neon } from '@neondatabase/serverless';
+import { readFileSync } from 'node:fs';
+
+function loadDatabaseUrl() {
+  if (process.env.DATABASE_URL) return process.env.DATABASE_URL;
+  const env = readFileSync('.env.local', 'utf8');
+  const line = env.split('\n').find((l) => l.startsWith('DATABASE_URL='));
+  if (!line) throw new Error('DATABASE_URL not found in env or .env.local');
+  return line.slice('DATABASE_URL='.length).replace(/^"|"$/g, '');
+}
+
+const sql = neon(loadDatabaseUrl());
+const apply = process.argv.includes('--apply');
+const sizeArg = process.argv.indexOf('--size');
+const SIZE = sizeArg === -1 ? 60 : Number(process.argv[sizeArg + 1]);
+// 24 buckets of 15 degrees: one per hour of local solar time.
+const BUCKETS = 24;
+
+const candidates = await sql`
+  SELECT w.id, w.lng, count(*)::int AS confirmed_sunsets
+  FROM manual_labels m
+  JOIN webcam_snapshots s ON s.id = m.image_id AND m.source = 'webcam'
+  JOIN webcams w ON w.id = s.webcam_id
+  WHERE m.is_sunset AND w.lng IS NOT NULL
+  GROUP BY w.id, w.lng
+  HAVING count(*) >= 3
+  ORDER BY count(*) DESC
+`;
+
+// Round-robin across longitude buckets so the panel is not all one meridian.
+const byBucket = new Map();
+for (const c of candidates) {
+  const b = Math.floor(((Number(c.lng) + 180) % 360) / (360 / BUCKETS));
+  if (!byBucket.has(b)) byBucket.set(b, []);
+  byBucket.get(b).push(c);
+}
+
+const picked = [];
+let exhausted = false;
+while (picked.length < SIZE && !exhausted) {
+  exhausted = true;
+  for (const list of byBucket.values()) {
+    if (picked.length >= SIZE) break;
+    const next = list.shift();
+    if (next) {
+      picked.push(next);
+      exhausted = false;
+    }
+  }
+}
+
+console.log(`candidates: ${candidates.length}, buckets used: ${byBucket.size}`);
+console.log(`picked ${picked.length} of a requested ${SIZE}:`);
+for (const p of picked) {
+  console.log(`  webcam ${p.id}  lng ${Number(p.lng).toFixed(1)}  ${p.confirmed_sunsets} confirmed sunsets`);
+}
+
+if (!apply) {
+  console.log('\nDRY RUN. Re-run with --apply to write run_panel.');
+  process.exit(0);
+}
+
+for (const p of picked) {
+  await sql`
+    INSERT INTO run_panel (webcam_id, note)
+    VALUES (${Number(p.id)}, ${`seeded 2026-09-08: ${p.confirmed_sunsets} confirmed sunsets, lng ${Number(p.lng).toFixed(1)}`})
+    ON CONFLICT (webcam_id) DO NOTHING
+  `;
+}
+console.log(`\nwrote ${picked.length} rows to run_panel.`);
+console.log('Now enable capture: node scripts/set-runtime-flag.mjs run_panel_capture on --apply');


### PR DESCRIPTION
**Do not merge before the show on Friday 2026-09-12.** It edits the `update-cameras` cron. With both flags off — the seeded default — the diff is inert on that tick, but merge-day risk is merge-day risk.

**The migration is deliberately unapplied.** Order is in the plan's Operator checklist: pre-flight `SELECT DISTINCT intake_reason`, apply migration, merge, seed panel, flip the capture flag.

### Why

Both model heads sit at or above the operator's own reproducibility (quality self-Pearson 0.673 vs the model's 0.697; detection self-F1 0.807 vs ~0.800), so more absolute ratings cannot help. Only two label boundaries reach a model: `is_sunset` at 13.6% flip rate and `rating >= 4` at 12.6%. Marking where a camera's solar event *crosses* those boundaries turns an absolute judgment into a comparison under fixed framing, which is the only proposal here that could raise the ceiling rather than measure against it.

### What is in the branch

Spec plus Phase 1, which is collection only. The marking queue and the reproducibility experiment are Phase 2, with their own plan.

Seven tasks: the migration; `runKey`; the panel loader; the cron wiring; a longitude-bucketed panel seeder; an inventory report separating uniform runs from model-selected ones; and the disagreement-intake flag.

### The two intake changes

**Adds** a 60-camera panel keeping whole solar events regardless of score, at ~1,080 frames/day. Archive runs today are model-selected subsequences: inside 6+ frame runs over 45 days, 4,864 frames entered as `disagreement` against 66 as `trickle`. The N-to-1 crossing is where both heads agree nothing is there, so the boundary carrying 21 of the 35 ceiling disagreements is the one intake drops.

**Removes** far more than it adds. The disagreement arm has banked **32,013 frames of which zero were ever labeled**, at ~5,000/day, while labeling stopped 2026-08-30 with the ceiling verdict. It becomes a runtime flag seeded off rather than a deletion, because a hard example is model-relative and goes stale when the model changes. `model_disagreement_kind` is still computed and written, so the Hard Examples queue keeps its backlog and keeps getting fresh examples free from the unbiased arms.

### Bugs review caught

- The panel loader would have aborted a whole cron tick on a database blip. Now fails closed, mirroring `isFlagEnabled`.
- The inventory report derived a run from the stored `phase` column, which the cron stamps `'sunset'` unconditionally because scoring runs before classification. Switched to geometry per #180. It had been silently discarding ~600 real runs: labelable runs went 1,018 → 1,617.
- Snapshot cleanup spared `scene_capture` but not `'run'`, so it would have deleted exactly the crossing frames. Inert today, closed anyway.

### Verification

`npm run test` 2,507 passing, `npm run build` clean. Every task reviewed, one fix round on the cron wiring, one whole-branch review with zero Critical findings.

### Known minors, deliberately not fixed

1. `route.test.ts` has one older test using a blanket `isFlagEnabledMock.mockResolvedValue(true)`, which now also enables the disagreement intake. Harmless only because the disagreement-kind mock defaults to null. One line to make key-aware.
2. `loadRunPanel()` and the flag read are two sequential awaits; `Promise.all` would save one round trip per 10-minute tick. Not worth reordering awaits on the live path during show week.

### Note on authorship

Commit `56ae9b970` is from a different Claude session working in the same worktree. It is the both-phases change and it is correct. My commit `28fbee0b5` has a message claiming to carry those doc edits; it does not — git had already taken them, and mine contains only Task 7. Left unamended rather than force-pushing a held branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GPUKRUyd3WuW4zLwEHXUqc
