### PR TITLE
fix(solo2): a new dwell is read in the render that brings it, not after the paint

### DIFF
--- a/app/components/solo2/useStage.test.ts
+++ b/app/components/solo2/useStage.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { renderHook, act } from '@testing-library/react';
 import { useStage } from './useStage';
-import { fitPlan } from '@/app/lib/solo2/plan';
+import { fitPlan, type Stage } from '@/app/lib/solo2/plan';
 
 const plan = fitPlan({ dwellS: 6, leadS: 2, minStepS: 1 }, 3); // 2 s a frame, lead over the last 2 s
 
@@ -31,5 +31,26 @@ describe('useStage', () => {
     expect(result.current).toEqual({ index: 2, leadProgress: 0.5, exitProgress: 0 });
     rerender({ start: 100_000 });
     expect(result.current).toEqual({ index: 0, leadProgress: 0, exitProgress: 0 });
+  });
+});
+
+describe('useStage across a change of dwell', () => {
+  /**
+   * The render that brings a new dwell is the one the browser PAINTS. An
+   * effect that corrects the stage afterwards runs a frame too late, so the
+   * glass paints the previous dwell's index against the new run — its newest
+   * picture — before snapping back to the oldest. Reported 2026-09-09 as a
+   * flash of a lighter, later picture at the start of a sunrise run.
+   */
+  it('reads the new dwell during the render that brings it, not after the paint', () => {
+    const seen: Stage[] = [];
+    const { rerender } = renderHook(
+      (p: { start: number }) => { const s = useStage(plan, p.start); seen.push(s); return s; },
+      { initialProps: { start: 100_000 - 5_000 } },
+    );
+    expect(seen[seen.length - 1]).toEqual({ index: 2, leadProgress: 0.5, exitProgress: 0 });
+    seen.length = 0;
+    rerender({ start: 100_000 });
+    expect(seen[0]).toEqual({ index: 0, leadProgress: 0, exitProgress: 0 });
   });
 });

--- a/app/components/solo2/useStage.ts
+++ b/app/components/solo2/useStage.ts
@@ -10,15 +10,32 @@ const same = (a: Stage, b: Stage) =>
  * Where the current dwell is, re-read from the wall clock every `tickMs`
  * (camera-run spec §4.2). `startMs` is when the dwell began; it changes once
  * per dwell, so a tab that loads mid-dwell joins at the right frame.
+ *
+ * A NEW dwell is read during the render that brings it, never in the effect
+ * afterwards. An effect runs after the browser has painted, so a stage kept
+ * only in state stays on the PREVIOUS dwell's index for the first painted
+ * frame of the new one — and that index, clamped to the new run, picks its
+ * NEWEST picture. On glass that was a flash of a later, lighter frame at the
+ * head of a sunrise run before it snapped back to the oldest (reported
+ * 2026-09-09), carrying the lead's push at full scale and the exit's veil
+ * with it. The dwell's start is its identity here, the same key the frame
+ * stack rebuilds on.
  */
 export function useStage(plan: DwellPlan, startMs: number, tickMs = 250): Stage {
-  const [stage, setStage] = useState<Stage>(() => stageAt(Date.now() - startMs, plan));
+  const [state, setState] = useState<{ startMs: number; stage: Stage }>(
+    () => ({ startMs, stage: stageAt(Date.now() - startMs, plan) }),
+  );
+  let stage = state.stage;
+  if (state.startMs !== startMs) {
+    stage = stageAt(Date.now() - startMs, plan);
+    setState({ startMs, stage });
+  }
   const { dwellS, frames, stepS, lastStepS, leadS, arrivalS, exitS } = plan;
   useEffect(() => {
     const p = { dwellS, frames, stepS, lastStepS, leadS, arrivalS, exitS };
-    const read = () => setStage((prev) => {
+    const read = () => setState((prev) => {
       const nextStage = stageAt(Date.now() - startMs, p);
-      return same(prev, nextStage) ? prev : nextStage;
+      return prev.startMs === startMs && same(prev.stage, nextStage) ? prev : { startMs, stage: nextStage };
     });
     read();
     const t = setInterval(read, tickMs);

--- a/app/studio/solo/useLoopingStage.test.ts
+++ b/app/studio/solo/useLoopingStage.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { renderHook, act } from '@testing-library/react';
 import { useLoopingStage } from './useLoopingStage';
-import { fitPlan } from '@/app/lib/solo2/plan';
+import { fitPlan, type Stage } from '@/app/lib/solo2/plan';
 
 const plan = fitPlan({ dwellS: 6, leadS: 0, minStepS: 1 }, 3); // 2 s a frame, above the floor so the budget divides
 const NOW = 100_000;
@@ -51,5 +51,25 @@ describe('useLoopingStage', () => {
   it('still holds it far past the dwell, however late the walker is', () => {
     const { result } = renderHook(() => useLoopingStage(plan, NOW - 60_000));
     expect(result.current.index).toBe(2);
+  });
+});
+
+describe('useLoopingStage across a change of dwell', () => {
+  /**
+   * The preview paints the render that brings a new dwell. Correcting the
+   * stage in an effect afterwards is a frame too late: the old dwell's index
+   * against the new run is the run's NEWEST picture, which flashed at the
+   * head of the run before it snapped back to the oldest (2026-09-09).
+   */
+  it('reads the new dwell during the render that brings it, not after the paint', () => {
+    const seen: Stage[] = [];
+    const { rerender } = renderHook(
+      (p: { start: number }) => { const s = useLoopingStage(plan, p.start); seen.push(s); return s; },
+      { initialProps: { start: NOW - 4_000 } },
+    );
+    expect(seen[seen.length - 1].index).toBe(2);
+    seen.length = 0;
+    rerender({ start: NOW });
+    expect(seen[0].index).toBe(0);
   });
 });

--- a/app/studio/solo/useLoopingStage.ts
+++ b/app/studio/solo/useLoopingStage.ts
@@ -40,13 +40,25 @@ function stageOf(startMs: number | null, plan: DwellPlan): Stage {
  * longer wraps at all — see `stageOf`.
  */
 export function useLoopingStage(plan: DwellPlan, startMs: number | null, tickMs = 250): Stage {
-  const [stage, setStage] = useState<Stage>(() => stageOf(startMs, plan));
+  const [state, setState] = useState<{ startMs: number | null; stage: Stage }>(
+    () => ({ startMs, stage: stageOf(startMs, plan) }),
+  );
+  // The new dwell is read HERE, in the render that brings it, because an
+  // effect runs after the browser has painted: a stage kept only in state
+  // paints the previous dwell's index against the new run, which clamps to
+  // the run's newest picture and flashes a later frame at the head of the
+  // run (2026-09-09). Same fix, same reason, as the glass's `useStage`.
+  let stage = state.stage;
+  if (state.startMs !== startMs) {
+    stage = stageOf(startMs, plan);
+    setState({ startMs, stage });
+  }
   const { dwellS, frames, stepS, lastStepS, leadS, arrivalS, exitS } = plan;
   useEffect(() => {
     const p = { dwellS, frames, stepS, lastStepS, leadS, arrivalS, exitS };
-    const read = () => setStage((prev) => {
+    const read = () => setState((prev) => {
       const nextStage = stageOf(startMs, p);
-      return same(prev, nextStage) ? prev : nextStage;
+      return prev.startMs === startMs && same(prev.stage, nextStage) ? prev : { startMs, stage: nextStage };
     });
     read();
     const t = setInterval(read, tickMs);


### PR DESCRIPTION
## The flash

At the head of a camera run the glass showed a later, lighter picture for an
instant, then snapped back to the run's oldest frame. Seen on the sunrise
screen, on the Alberta camera, where "further into the day" is obvious.

## Why

`useStage` held the dwell's stage in React state and only re-read it in a
`useEffect`. Effects run **after** the browser paints. So the first painted
render of every new dwell used the *previous* dwell's stage — its index at the
end of its run, its lead at full push, its exit already past its start.

`Solo2Frame` clamps that index to the run it is given:

```ts
const shown = Math.min(stage.index, sequence.length - 1);
```

Clamped to a fresh run, an end-of-run index is the run's **newest** picture.
That is exactly the flash, and it explains why it was always a frame further
into the day than the one that replaced it. One paint later the effect reset
the stage to 0 and the run started properly.

## The fix

The dwell's start is its identity — `index.tsx` already passes it as the
`dwellKey` the frame stack rebuilds on. Both clocks now re-read the stage
**during the render where that start changes**, and keep the interval only for
the ticks inside a dwell. The studio preview's `useLoopingStage` had the same
defect and gets the same fix, so the preview and the glass still agree.

## Why the old tests missed it

`renderHook`'s `rerender` flushes effects inside `act`, so the existing
"a new start resets to the first frame" test only ever saw the *corrected*
value — it passed while the bug was live. The new tests record what every
render **returns** and assert on the first one after the dwell changes, which
is the render the browser paints.

## Verification

- New test fails on `main` (`index: 2, leadProgress: 0.5` where `index: 0` is
  required), passes here.
- `npm run test` — 2566 passed, 295 files.
- `npm run lint` — no new warnings.
- `npm run build` — clean.

Not yet seen on glass. After merge: `bash scripts/pi/kiosk-doctor.sh --sync --reload`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012ncQ2TmVELM2qBmzbpSYj3
