### PR TITLE
fix(solo2): a camera is sized by the camera, not by its newest frame

### DIFF
--- a/app/lib/solo2/run.test.ts
+++ b/app/lib/solo2/run.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { budgetS, cameraGroups, planDialsFor, poolEntries, qualityRank, representative, runOf, type RunEntry, capFor } from './run';
+import { budgetS, cameraGroups, planDialsFor, poolEntries, qualityRank, representative, runOf, standsFor, type RunEntry, capFor } from './run';
 
 const f = (id: number, cam: number, capturedAt: number, extra: Partial<RunEntry> = {}): RunEntry => ({
   snapshotId: id, webcamId: cam, bin: 'sunset', quality: 0.5, detection: 0.8, isNew: false, tally: 0, enteredAt: id,
@@ -163,5 +163,52 @@ describe('the dwell boost and trim: a grey frame gives back a little time, the b
     const p = planDialsFor(pool[2], { ...d, minStepS: 4 }, pool);
     expect(p.dwellS).toBeCloseTo(16.25);
     expect(p.minStepS).toBe(4);
+  });
+});
+
+describe('the run is sized by the camera, not by the drawn frame', () => {
+  // 2026-09-08: `next2` chooses a camera by its representative — the best
+  // frame's bin — then returns the raw newest frame, and everything downstream
+  // read the bin off THAT. One snapshot the detection head called non-sunset
+  // dropped the camera from up to 16 frames to 5, and its budget with it.
+  // Measured that day: 30 of 38 non-sunset draws were of cameras still holding
+  // sunset frames; Stromness had 13 of 23 and ran five.
+  const d = { runFramesSunset: 16, runFramesOther: 5, runShape: 'rank' as const, dwellS: 13, dwellBoost: 25, dwellTrim: 25 };
+  // Camera 7's best frame is a strong sunset; its NEWEST frame is not a sunset.
+  const camera7 = [
+    f(1, 7, 100, { bin: 'sunset', quality: 0.9 }),
+    f(2, 7, 200, { bin: 'sunset', quality: 0.8 }),
+    f(3, 7, 300, { bin: 'non_sunset', quality: null, detection: 0.4 }),
+  ];
+  const rival = f(9, 8, 300, { bin: 'sunset', quality: 0.1 });
+  const pool = [...camera7, rival];
+  const newest = camera7[2];
+
+  it('caps by the camera, so the newest frame\'s bin cannot shrink the run', () => {
+    // The camera stands top of two sunsets: the whole sunset cap, not the 5 its
+    // own newest frame would have asked for.
+    expect(capFor(newest, d, pool, true)).toBe(16);
+  });
+
+  it('budgets by the camera too, so the dwell and the cap agree about what it is', () => {
+    // Rank 1: the dial plus the boost, not the dial less the trim.
+    expect(budgetS(newest, d, pool, true)).toBeCloseTo(13 * 1.25);
+  });
+
+  it('still sizes a camera whose frames are all non-sunset by the non-sunset dial', () => {
+    const grey = [f(4, 6, 100, { bin: 'non_sunset', quality: null }), f(5, 6, 200, { bin: 'non_sunset', quality: null })];
+    expect(capFor(grey[1], d, [...grey, ...pool], true)).toBe(5);
+    expect(budgetS(grey[1], d, [...grey, ...pool], true)).toBeCloseTo(13 * 0.75);
+  });
+
+  it('with the camera run off, a frame is sized as itself: there is no camera to stand for it', () => {
+    expect(capFor(newest, d, pool, false)).toBe(5);
+  });
+
+  it('standsFor falls back to the entry when there is no camera or nothing to group', () => {
+    expect(standsFor(newest, pool, true)).toMatchObject({ webcamId: 7, bin: 'sunset', quality: 0.9 });
+    expect(standsFor(newest, undefined, true)).toBe(newest);
+    expect(standsFor(newest, pool, false)).toBe(newest);
+    expect(standsFor({ bin: 'sunset' }, pool, true)).toEqual({ bin: 'sunset' });
   });
 });

--- a/app/lib/solo2/run.ts
+++ b/app/lib/solo2/run.ts
@@ -95,6 +95,36 @@ function standing<T extends RunEntry>(e: Pick<BinEntry, 'bin'> & Partial<T>, d: 
   return qualityRank(e as T, entries, cameraRun);
 }
 
+/**
+ * The entry the shaping rules must read for `e`: with the camera run on, the
+ * camera's representative — the very entry `next2` chose the camera by.
+ *
+ * The rules see one synthetic entry per camera (`poolEntries`), and
+ * `representative` stamps it with the BEST frame's bin and quality, so a
+ * camera qualifies as a sunset if any of its frames is one. But `next2` then
+ * returns the raw newest frame, because a draw has to name a real snapshot.
+ * Reading the bin off that frame meant a camera was CHOSEN on its best picture
+ * and SIZED on its newest: one snapshot landing the wrong side of the
+ * detection threshold dropped the run from up to sixteen frames to five and the
+ * budget to the dial less the trim. Measured 2026-09-08, 30 of 38 draws logged
+ * non-sunset were of cameras still holding sunset frames — Stromness had 13 of
+ * 23 and ran five.
+ *
+ * Resolving it here rather than at the call sites is deliberate: six surfaces
+ * call `capFor`/`budgetS`, and a rule each of them has to remember is a rule
+ * that drifts.
+ *
+ * Falls back to `e` when the run is off, when there is nothing to group
+ * against, or when `e` carries no camera — the same three guards `standing`
+ * already uses to decide there is nothing to rank.
+ */
+export function standsFor<T extends RunEntry>(
+  e: Pick<BinEntry, 'bin'> & Partial<T>, entries: T[] | undefined, cameraRun: boolean,
+): Pick<BinEntry, 'bin'> & Partial<T> {
+  if (!cameraRun || !entries || e.webcamId === undefined) return e;
+  return poolEntries(entries.filter((x) => x.webcamId === e.webcamId), cameraRun)[0] ?? e;
+}
+
 /** The two ends the budget swings between, as dial fields; both optional so older callers read as the dial. */
 export interface BudgetDials { dwellS: number; dwellBoost?: number; dwellTrim?: number }
 
@@ -108,6 +138,8 @@ export interface BudgetDials { dwellS: number; dwellBoost?: number; dwellTrim?: 
  * frame may get are different worries. The same shape as the frame cap,
  * applied to the clock, so a lone frame with no run to lengthen still
  * feels the difference.
+ *
+ * Read off the camera, not off the drawn frame (`standsFor`).
  */
 export function budgetS<T extends RunEntry>(
   e: Pick<BinEntry, 'bin'> & Partial<T>, d: CapDials & BudgetDials, entries?: T[], cameraRun = true,
@@ -115,7 +147,8 @@ export function budgetS<T extends RunEntry>(
   const boost = (d.dwellBoost ?? 0) / 100;
   const trim = (d.dwellTrim ?? 0) / 100;
   if (boost === 0 && trim === 0) return d.dwellS;
-  const rank = e.bin === 'sunset' ? standing(e, d, entries, cameraRun) : 0;
+  const stands = standsFor(e, entries, cameraRun);
+  const rank = stands.bin === 'sunset' ? standing(stands, d, entries, cameraRun) : 0;
   return d.dwellS * (1 - trim + (trim + boost) * rank);
 }
 
@@ -153,11 +186,15 @@ export function qualityRank<T extends RunEntry>(e: T, entries: T[], cameraRun: b
  * than a fixed number the model's scale could drift away from.
  *
  * Without `entries` there is nothing to rank against, and the cap is flat.
+ *
+ * The bin is read off the camera, not off the drawn frame (`standsFor`): a run
+ * is a camera's frames, so the cap on it is a fact about the camera.
  */
 export function capFor<T extends RunEntry>(
   e: Pick<BinEntry, 'bin'> & Partial<T>, d: CapDials, entries?: T[], cameraRun = true,
 ): number {
-  if (e.bin !== 'sunset') return d.runFramesOther;
+  const stands = standsFor(e, entries, cameraRun);
+  if (stands.bin !== 'sunset') return d.runFramesOther;
   const lo = Math.min(d.runFramesOther, d.runFramesSunset);
-  return Math.round(lo + (d.runFramesSunset - lo) * standing(e, d, entries, cameraRun));
+  return Math.round(lo + (d.runFramesSunset - lo) * standing(stands, d, entries, cameraRun));
 }

--- a/app/studio/solo/FeedColumn.tsx
+++ b/app/studio/solo/FeedColumn.tsx
@@ -4,7 +4,7 @@ import { useEffect, useState, type ReactNode } from 'react';
 import type { EntryView, StateView } from '@/app/api/kiosk/solo/view';
 import type { Feed, SoloDials } from '@/app/lib/solo/types';
 import type { SoloVersionSpec } from '@/app/lib/solo/versions';
-import { budgetS, cameraGroups, capFor, planDialsFor, representative, runOf } from '@/app/lib/solo2/run';
+import { budgetS, cameraGroups, capFor, planDialsFor, representative, runOf, standsFor } from '@/app/lib/solo2/run';
 import { fitPlan } from '@/app/lib/solo2/plan';
 import { SOLO2_SETTINGS_SCHEMA } from '@/app/lib/solo2/settingsSchema';
 import type { Solo2Dials } from '@/app/lib/solo2/types';
@@ -142,7 +142,11 @@ export function FeedColumn({ feed, server, projected, liveDials, nowMs, version,
     const playedIds = new Set(played.map((f) => f.snapshotId));
     const skipped = runOf(e, all, true).filter((f) => !playedIds.has(f.snapshotId));
     if (played.length <= 1 && skipped.length === 0) return undefined;
-    return { earlier: played.slice(0, -1), skipped, capLabel: capLabelOf(e.bin, cap, d2), stepS: fitPlan(planDialsFor(e, d2, all, true), played.length).stepS };
+    // The label names the dial the cap actually came from, so it reads the bin
+    // off the camera exactly as `capFor` does. Off the drawn frame it could
+    // announce the non-sunset dial beside a sixteen-frame sunset run.
+    const capBin = standsFor(e, all, true).bin ?? e.bin;
+    return { earlier: played.slice(0, -1), skipped, capLabel: capLabelOf(capBin, cap, d2), stepS: fitPlan(planDialsFor(e, d2, all, true), played.length).stepS };
   };
 
   // The queue: each draw with the run it plays.


### PR DESCRIPTION
The bin inconsistency behind the long-versus-short runs.

## What was wrong

With the camera run on, the rules see one synthetic entry per camera. `representative` stamps it with the **best** frame's bin and quality, so a camera qualifies as a sunset if any of its frames is one.

`next2` then returns the raw newest frame, because a draw has to name a real snapshot. `capFor` and `budgetS` read the bin off that frame.

So a camera was **chosen** on its best picture and **sized** on its newest one. One snapshot landing the wrong side of the detection threshold cost it both the run and the clock:

| sized by | frame cap | dwell budget | dwell at the live dials |
|---|---|---|---|
| the camera (its best frame) | up to 16 | dial + boost, 16.25 s | up to 70 s |
| its newest frame, non-sunset | 5 | dial − trim, 9.75 s | 26 s |

Measured on the sunset feed on 2026-09-08: **30 of 38** draws logged non-sunset were of cameras still holding sunset frames. Stromness had 13 of its 23 active frames binned sunset and ran five.

## What this does

`standsFor` resolves the camera's representative, and `capFor` and `budgetS` read the bin off that.

It lives inside those two functions rather than at the call sites on purpose. Six surfaces call them — the glass, the studio's queue, the preview, the tape's projection — and a rule each of them has to remember is a rule that drifts. `qualityRank` already resolved the camera this way internally, so this is the file's existing idiom, not a new one.

The studio's cap label reads the same way, so it can no longer name the non-sunset dial beside a sixteen-frame sunset run.

**Selection is untouched.** Neither function picks anything. This changes only how long a chosen camera runs and how long its dwell lasts.

## Verification

- 2497 tests pass, build clean, lint clean.
- The behavioural tests in `app/lib/solo2/run.test.ts` were confirmed to **fail** against the old sizing.
- Merged against `fix/solo2-pin-the-dwell` (PR #184) with `git merge --no-commit`: no conflict, 2519 tests pass on the merged tree, build clean. Zero file overlap between the two, which is exactly the case that broke `main` twice before.

## Not changed here

`logDraw` still stamps the drawn frame's own bin and scores, so the tape colours a block by the frame rather than by the camera that sized it. That is worth deciding separately: it changes what `bin` means in `kiosk_draws` mid-stream, and the replay reads it.

Still open from the same investigation: the last frame of a run holds for its own step plus the next dwell's arrival, 10 s against 4 s for the middle frames.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KAQBRAAYo5HwLtT2183rxG
