### PR TITLE
feat(kiosk): a page that has fallen behind the build says so, and the glass reloads itself

### DIFF
--- a/app/api/kiosk/settings/route.test.ts
+++ b/app/api/kiosk/settings/route.test.ts
@@ -1,5 +1,6 @@
 // @vitest-environment node
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { BUILD_ID } from '@/app/lib/buildStamp';
 import { NextResponse } from 'next/server';
 
 const requireOwnerMock = vi.fn();
@@ -89,6 +90,9 @@ describe('GET /api/kiosk/settings', () => {
       studio: { namespaces: { v1: { floorPx: 150 } }, revision: 1 },
       live: { namespaces: { v1: { floorPx: 100 } }, revision: 0 },
       lastPollAt: '2026-08-30T12:00:00Z',
+      // Which deployment answered, so a studio tab can tell it has fallen
+      // behind the build it is talking to (buildStamp.ts).
+      build: BUILD_ID,
     });
   });
 });

--- a/app/api/kiosk/settings/route.ts
+++ b/app/api/kiosk/settings/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server';
 import { requireOwner } from '@/app/lib/owner';
+import { BUILD_ID } from '@/app/lib/buildStamp';
 import { getProfileSettings, putStudioNamespace } from '@/app/lib/settings/store';
 import { getKioskLastPoll } from '@/app/lib/cache';
 import { droppedKeys, sanitizeValues, stripDefaults } from '@/app/lib/settings/schema';
@@ -22,7 +23,7 @@ export async function GET() {
     getProfileSettings('live'),
     getKioskLastPoll(),
   ]);
-  return NextResponse.json({ studio, live, lastPollAt });
+  return NextResponse.json({ studio, live, lastPollAt, build: BUILD_ID });
 }
 
 export async function PATCH(request: Request) {

--- a/app/api/kiosk/solo/state/route.ts
+++ b/app/api/kiosk/solo/state/route.ts
@@ -10,6 +10,7 @@ import { countAdmittedSince, getScreenState, getSweptZone, listActiveEntries, li
 import { isFlagEnabled, SWEEP_FORCE_DAY_RING } from '@/app/lib/runtimeFlags';
 import { sweepGeometry } from '@/app/api/cron/update-cameras/lib/sweepGeometry';
 import { TERMINATOR_DAY_SIDE_OFFSETS_DEG } from '@/app/lib/masterConfig';
+import { BUILD_ID } from '@/app/lib/buildStamp';
 import { buildStateView, parseFeed, TAPE_PAST, toTapeInput, toViewEntry } from '../view';
 
 export const dynamic = 'force-dynamic';
@@ -55,7 +56,12 @@ export async function GET(request: NextRequest) {
   // guaranteed rings are the best available guess.
   const geometry = sweepGeometry(forcedDayRing ? TERMINATOR_DAY_SIDE_OFFSETS_DEG : []);
   const zone = sweptZone ?? { minDeg: geometry.coverageMinDeg, maxDeg: geometry.coverageMaxDeg };
-  return NextResponse.json(buildStateView({
-    feed, dials, entries: entries.map(toViewEntry), screen, nowMs, admitted, zone, version, tape: tape.map(toTapeInput),
-  }));
+  return NextResponse.json({
+    ...buildStateView({
+      feed, dials, entries: entries.map(toViewEntry), screen, nowMs, admitted, zone, version, tape: tape.map(toTapeInput),
+    }),
+    // Stamped here rather than inside the projection: it says which deployment
+    // answered, which is a fact about this response and not about the queue.
+    build: BUILD_ID,
+  });
 }

--- a/app/api/kiosk/solo/view.ts
+++ b/app/api/kiosk/solo/view.ts
@@ -111,6 +111,14 @@ export interface StateView {
   zone: Zone;
   /** The last draws on this screen, oldest first (stages-and-tape spec §4). Empty until the log is migrated. */
   tape: TapeEntry[];
+  /**
+   * The build the deployment answering this poll was compiled from
+   * (buildStamp.ts). The glass compares it against the one its own chunks
+   * carry and reloads when they part, which is the only thing that moves a
+   * kiosk tab onto new code. Optional because the route stamps it rather than
+   * the projection, so every other caller of buildStateView omits it.
+   */
+  build?: string;
 }
 
 const scoreOf = (e: ViewEntry) => (e.bin === 'sunset' ? e.quality ?? -1 : e.detection);

--- a/app/components/solo/useSoloGlass.ts
+++ b/app/components/solo/useSoloGlass.ts
@@ -4,6 +4,7 @@ import { useEffect, useRef, useState } from 'react';
 import type { EntryView, StateView, ViewEntry } from '@/app/api/kiosk/solo/view';
 import type { Feed } from '@/app/lib/solo/types';
 import type { SoloVersionName } from '@/app/lib/solo/versions';
+import { useBuildReload } from '@/app/components/useBuildReload';
 
 export const STATE_REFRESH_MS = 60_000;
 /** The least time between two fires of the dwell timer, so a failed advance retries rather than spins. */
@@ -151,6 +152,12 @@ export function useSoloGlass({ feed, drive, dozing, version = 'solo' }: {
     }, wait);
     return () => clearTimeout(t);
   }, [feed, version, endsAtMs, screenSlot, tick]);
+
+  // The glass is the one surface nobody reloads by hand, so it reloads itself
+  // when the deployment answering this poll has moved past the build it is
+  // running. Settings already reach the Pi within a minute; this is the code
+  // half of the same promise.
+  useBuildReload(view?.build ?? null);
 
   return {
     current: view?.current?.entry ?? null,

--- a/app/components/useBuildReload.test.ts
+++ b/app/components/useBuildReload.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { CONFIRM_MS, RELOAD_COOLDOWN_MS, BUILD_ID } from '@/app/lib/buildStamp';
+import { useBuildReload, LAST_RELOAD_KEY } from './useBuildReload';
+
+/**
+ * BUILD_ID is 'dev' under vitest, and a dev build never compares — which is
+ * the point of that rule, and means these tests must stamp the client end
+ * themselves. The module reads the constant at import time, so the test
+ * replaces it the same way.
+ */
+vi.mock('@/app/lib/buildStamp', async () => {
+  const actual = await vi.importActual<typeof import('@/app/lib/buildStamp')>('@/app/lib/buildStamp');
+  return { ...actual, BUILD_ID: 'aaaaaaaaaaaa' };
+});
+
+const reload = vi.fn();
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  reload.mockClear();
+  window.localStorage.clear();
+  Object.defineProperty(window, 'location', {
+    configurable: true,
+    value: { ...window.location, reload },
+  });
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('useBuildReload', () => {
+  it('holds still while the tab and the server agree', () => {
+    renderHook(() => useBuildReload(BUILD_ID));
+    vi.advanceTimersByTime(CONFIRM_MS * 3);
+    expect(reload).not.toHaveBeenCalled();
+  });
+
+  it('holds still before the poll has answered', () => {
+    renderHook(() => useBuildReload(null));
+    vi.advanceTimersByTime(CONFIRM_MS * 3);
+    expect(reload).not.toHaveBeenCalled();
+  });
+
+  // A rollout can hand out one response from each side, so a single
+  // disagreement must not black out the glass.
+  it('does not reload on a mismatch that has not held long enough', () => {
+    renderHook(() => useBuildReload('bbbbbbbbbbbb'));
+    vi.advanceTimersByTime(CONFIRM_MS - 1_000);
+    expect(reload).not.toHaveBeenCalled();
+  });
+
+  it('reloads once the mismatch has held', () => {
+    renderHook(() => useBuildReload('bbbbbbbbbbbb'));
+    vi.advanceTimersByTime(CONFIRM_MS + 1_000);
+    expect(reload).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not reload again inside the cooldown', () => {
+    window.localStorage.setItem(LAST_RELOAD_KEY, String(Date.now() - 1_000));
+    renderHook(() => useBuildReload('bbbbbbbbbbbb'));
+    vi.advanceTimersByTime(CONFIRM_MS + 1_000);
+    expect(reload).not.toHaveBeenCalled();
+  });
+
+  it('reloads again once the cooldown has passed', () => {
+    window.localStorage.setItem(LAST_RELOAD_KEY, String(Date.now() - RELOAD_COOLDOWN_MS - 1_000));
+    renderHook(() => useBuildReload('bbbbbbbbbbbb'));
+    vi.advanceTimersByTime(CONFIRM_MS + 1_000);
+    expect(reload).toHaveBeenCalledTimes(1);
+  });
+
+  // The reload is remembered before it is asked for, so the tab that comes
+  // back knows one already happened even if the mismatch outlives it.
+  it('records the reload it performed', () => {
+    renderHook(() => useBuildReload('bbbbbbbbbbbb'));
+    vi.advanceTimersByTime(CONFIRM_MS + 1_000);
+    expect(window.localStorage.getItem(LAST_RELOAD_KEY)).not.toBeNull();
+  });
+});

--- a/app/components/useBuildReload.ts
+++ b/app/components/useBuildReload.ts
@@ -1,0 +1,81 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+import { BUILD_ID, isStaleBuild, shouldReload } from '@/app/lib/buildStamp';
+
+/** Where a tab remembers its last self-reload, so a stubborn mismatch cannot loop. */
+export const LAST_RELOAD_KEY = 'kiosk:lastBuildReloadAt';
+
+/** How often a confirmed mismatch is re-checked while it lasts. */
+const CHECK_MS = 15_000;
+
+function readLastReload(): number | null {
+  try {
+    const raw = window.localStorage.getItem(LAST_RELOAD_KEY);
+    if (!raw) return null;
+    const ms = Number(raw);
+    return Number.isFinite(ms) ? ms : null;
+  } catch {
+    // Incognito with site data blocked, and the thumbnail contexts. Without
+    // the memory the cooldown cannot be enforced across the reload, which is
+    // survivable: the reloaded tab holds the new build and stops being stale.
+    return null;
+  }
+}
+
+function writeLastReload(ms: number): void {
+  try {
+    window.localStorage.setItem(LAST_RELOAD_KEY, String(ms));
+  } catch {
+    // See above; nothing here is worth failing a reload over.
+  }
+}
+
+/**
+ * Reloads the page once the deployment answering its polls has moved on from
+ * the build this page is running.
+ *
+ * The kiosk tabs run the JavaScript they loaded at boot and nothing has ever
+ * moved them off it: after a kiosk-affecting merge, someone had to run
+ * `scripts/pi/kiosk-doctor.sh --sync --reload` by hand, and when nobody did,
+ * the glass drew an old composition beside a studio drawing the new one — a
+ * disagreement with no bug behind it (2026-09-06, again 2026-09-08).
+ *
+ * Deliberately slow to act. The mismatch has to hold for CONFIRM_MS before
+ * anything happens, because a rollout swaps the serving bundle over a few
+ * seconds and a stamp read mid-swap can disagree once and agree again; and a
+ * tab will not reload twice inside RELOAD_COOLDOWN_MS, because the one way
+ * this could hurt the glass is a loop against an edge cache still handing out
+ * the old HTML. Settings still reach the Pi on their own within a minute;
+ * this is only about code.
+ *
+ * Pass the `build` the poll returned. Null or undefined — an older deployment,
+ * a poll that has not landed — means no information, and nothing happens.
+ */
+export function useBuildReload(serverBuild: string | null | undefined): void {
+  // Kept across renders, not in state: seeing the mismatch must not itself
+  // cause the render that re-reads it.
+  const staleSinceMs = useRef<number | null>(null);
+
+  useEffect(() => {
+    if (!isStaleBuild(BUILD_ID, serverBuild)) {
+      staleSinceMs.current = null;
+      return;
+    }
+    if (staleSinceMs.current == null) staleSinceMs.current = Date.now();
+
+    const check = () => {
+      if (!shouldReload({
+        staleSinceMs: staleSinceMs.current,
+        nowMs: Date.now(),
+        lastReloadAtMs: readLastReload(),
+      })) return;
+      writeLastReload(Date.now());
+      window.location.reload();
+    };
+
+    check();
+    const t = setInterval(check, CHECK_MS);
+    return () => clearInterval(t);
+  }, [serverBuild]);
+}

--- a/app/lib/buildStamp.test.ts
+++ b/app/lib/buildStamp.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest';
+import {
+  DEV_BUILD, CONFIRM_MS, RELOAD_COOLDOWN_MS, isStaleBuild, shouldReload,
+} from './buildStamp';
+
+describe('isStaleBuild', () => {
+  it('is false when the two stamps match', () => {
+    expect(isStaleBuild('abc123', 'abc123')).toBe(false);
+  });
+
+  it('is true when a tab built from one commit talks to a server built from another', () => {
+    expect(isStaleBuild('abc123', 'def456')).toBe(true);
+  });
+
+  it('is false before the first poll answers', () => {
+    expect(isStaleBuild('abc123', null)).toBe(false);
+    expect(isStaleBuild('abc123', undefined)).toBe(false);
+    expect(isStaleBuild('abc123', '')).toBe(false);
+  });
+
+  // `next dev` has no commit to stamp with, so both ends read DEV_BUILD and a
+  // developer editing code must never be told their own tab is behind.
+  it('is false whenever either end is a dev build', () => {
+    expect(isStaleBuild(DEV_BUILD, 'def456')).toBe(false);
+    expect(isStaleBuild('abc123', DEV_BUILD)).toBe(false);
+    expect(isStaleBuild(DEV_BUILD, DEV_BUILD)).toBe(false);
+  });
+});
+
+describe('shouldReload', () => {
+  const now = 1_000_000_000;
+
+  it('does not reload a tab that is not stale', () => {
+    expect(shouldReload({ staleSinceMs: null, nowMs: now, lastReloadAtMs: null })).toBe(false);
+  });
+
+  // A deploy replaces the serving bundle over a few seconds, so a stamp read
+  // mid-swap can disagree once and agree again. Waiting the mismatch out costs
+  // nothing and keeps a rollout from blanking both screens.
+  it('waits for the mismatch to persist before reloading', () => {
+    expect(shouldReload({ staleSinceMs: now - 1_000, nowMs: now, lastReloadAtMs: null })).toBe(false);
+    expect(shouldReload({ staleSinceMs: now - CONFIRM_MS, nowMs: now, lastReloadAtMs: null })).toBe(true);
+  });
+
+  // The one way this could hurt the glass is a loop: a mismatch that survives
+  // its own reload (an edge cache still serving the old HTML) would otherwise
+  // reload every minute for as long as it lasted.
+  it('will not reload again inside the cooldown', () => {
+    const stale = { staleSinceMs: now - CONFIRM_MS, nowMs: now };
+    expect(shouldReload({ ...stale, lastReloadAtMs: now - 1_000 })).toBe(false);
+    expect(shouldReload({ ...stale, lastReloadAtMs: now - RELOAD_COOLDOWN_MS })).toBe(true);
+  });
+});

--- a/app/lib/buildStamp.ts
+++ b/app/lib/buildStamp.ts
@@ -1,0 +1,66 @@
+/**
+ * Which build a page is running, so a tab can tell it has fallen behind the
+ * one production is serving.
+ *
+ * The problem this solves: a browser tab runs the JavaScript it loaded until
+ * something reloads it. Nothing in the app ever did. A studio left open across
+ * a deploy goes on drawing the old caption, the old dials and the old
+ * defaults, and disagrees with the glass about a composition they share every
+ * line of code for — which reads as a bug in the code and is not one. The Pi's
+ * kiosk tabs have the same problem from the other end: they held a build 12
+ * hours older than main until someone ran the doctor script by hand.
+ *
+ * The stamp is the commit the bundle was BUILT from, inlined by next.config's
+ * `env` at build time. Both halves read this same constant: the client from
+ * the chunk it loaded, the server from the deployment answering the poll. They
+ * differ exactly when the tab is behind, and no runtime environment variable
+ * has to be present for that comparison to be right — a missing one would make
+ * every tab look stale forever, which on the glass would be a reload loop.
+ */
+
+/** What both ends stamp when there is no commit to name: `next dev`, and tests. */
+export const DEV_BUILD = 'dev';
+
+/**
+ * The build this bundle was compiled from. Inlined at build time, so the value
+ * a tab holds is the value its own chunks were built with, however old.
+ */
+export const BUILD_ID: string = process.env.NEXT_PUBLIC_BUILD_ID || DEV_BUILD;
+
+/** How long a mismatch must hold before the glass reloads itself. */
+export const CONFIRM_MS = 90_000;
+
+/** The shortest gap between two self-reloads, so a mismatch cannot loop. */
+export const RELOAD_COOLDOWN_MS = 15 * 60_000;
+
+/**
+ * Whether a page loaded from `client` is behind the server answering it.
+ *
+ * Deliberately false unless both stamps are real and different: an absent
+ * server stamp (an older deployment, a poll that has not landed) means "no
+ * information", never "you are stale", and a dev build is never compared
+ * because every `next dev` bundle carries the same one.
+ */
+export function isStaleBuild(client: string, server: string | null | undefined): boolean {
+  if (!client || !server) return false;
+  if (client === DEV_BUILD || server === DEV_BUILD) return false;
+  return client !== server;
+}
+
+/**
+ * Whether the glass should reload itself now: the mismatch has held long
+ * enough to be a deploy rather than a rollout's half-second, and this tab has
+ * not already reloaded for one recently.
+ */
+export function shouldReload({ staleSinceMs, nowMs, lastReloadAtMs }: {
+  /** When this tab first saw the mismatch, or null while it agrees with the server. */
+  staleSinceMs: number | null;
+  nowMs: number;
+  /** When this tab last reloaded itself, across reloads; null when it never has. */
+  lastReloadAtMs: number | null;
+}): boolean {
+  if (staleSinceMs == null) return false;
+  if (nowMs - staleSinceMs < CONFIRM_MS) return false;
+  if (lastReloadAtMs != null && nowMs - lastReloadAtMs < RELOAD_COOLDOWN_MS) return false;
+  return true;
+}

--- a/app/studio/DeployHistory.test.tsx
+++ b/app/studio/DeployHistory.test.tsx
@@ -27,7 +27,7 @@ function api(over: Partial<StudioSettingsApi> = {}): StudioSettingsApi {
     effective: () => ({}), setKnob: vi.fn(), resetSection: vi.fn(), applyNamespace: () => [],
     diffByNamespace: {}, diffCount: 1,
     deploy: async () => {}, revert: async () => {}, saveTake: vi.fn(async () => null), deployedAtMs: null, droppedKeys: [],
-    deploys, loadDeploy: vi.fn(async () => []), relabelDeploy: vi.fn(async () => {}), lastDeployRecorded: null,
+    deploys, loadDeploy: vi.fn(async () => []), relabelDeploy: vi.fn(async () => {}), lastDeployRecorded: null, staleBuild: false,
     ...over,
   };
 }

--- a/app/studio/Header.test.tsx
+++ b/app/studio/Header.test.tsx
@@ -16,7 +16,7 @@ function api(over: Partial<StudioSettingsApi> = {}): StudioSettingsApi {
     setKnob: vi.fn(), resetSection: vi.fn(), applyNamespace: () => [],
     diffByNamespace: { shared: ['activeVersion'] }, diffCount: 3,
     deploy: async () => {}, revert: vi.fn(async () => {}), saveTake: async () => null, deployedAtMs: null, droppedKeys: [],
-    deploys: [], loadDeploy: async () => [], relabelDeploy: async () => {}, lastDeployRecorded: null,
+    deploys: [], loadDeploy: async () => [], relabelDeploy: async () => {}, lastDeployRecorded: null, staleBuild: false,
     ...over,
   };
 }
@@ -52,6 +52,23 @@ describe('Header', () => {
     render(<Header api={api({ diffCount: 0, diffByNamespace: {}, droppedKeys: [{ key: 'x', reason: 'unknown' }, { key: 'y', reason: 'invalid' }] })} nowMs={NOW} />);
     expect(screen.getByTestId('status-line')).toHaveTextContent('dials match glass');
     expect(screen.getByTestId('status-dropped')).toHaveTextContent('2 dropped');
+  });
+  // The preview and the glass draw from the same components, so the only way
+  // they can disagree about a composition is that this tab is running older
+  // code than the site is serving. Saying so here is what stops that reading
+  // as a bug in the caption.
+  it('says nothing about the build while the tab is current', () => {
+    render(<Header api={api()} nowMs={NOW} />);
+    expect(screen.queryByTestId('status-stale-build')).toBeNull();
+  });
+  it('offers a reload when the tab is behind the deployment it is talking to', () => {
+    render(<Header api={api({ staleBuild: true })} nowMs={NOW} />);
+    const chip = screen.getByTestId('status-stale-build');
+    expect(chip).toHaveTextContent('new build');
+    const reload = vi.fn();
+    Object.defineProperty(window, 'location', { configurable: true, value: { ...window.location, reload } });
+    fireEvent.click(chip);
+    expect(reload).toHaveBeenCalled();
   });
   it('renders deploy, the nav toggle in its slot and the extra slot, all unshrinkable, with the status line the only flexible member', () => {
     render(<Header api={api()} nowMs={NOW} extra={<button>save take</button>} />);

--- a/app/studio/Header.tsx
+++ b/app/studio/Header.tsx
@@ -20,6 +20,17 @@ const red = '#e5484d';
 const DISCARD_TITLE =
   "Copy the glass's dials back into the studio, discarding undeployed edits";
 
+/**
+ * What a stale tab means, said where the operator is looking when it bites.
+ * The preview and the glass draw a composition from the same components, so
+ * the only way they can disagree is that one of them is running older code —
+ * and the tab nobody ever reloads is this one.
+ */
+const STALE_BUILD_TITLE =
+  'This tab is running an older build than the site is serving, so its ' +
+  'preview can disagree with the glass and its rail can be missing dials ' +
+  'that exist. Reload to catch up; dial values are already saved.';
+
 /** What a dropped key means, in the one place that now reports them. */
 const DROPPED_TITLE =
   'The server stored every other value but discarded these. An ' +
@@ -190,6 +201,29 @@ export function Header({
         }}
       >
         {parts.join(' · ')}
+        {api.staleBuild && (
+          <>
+            {' · '}
+            <button
+              type="button"
+              data-testid="status-stale-build"
+              title={STALE_BUILD_TITLE}
+              onClick={() => window.location.reload()}
+              style={{
+                background: 'transparent',
+                border: 'none',
+                padding: 0,
+                fontFamily: mono,
+                fontSize: 11,
+                color: red,
+                fontWeight: 700,
+                cursor: 'pointer',
+              }}
+            >
+              ⚠ new build — reload
+            </button>
+          </>
+        )}
         {api.droppedKeys.length > 0 && (
           <>
             {' · '}

--- a/app/studio/Rail.test.tsx
+++ b/app/studio/Rail.test.tsx
@@ -24,7 +24,7 @@ function api(over: Partial<StudioSettingsApi> = {}): StudioSettingsApi {
     setKnob: vi.fn(), resetSection: vi.fn(), applyNamespace: () => [],
     diffByNamespace: {}, diffCount: 0,
     deploy: async () => {}, revert: async () => {}, saveTake: async () => null, deployedAtMs: null, droppedKeys: [],
-    deploys: [], loadDeploy: async () => [], relabelDeploy: async () => {}, lastDeployRecorded: null,
+    deploys: [], loadDeploy: async () => [], relabelDeploy: async () => {}, lastDeployRecorded: null, staleBuild: false,
     ...over,
   };
 }

--- a/app/studio/StudioClient.test.tsx
+++ b/app/studio/StudioClient.test.tsx
@@ -54,7 +54,7 @@ function api(): StudioSettingsApi {
     setKnob: vi.fn(), resetSection: vi.fn(), applyNamespace: () => [],
     diffByNamespace: {}, diffCount: 0,
     deploy: async () => {}, revert: async () => {}, saveTake: async () => null, deployedAtMs: null, droppedKeys: [],
-    deploys: [], loadDeploy: async () => [], relabelDeploy: async () => {}, lastDeployRecorded: null,
+    deploys: [], loadDeploy: async () => [], relabelDeploy: async () => {}, lastDeployRecorded: null, staleBuild: false,
   };
 }
 

--- a/app/studio/useStudioSettings.ts
+++ b/app/studio/useStudioSettings.ts
@@ -16,6 +16,7 @@ import {
 import { schemaFor, KNOWN_NAMESPACES } from '@/app/lib/settings/knownSchemas';
 import type { ProfileSettings } from '@/app/lib/settings/store';
 import type { DeployRow, DroppedDeployKey } from '@/app/lib/settings/deploys';
+import { BUILD_ID, isStaleBuild } from '@/app/lib/buildStamp';
 
 const DEBOUNCE_MS = 400;
 const SETTINGS_URL = '/api/kiosk/settings';
@@ -25,6 +26,8 @@ interface SettingsResponse {
   studio: ProfileSettings;
   live: ProfileSettings;
   lastPollAt: string | null;
+  /** The build the deployment answering this poll was compiled from (buildStamp.ts). */
+  build?: string;
 }
 
 export interface StudioSettingsApi {
@@ -59,6 +62,14 @@ export interface StudioSettingsApi {
   lastDeployRecorded: boolean | null;
   deployedAtMs: number | null; // Date.now() at last successful deploy this session
   droppedKeys: DroppedKey[]; // keys the last PATCH per namespace could not store
+  /**
+   * Whether this tab is running an older build than the deployment it is
+   * talking to. A studio left open across a deploy goes on drawing the old
+   * preview with the old dial set, and then disagrees with the glass about a
+   * composition they share every line of code for — which reads as a bug and
+   * is not one. False until a poll says otherwise, and always false in dev.
+   */
+  staleBuild: boolean;
 }
 
 const fetcher = (url: string) => fetch(url).then((r) => r.json());
@@ -387,5 +398,6 @@ export function useStudioSettings(): StudioSettingsApi {
     lastDeployRecorded,
     deployedAtMs,
     droppedKeys,
+    staleBuild: isStaleBuild(BUILD_ID, data?.build),
   };
 }

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,6 +1,20 @@
 import type { NextConfig } from 'next';
 
+/**
+ * The commit this build was compiled from, inlined into every bundle — client
+ * chunks and server routes alike — so a page can tell whether it is still the
+ * one production is serving. See app/lib/buildStamp.ts for why it is read at
+ * build time rather than from the runtime environment.
+ *
+ * Vercel sets VERCEL_GIT_COMMIT_SHA in the build container. Locally there is
+ * nothing to name, and 'dev' switches the comparison off entirely.
+ */
+const BUILD_ID = process.env.VERCEL_GIT_COMMIT_SHA?.slice(0, 12) || 'dev';
+
 const nextConfig: NextConfig = {
+  env: {
+    NEXT_PUBLIC_BUILD_ID: BUILD_ID,
+  },
   images: {
     remotePatterns: [
       {


### PR DESCRIPTION
## Why

Twice now a composition mismatch between the glass and the studio preview has been read as a bug in shared code, and twice it was a browser tab running JavaScript it loaded hours earlier.

- **2026-09-06** the stale tab was the Pi's: the caption sat at `pictureTop`'s default, a dial deleted in #145.
- **2026-09-08** (tonight) it was the studio's, drawing the pre-#186 caption order beside a Pi drawing the new one.

Both surfaces call the same pure layout functions, so no code path can transpose them. That is exactly why the disagreement is expensive: the evidence you need is not in the code, it is which build each page is running, and nothing in the app could tell you that.

## What this adds

| | before | after |
|---|---|---|
| studio tab across a deploy | draws the old preview silently | red `⚠ new build — reload` in the status strip |
| kiosk tab across a deploy | runs old code until someone runs kiosk-doctor | reloads itself after 90 s |

- `next.config` inlines the build's commit as `NEXT_PUBLIC_BUILD_ID`. **Both ends of the comparison read that same build-time constant** — the client from the chunk it loaded, the server from the deployment answering the poll. No runtime env var has to be present for the comparison to be right, which matters: a missing one would make every tab look stale forever, and on the glass that is a reload loop.
- The stamp rides on the two routes that are **already polled** — the solo state route (glass, 60 s) and the settings route (studio, 30 s). No new request on either surface.
- The glass reloads only after the mismatch has held **90 s** (a rollout swaps the serving bundle over a few seconds and can disagree once), and never twice inside **15 minutes**, remembered in `localStorage` across the reload, so a mismatch that survives its own reload cannot loop.
- Silent in dev: with no commit to name, both ends stamp `dev` and the comparison is off.

This is the follow-up idea recorded when the kiosk reload runbook landed (#127). It does not replace `kiosk-doctor` for a tab that is wedged rather than merely old.

## Verification

- A build with `VERCEL_GIT_COMMIT_SHA` set inlines the 12-char stamp into a client chunk **and** both server route bundles; the full sha never ships.
- `npm run test` — 2559 passed, 295 files.
- `npm run lint` — no new warnings.
- 14 new tests: the comparison rules, the reload's confirm delay and cooldown, and the header chip.

## Before the show

Worth merging before the Wednesday freeze: after it, every kiosk-affecting merge picks itself up on the glass instead of needing a hand. If you would rather the glass never reload itself during the show, say so and I will gate the kiosk half behind a dial.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XsPKPsCn9rZxmAx958g833
