### PR TITLE
docs: ideas and unbuilt work go to GitHub issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/idea.md
+++ b/.github/ISSUE_TEMPLATE/idea.md
@@ -1,0 +1,23 @@
+---
+name: Idea
+about: Something worth building, not being built right now
+labels: idea
+---
+
+<!--
+Keep this cheap. If it takes more than a couple of minutes you are designing,
+and designing happens later via the brainstorming skill. See CLAUDE.md,
+"Ideas and unbuilt work go to GitHub issues".
+-->
+
+**What**
+
+<!-- One or two sentences. -->
+
+**Why now, or why not yet**
+
+<!-- What makes it worth doing, and anything blocking it. -->
+
+**Where the thinking lives**
+
+<!-- Spec/plan path, PR, or memory entry if one exists. Otherwise "nothing yet". -->

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -129,6 +129,35 @@ failure table: `docs/ops/pushing-an-update-to-the-glass.md`.
 Work the pipeline in order before assuming a code bug: pixel stats → EXIF →
 boots/config → `snap-now.sh` on the device.
 
+## Ideas and unbuilt work go to GitHub issues
+
+**An idea that is not being built right now is an issue, not a doc.** Before
+this rule the backlog lived in "open: …" tails on memory entries, in loose root
+`.md` files, and in spec docs with no PR — so nothing had one list and the
+memory index outgrew its size limit trying to be one.
+
+Three labels, and only these:
+
+- `idea` — captured, not designed. One paragraph. Costs 30 seconds.
+- `speced` — has a design doc and could be picked up as-is.
+- `open-question` — a decision to make, not work to do.
+
+The lifecycle, and where brainstorming fits:
+
+1. An idea shows up mid-session → `gh issue create --label idea` immediately.
+   Do **not** design it. The point is to stop losing it, not to start it.
+2. It gets picked up → the `superpowers:brainstorming` skill runs *on that
+   issue*, and writes its spec to `docs/superpowers/specs/` as it always has.
+3. Paste the spec path into the issue, relabel `speced`.
+4. The PR body says `Closes #N`.
+
+Issues do not replace specs or plans. The issue is the spine and carries the
+stable id from first mention to merge; `docs/superpowers/specs/` and
+`docs/superpowers/plans/` still hold the thinking. Keep this file conventions
+only, and **stop using `MEMORY.md` as a board** — a memory entry records what a
+future session needs to understand a thing, and the issue tracks whether it is
+done.
+
 ## Where knowledge lives
 
 `docs/solutions/` holds accumulated lessons, filed by category
@@ -143,3 +172,7 @@ orienting or naming things.
 
 The repo root has accumulated a lot of loose planning `.md` files — treat
 `docs/` as authoritative over root-level notes.
+
+Docs are what is *known*; `gh issue list` is what is *open*. If you want to
+know whether something got built, that is the issue list, not a doc and not a
+memory entry.


### PR DESCRIPTION
Docs only. No code, no migration, safe to sit through the freeze.

## The problem

The premise we started from was that ideas are buried in `CLAUDE.md`. They are not — that file is 145 lines of conventions and every line earns its place. The real state of the backlog:

| Where "not yet built" currently lives | Count |
| --- | --- |
| GitHub issues | 2, one open since June |
| Memory entries ending in `open: …` | 6 tails across 126 files |
| Spec docs | 48 |
| Plan docs | 57 |
| Loose root `.md` files | 13 |

Nothing has one list. `MEMORY.md` became the de-facto board and is now 32KB against a 24KB limit, so it is truncating — the board is already dropping entries.

## The change

A new `CLAUDE.md` section making issues the home for decided-but-unbuilt work and open questions, plus a deliberately thin issue template.

Three labels, created on the repo already:

- `idea` — captured, not designed
- `speced` — has a design doc, ready to pick up
- `open-question` — a decision to make, not work to do

## How this coexists with superpowers brainstorming

They sit at different points in the same pipeline, so there is nothing to reconcile. An idea arrives mid-session and becomes a one-paragraph issue in 30 seconds with no design work. When it gets picked up, the brainstorming skill runs *on that issue* and writes its spec to `docs/superpowers/specs/` exactly as before. The spec path goes back on the issue, the label moves to `speced`, and the PR closes it.

Today brainstorming starts from nothing and ends in a doc nobody re-finds. The only thing that changes is that each thread now has a stable id from first mention to merge. Specs and plans are untouched.

## Not in this PR

The historical harvest. Sweeping 126 memory files and ~100 docs into issues is a half-day of triage and it competes with opening night on Friday. That comes after the show, as a single list to triage in one pass.

## Also worth a look

`git worktree list` shows 8 open worktrees against the stated cap of three active lanes. That is the kind of drift this convention is meant to make visible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015SzsMoFpHSvNLeVbVH6tHb
