### PR TITLE
fix(solo2): the draw decides the dwell, and the glass plays what it decided

### DIFF
--- a/app/api/kiosk/solo/advance/route.test.ts
+++ b/app/api/kiosk/solo/advance/route.test.ts
@@ -72,7 +72,7 @@ describe('POST /api/kiosk/solo/advance', () => {
     getScreenState.mockResolvedValue({ feed: 'sunrise', currentSnapshotId: 2, shownSince: 1, slot: 41, sunsetStreak: 0 });
     expect((await post({ feed: 'sunrise', slot: 42 })).status).toBe(200);
     expect(commitAdvance).toHaveBeenCalledWith('sunrise', 42, expect.objectContaining({ snapshotId: 1 }), 1,
-      [expect.objectContaining({ snapshotId: 1 })], 'solo');
+      [expect.objectContaining({ snapshotId: 1 })], 'solo', expect.any(Number));
     // Moving the clock a long way does not move the accepted slot.
     vi.setSystemTime(new Date(1_000_500_000_000));
     expect((await post({ feed: 'sunrise', slot: 42 })).status).toBe(200);
@@ -85,7 +85,7 @@ describe('POST /api/kiosk/solo/advance', () => {
     expect(body.current.entry.snapshotId).toBe(1);
     expect(body.current.entry.tally).toBe(1);
     expect(commitAdvance).toHaveBeenCalledWith('sunrise', 0, expect.objectContaining({ snapshotId: 1 }), 1,
-      [expect.objectContaining({ snapshotId: 1 })], 'solo');
+      [expect.objectContaining({ snapshotId: 1 })], 'solo', expect.any(Number));
   });
   it('version=solo2 marks every frame of the camera run shown, and the pick is the newest', async () => {
     // Camera 101 has frames 1 (older) and 3 (newer); camera 102 has frame 2.
@@ -96,9 +96,25 @@ describe('POST /api/kiosk/solo/advance', () => {
     const body = await res.json();
     expect(body.current.entry.snapshotId).toBe(3);
     expect(commitAdvance).toHaveBeenLastCalledWith('sunrise', 0, expect.objectContaining({ snapshotId: 3 }), 1,
-      [expect.objectContaining({ snapshotId: 1 }), expect.objectContaining({ snapshotId: 3 })], 'solo2');
+      [expect.objectContaining({ snapshotId: 1 }), expect.objectContaining({ snapshotId: 3 })], 'solo2', expect.any(Number));
     const tallies = Object.fromEntries(body.entries.map((e: { snapshotId: number; tally: number }) => [e.snapshotId, e.tally]));
     expect(tallies).toEqual({ 1: 1, 2: 0, 3: 1 });
+  });
+  it('pins the engine\'s dwell and its run, and publishes exactly what it pinned', async () => {
+    // The one write and the one response must carry the same decision. While
+    // the end was recomputed per fetch it drifted away from the draw that made
+    // it, and the glass stepped a run the published end had never been sized
+    // for (reported 2026-09-08).
+    listActiveEntries.mockResolvedValue([
+      { ...entry(1, 0.9), capturedAt: 100 }, { ...entry(2, 0.8), capturedAt: 150 }, { ...entry(3, 0.7), webcamId: 101, capturedAt: 300 },
+    ]);
+    const res = await post({ feed: 'sunrise', slot: 0, version: 'solo2' });
+    const body = await res.json();
+    const pinnedDwellMs = commitAdvance.mock.calls.at(-1)![6] as number;
+    expect(pinnedDwellMs).toBeGreaterThan(0);
+    expect(body.current.shownSnapshotIds).toEqual([1, 3]);
+    expect(body.current.endsAtMs).toBe(body.current.shownSince + pinnedDwellMs);
+    expect(body.schedule.nextBoundaryMs).toBe(body.current.endsAtMs);
   });
   it('version=solo2 with valleys 1 draws the valley on an odd slot', async () => {
     getLiveSettingsCached.mockResolvedValue({ namespaces: { solo2: { valleys: 1 } }, revision: 1 });

--- a/app/api/kiosk/solo/advance/route.ts
+++ b/app/api/kiosk/solo/advance/route.ts
@@ -67,7 +67,11 @@ export async function POST(request: Request) {
     if (pick) {
       const after = afterShowing(pick, state);
       const shown = version.shown(entries, pick, dials);
-      advanced = await commitAdvance(feed, slot, pick, after.sunsetStreak, shown, version.name);
+      // Decided ONCE, here, against the pool this draw actually saw, and
+      // stored alongside the start instant. Every surface reads it back
+      // rather than working it out again from a pool that has since moved.
+      const dwellMs = version.dwellMs(entries, pick, dials);
+      advanced = await commitAdvance(feed, slot, pick, after.sunsetStreak, shown, version.name, dwellMs);
       if (advanced) {
         for (const f of shown) {
           const stored = entries.find((e) => e.snapshotId === f.snapshotId)!;
@@ -75,7 +79,10 @@ export async function POST(request: Request) {
           stored.isNew = false;
           stored.lastShownAt = nowMs;
         }
-        screen = { feed, currentSnapshotId: pick.snapshotId, shownSince: nowMs, slot, sunsetStreak: after.sunsetStreak };
+        screen = {
+          feed, currentSnapshotId: pick.snapshotId, shownSince: nowMs, slot, sunsetStreak: after.sunsetStreak,
+          dwellMs, shownSnapshotIds: shown.map((e) => e.snapshotId),
+        };
       }
     }
   }

--- a/app/api/kiosk/solo/view.test.ts
+++ b/app/api/kiosk/solo/view.test.ts
@@ -184,3 +184,43 @@ describe('buildStateView with a version', () => {
     expect(v.nextRoles).toEqual(v.next.map(() => 'peak'));
   });
 });
+
+describe('buildStateView: the dwell is read from the draw, not recomputed', () => {
+  // 2026-09-08: the end was recomputed from the live pool on every fetch, so
+  // it moved while the frame was still on glass and the queue's projection
+  // moved with it. The draw pins both; the view publishes what it pinned.
+  const entries = [stored(1, 'sunset', 0.9), stored(2, 'sunset', 0.8)];
+  const shownSince = 1_700_000_000_000;
+  const build = (screen: Parameters<typeof buildStateView>[0]['screen']) =>
+    buildStateView({ feed: 'sunset', dials: D, entries, screen, nowMs: 1_000_000, admitted: { sunset: 0, nonSunset: 0 }, zone: ZONE });
+
+  it('prefers the pinned length over anything the dials would say now', () => {
+    const v = build({ feed: 'sunset', currentSnapshotId: 1, shownSince, slot: 9, sunsetStreak: 0, dwellMs: 22_000 });
+    expect(v.current?.endsAtMs).toBe(shownSince + 22_000);
+    expect(v.current?.endsAtMs).not.toBe(shownSince + D.dwellS * 1000);
+  });
+
+  it('publishes the frames the draw pinned, so the glass plays fact', () => {
+    const v = build({ feed: 'sunset', currentSnapshotId: 1, shownSince, slot: 9, sunsetStreak: 0, shownSnapshotIds: [2, 1] });
+    expect(v.current?.shownSnapshotIds).toEqual([2, 1]);
+  });
+
+  it('falls back to the recompute for a row written before the pin', () => {
+    const v = build({ feed: 'sunset', currentSnapshotId: 1, shownSince, slot: 9, sunsetStreak: 0 });
+    expect(v.current?.endsAtMs).toBe(shownSince + D.dwellS * 1000);
+    expect(v.current?.shownSnapshotIds).toEqual([1]); // solo shows the pick alone
+  });
+
+  it('the countdown and the queue both start from the pinned end, never two numbers', () => {
+    const v = build({ feed: 'sunset', currentSnapshotId: 1, shownSince, slot: 9, sunsetStreak: 0, dwellMs: 22_000 });
+    expect(v.schedule.nextBoundaryMs).toBe(v.current?.endsAtMs);
+  });
+
+  it('marks every pinned frame as on glass, not the ones a fresh run would pick', () => {
+    const v = build({ feed: 'sunset', currentSnapshotId: 1, shownSince, slot: 9, sunsetStreak: 0, shownSnapshotIds: [2, 1] });
+    const stage = (id: number) => [...v.bins.sunset, ...v.bins.nonSunset, ...v.next, v.current!.entry]
+      .find((e) => e.snapshotId === id)?.stage;
+    expect(stage(2)).toEqual({ kind: 'onGlass' });
+    expect(stage(1)).toEqual({ kind: 'onGlass' });
+  });
+});

--- a/app/api/kiosk/solo/view.ts
+++ b/app/api/kiosk/solo/view.ts
@@ -81,8 +81,19 @@ export interface StateView {
      * The server owns WHEN a dwell ends because its length is a function of
      * engine state; a client owns only how far along it is. Null when the
      * screen has no shown-since to measure from.
+     *
+     * Read from what the draw pinned, not recomputed. The pool this dwell was
+     * measured against changes every minute, so recomputing moved the end
+     * while the frame was still on glass.
      */
     endsAtMs: number | null;
+    /**
+     * The frames this dwell plays, in play order, the drawn frame last, as
+     * the draw pinned them. A solo2 run; `[entry]` for solo. The glass renders
+     * exactly this list, so what steps on glass and what the published end was
+     * sized for are one decision rather than two derivations that can differ.
+     */
+    shownSnapshotIds: number[];
   } | null;
   next: EntryView[];
   /** Parallel to `next`: what each draw is inside its bar. All peaks for solo. */
@@ -138,12 +149,27 @@ export function buildStateView(input: {
   const firstSlot = (screen?.slot ?? -1) + 1;
   // Project past the queue so every eligible frame gets a draw position (stages spec §3.1).
   const eligibleCount = entries.filter((e) => isEligible(e, dials)).length;
+  /**
+   * This dwell's length, as the draw decided it. The recompute is the
+   * fallback for a screen row written before the dwell was pinned, and for
+   * any caller that supplies no screen row at all (the studio replaying its
+   * own dials). It must never be preferred: the pool it would measure
+   * against is not the pool the draw saw.
+   */
+  const dwellMs = currentEntry
+    ? screen?.dwellMs ?? version.dwellMs(entries, currentEntry, dials)
+    : null;
+  /** Likewise the frames it plays, pinned at the draw. */
+  const currentRunIds = currentEntry
+    ? screen?.shownSnapshotIds ?? version.shown(entries, currentEntry, dials).map((e) => e.snapshotId)
+    : [];
+  const endsAtMs = currentEntry && screen?.shownSince != null && dwellMs != null
+    ? screen.shownSince + dwellMs
+    : null;
   // The first projected draw goes on glass when the current dwell ends; with
   // nothing on glass, now. The projection's timestamps are then real, which
   // a slot counter can no longer supply on its own (spec §5).
-  const projectionStartMs = currentEntry && screen?.shownSince != null
-    ? screen.shownSince + version.dwellMs(entries, currentEntry, dials)
-    : nowMs;
+  const projectionStartMs = endsAtMs ?? nowMs;
   const draws = version.project(entries, dials, state, eligibleCount + NEXT_COUNT, firstSlot, feed, projectionStartMs);
   const next = draws.slice(0, NEXT_COUNT);
   const stages = assignStages({ entries, dials, state, firstSlot, draws, queueDepth: NEXT_COUNT });
@@ -160,7 +186,9 @@ export function buildStateView(input: {
       stages.set(f.snapshotId, stage);
     }
   }
-  if (currentEntry) for (const f of version.shown(entries, currentEntry, dials)) stages.set(f.snapshotId, { kind: 'onGlass' });
+  // The frames on glass are the ones the draw pinned, not the ones a fresh
+  // derivation would pick now: the studio must mark what is actually up.
+  for (const id of currentRunIds) stages.set(id, { kind: 'onGlass' });
   const view = (e: ViewEntry): EntryView => ({
     ...e,
     eligible: isEligible(e, dials),
@@ -179,9 +207,8 @@ export function buildStateView(input: {
         entry: view(currentEntry),
         shownSince: screen?.shownSince ?? null,
         slot: screen?.slot ?? null,
-        endsAtMs: screen?.shownSince != null
-          ? screen.shownSince + version.dwellMs(entries, currentEntry, dials)
-          : null,
+        endsAtMs,
+        shownSnapshotIds: currentRunIds,
       }
       : null,
     next: next.map((e) => view(byId.get(e.snapshotId)!)),
@@ -194,9 +221,7 @@ export function buildStateView(input: {
       slot: screen?.slot ?? 0,
       // The server's own published end, so every countdown on every surface
       // reads one number rather than each deriving its own (spec §5.1).
-      nextBoundaryMs: screen?.shownSince != null && currentEntry
-        ? screen.shownSince + version.dwellMs(entries, currentEntry, dials)
-        : nowMs,
+      nextBoundaryMs: endsAtMs ?? nowMs,
     },
     lastPull: { admitted: input.admitted },
     entries,

--- a/app/components/solo/useSoloGlass.ts
+++ b/app/components/solo/useSoloGlass.ts
@@ -15,6 +15,17 @@ export interface SoloGlass {
   shownSince: number | null;
   /** When this dwell ends, ms since epoch, as the server computed it (spec §5.1). Null before the first state arrives. */
   endsAtMs: number | null;
+  /**
+   * The frames this dwell plays, in play order, the drawn frame last, as the
+   * DRAW pinned them. Empty before the first state arrives.
+   *
+   * A renderer must play this list rather than re-deriving a run from
+   * `entries`. That pool is refetched every minute and changes every minute,
+   * and a run's window is anchored at its newest frame, so a re-derivation
+   * mid-dwell prepends older frames and shifts every index under a clock that
+   * has already started.
+   */
+  shownSnapshotIds: number[];
   next: EntryView | null;
   slot: number;
   boundaryMs: number;
@@ -22,7 +33,7 @@ export interface SoloGlass {
   queueLength: number;
   /** The whole projected queue, for preloading beyond the first. */
   nextEntries: EntryView[];
-  /** Every active entry, so a renderer can derive a prelude (solo2). */
+  /** Every active entry: the queue's frames, and the fallback when a dwell predates the pin. */
   entries: ViewEntry[];
 }
 
@@ -145,6 +156,7 @@ export function useSoloGlass({ feed, drive, dozing, version = 'solo' }: {
     current: view?.current?.entry ?? null,
     shownSince: view?.current?.shownSince ?? null,
     endsAtMs,
+    shownSnapshotIds: view?.current?.shownSnapshotIds ?? [],
     next: view?.next[0] ?? null,
     slot: screenSlot ?? 0,
     boundaryMs: endsAtMs ?? Date.now(),

--- a/app/components/solo2/index.test.tsx
+++ b/app/components/solo2/index.test.tsx
@@ -12,9 +12,13 @@ const entries = [entry(1, 100), entry(2, 200), entry(3, 300), entry(9, 250, 8)];
 // The server always stamps shown-since for a frame on glass, and publishes
 // the dwell's end as an instant beside it (spec §5.1). A client never works
 // a start backwards from an end and a dial, which a budget makes wrong.
+//
+// An empty `shownSnapshotIds` is a screen row from before the dwell was
+// pinned, so these fixtures exercise the fallback derivation. The pinned path
+// has its own tests at the foot of this file.
 const glass = { current: entry(3, 300), shownSince: 0 as number | null, next: null, slot: 1,
   endsAtMs: 20_000 as number | null, boundaryMs: 20_000, error: null, queueLength: 1,
-  nextEntries: [], entries };
+  nextEntries: [], entries, shownSnapshotIds: [] as number[] };
 vi.mock('@/app/components/solo/useSoloGlass', () => ({ useSoloGlass: vi.fn(() => glass) }));
 import { useSoloGlass } from '@/app/components/solo/useSoloGlass';
 const mocked = vi.mocked(useSoloGlass);
@@ -83,4 +87,54 @@ it('a follower whose published end moves without a new frame keeps its dwell clo
   mocked.mockImplementation(() => ({ ...glass, endsAtMs: 40_000, boundaryMs: 40_000 }));
   rerender(<Solo2Kiosk webcams={[]} width={100} height={50} feed="sunset" />);
   expect(screen.getByTestId('top')).toHaveAttribute('src', 'u3'); // not back to u1
+});
+
+// The pinned dwell (2026-09-08). The draw decides the run and the span; the
+// glass plays them. Before this, both were re-derived from `entries` on every
+// render, and `entries` is refetched every minute from a pool that changes
+// every minute.
+const PINNED = [1, 2, 3];
+const pinned = { ...glass, shownSnapshotIds: PINNED, shownSince: 0, endsAtMs: 20_000, boundaryMs: 20_000 };
+
+it('plays the frames the draw pinned, in the order it pinned them', () => {
+  // 20 s span, 1.5 s arrival, 3 frames: 6.17 s each. 8.5 s in is frame 2.
+  vi.setSystemTime(new Date(8_500));
+  mocked.mockImplementation(() => pinned);
+  render(<Solo2Kiosk webcams={[]} width={100} height={50} feed="sunset" />);
+  expect(screen.getByTestId('top')).toHaveAttribute('src', 'u2');
+});
+
+it('steps across the pinned span, not the span a dial would compute', () => {
+  mocked.mockImplementation(() => ({ ...pinned, endsAtMs: 62_000, boundaryMs: 62_000 }));
+  // 62 s span, 1.5 s arrival, 3 frames: 20.17 s each. 8.5 s in is still frame 1.
+  vi.setSystemTime(new Date(8_500));
+  render(<Solo2Kiosk webcams={[]} width={100} height={50} feed="sunset" />);
+  expect(screen.getByTestId('top')).toHaveAttribute('src', 'u1');
+});
+
+it('does not step backwards when the pool grows under a running dwell', () => {
+  // The bug of 2026-09-08. A re-derivation reads the frame cap as a rank
+  // among the sunsets present, and `runOf` anchors its window at the NEWEST
+  // frame — so a wider cap prepends older frames and every index shifts. Here
+  // camera 8 weakens, which lifts camera 7 to the top of the ranking and
+  // would widen its run from three frames to four, putting u0 at the front.
+  vi.setSystemTime(new Date(8_500));
+  mocked.mockImplementation(() => pinned);
+  const { rerender } = render(<Solo2Kiosk webcams={[]} width={100} height={50} feed="sunset" />);
+  expect(screen.getByTestId('top')).toHaveAttribute('src', 'u2');
+
+  const grown = [entry(0, 50), entry(1, 100), entry(2, 200), entry(3, 300), { ...entry(9, 250, 8), quality: 0.1 }];
+  mocked.mockImplementation(() => ({ ...pinned, entries: grown }));
+  rerender(<Solo2Kiosk webcams={[]} width={100} height={50} feed="sunset" />);
+  // Same picture, same second: the run is fact from the draw, not a re-read.
+  expect(screen.getByTestId('top')).toHaveAttribute('src', 'u2');
+});
+
+it('a frame the pool dropped mid-dwell costs its picture, never the step rate', () => {
+  // u2 is gone from the pool but keeps its place in the timing, so the frames
+  // that remain still change on the beat the published end was sized for.
+  vi.setSystemTime(new Date(14_000)); // frame 3 of 3
+  mocked.mockImplementation(() => ({ ...pinned, entries: [entry(1, 100), entry(3, 300)] }));
+  render(<Solo2Kiosk webcams={[]} width={100} height={50} feed="sunset" />);
+  expect(screen.getByTestId('top')).toHaveAttribute('src', 'u3');
 });

--- a/app/components/solo2/index.tsx
+++ b/app/components/solo2/index.tsx
@@ -6,7 +6,7 @@ import type { EntryView } from '@/app/api/kiosk/solo/view';
 import { mergeSettings } from '@/app/lib/settings/schema';
 import { SOLO2_SETTINGS_SCHEMA, dialsFrom2 } from '@/app/lib/solo2/settingsSchema';
 import { withCaption } from '@/app/lib/solo/captionSchema';
-import { fitPlan } from '@/app/lib/solo2/plan';
+import { fitPlan, planOf } from '@/app/lib/solo2/plan';
 import { capFor, planDialsFor, runOf } from '@/app/lib/solo2/run';
 import { useSoloGlass } from '@/app/components/solo/useSoloGlass';
 import { Solo2Frame } from './Solo2Frame';
@@ -59,10 +59,37 @@ export function Solo2Kiosk(props: MosaicProps) {
   }
   const previous = dwell.previous;
 
-  // The same capped run the server used to size this dwell (spec §4), so the
-  // step rate on glass and the published end can never disagree.
-  const run = current ? runOf(current, glass.entries, dials.cameraRun, capFor(current, dials, glass.entries, dials.cameraRun)) : [];
-  const plan = fitPlan(current ? planDialsFor(current, dials, glass.entries, dials.cameraRun) : dials, run.length);
+  /**
+   * The run and the plan are READ, not re-derived: the draw pinned both, and
+   * the server publishes them as `shownSnapshotIds` and `endsAtMs`.
+   *
+   * This used to call `runOf`/`fitPlan` over `glass.entries` on every render.
+   * That pool is refetched every minute and changes every minute, the frame
+   * cap is a rank within it, and `runOf` anchors its window at the newest
+   * frame — so a wider cap PREPENDED older frames while the dwell's clock was
+   * already running, and the clock-driven index landed on a different picture.
+   * On glass that read as the run stepping backwards and the caption's
+   * "minutes ago" counting up (reported 2026-09-08).
+   *
+   * The fallback is the old derivation, reached only for a screen row written
+   * before the dwell was pinned.
+   */
+  const byId = new Map(glass.entries.map((e) => [e.snapshotId, e]));
+  const pinnedIds = glass.shownSnapshotIds;
+  // A frame the pool dropped mid-dwell cannot be drawn, but it keeps its place
+  // in the timing: `plan.frames` stays the pinned count, so the step rate is
+  // unchanged and only the missing picture is skipped.
+  const pinnedRun = pinnedIds.map((id) => byId.get(id)).filter((e): e is EntryView => !!e);
+  const pinnedTotalS = glass.endsAtMs != null && glass.shownSince != null
+    ? (glass.endsAtMs - glass.shownSince) / 1000
+    : null;
+  const pinned = pinnedRun.length > 0 && pinnedTotalS != null && pinnedTotalS > 0;
+  const run = pinned
+    ? pinnedRun
+    : current ? runOf(current, glass.entries, dials.cameraRun, capFor(current, dials, glass.entries, dials.cameraRun)) : [];
+  const plan = pinned
+    ? planOf(pinnedTotalS, pinnedIds.length, dials)
+    : fitPlan(current ? planDialsFor(current, dials, glass.entries, dials.cameraRun) : dials, run.length);
   const stage = useStage(plan, dwell.startMs);
 
   // Preload the projected next frame and its run, so the arrival is clean.

--- a/app/lib/solo/store.test.ts
+++ b/app/lib/solo/store.test.ts
@@ -95,6 +95,45 @@ describe('screen state', () => {
     sqlMock.mockResolvedValueOnce([]);
     expect(await getScreenState('sunset')).toBeNull();
   });
+  it('getScreenState reads the pinned dwell, mapping Neon strings to numbers', async () => {
+    sqlMock.mockResolvedValueOnce([{
+      feed: 'sunset', current_snapshot_id: '9', shown_since: '2026-09-08T23:49:47Z', slot: '42', sunset_streak: '3',
+      dwell_ms: '22000', shown_snapshot_ids: ['7', '8', '9'],
+    }]);
+    expect(await getScreenState('sunset')).toMatchObject({ dwellMs: 22_000, shownSnapshotIds: [7, 8, 9] });
+  });
+  it('getScreenState leaves a pre-migration row unpinned, so readers fall back', async () => {
+    sqlMock.mockResolvedValueOnce([{
+      feed: 'sunset', current_snapshot_id: '9', shown_since: null, slot: '42', sunset_streak: '0',
+      dwell_ms: null, shown_snapshot_ids: null,
+    }]);
+    expect(await getScreenState('sunset')).toMatchObject({ dwellMs: null, shownSnapshotIds: null });
+  });
+  it('commitAdvance pins the dwell beside the instant it starts, in one statement', async () => {
+    sqlMock.mockResolvedValueOnce([{ feed: 'sunset' }]).mockResolvedValueOnce([]).mockResolvedValueOnce([]);
+    const e = (id: number) => ({ snapshotId: id, webcamId: 3, bin: 'sunset' as const, quality: 0.9, detection: 0.8, isNew: true, tally: 0, enteredAt: 0 });
+    await commitAdvance('sunset', 42, e(9), 1, [e(7), e(8), e(9)], 'solo2', 22_000);
+    const upsert = (sqlMock.mock.calls[0][0] as TemplateStringsArray).join('?');
+    // The same row and the same write as shown_since. A start and a length
+    // assembled from two different moments is the drift this column exists to
+    // stop, so they must not be separable.
+    expect(upsert).toMatch(/shown_since = excluded\.shown_since/);
+    expect(upsert).toMatch(/dwell_ms = excluded\.dwell_ms/);
+    expect(upsert).toMatch(/shown_snapshot_ids = excluded\.shown_snapshot_ids/);
+    expect(sqlMock.mock.calls[0].slice(1)).toEqual(['sunset', 9, 42, 1, 22_000, [7, 8, 9]]);
+  });
+  it('commitAdvance rounds a fractional dwell: the column is an integer', async () => {
+    sqlMock.mockResolvedValueOnce([{ feed: 'sunset' }]).mockResolvedValueOnce([]).mockResolvedValueOnce([]);
+    const e = { snapshotId: 7, webcamId: 3, bin: 'sunset' as const, quality: 0.9, detection: 0.8, isNew: true, tally: 0, enteredAt: 0 };
+    await commitAdvance('sunset', 42, e, 1, [e], 'solo2', 21_666.667);
+    expect(sqlMock.mock.calls[0].slice(1)).toEqual(['sunset', 7, 42, 1, 21_667, [7]]);
+  });
+  it('commitAdvance leaves the dwell unpinned when no length is supplied', async () => {
+    sqlMock.mockResolvedValueOnce([{ feed: 'sunset' }]).mockResolvedValueOnce([]).mockResolvedValueOnce([]);
+    const e = { snapshotId: 7, webcamId: 3, bin: 'sunset' as const, quality: 0.9, detection: 0.8, isNew: true, tally: 0, enteredAt: 0 };
+    await commitAdvance('sunset', 42, e, 1);
+    expect(sqlMock.mock.calls[0].slice(1)).toEqual(['sunset', 7, 42, 1, null, [7]]);
+  });
   it('commitAdvance is a no-op when the slot was already committed', async () => {
     sqlMock.mockResolvedValueOnce([]); // upsert returned nothing: slot unchanged
     const ok = await commitAdvance('sunset', 42, { snapshotId: 7, webcamId: 3, bin: 'sunset', quality: 0.9, detection: 0.8, isNew: true, tally: 0, enteredAt: 0 }, 1);

--- a/app/lib/solo/store.ts
+++ b/app/lib/solo/store.ts
@@ -244,15 +244,34 @@ export interface ScreenRow {
   shownSince: number | null;
   slot: number | null;
   sunsetStreak: number;
+  /**
+   * How long this dwell occupies the glass, ms, as the engine decided it at
+   * the draw. Null for rows written before the dwell migration.
+   *
+   * Stored rather than recomputed because a dwell's length is a function of
+   * the pool AT THE DRAW, and the pool moves every minute. Recomputing it on
+   * each fetch let the published end drift while the frame was still up.
+   */
+  dwellMs?: number | null;
+  /**
+   * The frames this dwell plays, in play order, the drawn frame last: the
+   * same array the draw log stamps, kept on the screen row so the glass reads
+   * fact rather than re-deriving a run from a pool that has since changed.
+   *
+   * Optional alongside `dwellMs` for the same reason: a row from before the
+   * migration has neither, and every reader falls back to the old recompute.
+   */
+  shownSnapshotIds?: number[] | null;
 }
 
 export async function getScreenState(feed: Feed): Promise<ScreenRow | null> {
   const rows = (await sql`
-    select feed, current_snapshot_id, shown_since, slot, sunset_streak
+    select feed, current_snapshot_id, shown_since, slot, sunset_streak, dwell_ms, shown_snapshot_ids
     from kiosk_screen_state where feed = ${feed}
   `) as unknown as {
     feed: Feed; current_snapshot_id: string | number | null; shown_since: string | null;
     slot: string | number | null; sunset_streak: string | number;
+    dwell_ms: string | number | null; shown_snapshot_ids: (string | number)[] | null;
   }[];
   const r = rows[0];
   if (!r) return null;
@@ -262,6 +281,8 @@ export async function getScreenState(feed: Feed): Promise<ScreenRow | null> {
     shownSince: ms(r.shown_since),
     slot: r.slot == null ? null : num(r.slot),
     sunsetStreak: num(r.sunset_streak),
+    dwellMs: r.dwell_ms == null ? null : num(r.dwell_ms),
+    shownSnapshotIds: r.shown_snapshot_ids == null ? null : r.shown_snapshot_ids.map(num),
   };
 }
 
@@ -274,6 +295,12 @@ export async function getScreenState(feed: Feed): Promise<ScreenRow | null> {
 /**
  * Move the screen to `entry` for `slot`, once per slot, and mark `shown`
  * (the frames the dwell plays; `entry` alone for solo) as on glass.
+ *
+ * `dwellMs` is how long the engine says this dwell lasts. It is written into
+ * the same row, in the same statement, as the instant the dwell starts, so
+ * the pair can never be assembled from two different moments — which is what
+ * happened while the end was recomputed on each fetch from a pool that had
+ * moved on. The frames are stored beside it for the same reason.
  */
 export async function commitAdvance(
   feed: Feed,
@@ -282,15 +309,20 @@ export async function commitAdvance(
   sunsetStreak: number,
   shown: BinEntry[] = [entry],
   version: SoloVersionName = 'solo',
+  dwellMs: number | null = null,
 ): Promise<boolean> {
+  const shownIds = shown.map((e) => e.snapshotId);
   const rows = (await sql`
-    insert into kiosk_screen_state (feed, current_snapshot_id, shown_since, slot, sunset_streak, updated_at)
-    values (${feed}, ${entry.snapshotId}, now(), ${slot}, ${sunsetStreak}, now())
+    insert into kiosk_screen_state (feed, current_snapshot_id, shown_since, slot, sunset_streak, dwell_ms, shown_snapshot_ids, updated_at)
+    values (${feed}, ${entry.snapshotId}, now(), ${slot}, ${sunsetStreak},
+            ${dwellMs == null ? null : Math.round(dwellMs)}, ${shownIds}::bigint[], now())
     on conflict (feed) do update
       set current_snapshot_id = excluded.current_snapshot_id,
           shown_since = excluded.shown_since,
           slot = excluded.slot,
           sunset_streak = excluded.sunset_streak,
+          dwell_ms = excluded.dwell_ms,
+          shown_snapshot_ids = excluded.shown_snapshot_ids,
           updated_at = now()
       where kiosk_screen_state.slot is distinct from excluded.slot
     returning feed
@@ -306,7 +338,7 @@ export async function commitAdvance(
         -- in this one operation (spec §6.1.1). Two counters that agree is the
         -- failure that would not announce itself.
         last_shown_slot = ${slot}
-    where feed = ${feed} and snapshot_id = any(${shown.map((e) => e.snapshotId)}::bigint[])
+    where feed = ${feed} and snapshot_id = any(${shownIds}::bigint[])
   `;
   await logDraw(feed, slot, entry, version, shown);
   return true;

--- a/app/lib/solo2/plan.test.ts
+++ b/app/lib/solo2/plan.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { arrivalS, describePlan, fitPlan, stageAt, stepFadeS, stretchThreshold } from './plan';
+import { arrivalS, describePlan, fitPlan, planOf, stageAt, stepFadeS, stretchThreshold } from './plan';
 
 const D = { dwellS: 20, leadS: 4, minStepS: 4 };
 
@@ -147,5 +147,43 @@ describe('stepFadeS', () => {
   it('a dial at zero is still a cut, and a negative one cannot go below zero', () => {
     expect(stepFadeS(0, { stepS: 5 })).toBe(0);
     expect(stepFadeS(-2, { stepS: 5 })).toBe(0);
+  });
+});
+
+describe('planOf: the budget rule run backward from a pinned total', () => {
+  it('spreads the pinned span across the frames, after the arrival', () => {
+    const p = planOf(22, 4, { ...D, transition: 'dip', fadeS: 6 });
+    expect(p.dwellS).toBe(22);
+    expect(p.frames).toBe(4);
+    expect(p.arrivalS).toBe(6);
+    expect(p.stepS).toBe(4); // (22 - 6) / 4
+  });
+
+  it('is the inverse of fitPlan: what fitPlan sized, planOf takes apart again', () => {
+    const dials = { ...D, transition: 'dip' as const, fadeS: 6 };
+    const forward = fitPlan(dials, 4);
+    const back = planOf(forward.dwellS, 4, dials);
+    expect(back).toEqual(forward);
+  });
+
+  it('ignores the dwell dial: the pinned span is the whole authority', () => {
+    // The dial says 20 s and the floor says 4 s a frame, which would size 3
+    // frames at 20 s. The draw pinned 62 s, so each frame gets 18.67 s.
+    const p = planOf(62, 3, { ...D, transition: 'dip', fadeS: 6 });
+    expect(p.dwellS).toBe(62);
+    expect(p.stepS).toBeCloseTo(18.667, 3);
+  });
+
+  it('never leaves a step of zero, whatever a degenerate span asks for', () => {
+    // stageAt divides by the step; a zero would make the frame index NaN and
+    // the glass render nothing.
+    const p = planOf(0, 3, { ...D, transition: 'dip', fadeS: 6 });
+    expect(p.stepS).toBeGreaterThan(0);
+    expect(p.arrivalS).toBe(0); // clamped to the total, so the step stays positive
+    expect(stageAt(1000, p).index).toBe(2);
+  });
+
+  it('caps the lead at the pinned span', () => {
+    expect(planOf(3, 1, { ...D, leadS: 9 }).leadS).toBe(3);
   });
 });

--- a/app/lib/solo2/plan.ts
+++ b/app/lib/solo2/plan.ts
@@ -61,6 +61,35 @@ export function fitPlan(d: PlanDials, frames: number): DwellPlan {
 }
 
 /**
+ * The plan for a dwell whose total is already DECIDED — the span the server
+ * pinned at the draw and published as `endsAtMs`.
+ *
+ * `fitPlan` runs the budget rule forward, from a dial to a total. This runs it
+ * backward, from a total to a step, and it is what any surface rendering a
+ * live dwell should use. The difference matters because the forward rule reads
+ * the pool, and the pool moves: recomputing mid-dwell re-sized the step and the
+ * frame count under a clock that had already started, which stepped the run to
+ * a different picture and made the caption's "minutes ago" jump upward instead
+ * of counting down (reported 2026-09-08).
+ *
+ * The arrival still comes from the dials, since it is the fade's own length and
+ * not a function of the pool. It is clamped to the total so a short pinned
+ * dwell cannot leave a negative step.
+ */
+export function planOf(totalS: number, frames: number, d: PlanDials): DwellPlan {
+  const n = Math.max(1, Math.floor(frames));
+  const total = Math.max(0, totalS);
+  const arrival = Math.min(arrivalS(d), total);
+  return {
+    dwellS: total,
+    frames: n,
+    stepS: Math.max(0.001, (total - arrival) / n),
+    leadS: Math.min(total, Math.max(0, d.leadS)),
+    arrivalS: arrival,
+  };
+}
+
+/**
  * The frame count at which the dwell starts stretching (spec §3.1). Printed
  * beside the dials so an operator can see whether a cap will ever move the
  * clock: at or below this, a cap buys pictures rather than time.

--- a/app/studio/solo/Tape.test.tsx
+++ b/app/studio/solo/Tape.test.tsx
@@ -176,3 +176,25 @@ it('a projected dwell shows the frames the cap cut as dim stubs before the run, 
   // The run's own frames still add up to the dwell: 2 × 5 s + the chosen one's 10 s.
   expect(screen.getByTestId('tape-next-0')).toHaveStyle({ width: `${20 * PX_PER_S - 2 * 5 * PX_PER_S}px` });
 });
+
+it('a run\'s earlier frames open like any other block', () => {
+  // They were rendered without a handler, which `Thumb` turns into a disabled
+  // button. They are also the blocks an operator most needs to open: a 6 px
+  // sliver of sky identifies nothing (reported 2026-09-08).
+  const onSelect = vi.fn();
+  const earlier = [entry(7), entry(8)];
+  render(<Tape past={[]} current={entry(3)} next={[entry(4)]} nextSequences={[{ earlier, stepS: 1.5 }]}
+    pastDials={D} nextDials={D} onSelect={onSelect} />);
+  const pre = screen.getByTestId('tape-next-0-pre-7');
+  expect(pre).not.toBeDisabled();
+  fireEvent.click(pre);
+  expect(onSelect).toHaveBeenCalledWith(expect.objectContaining({ snapshotId: 7 }));
+});
+
+it('the fade X is not a click target: it straddles the blocks either side of it', () => {
+  // At the live 6 s fade it lies over 12 px of both neighbours, and while it
+  // took pointer events it swallowed clicks meant for them.
+  render(<Tape past={past} current={entry(3)} currentSince={since} currentEndsAt={since + 20_000} next={[entry(4)]}
+    pastDials={{ dwellS: 20, fadeS: 6 }} nextDials={{ dwellS: 20, fadeS: 6 }} onSelect={vi.fn()} />);
+  expect(screen.getByTestId('tape-fade-0')).toHaveStyle({ pointerEvents: 'none' });
+});

--- a/app/studio/solo/Tape.tsx
+++ b/app/studio/solo/Tape.tsx
@@ -55,12 +55,20 @@ function Thumb({ testId, src, color, width, dashed = false, dim = false, ring = 
   );
 }
 
-/** The Final Cut "X": the seconds during which both pictures are on glass. */
+/**
+ * The Final Cut "X": the seconds during which both pictures are on glass.
+ *
+ * It straddles the cut by half its width each way, so at the live 6 s fade it
+ * lies over 12 px of both neighbours. Never a click target: it paints above
+ * them, and while it took pointer events it swallowed clicks along the edges
+ * of the very blocks an operator was reaching for.
+ */
 function Fade({ testId, seconds }: { testId: string; seconds: number }) {
   const width = Math.max(4, seconds * PX_PER_S);
   return (
     <div data-testid={testId} title={`crossfade ${secs(seconds)}: both pictures on glass`} style={{
       flex: 'none', width, height: THUMB_H, marginLeft: -width / 2, marginRight: -width / 2, position: 'relative', zIndex: 1,
+      pointerEvents: 'none',
       background: 'linear-gradient(135deg, rgba(245,163,68,0) 0%, rgba(245,163,68,0.55) 50%, rgba(245,163,68,0) 100%)',
       borderLeft: '1px solid rgba(245,163,68,0.8)', borderRight: '1px solid rgba(245,163,68,0.8)', boxSizing: 'border-box',
     }} />
@@ -241,9 +249,13 @@ export function Tape({ past, current, currentSince, currentEndsAt, next, nextSeq
             <Thumb key={`cut-${f.snapshotId}`} testId={`tape-next-${i}-cut-${f.snapshotId}`} src={f.imageUrl} width={CUT_STUB_PX} color="#2a3242" dashed dim
               title={`not played · ${f.title} · over the ${seq.capLabel ?? 'most-frames cap'}`} onClick={() => onSelect(f)} />
           ))}
+          {/* Clickable like every other block. Without a handler `Thumb`
+              disables the button, and these are the frames an operator most
+              wants to open: the run's earlier pictures are the ones they
+              cannot identify from a 6 px sliver. */}
           {seq.earlier.map((f) => (
             <Thumb key={f.snapshotId} testId={`tape-next-${i}-pre-${f.snapshotId}`} src={f.imageUrl} width={stepPx} color="#2a3242" dashed
-              title={`run · ${f.title} · ${secs(seq.stepS)}`} />
+              title={`run · ${f.title} · ${secs(seq.stepS)}`} onClick={() => onSelect(f)} />
           ))}
           <Thumb testId={`tape-next-${i}`} src={e.imageUrl} width={mainWidth} color={COLOR[e.bin]} dashed
             repeat={repeatOf(e.snapshotId)} title={title} onClick={() => onSelect(e)} />

--- a/database/migrations/20260908_kiosk_screen_state_dwell.sql
+++ b/database/migrations/20260908_kiosk_screen_state_dwell.sql
@@ -1,0 +1,34 @@
+-- Pin the dwell to the draw that made it.
+--
+-- Until now the screen row stored only WHEN a frame went on glass, and every
+-- reader worked out the rest for itself: the state view recomputed the
+-- dwell's length from the live pool on every fetch, and the solo2 glass
+-- recomputed the run the same way on every render. Both inputs move. The
+-- sunset pool took an admission in all 60 of the last 60 minutes and shed 42
+-- entries in one of them, and the frame cap is a rank among that pool, so a
+-- refetch mid-dwell could lengthen the dwell and slide the run's window.
+-- Because the window is anchored at the newest frame, a wider cap PREPENDS
+-- older frames, and the clock-driven index then pointed at a different
+-- picture: the glass stepped backwards and the caption's "minutes ago" jumped
+-- up instead of counting down (reported 2026-09-08).
+--
+--   dwell_ms            how long this dwell occupies the glass, decided once
+--                       by the engine at commit. shown_since + dwell_ms is
+--                       the published end.
+--   shown_snapshot_ids  the frames this dwell plays, in play order, the drawn
+--                       frame last. The same array logDraw stamps on
+--                       kiosk_draws, kept here too so the glass never depends
+--                       on the best-effort draw log.
+--
+-- Rows written before this keep NULLs and every reader falls back to the old
+-- recompute, so an unapplied migration costs the fix, not the glass.
+--
+-- Forward-only, idempotent. APPLY BEFORE MERGING the code: commitAdvance
+-- writes these in the same upsert that moves the screen, and that write is
+-- NOT wrapped in a try/catch — a missing column would fail the advance and
+-- freeze both screens.
+--   node scripts/apply-migration.mjs database/migrations/20260908_kiosk_screen_state_dwell.sql
+--   node scripts/apply-migration.mjs database/migrations/20260908_kiosk_screen_state_dwell.sql --apply
+
+ALTER TABLE kiosk_screen_state ADD COLUMN IF NOT EXISTS dwell_ms           INTEGER;
+ALTER TABLE kiosk_screen_state ADD COLUMN IF NOT EXISTS shown_snapshot_ids BIGINT[];


### PR DESCRIPTION
Three things reported on the glass on 2026-09-08, two of which are one bug.

## What was wrong

A camera run stepped **backwards** and the caption's "minutes ago" counted up instead of down. Separately, two draws of the same camera minutes apart held the glass for very different spans.

Both come from the same place. The run and the dwell's end were re-derived from the live pool on every read, by three surfaces independently, while the dwell's clock had already started.

The pool is not stable enough to be re-read. Measured on the sunset feed:

| | |
|---|---|
| minutes in the last 60 with an admission | 60 |
| entries removed in a single minute | up to 51 |
| sunset cameras present | 35 |

The frame cap is a rank among those 35 cameras, so that churn moves it, and `runOf` anchors its window at the **newest** frame. A wider cap therefore **prepends** older frames. `stageAt` indexes from the front of the array, so a run of `[A,B,C,D]` showing C at 14 s became `[X,Y,A,B,C,D]` showing A.

The server's own record was never wrong: all 328 multi-frame draws in a 90 minute window were in strict capture order. The reorder was created on the glass.

## What this does

The draw pins both facts, in the same write that records when the dwell began:

- `dwell_ms` — the span the engine sized for this draw
- `shown_snapshot_ids` — the frames it plays, in play order

The state view publishes them, the glass plays them, and `planOf` runs the budget rule backward from the pinned span, so the step rate and the published end cannot disagree. This deletes a derivation rather than adding one.

Every reader falls back to the old recompute when the columns are null, so an unapplied migration would cost the fix, not the glass.

Also, two tape fixes reported alongside: a run's earlier frames had no click handler, which `Thumb` renders as a disabled button, and those slivers are exactly the frames an operator cannot identify by eye. The fade X also took pointer events while overlapping 12 px of each neighbour.

## Migration

`20260908_kiosk_screen_state_dwell.sql` — **already applied to production** and recorded in the ledger. Two additive nullable columns, ignored by the code on `main`.

## Verification

- 2514 tests pass, build clean, lint shows only pre-existing warnings.
- The two regression tests in `app/components/solo2/index.test.tsx` were confirmed to **fail** against the old renderer and pass against the new one.

## Not addressed

- The 5-to-16 frame cap spread is a dial choice, not a defect. It is why the same camera runs 18 s one time and 54 s the next.
- The last frame of a run still holds for its own step plus the next dwell's 6 s arrival, so it reads as 10 s against 4 s for the middle frames.

## Still to check

Signed-in look at `/studio` for the tape clicks, then `kiosk-doctor --sync --reload` after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KAQBRAAYo5HwLtT2183rxG
