### PR TITLE
fix(solo2): the burn is added to the last frame, not taken out of it

### DIFF
--- a/app/lib/solo/replay.test.ts
+++ b/app/lib/solo/replay.test.ts
@@ -168,8 +168,10 @@ describe('replay', () => {
       sun(1, 0.9, { webcamId: 7, capturedAt: 100 }), sun(3, 0.7, { webcamId: 7, capturedAt: 300 }),
       sun(2, 0.8, { webcamId: 8, capturedAt: 150 }),
     ];
-    // A solo2 dwell is the 20 s budget plus the 1.5 s arrival segment (dwell-budget spec §3.3), so the window reaches past one of them.
-    const strip = replay({ feed: FEED, version: SOLO_VERSIONS.solo2, dials: d2, entries: rows, priorDraws: [], fromMs: at(SLOT0), toMs: at(SLOT0) + 21_500 });
+    // A solo2 dwell is the 20 s budget plus the camera change's two segments —
+    // a 1.5 s rise in front and a 0.75 s burn behind (dwell-budget spec §3.3)
+    // — so the window reaches past one of them.
+    const strip = replay({ feed: FEED, version: SOLO_VERSIONS.solo2, dials: d2, entries: rows, priorDraws: [], fromMs: at(SLOT0), toMs: at(SLOT0) + 22_250 });
     expect(strip.frames[0]).toMatchObject({ snapshotId: 3, shownSnapshotIds: [1, 3] });
     expect(strip.frames[1].snapshotId).toBe(2);
   });

--- a/app/lib/solo/versions.test.ts
+++ b/app/lib/solo/versions.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { arrivalS } from '@/app/lib/solo2/plan';
+import { arrivalS, exitS } from '@/app/lib/solo2/plan';
 import { schemaDefaults } from '@/app/lib/settings/schema';
 import { project } from './engine';
 import { SOLO_VERSIONS, resolveSoloVersion } from './versions';
@@ -38,9 +38,10 @@ describe('descriptors', () => {
     for (const v of Object.values(SOLO_VERSIONS)) {
       // solo2's spread swings the budget by rank; pinned so the dwell is the dial here.
       const d = { ...v.dialsFrom(schemaDefaults(v.schema)), dwellBoost: 0, dwellTrim: 0 };
-      // solo2's dwell opens with the camera change's own segment (dwell-budget
-      // spec §3.3); solo's dials have no fades, so its arrival is 0.
-      const expected = (d.dwellS + arrivalS(d)) * 1000;
+      // solo2's dwell carries the camera change's own segments outside the
+      // frames' budget (dwell-budget spec §3.3): the rise in front and the
+      // burn behind. solo's dials have no fades, so both are 0.
+      const expected = (d.dwellS + arrivalS(d) + exitS(d)) * 1000;
       expect(v.dwellMs(entries, entries[0], d)).toBe(expected);
       // Pure: same answer for a different pick, and no mutation of the input.
       expect(v.dwellMs(entries, entries[2], d)).toBe(expected);

--- a/app/lib/solo2/engine.test.ts
+++ b/app/lib/solo2/engine.test.ts
@@ -163,9 +163,12 @@ describe('the camera run', () => {
 describe('dwellMs2: the budget rule over the frames actually played', () => {
   // The spread swings the budget by rank; this suite is about the rule, so it pins the dial.
   const D2 = { ...dialsFrom2(schemaDefaults(SOLO2_SETTINGS_SCHEMA)), cameraRun: true, dwellBoost: 0, dwellTrim: 0 };
-  // The camera change's own segment at the default fades (dwell-budget spec
-  // §3.3): every dwell is this much longer than the frames' budget.
+  // The camera change's own segments at the default fades (dwell-budget spec
+  // §3.3): the rise in front of the frames and the burn behind them. Both sit
+  // outside the frames' budget, so every dwell is this much longer than it.
   const ARRIVAL = 1_500;
+  const EXIT = 750;
+  const CHANGE = ARRIVAL + EXIT;
   const frame = (id: number, cam: number, at: number, bin: 'sunset' | 'non_sunset' = 'sunset') => ({
     snapshotId: id, webcamId: cam, bin, quality: bin === 'sunset' ? 0.9 : null, detection: 0.9,
     isNew: false, tally: 0, enteredAt: at, capturedAt: at,
@@ -173,32 +176,32 @@ describe('dwellMs2: the budget rule over the frames actually played', () => {
 
   it('a lone frame holds the whole dwell', () => {
     const one = [frame(1, 7, 1000)];
-    expect(dwellMs2(one, one[0], D2)).toBe(D2.dwellS * 1000 + ARRIVAL);
+    expect(dwellMs2(one, one[0], D2)).toBe(D2.dwellS * 1000 + CHANGE);
   });
 
   it('below the threshold the dwell does not move however many frames play', () => {
     const five = Array.from({ length: 5 }, (_, i) => frame(i + 1, 7, (i + 1) * 1000));
-    expect(dwellMs2(five, five[4], D2)).toBe(D2.dwellS * 1000 + ARRIVAL);
+    expect(dwellMs2(five, five[4], D2)).toBe(D2.dwellS * 1000 + CHANGE);
   });
 
   it('above it the dwell stretches, and the sunset cap sets the ceiling', () => {
     const twelve = Array.from({ length: 12 }, (_, i) => frame(i + 1, 7, (i + 1) * 1000));
     // 12 frames capped to 8, each held at the 4 s floor: 32 s, not 48.
-    expect(dwellMs2(twelve, twelve[11], D2)).toBe(32_000 + ARRIVAL);
+    expect(dwellMs2(twelve, twelve[11], D2)).toBe(32_000 + CHANGE);
   });
 
   it('a non-sunset can never stretch the dwell at the default cap (spec §4.1)', () => {
     // The cap of 3 sits below the threshold of 5, so the budget is merely
     // divided more finely: this dial buys pictures, never screen time.
     const twelve = Array.from({ length: 12 }, (_, i) => frame(i + 1, 7, (i + 1) * 1000, 'non_sunset'));
-    expect(dwellMs2(twelve, twelve[11], D2)).toBe(D2.dwellS * 1000 + ARRIVAL);
+    expect(dwellMs2(twelve, twelve[11], D2)).toBe(D2.dwellS * 1000 + CHANGE);
     expect(shown2(twelve, twelve[11], D2)).toHaveLength(3);
   });
 
   it('raising the non-sunset cap past the threshold breaks that guarantee', () => {
     // Recorded because it is the invariant's failure mode, not a nicety.
     const twelve = Array.from({ length: 12 }, (_, i) => frame(i + 1, 7, (i + 1) * 1000, 'non_sunset'));
-    expect(dwellMs2(twelve, twelve[11], { ...D2, runFramesOther: 8 })).toBe(32_000 + ARRIVAL);
+    expect(dwellMs2(twelve, twelve[11], { ...D2, runFramesOther: 8 })).toBe(32_000 + CHANGE);
   });
 
   it('agrees with what shown2 puts on glass, always', () => {

--- a/app/lib/solo2/plan.test.ts
+++ b/app/lib/solo2/plan.test.ts
@@ -53,15 +53,16 @@ describe('the arrival segment: the camera change is added before frame 1, not ch
   });
 
   it('sits on top of the budget: the frames still divide dwellS, and the dwell is arrivalS longer', () => {
-    expect(fitPlan({ ...D, ...F }, 5)).toEqual({ dwellS: 21.5, frames: 5, stepS: 4, lastStepS: 4, leadS: 4, arrivalS: 1.5, exitS: 0.75 });
-    expect(fitPlan({ ...D, ...F }, 1)).toEqual({ dwellS: 21.5, frames: 1, stepS: 20, lastStepS: 20, leadS: 4, arrivalS: 1.5, exitS: 0.75 });
+    // 1.5 s arrival + 5 × 4 s + 0.75 s exit; the last frame's step carries the burn on its end.
+    expect(fitPlan({ ...D, ...F }, 5)).toEqual({ dwellS: 22.25, frames: 5, stepS: 4, lastStepS: 4.75, leadS: 4, arrivalS: 1.5, exitS: 0.75 });
+    expect(fitPlan({ ...D, ...F }, 1)).toEqual({ dwellS: 22.25, frames: 1, stepS: 20, lastStepS: 20.75, leadS: 4, arrivalS: 1.5, exitS: 0.75 });
     // A stretched run stretches from the same base.
-    expect(fitPlan({ ...D, ...F }, 8)).toEqual({ dwellS: 33.5, frames: 8, stepS: 4, lastStepS: 4, leadS: 4, arrivalS: 1.5, exitS: 0.75 });
+    expect(fitPlan({ ...D, ...F }, 8)).toEqual({ dwellS: 34.25, frames: 8, stepS: 4, lastStepS: 4.75, leadS: 4, arrivalS: 1.5, exitS: 0.75 });
   });
 
   it('does not move the stretch threshold: the frames\' budget is still dwellS', () => {
-    for (let frames = 1; frames <= 5; frames++) expect(fitPlan({ ...D, ...F }, frames).dwellS).toBeCloseTo(21.5, 6);
-    expect(fitPlan({ ...D, ...F }, 6).dwellS).toBeCloseTo(25.5, 6);
+    for (let frames = 1; frames <= 5; frames++) expect(fitPlan({ ...D, ...F }, frames).dwellS).toBeCloseTo(22.25, 6);
+    expect(fitPlan({ ...D, ...F }, 6).dwellS).toBeCloseTo(26.25, 6);
   });
 
   it('the stage clock waits out the arrival, so frame 1 holds a whole step once it is up', () => {
@@ -76,10 +77,10 @@ describe('the arrival segment: the camera change is added before frame 1, not ch
   });
 
   it('the lead still measures back from the end of the whole dwell', () => {
-    const p = fitPlan({ ...D, ...F }, 4); // dwell 21.5 s, lead over 17.5–21.5
-    expect(stageAt(17_499, p).leadProgress).toBe(0);
-    expect(stageAt(19_500, p).leadProgress).toBe(0.5);
-    expect(stageAt(21_500, p).leadProgress).toBe(1);
+    const p = fitPlan({ ...D, ...F }, 4); // dwell 22.25 s, lead over 18.25–22.25
+    expect(stageAt(18_249, p).leadProgress).toBe(0);
+    expect(stageAt(20_250, p).leadProgress).toBe(0.5);
+    expect(stageAt(22_250, p).leadProgress).toBe(1);
   });
 
   it('the studio line names it', () => {
@@ -158,20 +159,20 @@ describe('planOf: the budget rule run backward from a pinned total', () => {
     expect(p.dwellS).toBe(22);
     expect(p.frames).toBe(4);
     expect(p.arrivalS).toBe(3); // the rise half of the dip
-    expect(p.exitS).toBe(3); // the burn half, inside the last step
-    expect(p.stepS).toBe(4.75); // (22 - 3) / 4
-    expect(p.lastStepS).toBe(4.75); // the exit fits inside an even share
+    expect(p.exitS).toBe(3); // the burn half, on the end of the last step
+    expect(p.stepS).toBe(4); // (22 - 3 - 3) / 4
+    expect(p.lastStepS).toBe(7); // its own step, then the burn
   });
 
-  it('gives the last frame more than an even share when its dissolve-in and the exit will not fit one', () => {
-    // 3 s exit, 2 s dissolve-in, 4 s share: the last frame needs 5, the others
-    // give it up. 3 + 4×3 + 5 = 20 — what fitPlan sizes at the live dials.
+  it('gives the last frame a whole step of its own and then the burn', () => {
+    // 3 s rise, four 4 s frames, 3 s burn: 3 + 4×4 + 3 = 22 — what fitPlan
+    // sizes at the live dials, and the last frame holds its 4 s like the rest.
     const dials = { ...D, minStepS: 4, transition: 'dip' as const, fadeS: 6, sameCameraFadeS: 2 };
     const forward = fitPlan({ ...dials, dwellS: 12 }, 4);
-    expect(forward).toMatchObject({ dwellS: 20, stepS: 4, lastStepS: 5, arrivalS: 3, exitS: 3 });
-    const back = planOf(20, 4, dials);
+    expect(forward).toMatchObject({ dwellS: 22, stepS: 4, lastStepS: 7, arrivalS: 3, exitS: 3 });
+    const back = planOf(22, 4, dials);
     expect(back.stepS).toBeCloseTo(4, 6);
-    expect(back.lastStepS).toBeCloseTo(5, 6);
+    expect(back.lastStepS).toBeCloseTo(7, 6);
   });
 
   it('is the inverse of fitPlan: what fitPlan sized, planOf takes apart again', () => {
@@ -186,7 +187,7 @@ describe('planOf: the budget rule run backward from a pinned total', () => {
     // frames at 20 s. The draw pinned 62 s, so each frame gets 18.67 s.
     const p = planOf(62, 3, { ...D, transition: 'dip', fadeS: 6 });
     expect(p.dwellS).toBe(62);
-    expect(p.stepS).toBeCloseTo(19.667, 3); // (62 - 3) / 3
+    expect(p.stepS).toBeCloseTo(18.667, 3); // (62 - 3 - 3) / 3
   });
 
   it('never leaves a step of zero, whatever a degenerate span asks for', () => {
@@ -218,31 +219,83 @@ describe('the exit: a dip is charged half to the dwell it leaves', () => {
     expect(exitS({})).toBe(0);
   });
 
-  it('shortens the whole dwell by the half that now belongs to the leaving side', () => {
-    // Before: 6 + 4×4 = 22. Now: 3 + 4×3 + max(4, 2 + 3) = 20.
-    expect(fitPlan(live, 4).dwellS).toBe(20);
-    // At a change no longer than the step it fits inside the last frame and costs nothing.
-    expect(fitPlan({ ...live, fadeS: 4 }, 4)).toMatchObject({ dwellS: 18, stepS: 4, lastStepS: 4, arrivalS: 2, exitS: 2 });
+  it('moves half the change to the leaving side without changing what the change costs', () => {
+    // The dwell is the same length either way — 6 s of change is 6 s of change
+    // — but the half that shows the OLD picture now runs while the old picture
+    // is still on glass, instead of after the new dwell has already begun.
+    expect(fitPlan(live, 4)).toMatchObject({ dwellS: 22, stepS: 4, lastStepS: 7, arrivalS: 3, exitS: 3 });
+    expect(fitPlan({ ...live, fadeS: 4 }, 4)).toMatchObject({ dwellS: 20, stepS: 4, lastStepS: 6, arrivalS: 2, exitS: 2 });
   });
 
-  it('a lone frame has no dissolve-in, so only the exit has to fit', () => {
-    // Budget 13 shares nothing; 13 > 3, so the frame holds 13 and burns over its last 3.
-    expect(fitPlan(live, 1)).toMatchObject({ dwellS: 16, stepS: 13, lastStepS: 13, exitS: 3 });
+  it('a lone frame holds its whole step and then burns', () => {
+    // Budget 13 shares nothing, so the frame holds 13 and the burn follows it.
+    expect(fitPlan(live, 1)).toMatchObject({ dwellS: 19, stepS: 13, lastStepS: 16, exitS: 3 });
   });
 
   it('stageAt reports the exit over the last exitS, and the run index stays on the last frame through it', () => {
-    const p = fitPlan(live, 4); // 3 arrival, 4 4 4, last 5 (2 in + 3 burn): burn 17–20
-    expect(stageAt(16_999, p).exitProgress).toBe(0);
-    expect(stageAt(17_000, p).exitProgress).toBe(0);
-    expect(stageAt(18_500, p).exitProgress).toBe(0.5);
-    expect(stageAt(20_000, p).exitProgress).toBe(1);
-    expect(stageAt(18_500, p).index).toBe(3);
+    const p = fitPlan(live, 4); // 3 arrival, 4 4 4 4, then the burn: 19–22
+    expect(stageAt(18_999, p).exitProgress).toBe(0);
+    expect(stageAt(19_000, p).exitProgress).toBe(0);
+    expect(stageAt(20_500, p).exitProgress).toBe(0.5);
+    expect(stageAt(22_000, p).exitProgress).toBe(1);
+    expect(stageAt(20_500, p).index).toBe(3);
     // No exit, no progress.
     expect(stageAt(19_000, fitPlan({ ...live, transition: 'crossfade' }, 4)).exitProgress).toBe(0);
   });
 
-  it('the studio line says so, and names the longer last frame', () => {
-    expect(describePlan(fitPlan(live, 4))).toBe('4 frames × 4 s · last 5 s · arrival 3 s · exit 3 s');
+  it('the studio line says so', () => {
+    expect(describePlan(fitPlan(live, 4))).toBe('4 frames × 4 s · arrival 3 s · exit 3 s');
     expect(describePlan(fitPlan({ ...live, fadeS: 4 }, 4))).toBe('4 frames × 4 s · arrival 2 s · exit 2 s');
+  });
+});
+
+describe('the change is added at the ends, never taken out of a frame', () => {
+  // Reported 2026-09-08: "we're flashing the initial image ... the initial
+  // image dissolves really quickly", worst on the sunrise screen, where the
+  // `exposure` veil blows the picture out to white rather than down to black.
+  // The frame being flashed is the run's LAST: the exit burn was charged
+  // INSIDE its step, so the burn ate the still time. At the 6 s change the
+  // last frame finished dissolving in at the instant the burn began and was
+  // never once still — an entire picture concealed; shortening the change to
+  // 3 s handed back half a second of it, which is the flash.
+  const live = { dwellS: 13, leadS: 0, minStepS: 4, transition: 'dip' as const, sameCameraFadeS: 2 };
+
+  /** The seconds frame `i` holds with nothing moving over it: its step, less its dissolve-in and any burn. */
+  const stillS = (p: ReturnType<typeof fitPlan>, i: number, sameCameraFadeS: number) => {
+    const dissolveIn = i === 0 ? 0 : stepFadeS(sameCameraFadeS, p); // frame 1 arrives on the camera change
+    const start = p.arrivalS + p.stepS * i;
+    const end = i === p.frames - 1 ? p.dwellS - p.exitS : start + p.stepS;
+    return end - start - dissolveIn;
+  };
+
+  it.each([3, 6])('holds the last frame as long as the middle ones, at a %s s change', (fadeS) => {
+    const p = fitPlan({ ...live, fadeS }, 4);
+    expect(stillS(p, 3, live.sameCameraFadeS)).toBeCloseTo(stillS(p, 1, live.sameCameraFadeS), 6);
+    expect(stillS(p, 3, live.sameCameraFadeS)).toBeCloseTo(2, 6);
+  });
+
+  it('adds the exit to the last frame rather than absorbing it', () => {
+    const p = fitPlan({ ...live, fadeS: 3 }, 4);
+    expect(p.lastStepS).toBeCloseTo(p.stepS + p.exitS, 6);
+    // arrival 2 + 4 frames × 4 + exit 1.5
+    expect(p.dwellS).toBeCloseTo(19.5, 6);
+  });
+
+  it('planOf takes the same total apart the same way', () => {
+    const dials = { ...live, fadeS: 3 };
+    const forward = fitPlan(dials, 4);
+    expect(planOf(forward.dwellS, 4, dials)).toEqual(forward);
+    const back = planOf(19.5, 4, dials);
+    expect(back.stepS).toBeCloseTo(4, 6);
+    expect(back.lastStepS).toBeCloseTo(5.5, 6);
+  });
+
+  it('starts the burn the moment the last frame has held its step', () => {
+    const p = fitPlan({ ...live, fadeS: 3 }, 4); // arrival 2, steps 4 4 4, last 4 + 1.5 burn
+    expect(stageAt(17_999, p).exitProgress).toBe(0);
+    expect(stageAt(18_000, p).exitProgress).toBe(0);
+    expect(stageAt(18_750, p).exitProgress).toBeCloseTo(0.5, 6);
+    expect(stageAt(19_500, p).exitProgress).toBe(1);
+    expect(stageAt(18_750, p).index).toBe(3);
   });
 });

--- a/app/lib/solo2/plan.ts
+++ b/app/lib/solo2/plan.ts
@@ -9,9 +9,9 @@ export interface DwellPlan {
   /** Each frame's even share of the frames' budget. */
   stepS: number;
   /**
-   * The last frame's step. Equal to `stepS` whenever its dissolve-in and the
-   * exit fit inside one step; longer only when they do not, so the last
-   * picture is never burning down before it has finished arriving.
+   * The last frame's step: a whole `stepS` of its own, plus the exit. The
+   * burn is ADDED to it rather than taken out of it, so the last picture
+   * holds as still, and for as long, as every other frame of the run.
    */
   lastStepS: number;
   leadS: number;
@@ -26,16 +26,16 @@ export interface DwellPlan {
    */
   arrivalS: number;
   /**
-   * The burn-out at the END of the dwell, inside the last frame's step: the
+   * The burn-out at the END of the dwell, AFTER the last frame's step: the
    * seconds the last picture spends going down into the veil before the next
    * dwell rises out of it. 0 unless the change is a dip.
    *
-   * Charged here rather than to the next dwell's arrival because the picture
-   * on glass during it is THIS dwell's. Until 2026-09-08 the whole change was
-   * reserved at the front of the incoming dwell, so the outgoing one's last
-   * frame held a full still step and only then began to burn: at a 6 s change
-   * and a 4 s step, ten seconds between the last new picture of a run and the
-   * first of the next, against four through the middle of the run.
+   * Charged to this dwell rather than to the next one's arrival because the
+   * picture on glass during it is THIS dwell's. Until 2026-09-08 the whole
+   * change was reserved at the front of the incoming dwell, so the outgoing
+   * one's last frame held a full still step and only then began to burn: at a
+   * 6 s change and a 4 s step, ten seconds between the last new picture of a
+   * run and the first of the next, against four through the middle.
    */
   exitS: number;
 }
@@ -79,13 +79,18 @@ export function exitS(d: FadeDials): number {
 }
 
 /**
- * The last frame's step: a whole step when its dissolve-in and the exit fit,
- * else stretched to hold both. A lone frame has no dissolve-in — it arrives
- * on the camera change — so only the exit has to fit.
+ * The last frame's step: a whole step, plus the exit on the end of it.
+ *
+ * The burn is added rather than absorbed. Absorbing it — `max(stepS,
+ * dissolveIn + exit)` until 2026-09-08 — spent the last frame's still time on
+ * the burn: at the live dials (4 s step, 2 s dissolve, 6 s change) the last
+ * picture of every run finished arriving at the instant it began to leave and
+ * was never once still, and shortening the change to 3 s handed back half a
+ * second of it, which read on glass as a flash. The sunrise screen showed it
+ * worst, where an `exposure` veil blows the picture out to white.
  */
-function lastStepFor(stepS: number, n: number, exit: number, sameCameraFadeS: number | undefined): number {
-  const dissolveIn = n > 1 ? stepFadeS(sameCameraFadeS ?? 0, { stepS }) : 0;
-  return Math.max(stepS, dissolveIn + exit);
+function lastStepFor(stepS: number, exit: number): number {
+  return stepS + exit;
 }
 
 /**
@@ -93,7 +98,7 @@ function lastStepFor(stepS: number, n: number, exit: number, sameCameraFadeS: nu
  * frames share, floored at `minStepS`, and the arrival sits in front of it:
  *
  *     perFrame = max(minStepS, dwellS / n)
- *     total    = arrivalS + perFrame * (n - 1) + lastStepS
+ *     total    = arrivalS + perFrame * n + exitS
  *
  * At or below `n* = floor(dwellS / minStepS)` frames the budget is merely
  * divided more finely and the total stays `dwellS` — one image holds the
@@ -101,10 +106,9 @@ function lastStepFor(stepS: number, n: number, exit: number, sameCameraFadeS: nu
  * the frames shrinking, which is the whole point: a run is a timelapse and a
  * timelapse has one step, so eight frames run 4 s each for 32 s.
  *
- * The exit lives INSIDE the last frame's step (see `exitS`), so at a change
- * no longer than the step the last picture costs no more time than any other.
- * `lastStepS` grows past `stepS` only when the exit and the dissolve-in
- * cannot both fit.
+ * The change's two halves sit OUTSIDE the frames' budget, one at each end:
+ * the rise in front, the burn behind. No frame ever spends its own step
+ * arriving or leaving, so every picture in a run holds equally still.
  *
  * `plan.dwellS` is therefore the total this dwell occupies, not the dial.
  * The lead is capped at that total.
@@ -114,7 +118,7 @@ export function fitPlan(d: PlanDials, frames: number): DwellPlan {
   const stepS = Math.max(d.minStepS, d.dwellS / n);
   const arrival = arrivalS(d);
   const exit = exitS(d);
-  const lastStepS = lastStepFor(stepS, n, exit, d.sameCameraFadeS);
+  const lastStepS = lastStepFor(stepS, exit);
   const totalS = arrival + stepS * (n - 1) + lastStepS;
   return { dwellS: totalS, frames: n, stepS, lastStepS, leadS: Math.min(totalS, Math.max(0, d.leadS)), arrivalS: arrival, exitS: exit };
 }
@@ -140,20 +144,11 @@ export function planOf(totalS: number, frames: number, d: PlanDials): DwellPlan 
   const total = Math.max(0, totalS);
   const arrival = Math.min(arrivalS(d), total);
   const exit = Math.min(exitS(d), total - arrival);
-  const runS = total - arrival;
-  // The frames share the run evenly unless the last one needs more than its
-  // share to hold its dissolve-in plus the exit, in which case it takes what
-  // it needs and the others share the rest. The last step depends on the
-  // step (through the dissolve cap) and the step on the last step, so this
-  // settles by iteration; it converges in two passes because each pass can
-  // only lower the step, and the cap is monotonic in it.
-  let stepS = runS / n;
-  let lastStepS = lastStepFor(stepS, n, exit, d.sameCameraFadeS);
-  for (let i = 0; i < 3 && n > 1 && lastStepS > stepS + 1e-9; i++) {
-    stepS = Math.max(0, (runS - lastStepS) / (n - 1));
-    lastStepS = lastStepFor(stepS, n, exit, d.sameCameraFadeS);
-  }
-  if (n === 1) { stepS = runS; lastStepS = runS; }
+  // Both halves of the change come off the top; what is left is the frames'
+  // own, shared evenly, and the burn goes back on the end of the last one.
+  const runS = total - arrival - exit;
+  const stepS = runS / n;
+  const lastStepS = lastStepFor(stepS, exit);
   return {
     dwellS: total,
     frames: n,
@@ -223,17 +218,18 @@ export function stageAt(elapsedMs: number, p: DwellPlan): Stage {
 }
 
 /**
- * The line the studio prints: `4 frames × 5 s`, `1 frame · 20 s`, `· last 5 s`
- * when the last frame holds longer than the others, `· lead 4 s` when the lead
- * is on, `· arrival 1.5 s` when there is one, `· exit 3 s` when the change is a
- * dip and the last picture burns down inside its step.
+ * The line the studio prints: `4 frames × 5 s`, `1 frame · 20 s`, `· lead 4 s`
+ * when the lead is on, `· arrival 1.5 s` when there is one, `· exit 3 s` when
+ * the change is a dip and the last picture burns down after its step.
+ *
+ * The last frame's step is not named: it is always the step plus the exit now,
+ * so naming it would only repeat the exit back.
  */
 export function describePlan(p: DwellPlan): string {
   const s = (n: number) => `${Number(n.toFixed(1))} s`;
-  const frames = p.frames === 1 ? `1 frame · ${s(p.dwellS - p.arrivalS)}` : `${p.frames} frames × ${s(p.stepS)}`;
-  const last = p.frames > 1 && p.lastStepS > p.stepS + 0.05 ? ` · last ${s(p.lastStepS)}` : '';
+  const frames = p.frames === 1 ? `1 frame · ${s(p.stepS)}` : `${p.frames} frames × ${s(p.stepS)}`;
   const lead = p.leadS > 0 ? ` · lead ${s(p.leadS)}` : '';
   const arrival = p.arrivalS > 0 ? ` · arrival ${s(p.arrivalS)}` : '';
   const exit = p.exitS > 0 ? ` · exit ${s(p.exitS)}` : '';
-  return `${frames}${last}${lead}${arrival}${exit}`;
+  return `${frames}${lead}${arrival}${exit}`;
 }

--- a/app/lib/solo2/settingsSchema.ts
+++ b/app/lib/solo2/settingsSchema.ts
@@ -74,7 +74,7 @@ export const SOLO2_SETTINGS_SCHEMA: SettingsSchema = [
     label: 'camera change', section: 'arrival',
     description: 'The gesture, for both screens. cut: the new picture simply replaces the old. crossfade: the old picture fades out while the new one fades in on top of it. dip: the old picture fades away into a veil, then the new one fades up out of it. Only `dip` reads the veil dial below — the other two are already not ending in darkness.',
   },
-  { ...(solo('fadeS') as NumberKnob), default: 1.5, section: 'arrival', label: 'camera change (s)', description: 'How long a crossfade takes, or a dip (down plus up). Ignored by cut. A crossfade is charged to the front of the arriving dwell. A dip is split: the down half is the leaving dwell\'s exit, burned inside its last frame\'s step, and the up half is the arriving dwell\'s front. So at a dip no longer than the shortest frame, the last picture of a run costs no more time than any other — watch the dwell line on the Play tab.' },
+  { ...(solo('fadeS') as NumberKnob), default: 1.5, section: 'arrival', label: 'camera change (s)', description: 'How long a crossfade takes, or a dip (down plus up). Ignored by cut. A crossfade is charged to the front of the arriving dwell. A dip is split: the down half is the leaving dwell\'s exit and the up half is the arriving dwell\'s front. Both sit OUTSIDE the frames, so no picture ever spends its own time arriving or leaving. That makes this dial the gap at a camera change too: one frame\'s time plus this, against one frame\'s time through the middle of a run — watch the dwell line on the Play tab.' },
   {
     key: 'veilStyle', kind: 'enum', options: ['black', 'crossfade', 'lift', 'exposure'], default: 'black',
     label: 'sunrise change', section: 'arrival',

--- a/app/studio/solo/DwellBudget.tsx
+++ b/app/studio/solo/DwellBudget.tsx
@@ -17,8 +17,9 @@ const mono = 'ui-monospace, SFMono-Regular, Menlo, monospace';
 export function DwellBudget({ dials, frames = 1 }: { dials: PlanDials; frames?: number }) {
   const plan = fitPlan(dials, frames);
   const n = stretchThreshold(dials);
-  // The frames' budget alone: the arrival is on top of the dial by design, not a stretch.
-  const stretched = plan.dwellS - plan.arrivalS > dials.dwellS + 0.001;
+  // The frames' budget alone: both halves of the camera change sit on top of
+  // the dial by design — the rise in front, the burn behind — not a stretch.
+  const stretched = plan.dwellS - plan.arrivalS - plan.exitS > dials.dwellS + 0.001;
   const s = (v: number) => `${Number(v.toFixed(1))} s`;
   return (
     <div data-testid="dwell-budget" title="How the dwell splits for the camera on glass. Below the threshold the frames divide the dwell and it does not move; above it the frames hold at the floor and the dwell stretches." style={{

--- a/app/studio/solo/GlassPreview.test.tsx
+++ b/app/studio/solo/GlassPreview.test.tsx
@@ -70,8 +70,9 @@ it('solo2 plays the on-glass camera\'s run on the studio dials, looping on a loc
   const { SOLO2_SETTINGS_SCHEMA, dialsFrom2 } = await import('@/app/lib/solo2/settingsSchema');
   const { schemaDefaults } = await import('@/app/lib/settings/schema');
   vi.useFakeTimers();
-  // 3 frames → 2 s each, after the 1.5 s arrival segment the default dip adds
-  // at the front of every solo2 dwell (dwell-budget spec §3.3): 7.5 s a dwell.
+  // 3 frames → 2 s each, between the two segments the default dip adds outside
+  // the frames' budget (dwell-budget spec §3.3): a 1 s rise in front and a
+  // 0.75 s burn behind, so 7.75 s a dwell.
   const d2 = { ...dialsFrom2(schemaDefaults(SOLO2_SETTINGS_SCHEMA)), dwellS: 6, sameCameraFadeS: 1, minStepS: 1, dwellBoost: 0, dwellTrim: 0 };
   const older = (id: number, capturedAt: number) => ({ ...entry, snapshotId: id, imageUrl: `u${id}`, capturedAt });
   const entries = [older(5, entry.capturedAt - 20 * 60_000), older(6, entry.capturedAt - 10 * 60_000), entry];
@@ -84,7 +85,7 @@ it('solo2 plays the on-glass camera\'s run on the studio dials, looping on a loc
   expect(screen.getByTestId('top')).toHaveAttribute('src', 'u6');
   await act(async () => { vi.advanceTimersByTime(2_000); });
   expect(screen.getByTestId('top')).toHaveAttribute('src', 'u7');
-  await act(async () => { vi.advanceTimersByTime(2_000); });
+  await act(async () => { vi.advanceTimersByTime(2_400); }); // past the last frame's step and the burn behind it
   expect(screen.getByTestId('top')).toHaveAttribute('src', 'u5'); // round again
 });
 
@@ -127,7 +128,7 @@ it('solo2 plays the queued dwell\'s own camera run once the preview advances', a
   // The on-glass frame is camera 1's only frame: a run of one.
   expect(screen.queryByTestId('seq-1')).toBeNull();
 
-  await act(async () => { vi.advanceTimersByTime(7_600); }); // past the 6 s budget plus the 1.5 s arrival
+  await act(async () => { vi.advanceTimersByTime(8_100); }); // past the 6 s budget, the rise in front of it and the burn behind
   expect(screen.getByText(/^preview · frame 12/)).toBeInTheDocument();
   // Camera 2's run: 11 then 12, and the stage clock restarted with the step.
   expect(screen.getByTestId('seq-1')).toBeInTheDocument();
@@ -190,7 +191,7 @@ it('a run restarts by rebuilding its stack, never by fading back down to an earl
   vi.useFakeTimers();
   // minStepS 2 keeps the 6 s dwell divided evenly by 3 rather than stretched,
   // so this test is about the stack and not about the budget.
-  const d2 = { ...dialsFrom2(schemaDefaults(SOLO2_SETTINGS_SCHEMA)), dwellS: 6, minStepS: 2, sameCameraFadeS: 1, dwellBoost: 0, dwellTrim: 0 }; // 3 frames → 2 s each, after a 1.5 s arrival
+  const d2 = { ...dialsFrom2(schemaDefaults(SOLO2_SETTINGS_SCHEMA)), dwellS: 6, minStepS: 2, sameCameraFadeS: 1, dwellBoost: 0, dwellTrim: 0 }; // 3 frames → 2 s each, between a 1 s rise and a 0.75 s burn
   const older = (id: number, capturedAt: number) => ({ ...entry, snapshotId: id, imageUrl: `u${id}`, capturedAt });
   const entries = [older(5, entry.capturedAt - 20 * 60_000), older(6, entry.capturedAt - 10 * 60_000), entry];
   const s2 = { ...server, entries } as unknown as StateView;
@@ -201,7 +202,7 @@ it('a run restarts by rebuilding its stack, never by fading back down to an earl
   expect(screen.getByTestId('top')).toHaveAttribute('src', 'u7'); // last frame of the run
   const stackBefore = screen.getByTestId('stack');
 
-  await act(async () => { vi.advanceTimersByTime(2_000); }); // the dwell ends and replays
+  await act(async () => { vi.advanceTimersByTime(2_400); }); // the last frame's step and its burn end, and the dwell replays
   expect(screen.getByTestId('top')).toHaveAttribute('src', 'u5'); // back to the oldest frame
   // Rebuilt, so the later frames are simply gone rather than dissolving away
   // on top of the oldest one.
@@ -250,10 +251,10 @@ it('solo2 holds a stretched dwell for the run it plays, not for the dial', async
   render(<GlassPreview version={SOLO_VERSIONS.solo2} screens={[{ feed: 'sunset', server: s2, projected }]}
     dials={d2} panel={{ width: 1920, height: 1080 }} />);
 
-  await act(async () => { vi.advanceTimersByTime(7_600); }); // the dial (plus the 1.5 s arrival) is up; the run is not
+  await act(async () => { vi.advanceTimersByTime(7_600); }); // the dial (plus the 1 s rise) is up; the run is not
   expect(screen.getByTestId('top')).toHaveAttribute('src', 'u7'); // still the run's last frame
   expect(screen.getByText(/on glass now · frame 7/)).toBeInTheDocument();
 
-  await act(async () => { vi.advanceTimersByTime(3_000); }); // 10.5 s: the arrival and the 9 s run are done
+  await act(async () => { vi.advanceTimersByTime(3_200); }); // 10.8 s: the rise, the 9 s run and the burn are all done
   expect(screen.getByText(/^preview · frame 8/)).toBeInTheDocument();
 });

--- a/docs/superpowers/specs/2026-09-06-solo2-dwell-budget-design.md
+++ b/docs/superpowers/specs/2026-09-06-solo2-dwell-budget-design.md
@@ -139,7 +139,8 @@ total    = arrivalS + perFrame × n
 The run's clock — `stageAt` — starts when the arrival ends, so frame 1 is up
 throughout the arrival and then holds a whole step, like every frame after it.
 The last frame holds its whole step too, and then leaves under the next
-dwell's veil; nothing at the back needed to change.
+dwell's veil; nothing at the back needed to change — see §3.4, where it turned
+out something did.
 
 Three consequences:
 
@@ -157,6 +158,49 @@ Three consequences:
 - **solo has no arrival.** Its dials carry no camera-change fade, so
   `arrivalS` is 0 and its dwell is exactly the dial, as before. A version
   gains an arrival only by having the fade dials.
+
+### 3.4 The exit segment (added 2026-09-08, corrected the same day)
+
+A dip is two halves. Reserving the whole change at the front of the ARRIVING
+dwell meant the leaving dwell's last frame held a full still step and only
+then began to burn: at a 6 s change and a 4 s step, ten seconds between the
+last new picture of a run and the first of the next, against four through the
+middle. So the burn moved to the dwell it belongs to — the picture on glass
+during it is that dwell's last frame:
+
+```
+exitS = transition == dip ? fadeS / 2 : 0
+```
+
+**The correction.** The first cut charged the burn INSIDE the last frame's
+step — `lastStepS = max(stepS, dissolveIn + exit)` — which spent the last
+frame's still time on the burn instead of adding to it. At the live dials
+(4 s step, 2 s dissolve, 6 s change) the last picture of every run finished
+dissolving in at the instant the burn began and was **never once still**: an
+entire picture concealed. Shortening the change to 3 s handed back half a
+second of it, and Jesse reported it as a flash — worst on the sunrise screen,
+where an `exposure` veil blows the picture out to white rather than down to
+black.
+
+The rule is therefore symmetric with §3.3, and is the whole of it:
+
+```
+arrivalS = max(transition == cut ? 0 : riseS, sameCameraFadeS)
+exitS    = transition == dip ? fadeS / 2 : 0
+lastStep = perFrame + exitS
+total    = arrivalS + perFrame × n + exitS
+```
+
+**No frame ever spends its own step arriving or leaving.** The change's two
+halves sit outside the frames' budget, one at each end, so every picture in a
+run holds equally still — which is what the budget rule of §3 promises and
+what a timelapse has to look like.
+
+The cost is honest and visible: at a `fadeS` of `c` and a step of `s`, the
+boundary between two runs is `s + c` from the last new picture to the first
+of the next, against `s` through the middle. That gap is the change's length,
+and the only dial that shortens it is `fadeS`. Absorbing the burn hid the
+gap by deleting a picture, which is not a trade worth making.
 
 ## 4. Frame caps, per bin
 


### PR DESCRIPTION
## The flash

The frame being flashed is the run's **last**, not its first. The dip's burn
was charged *inside* the last frame's step, so it spent that frame's still
time instead of following it.

| camera change | middle frame, clean | last frame, clean |
|---|---|---|
| 6 s (before Jesse shortened it) | 2.0 s | **0.00 s** |
| 3 s (now) | 2.0 s | **0.50 s** |
| 3 s, with this fix | 2.0 s | **2.00 s** |

At 6 seconds the last picture of every run finished dissolving in at the
instant the burn began, so it was never once still — an entire picture
concealed, which is exactly what Jesse suspected. Shortening the change to 3
seconds handed back half a second of it. The sunrise screen shows it worst
because its veil style is `exposure`, so the picture blows out to white rather
than fading down to black.

## The rule

Both halves of the camera change now sit outside the frames' budget, one at
each end: the rise in front, the burn behind.

```
arrivalS = max(transition == cut ? 0 : riseS, sameCameraFadeS)
exitS    = transition == dip ? fadeS / 2 : 0
lastStep = perFrame + exitS
total    = arrivalS + perFrame × n + exitS
```

No frame ever spends its own step arriving or leaving, so every picture in a
run holds equally still. `planOf` runs the same rule backward from a pinned
total and no longer needs its convergence loop, because the last step is now
linear in the step.

## The cost, stated plainly

A run's boundary is one frame's time plus the whole change, against one
frame's time through the middle. At the live dials that is 5.5 s against 4 s.
Absorbing the burn hid that gap by deleting a picture, which is not a trade
worth making — the dial that shortens the gap is the change itself.

## Verification

- 2548 tests pass, lint clean, `npm run build` clean.
- New spec in `plan.test.ts` asserts the last frame holds as long as the
  middle ones, at both a 3 s and a 6 s change.
- Spec §3.4 added to `docs/superpowers/specs/2026-09-06-solo2-dwell-budget-design.md`.

**Unverified on glass.** After merge: `bash scripts/pi/kiosk-doctor.sh --sync --reload`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VFVmfKUKRPn69cbfBQevQH
