### PR TITLE
The caption leads with the time, and names the crossing only once it is past

### DIFF
--- a/app/api/kiosk/solo/view.ts
+++ b/app/api/kiosk/solo/view.ts
@@ -36,6 +36,10 @@ export interface ViewEntry extends BinEntry {
   timezone: string | null;
   /** Solar altitude at the camera when the picture was taken, degrees; null when unknown. */
   sunAltitudeDeg: number | null;
+  /** When the sun crossed the horizon there that day, ms; absent in polar summer. */
+  sunEventAt?: number | null;
+  /** Which crossing that was, so the caption can name it. */
+  sunPhase?: Feed | null;
 }
 
 export function toViewEntry(e: StoredEntry): ViewEntry {
@@ -44,6 +48,7 @@ export function toViewEntry(e: StoredEntry): ViewEntry {
     detection: e.detection, isNew: e.isNew, tally: e.tally, enteredAt: e.enteredAt, lastShownAt: e.lastShownAt,
     imageUrl: e.imageUrl, title: e.title, city: e.city, region: e.region, country: e.country,
     capturedAt: e.capturedAt, timezone: e.timezone, sunAltitudeDeg: e.sunAltitudeDeg,
+    sunEventAt: e.sunEventAt, sunPhase: e.sunPhase,
   };
 }
 

--- a/app/components/solo/Caption.tsx
+++ b/app/components/solo/Caption.tsx
@@ -3,9 +3,9 @@
 import { Fragment, useLayoutEffect, useRef, type CSSProperties, type ReactNode } from 'react';
 import type { Feed, SoloDials } from '@/app/lib/solo/types';
 import {
-  FONT_STACKS, LINE_HEIGHT, captionBox, captionLines, captionScale, gray, lineGaps,
-  pairTimeSegments, splitTime, tailTravel, timeSegments,
-  type CaptionEntry, type Rect,
+  FONT_STACKS, LINE_HEIGHT, captionBox, captionLines, captionScale, captionSequence, gray,
+  pairTimeSegments, splitTime, sunEventOf, tailTravel, timeSegments,
+  type CaptionEntry, type LineKey, type Rect,
 } from '@/app/lib/solo/caption';
 
 const TIME_KEYFRAMES = `
@@ -73,16 +73,20 @@ export function Caption({ entry, dials, picture, width, feed, step, now = Date.n
   const s = captionScale(width);
   const box = captionBox(dials, picture, width);
   const overlay = dials.captionLayout === 'overlay';
-  const inline = dials.timeLine === 'inline';
-  // Margins, not a flex gap: the time line can be pushed further down than
-  // the place line is, and captionHeight adds up the same two numbers.
-  const gaps = lineGaps(dials);
+  // Folding the time onto the place line only makes sense while the name
+  // leads; when the time is the headline it always has a line of its own.
+  const inline = dials.timeLine === 'inline' && dials.lineOrder === 'name-first';
+  // Margins, not a flex gap: every line owns the space above it, so the
+  // region can sit tight under the name while the time stands clear of
+  // both. captionHeight walks the same sequence and adds the same numbers.
+  const sequence = captionSequence(dials);
 
   // The reading the step is leaving, built with this caption's own dials so
   // the two ends of the fade are always the same format, then matched piece
   // for piece against the reading arriving.
   const leaving = step && step.fadeS > 0 && lines
-    ? timeSegments(dials.timeStyle, step.from.capturedAt, step.from.timezone, step.from.sunAltitudeDeg, now)
+    ? timeSegments(dials.timeStyle, step.from.capturedAt, step.from.timezone, step.from.sunAltitudeDeg,
+      now, sunEventOf(step.from))
     : null;
   const pairs = pairTimeSegments(leaving, lines?.timeParts ?? []);
   // Two frames of the same minute say the same thing; nothing to fade.
@@ -119,6 +123,7 @@ export function Caption({ entry, dials, picture, width, feed, step, now = Date.n
     position: 'absolute', left: box.left, top: box.top, bottom: box.bottom, width: box.width, maxWidth: box.maxWidth,
     textAlign: box.textAlign, display: 'flex', flexDirection: 'column',
     fontFamily: FONT_STACKS[dials.font], whiteSpace: 'nowrap',
+    letterSpacing: `${dials.captionTrack / 1000}em`,
     textShadow: overlay ? '0 1px 4px #000' : undefined,
   };
   const line: CSSProperties = { overflow: 'hidden', textOverflow: 'ellipsis' };
@@ -184,27 +189,51 @@ export function Caption({ entry, dials, picture, width, feed, step, now = Date.n
     </span>
   );
 
+  /* Drawn in the order the dials ask for, so flipping the order moves each
+     line's own space with it rather than leaving a hole at the top. */
+  const draw = (key: LineKey, gap: number) => {
+    const margin = gap * s;
+    if (key === 'title') {
+      return (
+        <div key={key} data-testid="caption-title" style={{
+          ...line, marginTop: margin, fontSize: dials.titleSize * s,
+          fontWeight: Number(dials.titleWeight), color: gray(dials.titleGray),
+          lineHeight: LINE_HEIGHT.title,
+        }}>
+          {lines.title}
+        </div>
+      );
+    }
+    if (key === 'place') {
+      if (!lines.place && !(inline && time)) return null;
+      return (
+        <div key={key} data-testid="caption-place" style={{
+          ...line, marginTop: margin, fontSize: dials.placeSize * s,
+          fontWeight: Number(dials.titleWeight), color: gray(dials.placeGray),
+          lineHeight: LINE_HEIGHT.place,
+        }}>
+          {lines.place}
+          {inline && time && lines.place ? <span style={{ color: gray(dials.timeGray) }}> · </span> : null}
+          {inline ? time : null}
+        </div>
+      );
+    }
+    if (inline || !time) return null;
+    return (
+      <div key={key} data-testid="caption-time-line" style={{
+        ...line, marginTop: margin, fontWeight: Number(dials.titleWeight),
+        lineHeight: LINE_HEIGHT.time,
+      }}>
+        {time}
+      </div>
+    );
+  };
+
   return (
     <>
       {stepping && <style>{TIME_KEYFRAMES}</style>}
       <div data-testid="caption" style={block}>
-        <div data-testid="caption-title" style={{
-          ...line, fontSize: dials.titleSize * s, fontWeight: Number(dials.titleWeight), color: gray(dials.titleGray), lineHeight: LINE_HEIGHT.title,
-        }}>
-          {lines.title}
-        </div>
-        {(lines.place || (inline && time)) && (
-          <div data-testid="caption-place" style={{ ...line, marginTop: gaps.place * s, fontSize: dials.placeSize * s, color: gray(dials.placeGray), lineHeight: LINE_HEIGHT.place }}>
-            {lines.place}
-            {inline && time && lines.place ? <span style={{ color: gray(dials.timeGray) }}> · </span> : null}
-            {inline ? time : null}
-          </div>
-        )}
-        {!inline && time && (
-          <div data-testid="caption-time-line" style={{ ...line, marginTop: gaps.time * s, lineHeight: LINE_HEIGHT.time }}>
-            {time}
-          </div>
-        )}
+        {sequence.map(({ key, gap }) => draw(key, gap))}
       </div>
     </>
   );

--- a/app/components/solo/SoloFrame.test.tsx
+++ b/app/components/solo/SoloFrame.test.tsx
@@ -6,7 +6,17 @@ import { schemaDefaults } from '@/app/lib/settings/schema';
 
 // The caption's default time reading is now "13 minutes ago", which moves
 // with the wall clock; these tests are about layout, so they pin the clock.
-const D = { ...dialsFrom(schemaDefaults(SOLO_SETTINGS_SCHEMA)), timeStyle: '12h-there' as const };
+// Layout tests, so the clock is pinned; and they were written for the
+// name-first arrangement, which is now a dial rather than the default. The
+// time-first default has its own test at the foot of this file.
+const D = {
+  ...dialsFrom(schemaDefaults(SOLO_SETTINGS_SCHEMA)),
+  timeStyle: '12h-there' as const,
+  lineOrder: 'name-first' as const,
+  titleSize: 21, titleGray: 71, placeSize: 17, placeGray: 57, timeSize: 12, timeGray: 46,
+  titleGap: 0, placeGap: 0, timeGap: 0, captionTrack: 0, font: 'system' as const,
+  feedPrefix: true,
+};
 const AT = Date.UTC(2026, 8, 5, 2, 42); // 7:42 pm in Mazatlán
 const e = {
   snapshotId: 1, webcamId: 1, bin: 'sunset' as const, quality: 0.91, detection: 0.88, isNew: false, tally: 2, enteredAt: 0,
@@ -37,16 +47,16 @@ it('caption sizes are glass pixels: the dialled px on a 1920 panel, and the gray
 
 it('the line gap spaces every line after the first; the time gap pushes the time further down still', () => {
   const { rerender } = render(<SoloFrame entry={e} previous={null} fadeS={0}
-    dials={{ ...D, lineGap: 6, timeGap: 0 }} width={1920} height={1080} />);
+    dials={{ ...D, placeGap: 6, timeGap: 6 }} width={1920} height={1080} />);
   expect(screen.getByTestId('caption-place')).toHaveStyle({ marginTop: '6px' });
   expect(screen.getByTestId('caption-time-line')).toHaveStyle({ marginTop: '6px' });
   rerender(<SoloFrame entry={e} previous={null} fadeS={0}
-    dials={{ ...D, lineGap: 6, timeGap: 14 }} width={1920} height={1080} />);
+    dials={{ ...D, placeGap: 6, timeGap: 20 }} width={1920} height={1080} />);
   expect(screen.getByTestId('caption-place')).toHaveStyle({ marginTop: '6px' });
   expect(screen.getByTestId('caption-time-line')).toHaveStyle({ marginTop: '20px' });
   // glass pixels like every other caption size: half the panel, half the gaps
   rerender(<SoloFrame entry={e} previous={null} fadeS={0}
-    dials={{ ...D, lineGap: 6, timeGap: 14 }} width={960} height={540} />);
+    dials={{ ...D, placeGap: 6, timeGap: 20 }} width={960} height={540} />);
   expect(screen.getByTestId('caption-time-line')).toHaveStyle({ marginTop: '10px' });
 });
 
@@ -146,4 +156,15 @@ it('the caption crossfades on the picture’s dial, and cuts with it at zero', (
   rerender(<SoloFrame entry={e} previous={prev} fadeS={0} dials={D} width={1920} height={1080} />);
   expect(screen.queryByTestId('caption-prev')).toBeNull();
   expect(screen.getByTestId('caption-layer').style.animation).toBe('');
+});
+
+it('by default the time leads: it is the first caption line, the name follows after its gap', () => {
+  const dials = dialsFrom(schemaDefaults(SOLO_SETTINGS_SCHEMA));
+  render(<SoloFrame entry={e} previous={null} fadeS={0} dials={dials} width={1920} height={1080} />);
+  const caption = screen.getByTestId('caption');
+  const order = Array.from(caption.children).map((c) => c.getAttribute('data-testid'));
+  expect(order).toEqual(['caption-time-line', 'caption-title', 'caption-place']);
+  // the leading line never carries space above it; the name carries its own
+  expect(screen.getByTestId('caption-time-line')).toHaveStyle({ marginTop: '0px' });
+  expect(screen.getByTestId('caption-title')).toHaveStyle({ marginTop: `${dials.titleGap}px` });
 });

--- a/app/components/solo2/Solo2Frame.test.tsx
+++ b/app/components/solo2/Solo2Frame.test.tsx
@@ -23,7 +23,12 @@ const E = ARRIVAL_EASES.gentle;
 
 // The caption's default time reading is now "13 minutes ago", which moves
 // with the wall clock; these tests are about the run, so they pin the clock.
-const D = { ...dialsFrom2(schemaDefaults(SOLO2_SETTINGS_SCHEMA)), timeStyle: '12h-there' as const };
+// The prefix is off by default now that the time line names the crossing;
+// these tests predate that and still exercise the dial itself.
+const D = {
+  ...dialsFrom2(schemaDefaults(SOLO2_SETTINGS_SCHEMA)),
+  timeStyle: '12h-there' as const, feedPrefix: true, lineOrder: 'name-first' as const,
+};
 const AT = Date.UTC(2026, 8, 5, 2, 42); // 7:42 pm in Mazatlán
 const e = {
   snapshotId: 3, webcamId: 1, bin: 'sunset' as const, quality: 0.91, detection: 0.88, isNew: false, tally: 2, enteredAt: 0,

--- a/app/components/solo2/index.test.tsx
+++ b/app/components/solo2/index.test.tsx
@@ -33,10 +33,12 @@ it('asks the glass hook for solo2, drives by default, follows in a preview', () 
   expect(useSoloGlass).toHaveBeenLastCalledWith(expect.objectContaining({ drive: false, dozing: true }));
 });
 
-it('late in the dwell, draws the drawn frame with its caption and the screen name', () => {
+it('late in the dwell, draws the drawn frame with its caption', () => {
   render(<Solo2Kiosk webcams={[]} width={100} height={50} feed="sunset" />);
   expect(screen.getByTestId('top')).toHaveAttribute('src', 'u3');
-  expect(screen.getByTestId('caption-title')).toHaveTextContent('Sunset: t3');
+  // The screen name no longer prefixes the title: the time line names the
+  // crossing instead, and only once it has actually happened.
+  expect(screen.getByTestId('caption-title')).toHaveTextContent('t3');
 });
 
 it('at the start of the dwell, the camera run begins at its oldest frame', () => {

--- a/app/kiosk/soloFonts.ts
+++ b/app/kiosk/soloFonts.ts
@@ -1,4 +1,4 @@
-import { Source_Sans_3, Source_Serif_4 } from 'next/font/google';
+import { Atkinson_Hyperlegible_Next, Source_Sans_3, Source_Serif_4 } from 'next/font/google';
 
 /**
  * The two faces the caption's font dial can pick beyond the system face and
@@ -12,5 +12,8 @@ import { Source_Sans_3, Source_Serif_4 } from 'next/font/google';
  */
 const sans = Source_Sans_3({ subsets: ['latin'], variable: '--solo-font-sans', display: 'swap' });
 const serif = Source_Serif_4({ subsets: ['latin'], variable: '--solo-font-serif', display: 'swap' });
+// Drawn for low vision: no two letters confusable and the counters stay
+// open, which is what holds a dim caption together at a distance.
+const atkinson = Atkinson_Hyperlegible_Next({ subsets: ['latin'], variable: '--solo-font-atkinson', display: 'swap' });
 
-export const soloFontClassName = `${sans.variable} ${serif.variable}`;
+export const soloFontClassName = `${sans.variable} ${serif.variable} ${atkinson.variable}`;

--- a/app/kiosk/soloFonts.ts
+++ b/app/kiosk/soloFonts.ts
@@ -14,6 +14,18 @@ const sans = Source_Sans_3({ subsets: ['latin'], variable: '--solo-font-sans', d
 const serif = Source_Serif_4({ subsets: ['latin'], variable: '--solo-font-serif', display: 'swap' });
 // Drawn for low vision: no two letters confusable and the counters stay
 // open, which is what holds a dim caption together at a distance.
-const atkinson = Atkinson_Hyperlegible_Next({ subsets: ['latin'], variable: '--solo-font-atkinson', display: 'swap' });
+// next/font has no metric overrides for this family, so it cannot compute a
+// size-adjusted fallback and says so at build time. The kiosk holds one page
+// for days, so the swap happens once — but on a caption pinned under a
+// picture, once is enough to see. `adjustFontFallback: false` takes the
+// guess out, and the explicit fallback keeps the shape close until the real
+// face lands.
+const atkinson = Atkinson_Hyperlegible_Next({
+  subsets: ['latin'],
+  variable: '--solo-font-atkinson',
+  display: 'swap',
+  adjustFontFallback: false,
+  fallback: ['system-ui', 'Segoe UI', 'Noto Sans', 'DejaVu Sans', 'sans-serif'],
+});
 
 export const soloFontClassName = `${sans.variable} ${serif.variable} ${atkinson.variable}`;

--- a/app/lib/settings/schema.ts
+++ b/app/lib/settings/schema.ts
@@ -6,6 +6,13 @@ export interface KnobBase {
   label: string;
   description: string;
   section: string; // folder name in the rail: 'sizing' | 'arrangement' | 'overlays' | 'glass' | ...
+  /**
+   * Optional sub-heading within a section, for a group whose knobs read
+   * better split by what they act on than listed by property. The caption
+   * uses it to gather each line's own size, brightness and spacing under
+   * that line's name.
+   */
+  band?: string;
 }
 
 export interface NumberKnob extends KnobBase {

--- a/app/lib/solo/caption.test.ts
+++ b/app/lib/solo/caption.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { captionBox, captionHeight, captionLines, displayTitle, drawFactor, formatAgo, formatTime, gray, lineGaps, pairTimeSegments, pictureRect, splitTime, tailTravel, timeSegments, timeText } from './caption';
+import { captionBox, captionHeight, captionLines, displayTitle, drawFactor, formatAgo, formatTime, gray, captionSequence, pairTimeSegments, pictureRect, splitTime, tailTravel, timeSegments, timeText } from './caption';
 
 // 02:42 UTC on 2026-09-05 is 7:42 pm the evening before in Mazatlán (UTC−7).
 const AT = Date.UTC(2026, 8, 5, 2, 42);
@@ -226,31 +226,45 @@ describe('splitTime', () => {
   });
 });
 
-describe('lineGaps', () => {
-  it('the time carries the line gap plus its own, so it can sit apart from the two lines above it', () => {
-    expect(lineGaps({ lineGap: 0, timeGap: 0 })).toEqual({ place: 0, time: 0 });
-    expect(lineGaps({ lineGap: 4, timeGap: 0 })).toEqual({ place: 4, time: 4 });
-    expect(lineGaps({ lineGap: 4, timeGap: 12 })).toEqual({ place: 4, time: 16 });
+describe('captionSequence', () => {
+  const d = { lineOrder: 'name-first' as const, titleGap: 4, placeGap: 6, timeGap: 12 };
+  it('draws name, region, time and gives the first line no space above it', () => {
+    expect(captionSequence(d)).toEqual([
+      { key: 'title', gap: 0 }, { key: 'place', gap: 6 }, { key: 'time', gap: 12 },
+    ]);
+  });
+  it('flipping the order carries each gap with its own line', () => {
+    expect(captionSequence({ ...d, lineOrder: 'time-first' })).toEqual([
+      { key: 'time', gap: 0 }, { key: 'title', gap: 4 }, { key: 'place', gap: 6 },
+    ]);
   });
 });
 
 describe('captionHeight', () => {
-  const d = { titleSize: 21, placeSize: 17, timeSize: 12, lineGap: 0, timeGap: 0, timeLine: 'own' as const };
+  const d = {
+    titleSize: 21, placeSize: 17, timeSize: 12,
+    lineOrder: 'name-first' as const, titleGap: 0, placeGap: 0, timeGap: 0, timeLine: 'own' as const,
+  };
   const lines = { place: 'Norrbotten County, Sweden', time: '7:42 pm there' };
   it('adds the lines that will exist at the glass line heights, plus the gaps between them, at scale', () => {
     // title 21 × 1.15 + place 17 × 1.3 + time 12 × 1.3
     expect(captionHeight(d, lines, 1)).toBeCloseTo(61.85);
     expect(captionHeight(d, { place: '', time: '' }, 1)).toBeCloseTo(21 * 1.15);
     expect(captionHeight(d, { place: '', time: '7:42 pm' }, 1)).toBeCloseTo(21 * 1.15 + 12 * 1.3);
-    expect(captionHeight({ ...d, lineGap: 4 }, lines, 1)).toBeCloseTo(61.85 + 8);
+    expect(captionHeight({ ...d, placeGap: 4, timeGap: 4 }, lines, 1)).toBeCloseTo(61.85 + 8);
     expect(captionHeight(d, lines, 0.5)).toBeCloseTo(61.85 / 2);
   });
-  it('the time gap pushes the time line down and the block grows by exactly that much', () => {
+  it('each line carries its own gap, so the region can sit tight while the time stands clear', () => {
     expect(captionHeight({ ...d, timeGap: 10 }, lines, 1)).toBeCloseTo(61.85 + 10);
-    expect(captionHeight({ ...d, lineGap: 4, timeGap: 10 }, lines, 1)).toBeCloseTo(61.85 + 8 + 10);
-    // with no place line the time is still the line that carries the extra gap
+    expect(captionHeight({ ...d, placeGap: 4, timeGap: 14 }, lines, 1)).toBeCloseTo(61.85 + 4 + 14);
+    // with no place line the time is still the line that carries its gap
     expect(captionHeight({ ...d, timeGap: 10 }, { place: '', time: '7:42 pm' }, 1)).toBeCloseTo(21 * 1.15 + 12 * 1.3 + 10);
     expect(captionHeight({ ...d, timeGap: 10 }, lines, 0.5)).toBeCloseTo((61.85 + 10) / 2);
+  });
+  it('the first line has no space above it, whichever line leads', () => {
+    const flipped = { ...d, lineOrder: 'time-first' as const, titleGap: 30, placeGap: 0, timeGap: 99 };
+    // time leads so its 99 is dropped; only the name's 30 is added
+    expect(captionHeight(flipped, lines, 1)).toBeCloseTo(61.85 + 30);
   });
   it('an inline time shares the place line, and makes one when there is no place', () => {
     expect(captionHeight({ ...d, timeLine: 'inline' }, lines, 1)).toBeCloseTo(21 * 1.15 + 17 * 1.3);
@@ -260,6 +274,7 @@ describe('captionHeight', () => {
     expect(captionHeight({ ...d, timeLine: 'inline', timeGap: 30 }, lines, 1)).toBeCloseTo(21 * 1.15 + 17 * 1.3);
   });
 });
+
 
 describe('captionBox', () => {
   const pic = pictureRect({ captionLayout: 'inset', pictureHeight: 87, pictureShift: 0 }, 1920, 1080); // 125, 70, 1671 × 940

--- a/app/lib/solo/caption.ts
+++ b/app/lib/solo/caption.ts
@@ -17,6 +17,10 @@ export interface CaptionEntry {
   capturedAt: number;
   timezone: string | null;
   sunAltitudeDeg: number | null;
+  /** When the sun crossed the horizon there that day, ms; null in polar summer. */
+  sunEventAt?: number | null;
+  /** Which crossing it was, so the caption can name it. */
+  sunPhase?: Feed | null;
 }
 
 function clock(capturedAt: number, timezone: string, hour12: boolean): string | null {
@@ -81,7 +85,7 @@ export function formatAgo(elapsedMs: number): string {
  */
 export function timeSegments(
   style: TimeStyle, capturedAt: number, timezone: string | null, sunAltitudeDeg: number | null,
-  now: number = Date.now(),
+  now: number = Date.now(), event: { at: number; phase: Feed } | null = null,
 ): TimeSegment[] {
   const twelve = timezone ? clock(capturedAt, timezone, true) : null;
   const sunPart = sunAltitudeDeg == null || !Number.isFinite(sunAltitudeDeg) ? null : sun(sunAltitudeDeg);
@@ -89,6 +93,16 @@ export function timeSegments(
   switch (style) {
     case 'off': return [];
     case 'ago': return one(formatAgo(now - capturedAt));
+    // Only ever the past tense. A ridge or a cloud bank can take the sun
+    // away earlier than the almanac says but never later, so an elapsed
+    // time is safe to print over any picture while a countdown is not.
+    // Before the crossing there is nothing safe to say about the sun, so
+    // the line falls back to how old the picture is.
+    case 'sun-past': {
+      if (!event || capturedAt < event.at) return one(formatAgo(now - capturedAt));
+      const word = event.phase === 'sunrise' ? 'Sunrise' : 'Sunset';
+      return one(`${word} ${formatAgo(capturedAt - event.at)}`);
+    }
     case '12h': return one(twelve);
     case '12h-there': return one(twelve ? `${twelve} there` : null);
     case '24h': return one(timezone ? clock(capturedAt, timezone, false) : null);
@@ -110,9 +124,14 @@ export const timeText = (segments: TimeSegment[]): string => segments.map((s) =>
  */
 export function formatTime(
   style: TimeStyle, capturedAt: number, timezone: string | null, sunAltitudeDeg: number | null,
-  now?: number,
+  now?: number, event: { at: number; phase: Feed } | null = null,
 ): string | null {
-  return timeText(timeSegments(style, capturedAt, timezone, sunAltitudeDeg, now)) || null;
+  return timeText(timeSegments(style, capturedAt, timezone, sunAltitudeDeg, now, event)) || null;
+}
+
+/** The sun crossing an entry carries, in the shape timeSegments wants. */
+export function sunEventOf(e: CaptionEntry): { at: number; phase: Feed } | null {
+  return e.sunEventAt != null && e.sunPhase ? { at: e.sunEventAt, phase: e.sunPhase } : null;
 }
 
 const norm = (s: string) => s.toLowerCase().replace(/[^a-z0-9]+/g, '');
@@ -168,7 +187,7 @@ export function captionLines(
   const t = displayTitle(e.title, d.titleClean);
   const prefix = d.feedPrefix && feed ? FEED_PREFIX[feed] : '';
   const place = [t.city, e.region, e.country].filter(Boolean).join(', ');
-  const timeParts = timeSegments(d.timeStyle, e.capturedAt, e.timezone, e.sunAltitudeDeg, now);
+  const timeParts = timeSegments(d.timeStyle, e.capturedAt, e.timezone, e.sunAltitudeDeg, now, sunEventOf(e));
   const time = timeText(timeParts);
   return { title: prefix + t.title, place, time, timeParts, sub: [place, time].filter(Boolean).join(' · ') };
 }
@@ -271,17 +290,30 @@ export interface CaptionBox {
 /** Line heights the caption draws with, as multiples of each line's font size. Caption.tsx uses these. */
 export const LINE_HEIGHT = { title: 1.15, place: 1.3, time: 1.3 } as const;
 
+/** The three caption lines, named. */
+export type LineKey = 'title' | 'place' | 'time';
+
+const GAP_KEY = { title: 'titleGap', place: 'placeGap', time: 'timeGap' } as const;
+const SIZE_KEY = { title: 'titleSize', place: 'placeSize', time: 'timeSize' } as const;
+
 /**
- * The space above each caption line, in glass pixels: nothing above the first
- * line, `lineGap` above any line after it, and `timeGap` on top of that above
- * the time when the time has a line of its own. Caption.tsx draws these as
- * margins and captionHeight adds them up, so the two always agree about how
- * far the block reaches.
+ * The lines in the order they are drawn, each with the space above it in
+ * glass pixels. Every line owns its own gap, so the region can sit tight
+ * under the name while the time stands well clear of both — which one
+ * shared gap plus a bonus for the time could not express.
+ *
+ * The first line has no space above it whichever line that is, so flipping
+ * the order moves the gaps with the lines rather than leaving a hole at the
+ * top of the block. Caption.tsx draws these as margins and captionHeight
+ * adds them up, so the two always agree about how far the block reaches.
  */
-export function lineGaps(
-  d: Pick<SoloDials, 'lineGap' | 'timeGap'>,
-): { place: number; time: number } {
-  return { place: d.lineGap, time: d.lineGap + d.timeGap };
+export function captionSequence(
+  d: Pick<SoloDials, 'lineOrder' | 'titleGap' | 'placeGap' | 'timeGap'>,
+): { key: LineKey; gap: number }[] {
+  const order: LineKey[] = d.lineOrder === 'time-first'
+    ? ['time', 'title', 'place']
+    : ['title', 'place', 'time'];
+  return order.map((key, i) => ({ key, gap: i === 0 ? 0 : d[GAP_KEY[key]] }));
 }
 
 /**
@@ -291,14 +323,22 @@ export function lineGaps(
  * Caption draws with, plus the gap above each line after the first.
  */
 export function captionHeight(
-  d: Pick<SoloDials, 'titleSize' | 'placeSize' | 'timeSize' | 'lineGap' | 'timeGap' | 'timeLine'>,
+  d: Pick<SoloDials, 'titleSize' | 'placeSize' | 'timeSize' | 'lineOrder'
+    | 'titleGap' | 'placeGap' | 'timeGap' | 'timeLine'>,
   lines: Pick<CaptionLines, 'place' | 'time'>, s: number,
 ): number {
-  const inline = d.timeLine === 'inline';
-  const gaps = lineGaps(d);
-  let total = d.titleSize * LINE_HEIGHT.title;
-  if (lines.place || (inline && lines.time)) total += gaps.place + d.placeSize * LINE_HEIGHT.place;
-  if (!inline && lines.time) total += gaps.time + d.timeSize * LINE_HEIGHT.time;
+  const inline = d.timeLine === 'inline' && d.lineOrder === 'name-first';
+  let total = 0;
+  let first = true;
+  for (const { key, gap } of captionSequence(d)) {
+    // The time folded onto the place line adds no line of its own, and the
+    // place line survives an empty place when it is carrying that time.
+    if (key === 'time' && inline) continue;
+    if (key === 'place' && !lines.place && !(inline && lines.time)) continue;
+    if (key === 'time' && !lines.time) continue;
+    total += (first ? 0 : gap) + d[SIZE_KEY[key]] * LINE_HEIGHT[key];
+    first = false;
+  }
   return total * s;
 }
 
@@ -343,6 +383,7 @@ export const FONT_STACKS: Record<CaptionFont, string> = {
   sans: 'var(--solo-font-sans), "Source Sans 3", system-ui, sans-serif',
   serif: 'var(--solo-font-serif), "Source Serif 4", Georgia, "Times New Roman", serif',
   mono: 'var(--font-geist-mono), ui-monospace, SFMono-Regular, Menlo, monospace',
+  atkinson: 'var(--solo-font-atkinson), "Atkinson Hyperlegible Next", system-ui, sans-serif',
 };
 
 /**

--- a/app/lib/solo/captionSchema.test.ts
+++ b/app/lib/solo/captionSchema.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import {
-  CAPTION_SCHEMA, CAPTION_SECTION, captionDialsFrom, linkedCaptionGroup, linkedCaptionValues, withCaption,
+  CAPTION_BANDS, CAPTION_SCHEMA, CAPTION_SECTION, captionDialsFrom, linkedCaptionGroup,
+  linkedCaptionValues, withCaption,
 } from './captionSchema';
 import { mergeSettings, schemaDefaults } from '@/app/lib/settings/schema';
 
@@ -99,5 +100,24 @@ describe('withCaption', () => {
     expect(withCaption(own).pictureHeight).toBe(87);
     expect(withCaption({ ...own, pictureHeight: 92 }, {}).pictureHeight).toBe(87);
     expect(withCaption({ ...own, pictureHeight: 92 }, { pictureHeight: 70 }).pictureHeight).toBe(70);
+  });
+});
+
+describe('CAPTION_BANDS', () => {
+  it('every caption knob is in exactly one band, so none can be dropped from the rail', () => {
+    const ids = CAPTION_BANDS.map((b) => b.id) as readonly string[];
+    for (const k of CAPTION_SCHEMA) {
+      expect(k.band, `${k.key} has no band`).toBeDefined();
+      expect(ids, `${k.key} is in an unknown band`).toContain(k.band);
+    }
+  });
+  it('the three lines come first, because they are what gets turned on the day', () => {
+    expect(CAPTION_BANDS.map((b) => b.id).slice(0, 3)).toEqual(['time', 'name', 'region']);
+  });
+  it('each line keeps its own size, brightness and spacing together', () => {
+    const inBand = (id: string) => CAPTION_SCHEMA.filter((k) => k.band === id).map((k) => k.key);
+    expect(inBand('time')).toEqual(expect.arrayContaining(['timeSize', 'timeGray', 'timeGap']));
+    expect(inBand('name')).toEqual(expect.arrayContaining(['titleSize', 'titleGray', 'titleGap']));
+    expect(inBand('region')).toEqual(expect.arrayContaining(['placeSize', 'placeGray', 'placeGap']));
   });
 });

--- a/app/lib/solo/captionSchema.test.ts
+++ b/app/lib/solo/captionSchema.test.ts
@@ -8,10 +8,11 @@ describe('CAPTION_SCHEMA', () => {
   it('defaults are the 2026-09-05 mockup', () => {
     expect(captionDialsFrom(schemaDefaults(CAPTION_SCHEMA))).toEqual({
       captionLayout: 'inset', pictureHeight: 87, pictureShift: 0, captionAlign: 'picture', captionGap: 18,
-      font: 'system', feedPrefix: true, titleClean: 'compass',
-      titleSize: 21, titleWeight: '300', titleGray: 71,
-      placeSize: 17, placeGray: 57, lineGap: 0,
-      timeStyle: 'ago', timeLine: 'own', timeGap: 0, timeSize: 12, timeGray: 46,
+      font: 'atkinson', feedPrefix: false, titleClean: 'compass',
+      lineOrder: 'time-first', captionTrack: 6,
+      titleSize: 30, titleWeight: '300', titleGray: 20,
+      placeSize: 22, placeGray: 20, titleGap: 30, placeGap: 0,
+      timeStyle: 'sun-past', timeLine: 'own', timeGap: 0, timeSize: 30, timeGray: 20,
     });
   });
 
@@ -21,7 +22,7 @@ describe('CAPTION_SCHEMA', () => {
     // cannot separate them: at the mockup sizes title + place stand about 47
     // glass px tall, and 60 px of gap left the time reading as the third line
     // of one block rather than as its own thing.
-    expect(timeGap?.kind === 'number' && timeGap.max).toBeGreaterThanOrEqual(200);
+    expect(timeGap?.kind === 'number' && timeGap.max).toBeGreaterThanOrEqual(100);
   });
 
   it('every knob is in the caption section, keys are unique, and every default is legal', () => {
@@ -55,7 +56,7 @@ describe('linkedCaptionValues', () => {
   it('names the group a caption key belongs to, and nothing for the rest', () => {
     expect(linkedCaptionGroup('placeSize')).toBe('size');
     expect(linkedCaptionGroup('timeGray')).toBe('gray');
-    expect(linkedCaptionGroup('lineGap')).toBe(null);
+    expect(linkedCaptionGroup('placeGap')).toBe(null);
     expect(linkedCaptionGroup('captionGap')).toBe(null);
   });
 

--- a/app/lib/solo/captionSchema.ts
+++ b/app/lib/solo/captionSchema.ts
@@ -9,6 +9,23 @@ import type {
 export const CAPTION_SECTION = 'caption';
 
 /**
+ * The caption knobs, gathered by what they act on rather than listed by
+ * property. A flat list interleaves the three lines — every size, then
+ * every brightness — which is not how anyone thinks about a caption or
+ * reaches for a dial mid-show. The lines come first because they are what
+ * gets turned on the day.
+ */
+export const CAPTION_BANDS = [
+  { id: 'time', label: 'time', hint: 'The line that says how recent the frame is, and names the crossing once it has happened.' },
+  { id: 'name', label: 'name', hint: 'The camera\u2019s own line: "City: Spot".' },
+  { id: 'region', label: 'region', hint: 'The county and country under the name.' },
+  { id: 'all', label: 'all three lines', hint: 'What every line shares: the face, its weight, the letter spacing, and which line leads.' },
+  { id: 'picture', label: 'the picture', hint: 'Where the picture sits on the panel and how far the words hang below it.' },
+] as const;
+
+export type CaptionBand = typeof CAPTION_BANDS[number]['id'];
+
+/**
  * The caption dials: the picture's frame on black and the words beneath it.
  *
  * They live in the SHARED settings namespace (sharedSchema.ts spreads them
@@ -25,112 +42,112 @@ export const CAPTION_SECTION = 'caption';
 export const CAPTION_SCHEMA: SettingsSchema = [
   {
     key: 'captionLayout', kind: 'enum', options: ['inset', 'overlay'], default: 'inset',
-    label: 'layout', section: CAPTION_SECTION,
+    label: 'layout', section: CAPTION_SECTION, band: 'picture',
     description: 'Inset: the picture sits smaller on black with the caption beneath it. Overlay: the picture fills the panel and the caption floats over it.',
   },
   {
     key: 'pictureHeight', kind: 'number', min: 20, max: 100, step: 1, default: 87,
-    label: 'picture height (%)', section: CAPTION_SECTION,
+    label: 'picture height (%)', section: CAPTION_SECTION, band: 'picture',
     description: 'How tall the inset picture is, as a percent of the panel. It keeps the panel\'s shape and stays locked on the panel\'s centre. Frames arrive at 400 × 224, so the readout beneath says how far the picture is blown up; 1× is pixel-for-pixel. The caption hangs the gap below the picture; set too tall, it leaves the panel, and the preview shows that.',
   },
   {
     key: 'pictureShift', kind: 'number', min: -15, max: 15, step: 1, default: 0,
-    label: 'nudge up / down (%)', section: CAPTION_SECTION,
+    label: 'nudge up / down (%)', section: CAPTION_SECTION, band: 'picture',
     description: 'Moves the picture and its caption together, as a percent of the panel\'s height: negative up, positive down. The gap between them does not change, so the pair balances on the panel as one block. Inset only; overlay fills the panel.',
   },
   {
     key: 'captionAlign', kind: 'enum', options: ['picture', 'center', 'panel'], default: 'picture',
-    label: 'caption aligned to', section: CAPTION_SECTION,
+    label: 'caption aligned to', section: CAPTION_SECTION, band: 'picture',
     description: 'Flush with the picture\'s left edge, centred on the panel, or at the panel\'s left margin.',
   },
   {
     key: 'captionGap', kind: 'number', min: 0, max: 80, step: 2, default: 18,
-    label: 'gap (px)', section: CAPTION_SECTION,
+    label: 'gap (px)', section: CAPTION_SECTION, band: 'picture',
     description: 'Space between the bottom of the picture and the caption.',
   },
   {
     key: 'feedPrefix', kind: 'boolean', default: false,
-    label: 'screen name', section: CAPTION_SECTION,
+    label: 'screen name', section: CAPTION_SECTION, band: 'all',
     description: 'Begin the title with the screen\'s name: "Sunrise: " on the left screen, "Sunset: " on the right.',
   },
   {
     key: 'font', kind: 'enum', options: ['atkinson', 'system', 'geist', 'sans', 'serif', 'mono'], default: 'atkinson',
-    label: 'font', section: CAPTION_SECTION,
+    label: 'font', section: CAPTION_SECTION, band: 'all',
     description: 'atkinson: Atkinson Hyperlegible Next, drawn for low vision — no two letters confusable and the counters stay open, which is what holds a dim caption together across a room. system: whatever the Pi has. geist: the site\'s face. sans: Source Sans 3. serif: Source Serif 4. mono: Geist Mono.',
   },
   {
     key: 'lineOrder', kind: 'enum', options: ['time-first', 'name-first'], default: 'time-first',
-    label: 'order', section: CAPTION_SECTION,
+    label: 'order', section: CAPTION_SECTION, band: 'all',
     description: 'time-first puts how recent the frame is above the camera name. The claim the piece makes is that a sun is going down somewhere right now, so the recency is the headline and the place is the answer to the question it provokes.',
   },
   {
     key: 'captionTrack', kind: 'number', min: -20, max: 60, step: 2, default: 6,
-    label: 'letter spacing', section: CAPTION_SECTION,
+    label: 'letter spacing', section: CAPTION_SECTION, band: 'all',
     description: 'Thousandths of an em, for the whole block. Pale letters on black spread optically: the counters fill in and words start to read as a bar at distance. A little positive tracking resists that, and is worth more here than it would be on paper.',
   },
   {
     key: 'titleClean', kind: 'enum', options: ['compass', 'raw', 'comma', 'dot', 'spot'], default: 'compass',
-    label: '“›” in titles', section: CAPTION_SECTION,
+    label: '“›” in titles', section: CAPTION_SECTION, band: 'name',
     description: 'Windy titles read "City › Compass: Spot". compass drops the "› Compass" part; comma / dot keep it with a quieter separator; spot shows only the spot name and moves the city down to the place line; raw shows the title as sent.',
   },
   {
     key: 'titleSize', kind: 'number', min: 10, max: 60, step: 1, default: 30,
-    label: 'title size (px)', section: CAPTION_SECTION,
+    label: 'title size (px)', section: CAPTION_SECTION, band: 'name',
     description: 'The camera name.',
   },
   {
     key: 'titleWeight', kind: 'enum', options: ['300', '400', '500', '600'], default: '300',
-    label: 'thickness', section: CAPTION_SECTION,
+    label: 'thickness', section: CAPTION_SECTION, band: 'all',
     description: 'Stroke weight for every caption line. As brightness falls the eye loses the fine parts of a letter first, so a thin weight at high grey gives out sooner than a normal weight at low grey — and the normal weight is the quieter of the two over a picture. 300 light, 400 regular, 500 medium, 600 semibold.',
   },
   {
     key: 'titleGray', kind: 'number', min: 0, max: 100, step: 1, default: 20,
-    label: 'title gray (%)', section: CAPTION_SECTION,
+    label: 'title gray (%)', section: CAPTION_SECTION, band: 'name',
     description: '100 is white.',
   },
   {
     key: 'placeSize', kind: 'number', min: 8, max: 60, step: 1, default: 22,
-    label: 'place size (px)', section: CAPTION_SECTION,
+    label: 'place size (px)', section: CAPTION_SECTION, band: 'region',
     description: 'The region and country line.',
   },
   {
     key: 'placeGray', kind: 'number', min: 0, max: 100, step: 1, default: 20,
-    label: 'place gray (%)', section: CAPTION_SECTION,
+    label: 'place gray (%)', section: CAPTION_SECTION, band: 'region',
     description: '100 is white.',
   },
   {
     key: 'titleGap', kind: 'number', min: 0, max: 140, step: 1, default: 30,
-    label: 'space above the name', section: CAPTION_SECTION,
+    label: 'space above the name', section: CAPTION_SECTION, band: 'name',
     description: 'Glass pixels above the camera name, ignored when the name is the first line. Space costs no ink, so it is the cheapest way to say the time and the place are different kinds of fact.',
   },
   {
     key: 'placeGap', kind: 'number', min: 0, max: 140, step: 1, default: 0,
-    label: 'space above the region', section: CAPTION_SECTION,
+    label: 'space above the region', section: CAPTION_SECTION, band: 'region',
     description: 'Glass pixels above the region line, ignored when the region is the first line. Zero binds it to the name as one block.',
   },
   {
     key: 'timeStyle', kind: 'enum', options: ['sun-past', 'off', 'ago', '12h', '12h-there', '24h', 'sun', '12h-sun'], default: 'sun-past',
-    label: 'time', section: CAPTION_SECTION,
+    label: 'time', section: CAPTION_SECTION, band: 'time',
     description: 'sun-past → names the crossing once it has happened ("Sunset 20 minutes ago"), and says how old the picture is before then. Only the past tense is printed: a ridge or a bank of cloud takes the sun away earlier than the almanac says but never later, so an elapsed time is safe over any picture while a countdown gets contradicted by the one it captions. ago → how long since the picture was taken ("13 minutes ago", "1 hour 5 minutes ago"). It says the sunset is happening somewhere else right now without asking anyone to convert a clock, and inside a camera run it counts down. The rest read the camera\'s own clock at the moment of the picture (12h → "7:42 pm", 12h-there → "7:42 pm there", 24h → "19:42"), the sun\'s height ("sun 1.2° above the horizon"), or both.',
   },
   {
     key: 'timeLine', kind: 'enum', options: ['own', 'inline'], default: 'own',
-    label: 'time placement', section: CAPTION_SECTION,
+    label: 'time placement', section: CAPTION_SECTION, band: 'time',
     description: 'own: the time on its own line under the place. inline: after the place with a middle dot.',
   },
   {
     key: 'timeGap', kind: 'number', min: 0, max: 140, step: 1, default: 0,
-    label: 'space above the time', section: CAPTION_SECTION,
+    label: 'space above the time', section: CAPTION_SECTION, band: 'time',
     description: 'Extra space above the time line only, on top of the line gap, so the time can sit apart from the title and the place instead of evenly under them. It reaches a quarter of the panel, far enough to drop the time clear of the pair above it; past what the panel can hold the time leaves the panel, and the preview\u2019s amber edge shows where that is. Nothing when the time is inline.',
   },
   {
     key: 'timeSize', kind: 'number', min: 8, max: 60, step: 1, default: 30,
-    label: 'time size (px)', section: CAPTION_SECTION,
+    label: 'time size (px)', section: CAPTION_SECTION, band: 'time',
     description: 'The time line.',
   },
   {
     key: 'timeGray', kind: 'number', min: 0, max: 90, step: 1, default: 20,
-    label: 'time gray (%)', section: CAPTION_SECTION,
+    label: 'time gray (%)', section: CAPTION_SECTION, band: 'time',
     description: '100 would be white; keep it quieter than the place.',
   },
 ] as const;

--- a/app/lib/solo/captionSchema.ts
+++ b/app/lib/solo/captionSchema.ts
@@ -1,7 +1,8 @@
 import { mergeSettings } from '@/app/lib/settings/schema';
 import type { SettingsSchema, SettingsValues } from '@/app/lib/settings/schema';
 import type {
-  CaptionAlign, CaptionDials, CaptionFont, CaptionLayout, TimeLine, TimeStyle, TitleClean, TitleWeight,
+  CaptionAlign, CaptionDials, CaptionFont, CaptionLayout, LineOrder, TimeLine, TimeStyle,
+  TitleClean, TitleWeight,
 } from './types';
 
 /** The rail section every caption knob sits in. */
@@ -48,14 +49,24 @@ export const CAPTION_SCHEMA: SettingsSchema = [
     description: 'Space between the bottom of the picture and the caption.',
   },
   {
-    key: 'feedPrefix', kind: 'boolean', default: true,
+    key: 'feedPrefix', kind: 'boolean', default: false,
     label: 'screen name', section: CAPTION_SECTION,
     description: 'Begin the title with the screen\'s name: "Sunrise: " on the left screen, "Sunset: " on the right.',
   },
   {
-    key: 'font', kind: 'enum', options: ['system', 'geist', 'sans', 'serif', 'mono'], default: 'system',
+    key: 'font', kind: 'enum', options: ['atkinson', 'system', 'geist', 'sans', 'serif', 'mono'], default: 'atkinson',
     label: 'font', section: CAPTION_SECTION,
-    description: 'system: whatever the Pi has. geist: the site\'s face. sans: Source Sans 3. serif: Source Serif 4. mono: Geist Mono.',
+    description: 'atkinson: Atkinson Hyperlegible Next, drawn for low vision — no two letters confusable and the counters stay open, which is what holds a dim caption together across a room. system: whatever the Pi has. geist: the site\'s face. sans: Source Sans 3. serif: Source Serif 4. mono: Geist Mono.',
+  },
+  {
+    key: 'lineOrder', kind: 'enum', options: ['time-first', 'name-first'], default: 'time-first',
+    label: 'order', section: CAPTION_SECTION,
+    description: 'time-first puts how recent the frame is above the camera name. The claim the piece makes is that a sun is going down somewhere right now, so the recency is the headline and the place is the answer to the question it provokes.',
+  },
+  {
+    key: 'captionTrack', kind: 'number', min: -20, max: 60, step: 2, default: 6,
+    label: 'letter spacing', section: CAPTION_SECTION,
+    description: 'Thousandths of an em, for the whole block. Pale letters on black spread optically: the counters fill in and words start to read as a bar at distance. A little positive tracking resists that, and is worth more here than it would be on paper.',
   },
   {
     key: 'titleClean', kind: 'enum', options: ['compass', 'raw', 'comma', 'dot', 'spot'], default: 'compass',
@@ -63,39 +74,44 @@ export const CAPTION_SCHEMA: SettingsSchema = [
     description: 'Windy titles read "City › Compass: Spot". compass drops the "› Compass" part; comma / dot keep it with a quieter separator; spot shows only the spot name and moves the city down to the place line; raw shows the title as sent.',
   },
   {
-    key: 'titleSize', kind: 'number', min: 10, max: 60, step: 1, default: 21,
+    key: 'titleSize', kind: 'number', min: 10, max: 60, step: 1, default: 30,
     label: 'title size (px)', section: CAPTION_SECTION,
     description: 'The camera name.',
   },
   {
     key: 'titleWeight', kind: 'enum', options: ['300', '400', '500', '600'], default: '300',
-    label: 'title weight', section: CAPTION_SECTION,
-    description: '300 light, 400 regular, 500 medium, 600 semibold.',
+    label: 'thickness', section: CAPTION_SECTION,
+    description: 'Stroke weight for every caption line. As brightness falls the eye loses the fine parts of a letter first, so a thin weight at high grey gives out sooner than a normal weight at low grey — and the normal weight is the quieter of the two over a picture. 300 light, 400 regular, 500 medium, 600 semibold.',
   },
   {
-    key: 'titleGray', kind: 'number', min: 0, max: 100, step: 1, default: 71,
+    key: 'titleGray', kind: 'number', min: 0, max: 100, step: 1, default: 20,
     label: 'title gray (%)', section: CAPTION_SECTION,
     description: '100 is white.',
   },
   {
-    key: 'placeSize', kind: 'number', min: 8, max: 40, step: 1, default: 17,
+    key: 'placeSize', kind: 'number', min: 8, max: 60, step: 1, default: 22,
     label: 'place size (px)', section: CAPTION_SECTION,
     description: 'The region and country line.',
   },
   {
-    key: 'placeGray', kind: 'number', min: 0, max: 100, step: 1, default: 57,
+    key: 'placeGray', kind: 'number', min: 0, max: 100, step: 1, default: 20,
     label: 'place gray (%)', section: CAPTION_SECTION,
     description: '100 is white.',
   },
   {
-    key: 'lineGap', kind: 'number', min: 0, max: 24, step: 1, default: 0,
-    label: 'line gap (px)', section: CAPTION_SECTION,
-    description: 'Extra space above every caption line after the first.',
+    key: 'titleGap', kind: 'number', min: 0, max: 140, step: 1, default: 30,
+    label: 'space above the name', section: CAPTION_SECTION,
+    description: 'Glass pixels above the camera name, ignored when the name is the first line. Space costs no ink, so it is the cheapest way to say the time and the place are different kinds of fact.',
   },
   {
-    key: 'timeStyle', kind: 'enum', options: ['off', 'ago', '12h', '12h-there', '24h', 'sun', '12h-sun'], default: 'ago',
+    key: 'placeGap', kind: 'number', min: 0, max: 140, step: 1, default: 0,
+    label: 'space above the region', section: CAPTION_SECTION,
+    description: 'Glass pixels above the region line, ignored when the region is the first line. Zero binds it to the name as one block.',
+  },
+  {
+    key: 'timeStyle', kind: 'enum', options: ['sun-past', 'off', 'ago', '12h', '12h-there', '24h', 'sun', '12h-sun'], default: 'sun-past',
     label: 'time', section: CAPTION_SECTION,
-    description: 'ago → how long since the picture was taken ("13 minutes ago", "1 hour 5 minutes ago"). It says the sunset is happening somewhere else right now without asking anyone to convert a clock, and inside a camera run it counts down. The rest read the camera\'s own clock at the moment of the picture (12h → "7:42 pm", 12h-there → "7:42 pm there", 24h → "19:42"), the sun\'s height ("sun 1.2° above the horizon"), or both.',
+    description: 'sun-past → names the crossing once it has happened ("Sunset 20 minutes ago"), and says how old the picture is before then. Only the past tense is printed: a ridge or a bank of cloud takes the sun away earlier than the almanac says but never later, so an elapsed time is safe over any picture while a countdown gets contradicted by the one it captions. ago → how long since the picture was taken ("13 minutes ago", "1 hour 5 minutes ago"). It says the sunset is happening somewhere else right now without asking anyone to convert a clock, and inside a camera run it counts down. The rest read the camera\'s own clock at the moment of the picture (12h → "7:42 pm", 12h-there → "7:42 pm there", 24h → "19:42"), the sun\'s height ("sun 1.2° above the horizon"), or both.',
   },
   {
     key: 'timeLine', kind: 'enum', options: ['own', 'inline'], default: 'own',
@@ -103,17 +119,17 @@ export const CAPTION_SCHEMA: SettingsSchema = [
     description: 'own: the time on its own line under the place. inline: after the place with a middle dot.',
   },
   {
-    key: 'timeGap', kind: 'number', min: 0, max: 240, step: 1, default: 0,
-    label: 'time gap (px)', section: CAPTION_SECTION,
+    key: 'timeGap', kind: 'number', min: 0, max: 140, step: 1, default: 0,
+    label: 'space above the time', section: CAPTION_SECTION,
     description: 'Extra space above the time line only, on top of the line gap, so the time can sit apart from the title and the place instead of evenly under them. It reaches a quarter of the panel, far enough to drop the time clear of the pair above it; past what the panel can hold the time leaves the panel, and the preview\u2019s amber edge shows where that is. Nothing when the time is inline.',
   },
   {
-    key: 'timeSize', kind: 'number', min: 8, max: 32, step: 1, default: 12,
+    key: 'timeSize', kind: 'number', min: 8, max: 60, step: 1, default: 30,
     label: 'time size (px)', section: CAPTION_SECTION,
     description: 'The time line.',
   },
   {
-    key: 'timeGray', kind: 'number', min: 0, max: 90, step: 1, default: 46,
+    key: 'timeGray', kind: 'number', min: 0, max: 90, step: 1, default: 20,
     label: 'time gray (%)', section: CAPTION_SECTION,
     description: '100 would be white; keep it quieter than the place.',
   },
@@ -180,12 +196,15 @@ export function captionDialsFrom(values: SettingsValues): CaptionDials {
     font: values.font as CaptionFont,
     feedPrefix: values.feedPrefix as boolean,
     titleClean: values.titleClean as TitleClean,
+    lineOrder: values.lineOrder as LineOrder,
+    captionTrack: values.captionTrack as number,
     titleSize: values.titleSize as number,
     titleWeight: values.titleWeight as TitleWeight,
     titleGray: values.titleGray as number,
     placeSize: values.placeSize as number,
     placeGray: values.placeGray as number,
-    lineGap: values.lineGap as number,
+    titleGap: values.titleGap as number,
+    placeGap: values.placeGap as number,
     timeStyle: values.timeStyle as TimeStyle,
     timeLine: values.timeLine as TimeLine,
     timeGap: values.timeGap as number,

--- a/app/lib/solo/settingsSchema.test.ts
+++ b/app/lib/solo/settingsSchema.test.ts
@@ -17,10 +17,11 @@ describe('SOLO_SETTINGS_SCHEMA', () => {
       showPlace: true, showScores: false, showRank: false, showTally: false,
       // the caption as dialled in on 2026-09-05, at its defaults because no shared values were laid over
       captionLayout: 'inset', pictureHeight: 87, pictureShift: 0, captionAlign: 'picture', captionGap: 18,
-      font: 'system', feedPrefix: true, titleClean: 'compass',
-      titleSize: 21, titleWeight: '300', titleGray: 71,
-      placeSize: 17, placeGray: 57, lineGap: 0,
-      timeStyle: 'ago', timeLine: 'own', timeGap: 0, timeSize: 12, timeGray: 46,
+      font: 'atkinson', feedPrefix: false, titleClean: 'compass',
+      lineOrder: 'time-first', captionTrack: 6,
+      titleSize: 30, titleWeight: '300', titleGray: 20,
+      placeSize: 22, placeGray: 20, titleGap: 30, placeGap: 0,
+      timeStyle: 'sun-past', timeLine: 'own', timeGap: 0, timeSize: 30, timeGray: 20,
     });
   });
 

--- a/app/lib/solo/store.ts
+++ b/app/lib/solo/store.ts
@@ -3,7 +3,7 @@ import tzLookup from 'tz-lookup';
 import { sql } from '@/app/lib/db';
 import type { BinEntry, BinKind, Feed } from './types';
 import type { SoloVersionName } from './versions';
-import { sunAltitudeDeg } from './zone';
+import { sunAltitudeDeg, sunEventAt } from './zone';
 
 /**
  * Every SQL touch of kiosk_bin_entries and kiosk_screen_state (spec §5).
@@ -25,6 +25,10 @@ export interface StoredEntry extends BinEntry {
   timezone: string | null;
   /** Solar altitude at the camera when the picture was taken, degrees. */
   sunAltitudeDeg: number | null;
+  /** When the sun crossed the horizon there that day, ms; absent inside the polar circles. */
+  sunEventAt?: number | null;
+  /** Which crossing that was, so the caption can name it. */
+  sunPhase?: Feed | null;
   firstShownAt: number | null;
   lastShownAt: number | null;
   /** Which draw it was last shown on — rest's currency (spec §6.1). */
@@ -80,6 +84,8 @@ function toEntry(feed: Feed, r: EntryRow): StoredEntry {
   const lat = num(r.lat);
   const lng = num(r.lng);
   const capturedAt = parseUtcText(r.captured_at);
+  const placed = Number.isFinite(capturedAt) && Number.isFinite(lat) && Number.isFinite(lng);
+  const event = placed ? sunEventAt(new Date(capturedAt), lat, lng) : null;
   return {
     feed,
     snapshotId: num(r.snapshot_id),
@@ -102,8 +108,9 @@ function toEntry(feed: Feed, r: EntryRow): StoredEntry {
     lng,
     capturedAt,
     timezone: zoneOf(lat, lng),
-    sunAltitudeDeg: Number.isFinite(capturedAt) && Number.isFinite(lat) && Number.isFinite(lng)
-      ? sunAltitudeDeg(new Date(capturedAt), lat, lng) : null,
+    sunAltitudeDeg: placed ? sunAltitudeDeg(new Date(capturedAt), lat, lng) : null,
+    sunEventAt: event?.at ?? null,
+    sunPhase: event?.phase ?? null,
   };
 }
 

--- a/app/lib/solo/types.ts
+++ b/app/lib/solo/types.ts
@@ -38,13 +38,15 @@ export interface BinEntry {
 export type CaptionLayout = 'overlay' | 'inset';
 export type CaptionAlign = 'picture' | 'center' | 'panel';
 /** The time part of the caption (solo2 spec §4.5). */
-export type TimeStyle = 'off' | '12h' | '12h-there' | '24h' | 'sun' | '12h-sun' | 'ago';
+export type TimeStyle = 'off' | '12h' | '12h-there' | '24h' | 'sun' | '12h-sun' | 'ago' | 'sun-past';
 /** The time on its own line, or after the place with a middle dot. */
 export type TimeLine = 'own' | 'inline';
 /** What to do with Windy's "City › Compass: Spot" titles. */
 export type TitleClean = 'raw' | 'comma' | 'dot' | 'compass' | 'spot';
 export type TitleWeight = '300' | '400' | '500' | '600';
-export type CaptionFont = 'system' | 'geist' | 'sans' | 'serif' | 'mono';
+export type CaptionFont = 'system' | 'geist' | 'sans' | 'serif' | 'mono' | 'atkinson';
+/** Which end of the block the time sits at. */
+export type LineOrder = 'name-first' | 'time-first';
 
 /**
  * The caption group — the picture's frame and the words beneath it. These
@@ -64,15 +66,23 @@ export interface CaptionDials {
   /** "Sunrise: " / "Sunset: " before the title, naming the screen. */
   feedPrefix: boolean;
   titleClean: TitleClean;
+  /** Which end of the block the time sits at. */
+  lineOrder: LineOrder;
+  /** Letter spacing for the whole block, thousandths of an em. */
+  captionTrack: number;
   titleSize: number;
+  /** Stroke weight for every caption line, not the title alone. */
   titleWeight: TitleWeight;
   titleGray: number;
+  /** Space above the name line, when it is not the first line. */
+  titleGap: number;
   placeSize: number;
   placeGray: number;
-  lineGap: number;
+  /** Space above the region line, when it is not the first line. */
+  placeGap: number;
   timeStyle: TimeStyle;
   timeLine: TimeLine;
-  /** Extra space above the time line, on top of lineGap; own-line time only. */
+  /** Space above the time line, when it is not the first line. */
   timeGap: number;
   timeSize: number;
   timeGray: number;

--- a/app/lib/solo/zone.ts
+++ b/app/lib/solo/zone.ts
@@ -1,3 +1,4 @@
+import SunCalc from 'suncalc';
 import { solarPhaseAt, sunAltitudeDeg } from '@/app/lib/solarPhase';
 import type { Feed } from './types';
 
@@ -26,4 +27,28 @@ export interface Zone {
 export function inFeedZone(at: Date, lat: number, lng: number, feed: Feed, zone: Zone): boolean {
   const alt = sunAltitudeDeg(at, lat, lng);
   return alt >= zone.minDeg && alt <= zone.maxDeg && feedAt(at, lat, lng) === feed;
+}
+
+/**
+ * The moment the sun crosses the horizon at a place, on the day of `at`, and
+ * which crossing it is. Sunrise when the sun is climbing, sunset when it is
+ * falling, so a frame is always measured against the event it belongs to.
+ *
+ * The caption uses this to say "Sunset 20 minutes ago" instead of counting
+ * down to one. Only the past tense is safe to print: a ridge, a building or a
+ * bank of cloud can only ever take the sun away EARLIER than this instant,
+ * never later, so a countdown gets contradicted by the picture it captions
+ * while an elapsed time never does.
+ *
+ * Null when SunCalc has no crossing to report, which happens inside the polar
+ * circles for much of the year.
+ */
+export function sunEventAt(
+  at: Date, lat: number, lng: number,
+): { at: number; phase: Feed } | null {
+  const phase = solarPhaseAt(at, lat, lng);
+  const times = SunCalc.getTimes(at, lat, lng);
+  const when = phase === 'sunrise' ? times.sunrise : times.sunset;
+  const ms = when instanceof Date ? when.getTime() : NaN;
+  return Number.isFinite(ms) ? { at: ms, phase } : null;
 }

--- a/app/lib/solo2/settingsSchema.test.ts
+++ b/app/lib/solo2/settingsSchema.test.ts
@@ -34,7 +34,7 @@ describe('solo2 settings schema', () => {
     const d = dialsFrom2(schemaDefaults(SOLO2_SETTINGS_SCHEMA));
     expect(d).toMatchObject({
       leadS: 0, leadScale: 1.03, cameraRun: true,
-      timeStyle: 'ago', valleys: 0, screens: 'together',
+      timeStyle: 'sun-past', valleys: 0, screens: 'together',
     });
     expect('prelude' in d).toBe(false);
     // Decided 2026-09-05: a camera change dips through black, the same camera dissolves.

--- a/app/studio/Rail.test.tsx
+++ b/app/studio/Rail.test.tsx
@@ -75,21 +75,22 @@ describe('Rail, solo kind', () => {
     fireEvent.change(screen.getByLabelText('valleys per peak'), { target: { value: '2' } });
     expect(a.setKnob).toHaveBeenCalledWith('solo2', 'valleys', 2);
     rerender(<Rail api={a} surface={STUDIO_SURFACES.solo2} tab="picture" onTab={noop} />);
-    fireEvent.change(screen.getByLabelText('title size (px)'), { target: { value: '30' } });
-    expect(a.setKnob).toHaveBeenCalledWith('shared', 'titleSize', 30);
+    fireEvent.change(screen.getByLabelText('title size (px)'), { target: { value: '36' } });
+    expect(a.setKnob).toHaveBeenCalledWith('shared', 'titleSize', 36);
   });
   it('with sizes linked, one size drag scales the other two; unlinked, it moves alone', () => {
     const a = api();
     render(<Rail api={a} surface={STUDIO_SURFACES.solo} tab="picture" onTab={noop} />);
-    fireEvent.change(screen.getByLabelText('title size (px)'), { target: { value: '42' } });
+    fireEvent.change(screen.getByLabelText('title size (px)'), { target: { value: '60' } });
     expect(a.setKnob).toHaveBeenCalledTimes(1);
-    expect(a.setKnob).toHaveBeenCalledWith('shared', 'titleSize', 42);
+    expect(a.setKnob).toHaveBeenCalledWith('shared', 'titleSize', 60);
 
     fireEvent.click(screen.getByLabelText('sizes'));
-    fireEvent.change(screen.getByLabelText('title size (px)'), { target: { value: '42' } });
-    // 21 → 42 is 2×, so place 17 → 34 and time 12 → 24.
-    expect(a.setKnob).toHaveBeenCalledWith('shared', 'placeSize', 34);
-    expect(a.setKnob).toHaveBeenCalledWith('shared', 'timeSize', 24);
+    fireEvent.change(screen.getByLabelText('title size (px)'), { target: { value: '60' } });
+    // 30 → 60 is 2×, so place 22 → 44 and time 30 → 60. All three lines share
+    // one range now that any of them can be the headline, so nothing clamps.
+    expect(a.setKnob).toHaveBeenCalledWith('shared', 'placeSize', 44);
+    expect(a.setKnob).toHaveBeenCalledWith('shared', 'timeSize', 60);
     // the grays are a link of their own and stay put
     expect(a.setKnob).not.toHaveBeenCalledWith('shared', 'placeGray', expect.anything());
   });
@@ -97,10 +98,10 @@ describe('Rail, solo kind', () => {
     const a = api();
     render(<Rail api={a} surface={STUDIO_SURFACES.solo} tab="picture" onTab={noop} />);
     fireEvent.click(screen.getByLabelText('grays'));
-    fireEvent.change(screen.getByLabelText('title gray (%)'), { target: { value: '81' } });
-    expect(a.setKnob).toHaveBeenCalledWith('shared', 'titleGray', 81);
-    expect(a.setKnob).toHaveBeenCalledWith('shared', 'placeGray', 67);
-    expect(a.setKnob).toHaveBeenCalledWith('shared', 'timeGray', 56);
+    fireEvent.change(screen.getByLabelText('title gray (%)'), { target: { value: '30' } });
+    expect(a.setKnob).toHaveBeenCalledWith('shared', 'titleGray', 30);
+    expect(a.setKnob).toHaveBeenCalledWith('shared', 'placeGray', 30);
+    expect(a.setKnob).toHaveBeenCalledWith('shared', 'timeGray', 30);
     // a caption dial outside the two groups is never carried along
     fireEvent.change(screen.getByLabelText('gap (px)'), { target: { value: '20' } });
     expect(a.setKnob).toHaveBeenLastCalledWith('shared', 'captionGap', 20);

--- a/app/studio/Rail.tsx
+++ b/app/studio/Rail.tsx
@@ -5,7 +5,7 @@ import type { StudioSettingsApi } from './useStudioSettings';
 import type { StudioSurface } from './surfaces';
 import { SHARED_NAMESPACE } from '@/app/lib/settings/sharedSchema';
 import {
-  CAPTION_SCHEMA, CAPTION_SECTION, linkedCaptionGroup, linkedCaptionValues, withCaption,
+  CAPTION_BANDS, CAPTION_SCHEMA, CAPTION_SECTION, linkedCaptionGroup, linkedCaptionValues, withCaption,
   type LinkedCaptionGroup,
 } from '@/app/lib/solo/captionSchema';
 import { SOURCE_FRAME, drawFactor, pictureRect } from '@/app/lib/solo/caption';
@@ -241,6 +241,25 @@ function GroupHeader({ title, color, hint, section, onReset, asSummary = false, 
  * time. It is editing state only — it lives for as long as the page does and
  * nothing about it is stored or deployed.
  */
+/**
+ * A sub-heading inside the caption group. Quieter than a GroupHeader and
+ * with no reset of its own: the band is a way of reading the list, not a
+ * section the settings store knows about.
+ */
+function BandHeader({ label, hint }: { label: string; hint: string }) {
+  return (
+    <div style={{
+      display: 'flex', alignItems: 'center', gap: 6,
+      margin: '12px 0 2px', padding: '0 4px 3px',
+      borderBottom: '1px solid #1d2432',
+      fontSize: 10, letterSpacing: '0.11em', textTransform: 'uppercase', color: '#8b95a7',
+    }}>
+      {label}
+      <Hint text={hint} />
+    </div>
+  );
+}
+
 function CaptionLinks({ linked, onToggle }: {
   linked: Record<LinkedCaptionGroup, boolean>;
   onToggle: (group: LinkedCaptionGroup, on: boolean) => void;
@@ -402,9 +421,18 @@ export function Rail({ api, surface, tab, onTab, runFrames = 1, children }: {
           <GroupHeader {...CAPTION_GROUP} section={CAPTION_SECTION}
             onReset={() => api.resetSection(SHARED_NAMESPACE, CAPTION_SECTION)} />
           <CaptionLinks linked={linked} onToggle={(g, on) => setLinked((l) => ({ ...l, [g]: on }))} />
-          {CAPTION_SCHEMA.map((k) => knob(k, {
-            ns: SHARED_NAMESPACE, values: shared, diff: sharedDiff, onChange: setCaptionKnob,
-          }))}
+          {CAPTION_BANDS.map((band) => {
+            const knobs = CAPTION_SCHEMA.filter((k) => k.band === band.id);
+            if (!knobs.length) return null;
+            return (
+              <div key={band.id} data-testid={`caption-band-${band.id}`}>
+                <BandHeader label={band.label} hint={band.hint} />
+                {knobs.map((k) => knob(k, {
+                  ns: SHARED_NAMESPACE, values: shared, diff: sharedDiff, onChange: setCaptionKnob,
+                }))}
+              </div>
+            );
+          })}
         </section>
       )}
       <div style={{ marginTop: 'auto', paddingTop: 10 }}>{children}</div>

--- a/app/studio/solo/GlassPreview.test.tsx
+++ b/app/studio/solo/GlassPreview.test.tsx
@@ -6,7 +6,9 @@ import { dialsFrom, SOLO_SETTINGS_SCHEMA } from '@/app/lib/solo/settingsSchema';
 import { schemaDefaults } from '@/app/lib/settings/schema';
 import type { StateView } from '@/app/api/kiosk/solo/view';
 
-const D = dialsFrom(schemaDefaults(SOLO_SETTINGS_SCHEMA));
+// The prefix is off by default now that the time line names the crossing;
+// this test is about the dial still naming each screen when it is on.
+const D = { ...dialsFrom(schemaDefaults(SOLO_SETTINGS_SCHEMA)), feedPrefix: true };
 const entry = {
   snapshotId: 7, webcamId: 1, bin: 'sunset' as const, quality: 0.9, detection: 0.9, isNew: false, tally: 1, enteredAt: 0,
   imageUrl: 'u7', title: 'Porjus › North-west: Northern Lights webcam', city: 'Porjus', region: 'Norrbotten County', country: 'Sweden',


### PR DESCRIPTION
Tuned in a bench that draws the caption at true panel size on black, so the
numbers are measured rather than guessed. One unit is 0.31 mm on any 27"
16:9 glass, and a line stops being readable when a lowercase x falls under
about 6 arcminutes. Bench: https://claude.ai/code/artifact/514efe46-d055-4d80-a931-a4c30ea4b53a

## What you will see

```
Sunset 20 minutes ago

Split: Riva promenade
Split-Dalmatia, Croatia
```

Atkinson Hyperlegible Next, every line at 20% grey on weight 300, time and
name at 30 with the region at 22 tight underneath, 30 of space between the
time and the name, tracking +6.

## The reasoning worth arguing with

**The time leads.** The claim the piece makes is that a sun is going down
somewhere right now. The recency is the headline; the place answers the
question it provokes. `lineOrder` flips it back.

**Only the past tense.** The new `sun-past` style names the crossing once it
has happened and says how old the picture is before then. A ridge, a
building line or a bank of cloud takes the sun away *earlier* than the
almanac says and never later, so an elapsed time is safe over any picture
while a countdown gets contradicted by the one it captions. On a grey frame
"Sunset in 34 minutes" is the display asserting something the viewer can see
is not true; "Sunset 20 minutes ago" survives both the mountain and the
afterglow.

**Thicker and dimmer beats thinner and brighter.** Low contrast deletes the
fine parts of a letter first, so weight 300 at 71% gives out sooner than a
sturdier stroke at 20% — and the dimmer one is quieter over the picture as
well. That trade is most of why the defaults moved so far.

**Per-line gaps.** One shared `lineGap` plus a bonus for the time could not
put the region tight under the name while the time stood clear of both. Each
line now owns the space above it, and the leading line's gap is dropped
whichever line leads.

**`feedPrefix` off.** "Sunset: City: Spot" put two colons on the line that
most needs its width, and the wall text for the show already carries the
concept once, permanently. The dial stays as a day-of escape hatch.

## Checks

- `npm run test` — 2495 passed, 293 files
- `npm run build` — clean
- `npm run lint` — pre-existing warnings only
- No migration.

## Before merging

**UNVERIFIED ON THE GLASS.** The distance arithmetic is worked from letter
size alone; contrast shortens it and the arithmetic cannot say by how much.
At 20% these settings want the ten-foot walk on the real panels. The size
and spacing dials are deliberately there to be moved on the day.

After merge: `bash scripts/pi/kiosk-doctor.sh --sync --reload`, then
`scripts/wt.sh rm feat/caption-time-first`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013HBAVsE9xjJbxRqiGfcgSM
