### PR TITLE
feat(solo2): a dip is charged half to the dwell it leaves, the tape draws the real seam, the tape zooms

### DIFF
--- a/app/components/solo2/Solo2Frame.test.tsx
+++ b/app/components/solo2/Solo2Frame.test.tsx
@@ -37,7 +37,7 @@ const run = [
   e,
 ];
 const plan = fitPlan({ ...D, leadS: 4 }, 3); // 20 s / 3 = 6.67 s a frame, above the 4 s floor
-const last = { index: 2, leadProgress: 0 };
+const last = { index: 2, leadProgress: 0, exitProgress: 0 };
 
 it('the last frame: inset on black, centred, with place and local time, no scores by default', () => {
   render(<Solo2Frame entry={e} run={run} previous={null} stage={last} plan={plan} dials={D} width={1920} height={1080} />);
@@ -50,7 +50,7 @@ it('the last frame: inset on black, centred, with place and local time, no score
 });
 
 it('an earlier frame of the run carries its own caption, time and scores', () => {
-  render(<Solo2Frame entry={e} run={run} previous={null} stage={{ index: 1, leadProgress: 0 }} plan={plan}
+  render(<Solo2Frame entry={e} run={run} previous={null} stage={{ index: 1, leadProgress: 0, exitProgress: 0 }} plan={plan}
     dials={{ ...D, showScores: true, showTally: true, showRank: true }} width={1920} height={1080} />);
   expect(screen.getByTestId('top')).toHaveAttribute('src', 'u2');
   expect(screen.getByText('Pier mid')).toBeInTheDocument();
@@ -62,7 +62,7 @@ it('an earlier frame of the run carries its own caption, time and scores', () =>
 });
 
 it('the run is stacked: frames up to the stage are opaque, later ones transparent, each dissolving over the same-camera fade capped at the share', () => {
-  const { rerender } = render(<Solo2Frame entry={e} run={run} previous={null} stage={{ index: 1, leadProgress: 0 }} plan={plan}
+  const { rerender } = render(<Solo2Frame entry={e} run={run} previous={null} stage={{ index: 1, leadProgress: 0, exitProgress: 0 }} plan={plan}
     dials={{ ...D, sameCameraFadeS: 1 }} width={1920} height={1080} />);
   const layers = () => screen.getAllByTestId(/^seq-/).map((l) => [l.getAttribute('data-testid'), l.style.opacity, l.style.transition]);
   expect(layers()).toEqual([
@@ -85,26 +85,26 @@ it('the run is stacked: frames up to the stage are opaque, later ones transparen
 });
 
 it('an empty run draws the entry alone', () => {
-  render(<Solo2Frame entry={e} run={[]} previous={null} stage={{ index: 0, leadProgress: 0 }} plan={fitPlan(D, 1)} dials={D} width={100} height={50} />);
+  render(<Solo2Frame entry={e} run={[]} previous={null} stage={{ index: 0, leadProgress: 0, exitProgress: 0 }} plan={fitPlan(D, 1)} dials={D} width={100} height={50} />);
   expect(screen.getByTestId('top')).toHaveAttribute('src', 'u3');
 });
 
 it('time style off leaves just the place; 24h inline reads place · 19:42', () => {
-  const { rerender } = render(<Solo2Frame entry={e} run={[e]} previous={null} stage={{ index: 0, leadProgress: 0 }} plan={plan} dials={{ ...D, timeStyle: 'off' }} width={1920} height={1080} />);
+  const { rerender } = render(<Solo2Frame entry={e} run={[e]} previous={null} stage={{ index: 0, leadProgress: 0, exitProgress: 0 }} plan={plan} dials={{ ...D, timeStyle: 'off' }} width={1920} height={1080} />);
   expect(screen.getByText('Baja California Sur, Mexico')).toBeInTheDocument();
   expect(screen.queryByTestId('caption-time')).toBeNull();
-  rerender(<Solo2Frame entry={e} run={[e]} previous={null} stage={{ index: 0, leadProgress: 0 }} plan={plan} dials={{ ...D, timeStyle: '24h', timeLine: 'inline' }} width={1920} height={1080} />);
+  rerender(<Solo2Frame entry={e} run={[e]} previous={null} stage={{ index: 0, leadProgress: 0, exitProgress: 0 }} plan={plan} dials={{ ...D, timeStyle: '24h', timeLine: 'inline' }} width={1920} height={1080} />);
   expect(screen.getByTestId('caption-place')).toHaveTextContent('Baja California Sur, Mexico · 19:42');
 });
 
 it('names the screen before the title with the prefix dial', () => {
-  render(<Solo2Frame entry={e} run={[e]} previous={null} stage={{ index: 0, leadProgress: 0 }} plan={plan} dials={D} feed="sunrise" width={1920} height={1080} />);
+  render(<Solo2Frame entry={e} run={[e]} previous={null} stage={{ index: 0, leadProgress: 0, exitProgress: 0 }} plan={plan} dials={D} feed="sunrise" width={1920} height={1080} />);
   expect(screen.getByTestId('caption-title')).toHaveTextContent('Sunrise: Pier');
 });
 
 it('cut shows no previous layer; crossfade keeps it and animates the top; dip adds the black veil', () => {
   const prev = { ...e, snapshotId: 0, webcamId: 99, imageUrl: 'u0' };
-  const one = { index: 0, leadProgress: 0 };
+  const one = { index: 0, leadProgress: 0, exitProgress: 0 };
   const { rerender } = render(<Solo2Frame entry={e} run={[e]} previous={prev} stage={one} plan={plan} dials={{ ...D, transition: 'cut' }} width={100} height={50} />);
   expect(screen.getAllByRole('presentation').map((i) => i.getAttribute('src'))).toEqual(['u3']);
   rerender(<Solo2Frame entry={e} run={[e]} previous={prev} stage={one} plan={plan} dials={{ ...D, transition: 'crossfade', fadeS: 2 }} width={100} height={50} />);
@@ -112,12 +112,16 @@ it('cut shows no previous layer; crossfade keeps it and animates the top; dip ad
   expect(screen.getByTestId('stack')).toHaveStyle({ animation: `solo2-fade-in 2s ${E} both` });
   expect(screen.queryByTestId('dip')).toBeNull();
   rerender(<Solo2Frame entry={e} run={[e]} previous={prev} stage={one} plan={plan} dials={{ ...D, transition: 'dip', fadeS: 2 }} width={100} height={50} />);
-  expect(screen.getByTestId('dip')).toHaveStyle({ animation: `solo2-dip 1s ${E} both` });
+  // The veil is already closed: the previous dwell raised it at its exit. This
+  // dwell only rises out of it, over the dip's second half, with no delay.
+  expect(screen.getByTestId('dip')).toHaveStyle({ opacity: '1' });
+  expect(screen.getByTestId('dip').style.animation).toBe('');
+  expect(screen.getByTestId('stack')).toHaveStyle({ animation: `solo2-fade-in 1s ${E} both` });
 });
 
 it('a change to the same camera dissolves over the same-camera fade, never through black', () => {
   const prev = { ...e, snapshotId: 0, imageUrl: 'u0' }; // same webcamId as e
-  render(<Solo2Frame entry={e} run={[e]} previous={prev} stage={{ index: 0, leadProgress: 0 }} plan={plan}
+  render(<Solo2Frame entry={e} run={[e]} previous={prev} stage={{ index: 0, leadProgress: 0, exitProgress: 0 }} plan={plan}
     dials={{ ...D, transition: 'dip', fadeS: 4, sameCameraFadeS: 1 }} width={100} height={50} />);
   expect(screen.getAllByRole('presentation').map((i) => i.getAttribute('src'))).toEqual(['u0', 'u3']);
   expect(screen.queryByTestId('dip')).toBeNull();
@@ -126,22 +130,23 @@ it('a change to the same camera dissolves over the same-camera fade, never throu
 
 it('the defaults dip through black between cameras', () => {
   const prev = { ...e, snapshotId: 0, webcamId: 99, imageUrl: 'u0' };
-  render(<Solo2Frame entry={e} run={[e]} previous={prev} stage={{ index: 0, leadProgress: 0 }} plan={plan} dials={D} width={100} height={50} />);
-  expect(screen.getByTestId('dip')).toHaveStyle({ animation: `solo2-dip 0.75s ${E} both` });
+  render(<Solo2Frame entry={e} run={[e]} previous={prev} stage={{ index: 0, leadProgress: 0, exitProgress: 0 }} plan={plan} dials={D} width={100} height={50} />);
+  expect(screen.getByTestId('dip')).toHaveStyle({ background: '#000000', opacity: '1' });
+  expect(screen.getByTestId('stack')).toHaveStyle({ animation: `solo2-fade-in 0.75s ${E} both` });
 });
 
 it('the lead pushes the frame in by progress and lands the next frame still', () => {
-  const { rerender } = render(<Solo2Frame entry={e} run={[e]} previous={null} stage={{ index: 0, leadProgress: 0.5 }} plan={plan}
+  const { rerender } = render(<Solo2Frame entry={e} run={[e]} previous={null} stage={{ index: 0, leadProgress: 0.5, exitProgress: 0 }} plan={plan}
     dials={{ ...D, leadS: 4, leadScale: 1.04 }} width={100} height={50} />);
   expect(screen.getByTestId('push')).toHaveStyle({ transform: 'scale(1.0200)', transition: 'transform 260ms linear' });
-  rerender(<Solo2Frame entry={{ ...e, snapshotId: 4 }} run={[{ ...e, snapshotId: 4 }]} previous={e} stage={{ index: 0, leadProgress: 0 }} plan={plan}
+  rerender(<Solo2Frame entry={{ ...e, snapshotId: 4 }} run={[{ ...e, snapshotId: 4 }]} previous={e} stage={{ index: 0, leadProgress: 0, exitProgress: 0 }} plan={plan}
     dials={{ ...D, leadS: 4, leadScale: 1.04 }} width={100} height={50} />);
   expect(screen.getByTestId('push')).toHaveStyle({ transform: 'scale(1.0000)', transition: 'none' });
 });
 
 it('the caption arrives on the picture’s transition: the same animation, and the outgoing words underneath', () => {
   const prev = { ...e, snapshotId: 0, webcamId: 99, imageUrl: 'u0', title: 'Old pier' };
-  const one = { index: 0, leadProgress: 0 };
+  const one = { index: 0, leadProgress: 0, exitProgress: 0 };
   const { rerender } = render(<Solo2Frame entry={e} run={[e]} previous={prev} stage={one} plan={plan}
     dials={{ ...D, transition: 'crossfade', fadeS: 2 }} width={1920} height={1080} />);
   expect(screen.getByTestId('caption-layer')).toHaveStyle({ animation: `solo2-fade-in 2s ${E} both` });
@@ -163,18 +168,18 @@ it('the outgoing caption dissolves away, so a veil-less change never leaves two 
   // change without a veil — a crossfade, a same-camera arrival, or a dip whose
   // veil colour is null — showed both at once (reported 2026-09-07).
   const prev = { ...e, snapshotId: 0, webcamId: 99, imageUrl: 'u0', title: 'Old pier' };
-  const one = { index: 0, leadProgress: 0 };
+  const one = { index: 0, leadProgress: 0, exitProgress: 0 };
   const { rerender } = render(<Solo2Frame entry={e} run={[e]} previous={prev} stage={one} plan={plan}
     dials={{ ...D, transition: 'crossfade', fadeS: 2 }} width={1920} height={1080} />);
   // It leaves on exactly the ramp the new caption arrives on, held at the end.
   expect(screen.getByTestId('caption-prev')).toHaveStyle({ animation: `solo2-fade-out 2s ${E} both` });
 
-  // A dip: the words leave while the veil closes, over the veil's own half.
+  // A dip: the words already left at the previous dwell's exit, with the
+  // picture; here they sit hidden under the closed veil.
   rerender(<Solo2Frame entry={e} run={[e]} previous={prev} stage={one} plan={plan}
     dials={{ ...D, transition: 'dip', fadeS: 2 }} width={1920} height={1080} />);
-  expect(screen.getByTestId('caption-prev')).toHaveStyle({ animation: `solo2-fade-out 1s ${E} both` });
-  expect(screen.getByTestId('caption-prev').style.animation.split(' ').slice(1, 2))
-    .toEqual(screen.getByTestId('dip').style.animation.split(' ').slice(1, 2));
+  expect(screen.getByTestId('caption-prev')).toHaveStyle({ opacity: '0' });
+  expect(screen.getByTestId('caption-prev').style.animation).toBe('');
 
   // A sunrise change of `crossfade` has no veil, so its dip becomes a crossfade
   // — the case #172 opened up, and the one that must not strand the old words.
@@ -187,7 +192,7 @@ it('the outgoing caption dissolves away, so a veil-less change never leaves two 
 
 it('on a dip the veil covers the outgoing caption, and the new words fade in after it', () => {
   const prev = { ...e, snapshotId: 0, webcamId: 99, imageUrl: 'u0' };
-  render(<Solo2Frame entry={e} run={[e]} previous={prev} stage={{ index: 0, leadProgress: 0 }} plan={plan}
+  render(<Solo2Frame entry={e} run={[e]} previous={prev} stage={{ index: 0, leadProgress: 0, exitProgress: 0 }} plan={plan}
     dials={{ ...D, transition: 'dip', fadeS: 2 }} width={1920} height={1080} />);
   const out = screen.getByTestId('caption-prev');
   const veil = screen.getByTestId('dip');
@@ -195,23 +200,27 @@ it('on a dip the veil covers the outgoing caption, and the new words fade in aft
   // Painted in this order, so the veil hides the old words rather than sitting behind them.
   expect(out.compareDocumentPosition(veil) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
   expect(veil.compareDocumentPosition(arriving) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
-  expect(arriving).toHaveStyle({ animation: `solo2-fade-in 1s ${E} 1s both` });
+  expect(arriving).toHaveStyle({ animation: `solo2-fade-in 1s ${E} both` });
 });
 
-it('a dip goes down and comes up on the same ramp: the veil and the arriving picture share duration and timing function', () => {
-  const prev = { ...e, snapshotId: 0, webcamId: 99, imageUrl: 'u0' };
-  render(<Solo2Frame entry={e} run={[e]} previous={prev} stage={{ index: 0, leadProgress: 0 }} plan={plan}
-    dials={{ ...D, transition: 'dip', fadeS: 2 }} width={100} height={50} />);
-  // An up-ramp of a different shape from the down-ramp is what made the new
-  // picture read as arriving three times faster than the old one left. The
-  // curve is a dial now, so what must hold is that the two halves share it AND
-  // that it is symmetric — an asymmetric curve runs a different shape backwards
-  // even when both halves name it.
+it('a dip goes down and comes up on the same ramp: the leaving veil and the arriving picture share duration and timing function', () => {
+  // The two halves now live in two dwells: the down-ramp is the leaving
+  // dwell's exit, the up-ramp the arriving dwell's front. They still have to
+  // match. An up-ramp of a different shape from the down-ramp is what made the
+  // new picture read as arriving three times faster than the old one left.
+  const dials = { ...D, transition: 'dip' as const, fadeS: 2 };
   const parse = (css: string) => {
     const m = css.match(/^(\S+) (\S+) (.*?)( \d[\d.]*s)? both$/);
     return m && { duration: m[2], easing: m[3] };
   };
-  const down = parse(screen.getByTestId('dip').style.animation);
+  const leaving = fitPlan(dials, 1);
+  const other = { ...e, snapshotId: 0, webcamId: 99, imageUrl: 'u0' };
+  const { unmount } = render(<Solo2Frame entry={e} run={[e]} previous={null} next={other}
+    stage={{ index: 0, leadProgress: 0, exitProgress: 0.5 }} plan={leaving} dials={dials} width={100} height={50} />);
+  const down = parse(screen.getByTestId('exit-veil').style.animation);
+  unmount();
+  render(<Solo2Frame entry={other} run={[other]} previous={e} stage={{ index: 0, leadProgress: 0, exitProgress: 0 }} plan={plan}
+    dials={dials} width={100} height={50} />);
   const up = parse(screen.getByTestId('stack').style.animation);
   expect(down).toBeTruthy();
   expect(up && up.duration).toBe(down && down.duration);
@@ -219,10 +228,55 @@ it('a dip goes down and comes up on the same ramp: the veil and the arriving pic
   expect(easingIsSymmetric(String(up && up.easing))).toBe(true);
 });
 
+describe('the exit: the last picture burns down inside its own step', () => {
+  // Reported 2026-09-08 as the last picture of a run "stuck for an awful long
+  // time": the whole dip was reserved at the front of the next dwell, so this
+  // one's last frame held a full still step before it began to go.
+  const dials = { ...D, transition: 'dip' as const, fadeS: 2, veilStyle: 'exposure' as const, burnLift: 1.6 };
+  const p = fitPlan(dials, 3); // exit 1 s
+  const other = { webcamId: 99 };
+  const frame = (stage: { index: number; leadProgress: number; exitProgress: number }, next: { webcamId: number } | null = other, feed: 'sunrise' | 'sunset' = 'sunrise') =>
+    render(<Solo2Frame entry={e} run={run} previous={null} next={next} stage={stage} plan={p} dials={dials} width={100} height={50} feed={feed} />);
+
+  it('nothing leaves before the exit begins', () => {
+    frame({ index: 2, leadProgress: 0, exitProgress: 0 });
+    expect(screen.queryByTestId('exit-veil')).toBeNull();
+    expect(screen.getByTestId('exit-burn').style.animation).toBe('');
+    expect(screen.getByTestId('exit-words').style.animation).toBe('');
+  });
+
+  it('once it begins, the veil closes over everything, the picture burns toward it and the words leave, all on one ramp', () => {
+    frame({ index: 2, leadProgress: 0, exitProgress: 0.3 });
+    expect(screen.getByTestId('exit-veil')).toHaveStyle({ background: '#ffffff', animation: `solo2-dip 1s ${E} both` });
+    expect(screen.getByTestId('exit-burn')).toHaveStyle({ animation: `solo2-burn-out 1s ${E} both` });
+    expect(screen.getByTestId('exit-words')).toHaveStyle({ animation: `solo2-fade-out 1s ${E} both` });
+    // The veil paints last, above the caption and the scores.
+    const veil = screen.getByTestId('exit-veil');
+    expect(screen.getByTestId('caption-layer').compareDocumentPosition(veil) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    // Sunset burns the other way; the lift rides the stack's custom property.
+    cleanup();
+    frame({ index: 2, leadProgress: 0, exitProgress: 0.3 }, other, 'sunset');
+    expect(screen.getByTestId('exit-veil')).toHaveStyle({ background: '#000000' });
+    expect(screen.getByTestId('stack').style.getPropertyValue('--solo2-lift')).toBe('0');
+  });
+
+  it('a later frame of the same camera arrives by dissolve, so the picture is not burned down before it', () => {
+    frame({ index: 2, leadProgress: 0, exitProgress: 0.5 }, { webcamId: e.webcamId });
+    expect(screen.queryByTestId('exit-veil')).toBeNull();
+    expect(screen.getByTestId('exit-burn').style.animation).toBe('');
+  });
+
+  it('a change that is not a dip has no exit', () => {
+    render(<Solo2Frame entry={e} run={run} previous={null} next={other} stage={{ index: 2, leadProgress: 0, exitProgress: 0.5 }}
+      plan={fitPlan({ ...dials, transition: 'crossfade' }, 3)} dials={{ ...dials, transition: 'crossfade' }} width={100} height={50} />);
+    expect(screen.queryByTestId('exit-veil')).toBeNull();
+  });
+});
+
 describe('what the change dips through', () => {
   const prev = { ...e, snapshotId: 0, webcamId: 99, imageUrl: 'u0' };
   const dip = (extra: Partial<typeof D>, feed: 'sunrise' | 'sunset' = 'sunrise') => {
-    render(<Solo2Frame entry={e} run={[e]} previous={prev} stage={{ index: 0, leadProgress: 0 }} plan={plan}
+    render(<Solo2Frame entry={e} run={[e]} previous={prev} stage={{ index: 0, leadProgress: 0, exitProgress: 0 }} plan={plan}
       dials={{ ...D, transition: 'dip', fadeS: 2, ...extra }} width={100} height={50} feed={feed} />);
   };
 
@@ -253,12 +307,14 @@ describe('what the change dips through', () => {
   it('exposure moves the picture toward the veil, each screen toward its own end', () => {
     dip({ veilStyle: 'exposure', burnLift: 1.6 });
     expect(screen.getByTestId('dip')).toHaveStyle({ background: '#ffffff' });
-    expect(screen.getByTestId('prev').style.animation).toBe(`solo2-burn-out 1s ${E} both`);
+    // The previous picture already burned down at its own exit; it sits at the lift.
+    expect(screen.getByTestId('prev').style.animation).toBe('');
+    expect(screen.getByTestId('prev')).toHaveStyle({ filter: 'brightness(1.6)' });
     expect(screen.getByTestId('stack').style.animation)
-      .toBe(`solo2-fade-in 1s ${E} 1s both, solo2-burn-in 1s ${E} 1s both`);
+      .toBe(`solo2-fade-in 1s ${E} both, solo2-burn-in 1s ${E} both`);
     // Carried as a custom property, never baked into the keyframes: two screens
     // share one document, and a `<style>` rule is global.
-    expect(screen.getByTestId('prev').style.getPropertyValue('--solo2-lift')).toBe('1.6');
+    expect(screen.getByTestId('stack').style.getPropertyValue('--solo2-lift')).toBe('1.6');
     cleanup();
     dip({ veilStyle: 'exposure', burnLift: 1.6 }, 'sunset');
     expect(screen.getByTestId('dip')).toHaveStyle({ background: '#000000' });
@@ -268,7 +324,8 @@ describe('what the change dips through', () => {
   it('no burn animation at all when the lift asks for nothing', () => {
     dip({ veilStyle: 'exposure', burnLift: 1 });
     expect(screen.getByTestId('prev').style.animation).toBe('');
-    expect(screen.getByTestId('stack').style.animation).toBe(`solo2-fade-in 1s ${E} 1s both`);
+    expect(screen.getByTestId('prev').style.filter).toBe('');
+    expect(screen.getByTestId('stack').style.animation).toBe(`solo2-fade-in 1s ${E} both`);
   });
 
   it('the veil stays inside the picture unless it is told to flood the panel', () => {
@@ -285,7 +342,7 @@ describe('what the change dips through', () => {
   });
 
   it('the ease dial reaches the steps inside a run, not just the change between cameras', () => {
-    render(<Solo2Frame entry={e} run={run} previous={null} stage={{ index: 1, leadProgress: 0 }} plan={plan}
+    render(<Solo2Frame entry={e} run={run} previous={null} stage={{ index: 1, leadProgress: 0, exitProgress: 0 }} plan={plan}
       dials={{ ...D, sameCameraFadeS: 1, arrivalEase: 'soft' }} width={100} height={50} feed="sunrise" />);
     expect(screen.getByTestId('seq-1')).toHaveStyle({ transition: `opacity 1s ${ARRIVAL_EASES.soft}` });
   });
@@ -294,7 +351,7 @@ describe('what the change dips through', () => {
 it('inside a run only the clock moves, and inside the clock only the part that changed: the two readings crossfade over the same seconds', () => {
   // A real run is one camera, so every frame carries the same words.
   const sameCam = run.map((f) => ({ ...f, title: 'Pier' }));
-  const { rerender } = render(<Solo2Frame entry={e} run={sameCam} previous={null} stage={{ index: 1, leadProgress: 0 }} plan={plan}
+  const { rerender } = render(<Solo2Frame entry={e} run={sameCam} previous={null} stage={{ index: 1, leadProgress: 0, exitProgress: 0 }} plan={plan}
     dials={{ ...D, sameCameraFadeS: 1 }} width={1920} height={1080} />);
   expect(drawnTime()).toBe('7:32 pm there');
   // Only the minute's first digit animates: "7:" holds and so does "2 pm there".
@@ -311,7 +368,7 @@ it('inside a run only the clock moves, and inside the clock only the part that c
   // the title, the place and "pm there" hold still while the clock swaps.
   const held = screen.getByTestId('caption-layer');
   const tail = screen.getByTestId('caption-time');
-  rerender(<Solo2Frame entry={e} run={sameCam} previous={null} stage={{ index: 2, leadProgress: 0 }} plan={plan}
+  rerender(<Solo2Frame entry={e} run={sameCam} previous={null} stage={{ index: 2, leadProgress: 0, exitProgress: 0 }} plan={plan}
     dials={{ ...D, sameCameraFadeS: 1 }} width={1920} height={1080} />);
   expect(screen.getByTestId('caption-layer')).toBe(held);
   expect(screen.getByTestId('caption-time')).toBe(tail);
@@ -321,7 +378,7 @@ it('inside a run only the clock moves, and inside the clock only the part that c
 });
 
 it('a run’s first frame has no clock to leave', () => {
-  render(<Solo2Frame entry={e} run={run} previous={null} stage={{ index: 0, leadProgress: 0 }} plan={plan}
+  render(<Solo2Frame entry={e} run={run} previous={null} stage={{ index: 0, leadProgress: 0, exitProgress: 0 }} plan={plan}
     dials={{ ...D, sameCameraFadeS: 1 }} width={1920} height={1080} />);
   expect(screen.queryByTestId('caption-time-out')).toBeNull();
   expect(screen.getByTestId('caption-time').style.animation).toBe('');
@@ -329,7 +386,7 @@ it('a run’s first frame has no clock to leave', () => {
 
 it('two frames of one minute say the same time, so nothing fades', () => {
   const sameMinute = [{ ...e, snapshotId: 1, imageUrl: 'u1' }, e]; // both taken at AT
-  render(<Solo2Frame entry={e} run={sameMinute} previous={null} stage={{ index: 1, leadProgress: 0 }} plan={plan}
+  render(<Solo2Frame entry={e} run={sameMinute} previous={null} stage={{ index: 1, leadProgress: 0, exitProgress: 0 }} plan={plan}
     dials={{ ...D, sameCameraFadeS: 1 }} width={1920} height={1080} />);
   expect(screen.queryByTestId('caption-time-out')).toBeNull();
   expect(screen.getByTestId('caption-time').style.animation).toBe('');

--- a/app/components/solo2/Solo2Frame.tsx
+++ b/app/components/solo2/Solo2Frame.tsx
@@ -55,7 +55,7 @@ export function arrival(
  * frame — and inside a run, where every frame is the same camera, the title
  * and the place hold still while only the clock steps.
  */
-export function Solo2Frame({ entry, run, previous, stage, plan, dials, width, height, feed, dwellKey }: {
+export function Solo2Frame({ entry, run, previous, next, stage, plan, dials, width, height, feed, dwellKey }: {
   /** The drawn frame: the run's last. */
   entry: EntryView;
   /**
@@ -69,6 +69,14 @@ export function Solo2Frame({ entry, run, previous, stage, plan, dials, width, he
   /** What the dwell plays, oldest first, `entry` last (run.ts `runOf`). */
   run: RunFrame[];
   previous: ViewEntry | null;
+  /**
+   * The camera expected to follow, when the caller knows it. A dip burns this
+   * dwell's last picture down at its exit so the next can rise out of the veil
+   * — but a later frame of the SAME camera arrives by dissolve, never through
+   * the veil, so it must not be burned down before it. Unknown reads as a
+   * change of camera.
+   */
+  next?: { webcamId: number } | null;
   stage: Stage;
   plan: DwellPlan;
   dials: Solo2Dials;
@@ -116,9 +124,14 @@ export function Solo2Frame({ entry, run, previous, stage, plan, dials, width, he
   // in (PR #160). Every curve `arrivalEase` offers is symmetric, so this
   // single value can go on all of them.
   const ease = look.ease;
+  // A dip is two halves, and this dwell only plays the second. The first —
+  // the previous picture burning down into the veil — was the previous
+  // dwell's exit, run on its own clock over the last seconds of its last
+  // frame (plan.ts `exitS`). So the veil is already closed when this dwell
+  // mounts, and the new picture rises out of it at once, over half the dial.
   const inAnimation =
     arrive.kind === 'crossfade' ? `solo2-fade-in ${arrive.fadeS}s ${ease} both`
-    : arrive.kind === 'dip' ? `solo2-fade-in ${arrive.fadeS / 2}s ${ease} ${arrive.fadeS / 2}s both`
+    : arrive.kind === 'dip' ? `solo2-fade-in ${arrive.fadeS / 2}s ${ease} both`
     : undefined;
   // The outgoing caption's half of that dissolve. A picture needs none — the
   // arriving frame is opaque and covers the one beneath it — but a caption is
@@ -128,18 +141,36 @@ export function Solo2Frame({ entry, run, previous, stage, plan, dials, width, he
   // no veil colour showed two clocks at once. It leaves over the same span the
   // picture takes to cover it: the whole fade on a crossfade, the closing half
   // on a dip, held at the end by `both`.
+  // On a dip the old words already left with the old picture, at the previous
+  // dwell's exit, so there is nothing to animate here: they sit hidden.
   const outAnimation =
     arrive.kind === 'crossfade' ? `solo2-fade-out ${arrive.fadeS}s ${ease} both`
-    : arrive.kind === 'dip' ? `solo2-fade-out ${arrive.fadeS / 2}s ${ease} both`
     : undefined;
   // The picture moves toward the veil rather than merely being covered by it:
   // up into white on a sunrise, down into black on a sunset. That is what
   // separates an exposure from a dip through a coloured card. Only on a dip,
-  // and only when the lift asks for something.
+  // and only when the lift asks for something. The burn-out half happened at
+  // the previous dwell's exit, so the previous picture sits at the lift and
+  // the new one comes back from it.
   const burning = arrive.kind === 'dip' && look.lift !== 1;
-  const burnOut = burning ? `solo2-burn-out ${arrive.fadeS / 2}s ${ease} both` : undefined;
-  const burnIn = burning ? `solo2-burn-in ${arrive.fadeS / 2}s ${ease} ${arrive.fadeS / 2}s both` : undefined;
-  const liftVar = burning ? ({ '--solo2-lift': String(look.lift) } as React.CSSProperties) : undefined;
+  const burnIn = burning ? `solo2-burn-in ${arrive.fadeS / 2}s ${ease} both` : undefined;
+  const liftVar = look.lift !== 1 ? ({ '--solo2-lift': String(look.lift) } as React.CSSProperties) : undefined;
+  const burnedStill = burning ? ({ filter: `brightness(${look.lift})` } as React.CSSProperties) : undefined;
+
+  // The exit (plan.ts `exitS`): over the last seconds of the last frame this
+  // picture burns down into the veil, on this dwell's own clock, so the next
+  // dwell finds the veil closed and only has to rise. Skipped when the next
+  // draw is a later frame of this same camera, which arrives by dissolve and
+  // must find the picture still lit. The caller says what it expects next;
+  // if the pool moves and a different camera arrives after all, that dwell
+  // opens on a closed veil without the burn — a hard step to the veil colour
+  // rather than a ramp, brief and rare.
+  const sameCameraNext = !!next && next.webcamId === entry.webcamId;
+  const exiting = plan.exitS > 0 && stage.exitProgress > 0 && dials.transition === 'dip'
+    && look.veilColor !== null && !sameCameraNext;
+  const exitBurn = exiting && look.lift !== 1 ? `solo2-burn-out ${plan.exitS}s ${ease} both` : undefined;
+  const exitVeil = exiting ? `solo2-dip ${plan.exitS}s ${ease} both` : undefined;
+  const exitWords = exiting ? `solo2-fade-out ${plan.exitS}s ${ease} both` : undefined;
 
   // The lead: a slow push over the last seconds, driven by the clock stage
   // so a late tab is in sync. No transition when the progress is 0, so a
@@ -158,20 +189,23 @@ export function Solo2Frame({ entry, run, previous, stage, plan, dials, width, he
       {showPrevious && (
         // eslint-disable-next-line @next/next/no-img-element
         <img key={`prev-${previous.snapshotId}`} src={previous.imageUrl} alt="" role="presentation" data-testid="prev"
-          style={{ ...pictureLayer, ...liftVar, animation: burnOut }} />
+          style={{ ...pictureLayer, ...burnedStill }} />
       )}
       {showPrevious && (
         // The words being left behind, under the veil and under the arriving
-        // caption, so the caption dissolves exactly as the picture does.
+        // caption, so the caption dissolves exactly as the picture does. On a
+        // dip they already left at the previous dwell's exit, so they hide.
         <div key={`caption-prev-${previous.snapshotId}`} data-testid="caption-prev"
-          style={{ ...captionLayer, animation: outAnimation }}>
+          style={{ ...captionLayer, animation: outAnimation, opacity: arrive.kind === 'dip' ? 0 : undefined }}>
           <Caption entry={previous} dials={dials} picture={picture} width={width} height={height} feed={feed} />
         </div>
       )}
       {arrive.kind === 'dip' && showPrevious && look.veilColor && (
+        // Already closed: the previous dwell raised it at its exit. This dwell
+        // only rises out of it, above.
         <div key={`dip-${dwellId}`} data-testid="dip" style={{
           ...(look.covers === 'panel' ? layer : pictureLayer),
-          background: look.veilColor, animation: `solo2-dip ${arrive.fadeS / 2}s ${ease} both`,
+          background: look.veilColor, opacity: 1,
         }} />
       )}
       {/* keyed by the drawn frame so the arrival runs once per dwell; the stage only changes opacities inside */}
@@ -179,25 +213,32 @@ export function Solo2Frame({ entry, run, previous, stage, plan, dials, width, he
         ...pictureLayer, ...liftVar,
         animation: [inAnimation, burnIn].filter(Boolean).join(', ') || undefined,
       }}>
-        <div style={pushStyle} data-testid="push">
-          {sequence.map((f, i) => (
-            <div key={f.snapshotId} data-testid={`seq-${i}`} style={{
-              ...layer, opacity: i <= shown ? 1 : 0,
-              // The same curve as the camera change: a step inside a run is a
-              // dissolve too, and Jesse asked for both to stop snapping.
-              transition: i > 0 && stepFade > 0 ? `opacity ${stepFade}s ${ease}` : 'none',
-            }}>
-              {/* eslint-disable-next-line @next/next/no-img-element */}
-              <img src={f.imageUrl} alt="" role="presentation" data-testid={i === shown ? 'top' : undefined} style={layer} />
-            </div>
-          ))}
+        {/* Its own layer, so starting the exit burn cannot restart the arrival above it. */}
+        <div style={{ ...layer, animation: exitBurn }} data-testid="exit-burn">
+          <div style={pushStyle} data-testid="push">
+            {sequence.map((f, i) => (
+              <div key={f.snapshotId} data-testid={`seq-${i}`} style={{
+                ...layer, opacity: i <= shown ? 1 : 0,
+                // The same curve as the camera change: a step inside a run is a
+                // dissolve too, and Jesse asked for both to stop snapping.
+                transition: i > 0 && stepFade > 0 ? `opacity ${stepFade}s ${ease}` : 'none',
+              }}>
+                {/* eslint-disable-next-line @next/next/no-img-element */}
+                <img src={f.imageUrl} alt="" role="presentation" data-testid={i === shown ? 'top' : undefined} style={layer} />
+              </div>
+            ))}
+          </div>
         </div>
       </div>
       {/* keyed like the stack, so the words arrive with the picture and once
           per dwell; inside the dwell only the clock moves. */}
       <div key={`caption-${dwellId}`} data-testid="caption-layer" style={{ ...captionLayer, animation: inAnimation }}>
-        <Caption entry={up} dials={dials} picture={picture} width={width} height={height} feed={feed}
-          step={shown > 0 ? { from: sequence[shown - 1], fadeS: stepFade, ease } : null} />
+        {/* The words leave with the picture at the exit, on the same ramp; a
+            veil that covers only the picture would otherwise leave them lit. */}
+        <div style={{ ...captionLayer, animation: exitWords }} data-testid="exit-words">
+          <Caption entry={up} dials={dials} picture={picture} width={width} height={height} feed={feed}
+            step={shown > 0 ? { from: sequence[shown - 1], fadeS: stepFade, ease } : null} />
+        </div>
       </div>
       {(dials.showScores || dials.showRank || dials.showTally) && (
         <div style={{
@@ -210,6 +251,15 @@ export function Solo2Frame({ entry, run, previous, stage, plan, dials, width, he
             <div>{scoreLine(up)}</div>
           )}
         </div>
+      )}
+      {exiting && (
+        // The veil closing over everything above, on this dwell's clock. Keyed
+        // to the dwell so it mounts once when the exit begins and goes with the
+        // dwell; the next one opens on its own veil, already at 1.
+        <div key={`exit-${dwellId}`} data-testid="exit-veil" style={{
+          ...(look.covers === 'panel' ? layer : pictureLayer),
+          background: look.veilColor ?? '#000', animation: exitVeil, pointerEvents: 'none',
+        }} />
       )}
     </div>
   );

--- a/app/components/solo2/index.tsx
+++ b/app/components/solo2/index.tsx
@@ -106,7 +106,7 @@ export function Solo2Kiosk(props: MosaicProps) {
   return (
     <div style={{ position: 'relative', width: props.width, height: props.height, background: '#000' }}>
       {current ? (
-        <Solo2Frame entry={current} run={run} previous={previous} stage={stage} plan={plan} dials={dials} dwellKey={dwell.startMs}
+        <Solo2Frame entry={current} run={run} previous={previous} next={nextEntry} stage={stage} plan={plan} dials={dials} dwellKey={dwell.startMs}
           width={props.width} height={props.height} feed={props.feed} />
       ) : null}
       {debug && (

--- a/app/components/solo2/useStage.test.ts
+++ b/app/components/solo2/useStage.test.ts
@@ -14,22 +14,22 @@ afterEach(() => vi.useRealTimers());
 describe('useStage', () => {
   it('walks the run then the lead on the wall clock', () => {
     const { result } = renderHook(() => useStage(plan, 100_000));
-    expect(result.current).toEqual({ index: 0, leadProgress: 0 });
+    expect(result.current).toEqual({ index: 0, leadProgress: 0, exitProgress: 0 });
     act(() => { vi.advanceTimersByTime(2_000); });
-    expect(result.current).toEqual({ index: 1, leadProgress: 0 });
+    expect(result.current).toEqual({ index: 1, leadProgress: 0, exitProgress: 0 });
     act(() => { vi.advanceTimersByTime(2_000); });
-    expect(result.current).toEqual({ index: 2, leadProgress: 0 });
+    expect(result.current).toEqual({ index: 2, leadProgress: 0, exitProgress: 0 });
     act(() => { vi.advanceTimersByTime(1_000); });
-    expect(result.current).toEqual({ index: 2, leadProgress: 0.5 });
+    expect(result.current).toEqual({ index: 2, leadProgress: 0.5, exitProgress: 0 });
   });
   it('joins a dwell that started earlier at the right frame', () => {
     const { result } = renderHook(() => useStage(plan, 100_000 - 2_500));
-    expect(result.current).toEqual({ index: 1, leadProgress: 0 });
+    expect(result.current).toEqual({ index: 1, leadProgress: 0, exitProgress: 0 });
   });
   it('a new start resets to the first frame', () => {
     const { result, rerender } = renderHook((p: { start: number }) => useStage(plan, p.start), { initialProps: { start: 100_000 - 5_000 } });
-    expect(result.current).toEqual({ index: 2, leadProgress: 0.5 });
+    expect(result.current).toEqual({ index: 2, leadProgress: 0.5, exitProgress: 0 });
     rerender({ start: 100_000 });
-    expect(result.current).toEqual({ index: 0, leadProgress: 0 });
+    expect(result.current).toEqual({ index: 0, leadProgress: 0, exitProgress: 0 });
   });
 });

--- a/app/components/solo2/useStage.ts
+++ b/app/components/solo2/useStage.ts
@@ -3,7 +3,8 @@
 import { useEffect, useState } from 'react';
 import { stageAt, type DwellPlan, type Stage } from '@/app/lib/solo2/plan';
 
-const same = (a: Stage, b: Stage) => a.index === b.index && a.leadProgress === b.leadProgress;
+const same = (a: Stage, b: Stage) =>
+  a.index === b.index && a.leadProgress === b.leadProgress && a.exitProgress === b.exitProgress;
 
 /**
  * Where the current dwell is, re-read from the wall clock every `tickMs`
@@ -12,9 +13,9 @@ const same = (a: Stage, b: Stage) => a.index === b.index && a.leadProgress === b
  */
 export function useStage(plan: DwellPlan, startMs: number, tickMs = 250): Stage {
   const [stage, setStage] = useState<Stage>(() => stageAt(Date.now() - startMs, plan));
-  const { dwellS, frames, stepS, leadS, arrivalS } = plan;
+  const { dwellS, frames, stepS, lastStepS, leadS, arrivalS, exitS } = plan;
   useEffect(() => {
-    const p = { dwellS, frames, stepS, leadS, arrivalS };
+    const p = { dwellS, frames, stepS, lastStepS, leadS, arrivalS, exitS };
     const read = () => setStage((prev) => {
       const nextStage = stageAt(Date.now() - startMs, p);
       return same(prev, nextStage) ? prev : nextStage;
@@ -22,6 +23,6 @@ export function useStage(plan: DwellPlan, startMs: number, tickMs = 250): Stage 
     read();
     const t = setInterval(read, tickMs);
     return () => clearInterval(t);
-  }, [startMs, tickMs, dwellS, frames, stepS, leadS, arrivalS]);
+  }, [startMs, tickMs, dwellS, frames, stepS, lastStepS, leadS, arrivalS, exitS]);
   return stage;
 }

--- a/app/lib/solo2/plan.test.ts
+++ b/app/lib/solo2/plan.test.ts
@@ -1,27 +1,27 @@
 import { describe, it, expect } from 'vitest';
-import { arrivalS, describePlan, fitPlan, planOf, stageAt, stepFadeS, stretchThreshold } from './plan';
+import { arrivalS, describePlan, exitS, fitPlan, planOf, stageAt, stepFadeS, stretchThreshold } from './plan';
 
 const D = { dwellS: 20, leadS: 4, minStepS: 4 };
 
 describe('fitPlan: the budget rule', () => {
   it('below the threshold the frames divide the budget and the dwell does not move', () => {
     // Jesse's own numbers: one image holds the full 20 s, five hold 4 s each.
-    expect(fitPlan(D, 1)).toEqual({ dwellS: 20, frames: 1, stepS: 20, leadS: 4, arrivalS: 0 });
-    expect(fitPlan(D, 2)).toEqual({ dwellS: 20, frames: 2, stepS: 10, leadS: 4, arrivalS: 0 });
-    expect(fitPlan(D, 5)).toEqual({ dwellS: 20, frames: 5, stepS: 4, leadS: 4, arrivalS: 0 });
+    expect(fitPlan(D, 1)).toEqual({ dwellS: 20, frames: 1, stepS: 20, lastStepS: 20, leadS: 4, arrivalS: 0, exitS: 0 });
+    expect(fitPlan(D, 2)).toEqual({ dwellS: 20, frames: 2, stepS: 10, lastStepS: 10, leadS: 4, arrivalS: 0, exitS: 0 });
+    expect(fitPlan(D, 5)).toEqual({ dwellS: 20, frames: 5, stepS: 4, lastStepS: 4, leadS: 4, arrivalS: 0, exitS: 0 });
     expect(fitPlan(D, 3).stepS).toBeCloseTo(6.667, 3);
     expect(fitPlan(D, 3).dwellS).toBeCloseTo(20, 6);
   });
   it('above it the DWELL stretches rather than the frames shrinking', () => {
     // This is the whole change: a run is a timelapse, and a timelapse has one
     // step. Eight frames run 4 s each for 32 s, not 2.5 s each for 20 s.
-    expect(fitPlan(D, 6)).toEqual({ dwellS: 24, frames: 6, stepS: 4, leadS: 4, arrivalS: 0 });
-    expect(fitPlan(D, 8)).toEqual({ dwellS: 32, frames: 8, stepS: 4, leadS: 4, arrivalS: 0 });
+    expect(fitPlan(D, 6)).toEqual({ dwellS: 24, frames: 6, stepS: 4, lastStepS: 4, leadS: 4, arrivalS: 0, exitS: 0 });
+    expect(fitPlan(D, 8)).toEqual({ dwellS: 32, frames: 8, stepS: 4, lastStepS: 4, leadS: 4, arrivalS: 0, exitS: 0 });
     expect(fitPlan(D, 12).stepS).toBe(4);
     expect(fitPlan(D, 12).dwellS).toBe(48);
   });
   it('at least one frame; the lead never exceeds the dwell it is measured against', () => {
-    expect(fitPlan(D, 0)).toEqual({ dwellS: 20, frames: 1, stepS: 20, leadS: 4, arrivalS: 0 });
+    expect(fitPlan(D, 0)).toEqual({ dwellS: 20, frames: 1, stepS: 20, lastStepS: 20, leadS: 4, arrivalS: 0, exitS: 0 });
     expect(fitPlan({ dwellS: 5, leadS: 8, minStepS: 4 }, 1).leadS).toBe(5);
     expect(fitPlan({ dwellS: 5, leadS: -1, minStepS: 4 }, 1).leadS).toBe(0);
     // A stretched dwell gives the lead more room: 30 s of lead fits inside a
@@ -40,7 +40,9 @@ describe('the arrival segment: the camera change is added before frame 1, not ch
 
   it('is the longest fade the dwell might open with: the camera change, or the same-camera dissolve', () => {
     expect(arrivalS(F)).toBe(1.5);
-    expect(arrivalS({ ...F, fadeS: 3 })).toBe(3);
+    // A dip is two halves and only the rise is an arrival; a crossfade is one gesture, all of it.
+    expect(arrivalS({ ...F, fadeS: 3 })).toBe(1.5);
+    expect(arrivalS({ ...F, transition: 'crossfade', fadeS: 3 })).toBe(3);
     expect(arrivalS({ ...F, sameCameraFadeS: 4 })).toBe(4);
     // A cut has no camera-change fade, but a later frame of the same camera still dissolves in.
     expect(arrivalS({ ...F, transition: 'cut' })).toBe(1.5);
@@ -51,10 +53,10 @@ describe('the arrival segment: the camera change is added before frame 1, not ch
   });
 
   it('sits on top of the budget: the frames still divide dwellS, and the dwell is arrivalS longer', () => {
-    expect(fitPlan({ ...D, ...F }, 5)).toEqual({ dwellS: 21.5, frames: 5, stepS: 4, leadS: 4, arrivalS: 1.5 });
-    expect(fitPlan({ ...D, ...F }, 1)).toEqual({ dwellS: 21.5, frames: 1, stepS: 20, leadS: 4, arrivalS: 1.5 });
+    expect(fitPlan({ ...D, ...F }, 5)).toEqual({ dwellS: 21.5, frames: 5, stepS: 4, lastStepS: 4, leadS: 4, arrivalS: 1.5, exitS: 0.75 });
+    expect(fitPlan({ ...D, ...F }, 1)).toEqual({ dwellS: 21.5, frames: 1, stepS: 20, lastStepS: 20, leadS: 4, arrivalS: 1.5, exitS: 0.75 });
     // A stretched run stretches from the same base.
-    expect(fitPlan({ ...D, ...F }, 8)).toEqual({ dwellS: 33.5, frames: 8, stepS: 4, leadS: 4, arrivalS: 1.5 });
+    expect(fitPlan({ ...D, ...F }, 8)).toEqual({ dwellS: 33.5, frames: 8, stepS: 4, lastStepS: 4, leadS: 4, arrivalS: 1.5, exitS: 0.75 });
   });
 
   it('does not move the stretch threshold: the frames\' budget is still dwellS', () => {
@@ -81,9 +83,9 @@ describe('the arrival segment: the camera change is added before frame 1, not ch
   });
 
   it('the studio line names it', () => {
-    expect(describePlan(fitPlan({ dwellS: 20, leadS: 0, minStepS: 4, ...F }, 4))).toBe('4 frames × 5 s · arrival 1.5 s');
-    expect(describePlan(fitPlan({ dwellS: 20, leadS: 0, minStepS: 4, ...F }, 1))).toBe('1 frame · 20 s · arrival 1.5 s');
-    expect(describePlan(fitPlan({ ...D, ...F }, 4))).toBe('4 frames × 5 s · lead 4 s · arrival 1.5 s');
+    expect(describePlan(fitPlan({ dwellS: 20, leadS: 0, minStepS: 4, ...F }, 4))).toBe('4 frames × 5 s · arrival 1.5 s · exit 0.8 s');
+    expect(describePlan(fitPlan({ dwellS: 20, leadS: 0, minStepS: 4, ...F }, 1))).toBe('1 frame · 20 s · arrival 1.5 s · exit 0.8 s');
+    expect(describePlan(fitPlan({ ...D, ...F }, 4))).toBe('4 frames × 5 s · lead 4 s · arrival 1.5 s · exit 0.8 s');
   });
 });
 
@@ -155,8 +157,21 @@ describe('planOf: the budget rule run backward from a pinned total', () => {
     const p = planOf(22, 4, { ...D, transition: 'dip', fadeS: 6 });
     expect(p.dwellS).toBe(22);
     expect(p.frames).toBe(4);
-    expect(p.arrivalS).toBe(6);
-    expect(p.stepS).toBe(4); // (22 - 6) / 4
+    expect(p.arrivalS).toBe(3); // the rise half of the dip
+    expect(p.exitS).toBe(3); // the burn half, inside the last step
+    expect(p.stepS).toBe(4.75); // (22 - 3) / 4
+    expect(p.lastStepS).toBe(4.75); // the exit fits inside an even share
+  });
+
+  it('gives the last frame more than an even share when its dissolve-in and the exit will not fit one', () => {
+    // 3 s exit, 2 s dissolve-in, 4 s share: the last frame needs 5, the others
+    // give it up. 3 + 4×3 + 5 = 20 — what fitPlan sizes at the live dials.
+    const dials = { ...D, minStepS: 4, transition: 'dip' as const, fadeS: 6, sameCameraFadeS: 2 };
+    const forward = fitPlan({ ...dials, dwellS: 12 }, 4);
+    expect(forward).toMatchObject({ dwellS: 20, stepS: 4, lastStepS: 5, arrivalS: 3, exitS: 3 });
+    const back = planOf(20, 4, dials);
+    expect(back.stepS).toBeCloseTo(4, 6);
+    expect(back.lastStepS).toBeCloseTo(5, 6);
   });
 
   it('is the inverse of fitPlan: what fitPlan sized, planOf takes apart again', () => {
@@ -171,7 +186,7 @@ describe('planOf: the budget rule run backward from a pinned total', () => {
     // frames at 20 s. The draw pinned 62 s, so each frame gets 18.67 s.
     const p = planOf(62, 3, { ...D, transition: 'dip', fadeS: 6 });
     expect(p.dwellS).toBe(62);
-    expect(p.stepS).toBeCloseTo(18.667, 3);
+    expect(p.stepS).toBeCloseTo(19.667, 3); // (62 - 3) / 3
   });
 
   it('never leaves a step of zero, whatever a degenerate span asks for', () => {
@@ -185,5 +200,49 @@ describe('planOf: the budget rule run backward from a pinned total', () => {
 
   it('caps the lead at the pinned span', () => {
     expect(planOf(3, 1, { ...D, leadS: 9 }).leadS).toBe(3);
+  });
+});
+
+describe('the exit: a dip is charged half to the dwell it leaves', () => {
+  // Reported 2026-09-08: the last picture of a run "stuck for an awful long
+  // time". The whole 6 s change was reserved at the front of the ARRIVING
+  // dwell, so the leaving dwell's last frame held a full still step and only
+  // then began to burn — ten seconds between the last new picture of a run
+  // and the first of the next, against four through the middle.
+  const live = { dwellS: 13, leadS: 0, minStepS: 4, transition: 'dip' as const, fadeS: 6, sameCameraFadeS: 2 };
+
+  it('exists only for a dip', () => {
+    expect(exitS(live)).toBe(3);
+    expect(exitS({ ...live, transition: 'crossfade' })).toBe(0);
+    expect(exitS({ ...live, transition: 'cut' })).toBe(0);
+    expect(exitS({})).toBe(0);
+  });
+
+  it('shortens the whole dwell by the half that now belongs to the leaving side', () => {
+    // Before: 6 + 4×4 = 22. Now: 3 + 4×3 + max(4, 2 + 3) = 20.
+    expect(fitPlan(live, 4).dwellS).toBe(20);
+    // At a change no longer than the step it fits inside the last frame and costs nothing.
+    expect(fitPlan({ ...live, fadeS: 4 }, 4)).toMatchObject({ dwellS: 18, stepS: 4, lastStepS: 4, arrivalS: 2, exitS: 2 });
+  });
+
+  it('a lone frame has no dissolve-in, so only the exit has to fit', () => {
+    // Budget 13 shares nothing; 13 > 3, so the frame holds 13 and burns over its last 3.
+    expect(fitPlan(live, 1)).toMatchObject({ dwellS: 16, stepS: 13, lastStepS: 13, exitS: 3 });
+  });
+
+  it('stageAt reports the exit over the last exitS, and the run index stays on the last frame through it', () => {
+    const p = fitPlan(live, 4); // 3 arrival, 4 4 4, last 5 (2 in + 3 burn): burn 17–20
+    expect(stageAt(16_999, p).exitProgress).toBe(0);
+    expect(stageAt(17_000, p).exitProgress).toBe(0);
+    expect(stageAt(18_500, p).exitProgress).toBe(0.5);
+    expect(stageAt(20_000, p).exitProgress).toBe(1);
+    expect(stageAt(18_500, p).index).toBe(3);
+    // No exit, no progress.
+    expect(stageAt(19_000, fitPlan({ ...live, transition: 'crossfade' }, 4)).exitProgress).toBe(0);
+  });
+
+  it('the studio line says so, and names the longer last frame', () => {
+    expect(describePlan(fitPlan(live, 4))).toBe('4 frames × 4 s · last 5 s · arrival 3 s · exit 3 s');
+    expect(describePlan(fitPlan({ ...live, fadeS: 4 }, 4))).toBe('4 frames × 4 s · arrival 2 s · exit 2 s');
   });
 });

--- a/app/lib/solo2/plan.ts
+++ b/app/lib/solo2/plan.ts
@@ -2,19 +2,42 @@ import type { Solo2Dials } from './types';
 
 /** One dwell's timeline, in seconds (camera-run spec §4.1). */
 export interface DwellPlan {
-  /** The whole dwell: the arrival, then the frames. */
+  /** The whole dwell: the arrival, then the frames, the last of which carries the exit. */
   dwellS: number;
   /** Frames the dwell plays, at least 1. */
   frames: number;
   /** Each frame's even share of the frames' budget. */
   stepS: number;
+  /**
+   * The last frame's step. Equal to `stepS` whenever its dissolve-in and the
+   * exit fit inside one step; longer only when they do not, so the last
+   * picture is never burning down before it has finished arriving.
+   */
+  lastStepS: number;
   leadS: number;
   /**
    * The camera change's own segment at the front of the dwell (dwell-budget
    * spec §3.3). Frame 1's step begins when it ends, so the first frame holds
    * as long as every other. 0 for dials without fades.
+   *
+   * For a dip this is the RISE only — the half of the change that shows this
+   * dwell's first picture. The half that showed the previous dwell's last
+   * picture is that dwell's `exitS`.
    */
   arrivalS: number;
+  /**
+   * The burn-out at the END of the dwell, inside the last frame's step: the
+   * seconds the last picture spends going down into the veil before the next
+   * dwell rises out of it. 0 unless the change is a dip.
+   *
+   * Charged here rather than to the next dwell's arrival because the picture
+   * on glass during it is THIS dwell's. Until 2026-09-08 the whole change was
+   * reserved at the front of the incoming dwell, so the outgoing one's last
+   * frame held a full still step and only then began to burn: at a 6 s change
+   * and a 4 s step, ten seconds between the last new picture of a run and the
+   * first of the next, against four through the middle of the run.
+   */
+  exitS: number;
 }
 
 /**
@@ -24,16 +47,45 @@ export interface DwellPlan {
 export type PlanDials = Pick<Solo2Dials, 'dwellS' | 'leadS' | 'minStepS'>
   & Partial<Pick<Solo2Dials, 'transition' | 'fadeS' | 'sameCameraFadeS'>>;
 
+type FadeDials = Partial<Pick<Solo2Dials, 'transition' | 'fadeS' | 'sameCameraFadeS'>>;
+
+/**
+ * The seconds of the camera change that show THIS dwell's first picture. A
+ * crossfade is one gesture, all of it spent with the new picture arriving
+ * over the old; a dip is two halves through a veil, and only the second
+ * shows the new picture. Cut: none.
+ */
+function riseS(d: FadeDials): number {
+  const fade = Math.max(0, d.fadeS ?? 0);
+  if (d.transition === 'dip') return fade / 2;
+  if (d.transition === 'crossfade') return fade;
+  return 0;
+}
+
 /**
  * How long the front of a dwell is spent arriving (dwell-budget spec §3.3).
- * Sized for the longest arrival the dwell might open with — the camera-change
- * fade, or the same-camera dissolve — because the server sizes a dwell
- * without knowing what was on glass before it. When the actual arrival is
- * shorter, frame 1 simply holds for the rest.
+ * Sized for the longest arrival the dwell might open with — the camera
+ * change's rise, or the same-camera dissolve — because the server sizes a
+ * dwell without knowing what was on glass before it. When the actual arrival
+ * is shorter, frame 1 simply holds for the rest.
  */
-export function arrivalS(d: Partial<Pick<Solo2Dials, 'transition' | 'fadeS' | 'sameCameraFadeS'>>): number {
-  const change = d.transition && d.transition !== 'cut' ? Math.max(0, d.fadeS ?? 0) : 0;
-  return Math.max(change, Math.max(0, d.sameCameraFadeS ?? 0));
+export function arrivalS(d: FadeDials): number {
+  return Math.max(riseS(d), Math.max(0, d.sameCameraFadeS ?? 0));
+}
+
+/** The seconds at the end of a dwell spent burning its last picture down into the veil. Only a dip has one. */
+export function exitS(d: FadeDials): number {
+  return d.transition === 'dip' ? Math.max(0, d.fadeS ?? 0) / 2 : 0;
+}
+
+/**
+ * The last frame's step: a whole step when its dissolve-in and the exit fit,
+ * else stretched to hold both. A lone frame has no dissolve-in — it arrives
+ * on the camera change — so only the exit has to fit.
+ */
+function lastStepFor(stepS: number, n: number, exit: number, sameCameraFadeS: number | undefined): number {
+  const dissolveIn = n > 1 ? stepFadeS(sameCameraFadeS ?? 0, { stepS }) : 0;
+  return Math.max(stepS, dissolveIn + exit);
 }
 
 /**
@@ -41,13 +93,18 @@ export function arrivalS(d: Partial<Pick<Solo2Dials, 'transition' | 'fadeS' | 's
  * frames share, floored at `minStepS`, and the arrival sits in front of it:
  *
  *     perFrame = max(minStepS, dwellS / n)
- *     total    = arrivalS + perFrame * n
+ *     total    = arrivalS + perFrame * (n - 1) + lastStepS
  *
  * At or below `n* = floor(dwellS / minStepS)` frames the budget is merely
  * divided more finely and the total stays `dwellS` — one image holds the
  * whole 20 s, five hold 4 s each. Above it the DWELL STRETCHES rather than
  * the frames shrinking, which is the whole point: a run is a timelapse and a
  * timelapse has one step, so eight frames run 4 s each for 32 s.
+ *
+ * The exit lives INSIDE the last frame's step (see `exitS`), so at a change
+ * no longer than the step the last picture costs no more time than any other.
+ * `lastStepS` grows past `stepS` only when the exit and the dissolve-in
+ * cannot both fit.
  *
  * `plan.dwellS` is therefore the total this dwell occupies, not the dial.
  * The lead is capped at that total.
@@ -56,8 +113,10 @@ export function fitPlan(d: PlanDials, frames: number): DwellPlan {
   const n = Math.max(1, Math.floor(frames));
   const stepS = Math.max(d.minStepS, d.dwellS / n);
   const arrival = arrivalS(d);
-  const totalS = arrival + stepS * n;
-  return { dwellS: totalS, frames: n, stepS, leadS: Math.min(totalS, Math.max(0, d.leadS)), arrivalS: arrival };
+  const exit = exitS(d);
+  const lastStepS = lastStepFor(stepS, n, exit, d.sameCameraFadeS);
+  const totalS = arrival + stepS * (n - 1) + lastStepS;
+  return { dwellS: totalS, frames: n, stepS, lastStepS, leadS: Math.min(totalS, Math.max(0, d.leadS)), arrivalS: arrival, exitS: exit };
 }
 
 /**
@@ -80,12 +139,29 @@ export function planOf(totalS: number, frames: number, d: PlanDials): DwellPlan 
   const n = Math.max(1, Math.floor(frames));
   const total = Math.max(0, totalS);
   const arrival = Math.min(arrivalS(d), total);
+  const exit = Math.min(exitS(d), total - arrival);
+  const runS = total - arrival;
+  // The frames share the run evenly unless the last one needs more than its
+  // share to hold its dissolve-in plus the exit, in which case it takes what
+  // it needs and the others share the rest. The last step depends on the
+  // step (through the dissolve cap) and the step on the last step, so this
+  // settles by iteration; it converges in two passes because each pass can
+  // only lower the step, and the cap is monotonic in it.
+  let stepS = runS / n;
+  let lastStepS = lastStepFor(stepS, n, exit, d.sameCameraFadeS);
+  for (let i = 0; i < 3 && n > 1 && lastStepS > stepS + 1e-9; i++) {
+    stepS = Math.max(0, (runS - lastStepS) / (n - 1));
+    lastStepS = lastStepFor(stepS, n, exit, d.sameCameraFadeS);
+  }
+  if (n === 1) { stepS = runS; lastStepS = runS; }
   return {
     dwellS: total,
     frames: n,
-    stepS: Math.max(0.001, (total - arrival) / n),
+    stepS: Math.max(0.001, stepS),
+    lastStepS: Math.max(0.001, lastStepS),
     leadS: Math.min(total, Math.max(0, d.leadS)),
     arrivalS: arrival,
+    exitS: exit,
   };
 }
 
@@ -121,6 +197,12 @@ export interface Stage {
   index: number;
   /** 0 until the lead begins, 1 at the boundary. */
   leadProgress: number;
+  /**
+   * 0 until the exit begins, 1 at the boundary. Positive only over the last
+   * `exitS` of the dwell, which is when the glass burns its last picture down
+   * into the veil. Always 0 for a plan with no exit.
+   */
+  exitProgress: number;
 }
 
 /**
@@ -134,14 +216,24 @@ export function stageAt(elapsedMs: number, p: DwellPlan): Stage {
   const index = Math.min(p.frames - 1, Math.floor(Math.max(0, t - p.arrivalS) / p.stepS));
   const leadStart = p.dwellS - p.leadS;
   const leadProgress = p.leadS > 0 ? Math.min(1, Math.max(0, (t - leadStart) / p.leadS)) : 0;
-  return { index, leadProgress };
+  const exit = p.exitS ?? 0;
+  const exitStart = p.dwellS - exit;
+  const exitProgress = exit > 0 ? Math.min(1, Math.max(0, (t - exitStart) / exit)) : 0;
+  return { index, leadProgress, exitProgress };
 }
 
-/** The line the studio prints: `4 frames × 5 s`, `1 frame · 20 s`, `· lead 4 s` when the lead is on, `· arrival 1.5 s` when there is one. */
+/**
+ * The line the studio prints: `4 frames × 5 s`, `1 frame · 20 s`, `· last 5 s`
+ * when the last frame holds longer than the others, `· lead 4 s` when the lead
+ * is on, `· arrival 1.5 s` when there is one, `· exit 3 s` when the change is a
+ * dip and the last picture burns down inside its step.
+ */
 export function describePlan(p: DwellPlan): string {
   const s = (n: number) => `${Number(n.toFixed(1))} s`;
   const frames = p.frames === 1 ? `1 frame · ${s(p.dwellS - p.arrivalS)}` : `${p.frames} frames × ${s(p.stepS)}`;
+  const last = p.frames > 1 && p.lastStepS > p.stepS + 0.05 ? ` · last ${s(p.lastStepS)}` : '';
   const lead = p.leadS > 0 ? ` · lead ${s(p.leadS)}` : '';
   const arrival = p.arrivalS > 0 ? ` · arrival ${s(p.arrivalS)}` : '';
-  return `${frames}${lead}${arrival}`;
+  const exit = p.exitS > 0 ? ` · exit ${s(p.exitS)}` : '';
+  return `${frames}${last}${lead}${arrival}${exit}`;
 }

--- a/app/lib/solo2/settingsSchema.ts
+++ b/app/lib/solo2/settingsSchema.ts
@@ -74,7 +74,7 @@ export const SOLO2_SETTINGS_SCHEMA: SettingsSchema = [
     label: 'camera change', section: 'arrival',
     description: 'The gesture, for both screens. cut: the new picture simply replaces the old. crossfade: the old picture fades out while the new one fades in on top of it. dip: the old picture fades away into a veil, then the new one fades up out of it. Only `dip` reads the veil dial below — the other two are already not ending in darkness.',
   },
-  { ...(solo('fadeS') as NumberKnob), default: 1.5, section: 'arrival', label: 'camera change (s)', description: 'How long a crossfade takes, or a dip (down plus up). Ignored by cut. This also sets the arrival segment at the front of every dwell, so a long change makes every dwell longer — watch the dwell line on the Play tab.' },
+  { ...(solo('fadeS') as NumberKnob), default: 1.5, section: 'arrival', label: 'camera change (s)', description: 'How long a crossfade takes, or a dip (down plus up). Ignored by cut. A crossfade is charged to the front of the arriving dwell. A dip is split: the down half is the leaving dwell\'s exit, burned inside its last frame\'s step, and the up half is the arriving dwell\'s front. So at a dip no longer than the shortest frame, the last picture of a run costs no more time than any other — watch the dwell line on the Play tab.' },
   {
     key: 'veilStyle', kind: 'enum', options: ['black', 'crossfade', 'lift', 'exposure'], default: 'black',
     label: 'sunrise change', section: 'arrival',
@@ -98,7 +98,7 @@ export const SOLO2_SETTINGS_SCHEMA: SettingsSchema = [
   {
     key: 'sameCameraFadeS', kind: 'number', min: 0, max: 5, step: 0.5, default: 1.5,
     label: 'same camera (s)', section: 'arrival',
-    description: 'How long one frame of a camera takes to dissolve into the next inside the run, and on a change to a later frame of the camera on glass. Never through black. 0 is a cut.',
+    description: 'How long one frame of a camera takes to dissolve into the next inside the run, and on a change to a later frame of the camera on glass. Never through black. 0 is a cut. Capped at half a step inside a run, so at a 4 s shortest frame nothing above 2 reaches the glass: raise the shortest frame first.',
   },
   {
     key: 'arrivalEase', kind: 'enum', options: ['linear', 'gentle', 'soft'], default: 'gentle',

--- a/app/studio/panels/SoloPanel.tsx
+++ b/app/studio/panels/SoloPanel.tsx
@@ -5,6 +5,7 @@ import type { EntryView, StateView } from '@/app/api/kiosk/solo/view';
 import type { Feed, SoloDials } from '@/app/lib/solo/types';
 import type { SoloVersionSpec } from '@/app/lib/solo/versions';
 import { FeedColumn } from '../solo/FeedColumn';
+import { useTapeZoom } from '../solo/Tape';
 import { FrameModal } from '../solo/FrameModal';
 
 const mono = 'ui-monospace, SFMono-Regular, Menlo, monospace';
@@ -40,6 +41,8 @@ export function SoloPanel({ version, liveDials, nowMs: fixedNowMs, sunrise, suns
   const [selected, setSelected] = useState<Selected | null>(null);
   const [selfNowMs, setSelfNowMs] = useState(() => Date.now());
   const nowMs = fixedNowMs ?? selfNowMs;
+  // One zoom for both tapes: they sit side by side and read as one instrument.
+  const [tapeZoom, setTapeZoom] = useTapeZoom();
 
   useEffect(() => {
     if (fixedNowMs !== undefined) return;
@@ -53,7 +56,7 @@ export function SoloPanel({ version, liveDials, nowMs: fixedNowMs, sunrise, suns
         const s = feed === 'sunrise' ? sunrise : sunset;
         return s.server && s.projected ? (
           <FeedColumn key={feed} feed={feed} server={s.server} projected={s.projected} liveDials={liveDials}
-            nowMs={nowMs} version={version}
+            nowMs={nowMs} version={version} tapeZoom={tapeZoom} onTapeZoom={setTapeZoom}
             onSelect={(entry, f, list) => setSelected({ list, index: Math.max(0, list.findIndex((x) => x.snapshotId === entry.snapshotId)), feed: f })} />
         ) : (
           <div key={feed} style={{ color: '#4b5568', fontFamily: mono, fontSize: 12 }}>{s.error ?? `loading ${feed}…`}</div>

--- a/app/studio/solo/FeedColumn.tsx
+++ b/app/studio/solo/FeedColumn.tsx
@@ -11,7 +11,8 @@ import type { Solo2Dials } from '@/app/lib/solo2/types';
 import type { Stage } from '@/app/lib/solo/stages';
 import { EntryRow, type Run } from './EntryRow';
 import { reasonLine } from './reason';
-import { Tape } from './Tape';
+import { Tape, type TapeDials } from './Tape';
+import { arrivalLook } from '@/app/lib/solo2/veil';
 
 const mono = 'ui-monospace, SFMono-Regular, Menlo, monospace';
 const LABEL: Record<Feed, string> = { sunrise: 'Sunrise · left screen', sunset: 'Sunset · right screen' };
@@ -72,6 +73,21 @@ const capLabelOf = (bin: 'sunset' | 'non_sunset', cap: number, d: Solo2Dials) =>
   return bin === 'sunset' && d.runShape === 'rank' ? `${dial} · ${cap} of ${d.runFramesSunset} by rank` : `${dial} · ${cap}`;
 };
 
+/**
+ * What the tape needs to draw each seam as the glass will play it. solo's
+ * dials have no transition and crossfade; solo2's say what the change is, and
+ * `arrivalLook` says what this screen's dip goes through (null: it crossfades).
+ */
+function tapeDials(d: SoloDials, feed: Feed): TapeDials {
+  const d2 = d as Partial<Solo2Dials>;
+  if (d2.transition === undefined) return { dwellS: d.dwellS, fadeS: d.fadeS };
+  const look = d2.veilStyle !== undefined ? arrivalLook(feed, d2 as Solo2Dials) : null;
+  return {
+    dwellS: d.dwellS, fadeS: d.fadeS, transition: d2.transition, sameCameraFadeS: d2.sameCameraFadeS,
+    veil: look ? look.veilColor : '#000000',
+  };
+}
+
 const TAPE_OPEN_KEY = 'studio.tape.open';
 
 /** The tape's open/closed state, remembered per browser so a closed tape stays closed across reloads. */
@@ -98,7 +114,7 @@ function useTapeOpen(): [boolean, () => void] {
  * the bins. The screen itself is drawn above, by GlassPreview, so nothing
  * here repeats the picture.
  */
-export function FeedColumn({ feed, server, projected, liveDials, nowMs, version, onSelect }: {
+export function FeedColumn({ feed, server, projected, liveDials, nowMs, version, onSelect, tapeZoom, onTapeZoom }: {
   feed: Feed;
   server: StateView;
   projected: StateView;
@@ -107,6 +123,9 @@ export function FeedColumn({ feed, server, projected, liveDials, nowMs, version,
   version?: SoloVersionSpec;
   /** The clicked frame, its screen, and the frames of its column in order, so a pop-up can step through them. */
   onSelect: (entry: EntryView, feed: Feed, list: EntryView[]) => void;
+  /** The tape's zoom, owned by the panel so both screens' tapes zoom together. */
+  tapeZoom?: number;
+  onTapeZoom?: (zoom: number) => void;
 }) {
   // The server's published end, not a boundary derived here (spec §5.1). A
   // dwell's length is engine state, so a countdown computed from the dwell
@@ -221,8 +240,8 @@ export function FeedColumn({ feed, server, projected, liveDials, nowMs, version,
         <Tape past={server.tape} current={current?.entry ?? null} currentSince={current?.shownSince ?? null}
           currentEndsAt={current?.endsAtMs ?? null} next={projected.next}
           nextSequences={queueBoxes.slice(current ? 1 : 0).map((b) => b.run)}
-          pastDials={{ dwellS: liveDials.dwellS, fadeS: liveDials.fadeS }} nextDials={{ dwellS: projected.dials.dwellS, fadeS: projected.dials.fadeS }}
-          onSelect={(e) => onSelect(e, feed, tapeList)} />
+          pastDials={tapeDials(liveDials, feed)} nextDials={tapeDials(projected.dials, feed)}
+          onSelect={(e) => onSelect(e, feed, tapeList)} zoom={tapeZoom} onZoom={onTapeZoom} />
       )}
       <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr 1.15fr', gap: 6 }}>
         {column('sunset', '#7ee2ac', 'Sunset bin',

--- a/app/studio/solo/GlassPreview.tsx
+++ b/app/studio/solo/GlassPreview.tsx
@@ -128,7 +128,7 @@ function PlayingScreen({ feed, server, projected, error, dials, panel, version }
         {dwell.entry ? (
           <StudioPanelFrame panel={panel} edge={PANEL_EDGE}>
             {solo2 ? (
-              <Solo2Frame entry={dwell.entry} run={run} previous={dwell.previous} stage={stage} plan={plan} dials={d2} dwellKey={dwell.startMs}
+              <Solo2Frame entry={dwell.entry} run={run} previous={dwell.previous} next={order[dwell.index + 1] ?? null} stage={stage} plan={plan} dials={d2} dwellKey={dwell.startMs}
                 width={panel.width} height={panel.height} feed={feed} />
             ) : (
               // No key: SoloFrame's fade is a mount animation on an <img> keyed

--- a/app/studio/solo/Tape.test.tsx
+++ b/app/studio/solo/Tape.test.tsx
@@ -1,6 +1,6 @@
 import { it, expect, vi } from 'vitest';
-import { render, screen, fireEvent } from '@testing-library/react';
-import { Tape, THUMB_H } from './Tape';
+import { cleanup, render, screen, fireEvent } from '@testing-library/react';
+import { Tape, THUMB_H, seamBetween } from './Tape';
 import { PX_PER_S } from './timeScale';
 import type { EntryView, TapeEntry } from '@/app/api/kiosk/solo/view';
 
@@ -22,7 +22,7 @@ it('lays out past, current, seam, and projected in order, outlined by bin', () =
     pastDials={D} nextDials={D} onSelect={vi.fn()} />);
   const strip = screen.getByTestId('tape');
   const ids = [...strip.querySelectorAll('[data-testid^="tape-"]')].map((n) => n.getAttribute('data-testid'));
-  expect(ids).toEqual(['tape-scale', 'tape-past-1-10', 'tape-past-2-11', 'tape-past-1-12',
+  expect(ids).toEqual(['tape-scale', 'tape-scale-label', 'tape-past-1-10', 'tape-past-2-11', 'tape-past-1-12',
     'tape-current', 'tape-playhead', 'tape-seam', 'tape-next-0', 'tape-next-1']);
   expect(screen.getByTestId('tape-past-1-10')).toHaveStyle({ borderLeftColor: '#7ee2ac' });
   expect(screen.getByTestId('tape-past-2-11')).toHaveStyle({ borderLeftColor: '#c3cad6' });
@@ -197,4 +197,90 @@ it('the fade X is not a click target: it straddles the blocks either side of it'
   render(<Tape past={past} current={entry(3)} currentSince={since} currentEndsAt={since + 20_000} next={[entry(4)]}
     pastDials={{ dwellS: 20, fadeS: 6 }} nextDials={{ dwellS: 20, fadeS: 6 }} onSelect={vi.fn()} />);
   expect(screen.getByTestId('tape-fade-0')).toHaveStyle({ pointerEvents: 'none' });
+});
+
+describe('the seam is what the glass will play there (2026-09-08)', () => {
+  // Until now the tape drew "crossfade N s: both pictures on glass" on every
+  // cut from `fadeS` alone. At the live `dip` that was a 6 s overlap on every
+  // seam where the real overlap was none — the operator's own instrument
+  // reporting a thing the glass does not do.
+  const dip = { dwellS: 20, fadeS: 6, transition: 'dip' as const, sameCameraFadeS: 2, veil: '#000000' };
+
+  it('a dip is a bar in the veil, and says there is no overlap', () => {
+    render(<Tape past={past} current={entry(3)} currentSince={since} currentEndsAt={since + 20_000} next={[entry(4)]}
+      pastDials={dip} nextDials={dip} onSelect={vi.fn()} />);
+    const seam = screen.getByTestId('tape-fade-0');
+    expect(seam.getAttribute('data-seam')).toBe('dip');
+    expect(seam.getAttribute('title')).toMatch(/^dip 6 s: .*No overlap/);
+    expect(seam).toHaveStyle({ width: `${6 * PX_PER_S}px` });
+    // The sunrise screen's dip goes through its own veil colour.
+    cleanup();
+    render(<Tape past={past} current={entry(3)} currentSince={since} next={[]} pastDials={{ ...dip, veil: '#ffffff' }} nextDials={dip} onSelect={vi.fn()} />);
+    expect(screen.getByTestId('tape-fade-0').style.background).toMatch(/#ffffff/);
+  });
+
+  it('a later frame of the same camera dissolves over the same-camera dial, whatever the change is', () => {
+    // past[0] and past[2] are both camera 101; past[1] is 102, current (3) is 103.
+    render(<Tape past={[drawn(1, 10, 0), drawn(5, 11, 20_000)]} current={entry(3)} currentSince={since} next={[]}
+      pastDials={dip} nextDials={dip} onSelect={vi.fn()} />);
+    // draw 1 (cam 101) → draw 5 (cam 105): a dip. Give draw 5 camera 101 instead:
+    cleanup();
+    const later = { ...drawn(5, 11, 20_000), webcamId: 101 };
+    render(<Tape past={[drawn(1, 10, 0), later]} current={entry(3)} currentSince={since} next={[]}
+      pastDials={dip} nextDials={dip} onSelect={vi.fn()} />);
+    const seam = screen.getByTestId('tape-fade-0');
+    expect(seam.getAttribute('data-seam')).toBe('dissolve');
+    expect(seam.getAttribute('title')).toMatch(/same camera · dissolve 2 s: both pictures on glass/);
+    expect(seam).toHaveStyle({ width: `${2 * PX_PER_S}px` });
+  });
+
+  it('a cut draws nothing at the seam', () => {
+    render(<Tape past={past} current={entry(3)} currentSince={since} next={[entry(4)]}
+      pastDials={{ ...dip, transition: 'cut' }} nextDials={{ ...dip, transition: 'cut' }} onSelect={vi.fn()} />);
+    expect(screen.queryAllByTestId(/^tape-fade-/)).toHaveLength(0);
+  });
+
+  it('a dip on a screen with no veil is a crossfade, as it is on the glass', () => {
+    render(<Tape past={past} current={entry(3)} currentSince={since} next={[]}
+      pastDials={{ ...dip, veil: null }} nextDials={dip} onSelect={vi.fn()} />);
+    expect(screen.getByTestId('tape-fade-0').getAttribute('data-seam')).toBe('crossfade');
+  });
+
+  it('seamBetween is pure and says the same thing', () => {
+    expect(seamBetween({ webcamId: 1 }, { webcamId: 2 }, dip)).toEqual({ kind: 'dip', seconds: 6, veil: '#000000' });
+    expect(seamBetween({ webcamId: 1 }, { webcamId: 1 }, dip)).toEqual({ kind: 'dissolve', seconds: 2, veil: null });
+    expect(seamBetween({ webcamId: 1 }, { webcamId: 1 }, { ...dip, sameCameraFadeS: 0 })).toEqual({ kind: 'cut', seconds: 0, veil: null });
+    expect(seamBetween(null, { webcamId: 2 }, { dwellS: 20, fadeS: 2 })).toEqual({ kind: 'crossfade', seconds: 2, veil: null });
+  });
+});
+
+describe('zoom', () => {
+  it('scales every block and the seam markers, and says so in the sticky cell', () => {
+    render(<Tape past={past} current={entry(3)} currentSince={since} currentEndsAt={since + 20_000} next={[entry(4)]}
+      pastDials={{ dwellS: 20, fadeS: 2 }} nextDials={{ dwellS: 20, fadeS: 2 }} onSelect={vi.fn()} zoom={2} onZoom={vi.fn()} />);
+    expect(screen.getByTestId('tape-scale-label')).toHaveTextContent(`${PX_PER_S * 2} px/s`);
+    expect(screen.getByTestId('tape-past-1-10')).toHaveStyle({ width: `${20 * PX_PER_S * 2}px`, height: `${THUMB_H * 2}px` });
+    expect(screen.getByTestId('tape-current')).toHaveStyle({ width: `${20 * PX_PER_S * 2}px` });
+    expect(screen.getByTestId('tape-next-0')).toHaveStyle({ width: `${20 * PX_PER_S * 2}px` });
+    expect(screen.getByTestId('tape-fade-0')).toHaveStyle({ width: `${2 * PX_PER_S * 2}px` });
+  });
+
+  it('− and + step through the zoom levels and stop at the ends', () => {
+    const onZoom = vi.fn();
+    const { rerender } = render(<Tape past={[]} current={entry(3)} next={[]} pastDials={D} nextDials={D} onSelect={vi.fn()} zoom={1} onZoom={onZoom} />);
+    fireEvent.click(screen.getByTestId('tape-zoom-in'));
+    expect(onZoom).toHaveBeenLastCalledWith(2);
+    fireEvent.click(screen.getByTestId('tape-zoom-out'));
+    expect(onZoom).toHaveBeenLastCalledWith(0.5);
+    rerender(<Tape past={[]} current={entry(3)} next={[]} pastDials={D} nextDials={D} onSelect={vi.fn()} zoom={4} onZoom={onZoom} />);
+    expect(screen.getByTestId('tape-zoom-in')).toBeDisabled();
+    rerender(<Tape past={[]} current={entry(3)} next={[]} pastDials={D} nextDials={D} onSelect={vi.fn()} zoom={0.5} onZoom={onZoom} />);
+    expect(screen.getByTestId('tape-zoom-out')).toBeDisabled();
+  });
+
+  it('without a handler the cell shows the scale and no buttons', () => {
+    render(<Tape past={[]} current={entry(3)} next={[]} pastDials={D} nextDials={D} onSelect={vi.fn()} />);
+    expect(screen.getByTestId('tape-scale-label')).toHaveTextContent(`${PX_PER_S} px/s`);
+    expect(screen.queryByTestId('tape-zoom-in')).toBeNull();
+  });
 });

--- a/app/studio/solo/Tape.tsx
+++ b/app/studio/solo/Tape.tsx
@@ -4,7 +4,7 @@ import { useEffect, useRef, useState, type ReactNode } from 'react';
 import type { EntryView, TapeEntry } from '@/app/api/kiosk/solo/view';
 import type { BinKind } from '@/app/lib/solo/types';
 import type { Run } from './EntryRow';
-import { PX_PER_S, SCALE_LABEL, SCALE_NOTE } from './timeScale';
+import { PX_PER_S, SCALE_NOTE } from './timeScale';
 
 const COLOR: Record<BinKind, string> = { sunset: '#7ee2ac', non_sunset: '#c3cad6' };
 const REPEAT = '#8b2e2e';
@@ -14,7 +14,7 @@ const mono = 'ui-monospace, SFMono-Regular, Menlo, monospace';
  * Width is time on the tape, so height carries no meaning and can be spent
  * entirely on legibility. At 22 px a block was a letterbox slice with most of
  * the sky cropped away; 48 is close to uncropped at the default dwell, where
- * a block is 80 px wide.
+ * a block is 80 px wide. Scales with the zoom, so a zoomed block keeps its shape.
  */
 export const THUMB_H = 48;
 /** The keyframes the playhead rides; defined once inside the strip. */
@@ -28,22 +28,63 @@ const HELD_AFTER = 1.5;
 /** …and its block is capped here so one long hold does not push everything off screen. */
 const MAX_DWELLS = 3;
 
+/**
+ * The zoom steps, as multiples of the studio's shared scale. 1 is the queue's
+ * scale, so the tape and the queue agree at rest; the others are for reading
+ * a seam or a run's sub-blocks, which at 4 px/s are slivers.
+ */
+export const TAPE_ZOOMS = [0.5, 1, 2, 4] as const;
+const ZOOM_KEY = 'studio.tape.zoom';
+
+/**
+ * The tape's zoom, remembered per browser. Lifted to the panel rather than
+ * kept per tape so both screens' tapes zoom together: they sit side by side
+ * and read as one instrument.
+ */
+export function useTapeZoom(): [number, (z: number) => void] {
+  const [zoom, setZoom] = useState(1);
+  useEffect(() => {
+    try {
+      const z = Number(localStorage.getItem(ZOOM_KEY));
+      if ((TAPE_ZOOMS as readonly number[]).includes(z)) setZoom(z);
+    } catch { /* storage unavailable: stay at 1 */ }
+  }, []);
+  const set = (z: number) => {
+    setZoom(z);
+    try { localStorage.setItem(ZOOM_KEY, String(z)); } catch { /* ignore */ }
+  };
+  return [zoom, set];
+}
+
+export type TapeTransition = 'cut' | 'crossfade' | 'dip';
+
 export interface TapeDials {
   dwellS: number;
   fadeS: number;
+  /**
+   * What a camera change is. Absent reads as a crossfade, which is what solo
+   * does and what the tape assumed for everything until 2026-09-08 — when at
+   * the live `dip` it drew a 6 s "both pictures on glass" on every seam where
+   * the real overlap was none.
+   */
+  transition?: TapeTransition;
+  /** A change to a later frame of the same camera dissolves over this, never through the veil. */
+  sameCameraFadeS?: number;
+  /** What a dip goes through on this screen, for the seam's colour; null crossfades instead. */
+  veil?: string | null;
 }
 
 const clock = (ms: number) => new Date(ms).toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' });
 const place = (f: { city: string; country: string }) => [f.city, f.country].filter(Boolean).join(', ');
 const secs = (s: number) => `${Number.isInteger(s) ? s : s.toFixed(1)} s`;
 
-function Thumb({ testId, src, color, width, dashed = false, dim = false, ring = false, repeat = false, title, onClick, children }: {
-  testId: string; src: string; color: string; width: number; dashed?: boolean; dim?: boolean; ring?: boolean; repeat?: boolean;
+function Thumb({ testId, src, color, width, height, dashed = false, dim = false, ring = false, repeat = false, title, onClick, children }: {
+  testId: string; src: string; color: string; width: number; height: number; dashed?: boolean; dim?: boolean; ring?: boolean; repeat?: boolean;
   title: string; onClick?: () => void; children?: ReactNode;
 }) {
   return (
     <button type="button" data-testid={testId} title={title} onClick={onClick} disabled={!onClick} style={{
-      flex: 'none', width, height: THUMB_H, padding: 0, background: '#000', cursor: onClick ? 'pointer' : 'default',
+      flex: 'none', width, height, padding: 0, background: '#000', cursor: onClick ? 'pointer' : 'default',
       borderWidth: 1.5, borderStyle: dashed ? 'dashed' : 'solid', borderColor: color, borderTopColor: repeat ? REPEAT : color,
       borderTopWidth: repeat ? 3 : 1.5, borderRadius: 3, boxShadow: ring ? RING : undefined, boxSizing: 'border-box',
       position: 'relative', overflow: 'hidden', opacity: dim ? 0.35 : 1,
@@ -55,22 +96,66 @@ function Thumb({ testId, src, color, width, dashed = false, dim = false, ring = 
   );
 }
 
+/** What happens at the cut between two draws, as the glass will actually play it. */
+export interface Seam {
+  kind: 'crossfade' | 'dissolve' | 'dip' | 'cut';
+  seconds: number;
+  veil: string | null;
+}
+
 /**
- * The Final Cut "X": the seconds during which both pictures are on glass.
- *
- * It straddles the cut by half its width each way, so at the live 6 s fade it
- * lies over 12 px of both neighbours. Never a click target: it paints above
- * them, and while it took pointer events it swallowed clicks along the edges
- * of the very blocks an operator was reaching for.
+ * The seam between draw `a` and draw `b` under `d`. A later frame of the
+ * same camera dissolves over the same-camera dial whatever the transition
+ * says (Solo2Frame `arrival`); otherwise the transition decides. This is
+ * what the glass does, so this is what the tape draws.
  */
-function Fade({ testId, seconds }: { testId: string; seconds: number }) {
-  const width = Math.max(4, seconds * PX_PER_S);
+export function seamBetween(
+  a: { webcamId: number } | null, b: { webcamId: number } | null, d: TapeDials,
+): Seam {
+  if (a && b && a.webcamId === b.webcamId) {
+    const s = Math.max(0, d.sameCameraFadeS ?? 0);
+    return { kind: s > 0 ? 'dissolve' : 'cut', seconds: s, veil: null };
+  }
+  const fade = Math.max(0, d.fadeS);
+  const kind = d.transition ?? 'crossfade';
+  if (kind === 'cut' || fade <= 0) return { kind: 'cut', seconds: 0, veil: null };
+  // A dip on a screen whose veil is null is a crossfade (veil.ts).
+  if (kind === 'dip' && d.veil === null) return { kind: 'crossfade', seconds: fade, veil: null };
+  return { kind, seconds: fade, veil: kind === 'dip' ? (d.veil ?? '#000000') : null };
+}
+
+/**
+ * The seam marker. A crossfade or a dissolve is the Final Cut "X": the seconds
+ * during which both pictures are on glass. A dip is a bar in the veil's colour:
+ * the seconds during which NEITHER picture is fully on glass, the first half
+ * the old one burning down inside its own block, the second the new one
+ * rising inside its. A cut draws nothing.
+ *
+ * It straddles the cut by half its width each way, which for a dip is exactly
+ * where the halves live. Never a click target: it paints above its neighbours,
+ * and while it took pointer events it swallowed clicks along their edges.
+ */
+function SeamMark({ testId, seam, px, height }: { testId: string; seam: Seam; px: number; height: number }) {
+  const width = Math.max(4, seam.seconds * px);
+  const base = {
+    flex: 'none', width, height, marginLeft: -width / 2, marginRight: -width / 2, position: 'relative', zIndex: 1,
+    pointerEvents: 'none', boxSizing: 'border-box',
+  } as const;
+  if (seam.kind === 'dip') {
+    const veil = seam.veil ?? '#000000';
+    return (
+      <div data-testid={testId} data-seam="dip" title={`dip ${secs(seam.seconds)}: down into the veil, then up. No overlap.`} style={{
+        ...base, background: `linear-gradient(90deg, ${veil}00 0%, ${veil} 45%, ${veil} 55%, ${veil}00 100%)`,
+        borderLeft: '1px solid rgba(139,149,167,0.5)', borderRight: '1px solid rgba(139,149,167,0.5)',
+      }} />
+    );
+  }
+  const what = seam.kind === 'dissolve' ? 'same camera · dissolve' : 'crossfade';
   return (
-    <div data-testid={testId} title={`crossfade ${secs(seconds)}: both pictures on glass`} style={{
-      flex: 'none', width, height: THUMB_H, marginLeft: -width / 2, marginRight: -width / 2, position: 'relative', zIndex: 1,
-      pointerEvents: 'none',
+    <div data-testid={testId} data-seam={seam.kind} title={`${what} ${secs(seam.seconds)}: both pictures on glass`} style={{
+      ...base,
       background: 'linear-gradient(135deg, rgba(245,163,68,0) 0%, rgba(245,163,68,0.55) 50%, rgba(245,163,68,0) 100%)',
-      borderLeft: '1px solid rgba(245,163,68,0.8)', borderRight: '1px solid rgba(245,163,68,0.8)', boxSizing: 'border-box',
+      borderLeft: '1px solid rgba(245,163,68,0.8)', borderRight: '1px solid rgba(245,163,68,0.8)',
     }} />
   );
 }
@@ -115,16 +200,18 @@ function Playhead({ sinceMs, endsAtMs, nowMs }: { sinceMs: number | null; endsAt
  * draw log, each as wide as the frame stayed on glass (a hold, when nothing
  * else was eligible, reads as a wide block); the frame on glass wears the
  * orange ring; a seam separates fact from the projection, whose blocks are
- * dashed and one dwell wide. A crossfade is an orange X straddling the cut,
- * as wide as the fade dial. A solo2 dwell with a camera run shows its earlier
- * frames as narrow sub-blocks before the chosen one, and the frames the
- * most-frames cap cut as dim stubs before those. A frame already seen
- * earlier on the strip carries a red top edge, the REPEAT tag's colour. When
- * nothing is on glass the seam is preceded by a black blank. Scrolls
- * sideways; on mount and whenever the past grows, the seam is brought to
- * about two thirds across.
+ * dashed and one dwell wide. Between any two draws sits the seam the glass
+ * will actually play there: an orange X for a crossfade or a same-camera
+ * dissolve, a bar in the veil's colour for a dip, nothing for a cut. A solo2
+ * dwell with a camera run shows its earlier frames as narrow sub-blocks before
+ * the chosen one, and the frames the most-frames cap cut as dim stubs before
+ * those. A frame already seen earlier on the strip carries a red top edge, the
+ * REPEAT tag's colour. When nothing is on glass the seam is preceded by a black
+ * blank. Scrolls sideways; on mount and whenever the past grows, the seam is
+ * brought to about two thirds across. The zoom, in the sticky cell at the
+ * left, scales the whole strip.
  */
-export function Tape({ past, current, currentSince, currentEndsAt, next, nextSequences, pastDials, nextDials, onSelect }: {
+export function Tape({ past, current, currentSince, currentEndsAt, next, nextSequences, pastDials, nextDials, onSelect, zoom = 1, onZoom }: {
   past: TapeEntry[];
   current: EntryView | null;
   /** When the current frame went on glass, ms; sizes the last past block. */
@@ -144,6 +231,10 @@ export function Tape({ past, current, currentSince, currentEndsAt, next, nextSeq
   /** The studio dials: what the projection is drawn with. */
   nextDials: TapeDials;
   onSelect: (entry: EntryView) => void;
+  /** Multiplies the shared scale; see `TAPE_ZOOMS`. */
+  zoom?: number;
+  /** When given, the sticky cell grows − and + buttons that step through `TAPE_ZOOMS`. */
+  onZoom?: (zoom: number) => void;
 }) {
   const strip = useRef<HTMLDivElement>(null);
   const seam = useRef<HTMLDivElement>(null);
@@ -152,12 +243,18 @@ export function Tape({ past, current, currentSince, currentEndsAt, next, nextSeq
     const m = seam.current;
     if (!s || !m) return;
     s.scrollLeft = Math.max(0, m.offsetLeft - s.clientWidth * (2 / 3));
-  }, [past.length, current?.snapshotId]);
+  }, [past.length, current?.snapshotId, zoom]);
 
   // Read once per frame on glass, after mount. The playhead's own motion is
   // CSS, so this never ticks; it only re-anchors when the picture changes.
   const [nowMs, setNowMs] = useState<number | null>(null);
   useEffect(() => { setNowMs(Date.now()); }, [currentSince, current?.snapshotId]);
+
+  const px = PX_PER_S * zoom;
+  const thumbH = Math.round(THUMB_H * zoom);
+  const zoomIndex = (TAPE_ZOOMS as readonly number[]).indexOf(zoom);
+  const zoomOut = zoomIndex > 0 ? TAPE_ZOOMS[zoomIndex - 1] : null;
+  const zoomIn = zoomIndex >= 0 && zoomIndex < TAPE_ZOOMS.length - 1 ? TAPE_ZOOMS[zoomIndex + 1] : null;
 
   const seen = new Set<number>();
   const repeatOf = (id: number) => {
@@ -165,7 +262,7 @@ export function Tape({ past, current, currentSince, currentEndsAt, next, nextSeq
     seen.add(id);
     return r;
   };
-  const dwellPx = (d: TapeDials) => Math.max(MIN_BLOCK_PX, d.dwellS * PX_PER_S);
+  const dwellPx = (d: TapeDials) => Math.max(MIN_BLOCK_PX, d.dwellS * px);
   /**
    * The on-glass block is as wide as this dwell actually lasts, from the
    * server's published end, so a run of eight reads wider than a single
@@ -174,16 +271,21 @@ export function Tape({ past, current, currentSince, currentEndsAt, next, nextSeq
   const currentPx = () => {
     const ms = currentEndsAt != null && currentSince != null ? currentEndsAt - currentSince : null;
     return ms != null && ms > 0
-      ? Math.max(MIN_BLOCK_PX, (ms / 1000) * PX_PER_S)
+      ? Math.max(MIN_BLOCK_PX, (ms / 1000) * px)
       : dwellPx(pastDials);
   };
 
   const blocks: ReactNode[] = [];
-  let fades = 0;
-  const fade = (seconds: number) => {
-    if (seconds > 0) blocks.push(<Fade key={`fade-${fades}`} testId={`tape-fade-${fades}`} seconds={seconds} />);
-    fades += 1;
+  let seams = 0;
+  const seamAfter = (a: { webcamId: number } | null, b: { webcamId: number } | null, d: TapeDials) => {
+    const s = seamBetween(a, b, d);
+    if (s.kind !== 'cut' && s.seconds > 0) {
+      blocks.push(<SeamMark key={`seam-${seams}`} testId={`tape-fade-${seams}`} seam={s} px={px} height={thumbH} />);
+    }
+    seams += 1;
   };
+  // The draw after the last past block, for its seam: the frame on glass, else the first projection.
+  const afterPast: { webcamId: number } | null = current ?? next[0] ?? null;
 
   past.forEach((f, i) => {
     // Measured, never computed: the next draw's time, else the current
@@ -198,9 +300,9 @@ export function Tape({ past, current, currentSince, currentEndsAt, next, nextSeq
     // Only a measured block can be known to have been held; an unmeasured one
     // is drawn at its nominal length and must not claim anything about it.
     const held = measured && dwells > HELD_AFTER;
-    const width = Math.max(MIN_BLOCK_PX, Math.min(dwells, MAX_DWELLS) * pastDials.dwellS * PX_PER_S);
+    const width = Math.max(MIN_BLOCK_PX, Math.min(dwells, MAX_DWELLS) * pastDials.dwellS * px);
     blocks.push(
-      <Thumb key={`${f.snapshotId}-${f.slot}`} testId={`tape-past-${f.snapshotId}-${f.slot}`} src={f.imageUrl} width={width}
+      <Thumb key={`${f.snapshotId}-${f.slot}`} testId={`tape-past-${f.snapshotId}-${f.slot}`} src={f.imageUrl} width={width} height={thumbH}
         color={COLOR[f.bin]} repeat={repeatOf(f.snapshotId)} onClick={() => onSelect(f)}
         title={`${f.title}${place(f) ? ` · ${place(f)}` : ''} · draw at ${clock(f.shownAt)} · on glass `
           + (measured ? secs(Math.round(onGlassS)) : 'unknown, nothing followed it')
@@ -208,12 +310,12 @@ export function Tape({ past, current, currentSince, currentEndsAt, next, nextSeq
         {held && <span data-testid="tape-held" style={{ position: 'absolute', right: 2, bottom: 0, fontFamily: mono, fontSize: 8, color: '#f5a344' }}>held</span>}
       </Thumb>,
     );
-    fade(pastDials.fadeS);
+    seamAfter(f, i + 1 < past.length ? past[i + 1] : afterPast, pastDials);
   });
 
   if (current) {
     blocks.push(
-      <Thumb key="current" testId="tape-current" src={current.imageUrl} width={currentPx()} color={COLOR[current.bin]} ring
+      <Thumb key="current" testId="tape-current" src={current.imageUrl} width={currentPx()} height={thumbH} color={COLOR[current.bin]} ring
         repeat={repeatOf(current.snapshotId)} onClick={() => onSelect(current)}
         title={`on glass${currentSince ? ` since ${clock(currentSince)}` : ''} · ${current.title}${place(current) ? ` · ${place(current)}` : ''}`}>
         <Playhead sinceMs={currentSince ?? null} endsAtMs={currentEndsAt ?? null} nowMs={nowMs} />
@@ -222,20 +324,21 @@ export function Tape({ past, current, currentSince, currentEndsAt, next, nextSeq
   } else {
     blocks.push(
       <div key="blank" data-testid="tape-blank" title="Nothing on glass: the screen is black until a frame is eligible" style={{
-        flex: 'none', width: dwellPx(pastDials), height: THUMB_H, background: '#000', border: '1.5px solid #2a3242', borderRadius: 3,
+        flex: 'none', width: dwellPx(pastDials), height: thumbH, background: '#000', border: '1.5px solid #2a3242', borderRadius: 3,
         boxSizing: 'border-box', fontFamily: mono, fontSize: 8, color: '#4b5568', display: 'grid', placeItems: 'center',
       }}>blank</div>,
     );
   }
   blocks.push(
     <div key="seam" ref={seam} data-testid="tape-seam" title="Left: what happened. Right: what the studio dials project."
-      style={{ flex: 'none', width: 2, height: THUMB_H + 6, background: '#f5a344', opacity: 0.6, margin: '0 2px' }} />,
+      style={{ flex: 'none', width: 2, height: thumbH + 6, background: '#f5a344', opacity: 0.6, margin: '0 2px' }} />,
   );
 
   next.forEach((e, i) => {
-    fade(nextDials.fadeS);
+    // The seam INTO this draw: from the frame on glass for the first, else from the draw before.
+    seamAfter(i === 0 ? current : next[i - 1], e, nextDials);
     const seq = nextSequences?.[i];
-    const stepPx = seq ? Math.max(6, seq.stepS * PX_PER_S) : 0;
+    const stepPx = seq ? Math.max(6, seq.stepS * px) : 0;
     const total = dwellPx(nextDials);
     const mainWidth = Math.max(MIN_BLOCK_PX, total - (seq?.earlier.length ?? 0) * stepPx);
     const title = `draw ${i + 1} · ${e.title}${place(e) ? ` · ${place(e)}` : ''}`
@@ -246,7 +349,7 @@ export function Tape({ past, current, currentSince, currentEndsAt, next, nextSeq
         <div key={`next-${i}`} data-testid={`tape-next-${i}-group`} style={{ flex: 'none', display: 'flex', gap: 1 }}>
           {/* Cut by the most-frames cap: no time on the strip, only a dim stub so the operator sees what a higher cap adds. */}
           {cut.map((f) => (
-            <Thumb key={`cut-${f.snapshotId}`} testId={`tape-next-${i}-cut-${f.snapshotId}`} src={f.imageUrl} width={CUT_STUB_PX} color="#2a3242" dashed dim
+            <Thumb key={`cut-${f.snapshotId}`} testId={`tape-next-${i}-cut-${f.snapshotId}`} src={f.imageUrl} width={CUT_STUB_PX} height={thumbH} color="#2a3242" dashed dim
               title={`not played · ${f.title} · over the ${seq.capLabel ?? 'most-frames cap'}`} onClick={() => onSelect(f)} />
           ))}
           {/* Clickable like every other block. Without a handler `Thumb`
@@ -254,34 +357,46 @@ export function Tape({ past, current, currentSince, currentEndsAt, next, nextSeq
               wants to open: the run's earlier pictures are the ones they
               cannot identify from a 6 px sliver. */}
           {seq.earlier.map((f) => (
-            <Thumb key={f.snapshotId} testId={`tape-next-${i}-pre-${f.snapshotId}`} src={f.imageUrl} width={stepPx} color="#2a3242" dashed
+            <Thumb key={f.snapshotId} testId={`tape-next-${i}-pre-${f.snapshotId}`} src={f.imageUrl} width={stepPx} height={thumbH} color="#2a3242" dashed
               title={`run · ${f.title} · ${secs(seq.stepS)}`} onClick={() => onSelect(f)} />
           ))}
-          <Thumb testId={`tape-next-${i}`} src={e.imageUrl} width={mainWidth} color={COLOR[e.bin]} dashed
+          <Thumb testId={`tape-next-${i}`} src={e.imageUrl} width={mainWidth} height={thumbH} color={COLOR[e.bin]} dashed
             repeat={repeatOf(e.snapshotId)} title={title} onClick={() => onSelect(e)} />
         </div>,
       );
     } else {
       blocks.push(
-        <Thumb key={`next-${i}`} testId={`tape-next-${i}`} src={e.imageUrl} width={total} color={COLOR[e.bin]} dashed
+        <Thumb key={`next-${i}`} testId={`tape-next-${i}`} src={e.imageUrl} width={total} height={thumbH} color={COLOR[e.bin]} dashed
           repeat={repeatOf(e.snapshotId)} title={title} onClick={() => onSelect(e)} />,
       );
     }
   });
 
+  const zoomButton = (label: string, to: number | null, testId: string) => (
+    <button type="button" data-testid={testId} disabled={to == null} onClick={() => to != null && onZoom?.(to)}
+      title={to == null ? undefined : `${label === '+' ? 'zoom in' : 'zoom out'} to ${PX_PER_S * to} px/s`} style={{
+        background: 'none', border: '1px solid #2a3242', borderRadius: 3, color: to == null ? '#2a3242' : '#9aa3b2',
+        fontFamily: mono, fontSize: 10, width: 16, height: 16, padding: 0, lineHeight: 1, cursor: to == null ? 'default' : 'pointer',
+      }}>{label}</button>
+  );
+
   return (
     <div ref={strip} data-testid="tape"
       title={`The tape: past draws, the frame on glass, then the projected next draws. ${SCALE_NOTE}`}
-      style={{ display: 'flex', alignItems: 'center', overflowX: 'auto', padding: '4px 2px', minHeight: THUMB_H + 12 }}>
+      style={{ display: 'flex', alignItems: 'center', overflowX: 'auto', padding: '4px 2px', minHeight: thumbH + 12 }}>
       <style>{
         `@keyframes ${PLAYHEAD_ANIM} { from { left: 0% } to { left: 100% } }`
         + ` @media (prefers-reduced-motion: reduce) { [data-testid="tape-playhead"] { animation: none } }`
       }</style>
       {/* Sticks to the left edge while the strip scrolls, so the scale is readable without hovering. */}
       <span data-testid="tape-scale" title={SCALE_NOTE} style={{
-        position: 'sticky', left: 0, zIndex: 2, flex: 'none', alignSelf: 'stretch', display: 'grid', placeItems: 'center',
+        position: 'sticky', left: 0, zIndex: 2, flex: 'none', alignSelf: 'stretch', display: 'flex', alignItems: 'center', gap: 4,
         fontFamily: mono, fontSize: 9, color: '#4b5568', background: '#0e1119', padding: '0 5px', cursor: 'help',
-      }}>{SCALE_LABEL}</span>
+      }}>
+        {onZoom && zoomButton('−', zoomOut, 'tape-zoom-out')}
+        <span data-testid="tape-scale-label">{px} px/s</span>
+        {onZoom && zoomButton('+', zoomIn, 'tape-zoom-in')}
+      </span>
       {past.length === 0 && (
         <span style={{ fontFamily: mono, fontSize: 9.5, color: '#4b5568', whiteSpace: 'nowrap', paddingRight: 6 }}>no draws logged yet</span>
       )}

--- a/app/studio/solo/useLoopingStage.ts
+++ b/app/studio/solo/useLoopingStage.ts
@@ -3,7 +3,8 @@
 import { useEffect, useState } from 'react';
 import { stageAt, type DwellPlan, type Stage } from '@/app/lib/solo2/plan';
 
-const same = (a: Stage, b: Stage) => a.index === b.index && a.leadProgress === b.leadProgress;
+const same = (a: Stage, b: Stage) =>
+  a.index === b.index && a.leadProgress === b.leadProgress && a.exitProgress === b.exitProgress;
 
 /**
  * Where a dwell that began at `startMs` is now. Clamped at the dwell, never
@@ -40,9 +41,9 @@ function stageOf(startMs: number | null, plan: DwellPlan): Stage {
  */
 export function useLoopingStage(plan: DwellPlan, startMs: number | null, tickMs = 250): Stage {
   const [stage, setStage] = useState<Stage>(() => stageOf(startMs, plan));
-  const { dwellS, frames, stepS, leadS, arrivalS } = plan;
+  const { dwellS, frames, stepS, lastStepS, leadS, arrivalS, exitS } = plan;
   useEffect(() => {
-    const p = { dwellS, frames, stepS, leadS, arrivalS };
+    const p = { dwellS, frames, stepS, lastStepS, leadS, arrivalS, exitS };
     const read = () => setStage((prev) => {
       const nextStage = stageOf(startMs, p);
       return same(prev, nextStage) ? prev : nextStage;
@@ -50,6 +51,6 @@ export function useLoopingStage(plan: DwellPlan, startMs: number | null, tickMs 
     read();
     const t = setInterval(read, tickMs);
     return () => clearInterval(t);
-  }, [startMs, tickMs, dwellS, frames, stepS, leadS, arrivalS]);
+  }, [startMs, tickMs, dwellS, frames, stepS, lastStepS, leadS, arrivalS, exitS]);
   return stage;
 }


### PR DESCRIPTION
**Stacked on #184.** Merge that first; this retargets to `main` when it does. Before merging this one, confirm its base reads `main`.

## The hold at the end of a run

The last picture of a run "stuck for an awful long time". The exposure shift stays; only the hold goes.

The whole 6 s dip was reserved at the **front of the arriving dwell**, so the leaving dwell's last frame held a full still step and only then began to burn. A dip is two halves, and the picture on glass during the first is the leaving dwell's. So that half is now the leaving dwell's `exitS`, burned down inside its last frame's step on its own clock, and the arriving dwell reserves only the rise.

| | dwell | last picture on glass | to the next new picture |
|---|---|---|---|
| before, at the live dials | 6 + 4×4 = 22 s | 7 s | 10 s |
| after, at the live dials | 3 + 4×3 + 5 = 20 s | 5 s | 8 s |
| after, `fadeS` 4 | 2 + 4×4 = 18 s | 4 s | 6 s |

With `fadeS` at or below the shortest frame, the last picture costs exactly one step. The 6 s shift does not quite fit a 4 s step, so `lastStepS` stretches by one second to hold it.

`Solo2Frame` plays the exit as one ramp: the veil closes over everything, the picture burns toward it, the words leave. A dip arrival now finds the veil closed and only rises. A crossfade is one gesture and is unchanged. A later frame of the same camera arrives by dissolve, so the exit is skipped when the caller's projected next is the same camera; if the pool moves and a different camera arrives after all, that dwell opens on a closed veil without the burn. Brief and rare.

## The tape lied at a dip

It drew "crossfade N s: both pictures on glass" on every seam from `fadeS` alone. At the live dip that was a 6 s overlap where the real one was none. `seamBetween` now says what the glass plays there: a dissolve over the same-camera dial for a later frame of one camera, a bar in the veil's colour for a dip that says "No overlap", nothing for a cut.

## Tape zoom

− and + in the sticky cell step through 0.5, 1, 2, 4× the shared scale. One zoom for both screens' tapes, remembered per browser. The queue keeps the shared scale; the tape's label says its own.

## Also

Two dial descriptions now say what was silent: a dip's fade is split across the seam, and the same-camera dissolve is capped at half a step, so at a 4 s shortest frame nothing above 2 reaches the glass.

## Verification

- 2532 tests pass, build clean, lint clean.
- Merge result against #185 (`fix/solo2-size-by-the-camera`): auto-merged, 2537 tests pass, build clean.
- Not yet seen on the glass or the signed-in studio.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KAQBRAAYo5HwLtT2183rxG
